### PR TITLE
fix: use kebab-case for skill name

### DIFF
--- a/skills/evlog/SKILL.md
+++ b/skills/evlog/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Review logging patterns
+name: review-logging-patterns
 description: Review code for logging patterns and suggest evlog adoption. Detects console.log spam, unstructured errors, and missing context. Guides wide event design, structured error handling, and request-scoped logging.
 license: MIT
 metadata:


### PR DESCRIPTION
Updated Skill name to kebab-case. Skill names with spaces break Claude Code's skill invocation,