### PR TITLE
feat(module): add Cloudflare Workers adapter

### DIFF
--- a/apps/docs/content/1.getting-started/2.installation.md
+++ b/apps/docs/content/1.getting-started/2.installation.md
@@ -3,7 +3,7 @@ title: Installation
 description: Install evlog in your Nuxt, Nitro, or standalone TypeScript project.
 ---
 
-evlog supports multiple environments: Nuxt, Nitro, and standalone TypeScript.
+evlog supports multiple environments: Nuxt, Nitro, Cloudflare Workers, and standalone TypeScript.
 
 ## Nuxt
 
@@ -258,6 +258,47 @@ export default defineNitroConfig({
   plugins: ['evlog/nitro'],
 })
 ```
+
+## Cloudflare Workers
+
+Use the Workers adapter for structured logs and correct platform severity.
+
+```typescript [src/index.ts]
+import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({
+  env: { service: 'edge-api' },
+})
+
+export default {
+  async fetch(request: Request) {
+    const log = createWorkersLogger(request)
+
+    try {
+      log.set({ route: 'health' })
+      const response = new Response('ok', { status: 200 })
+      log.emit({ status: response.status })
+      return response
+    } catch (error) {
+      log.error(error as Error)
+      log.emit({ status: 500 })
+      throw error
+    }
+  },
+}
+```
+
+Disable invocation logs to avoid duplicate request logs:
+
+```toml [wrangler.toml]
+[observability.logs]
+invocation_logs = false
+```
+
+Notes:
+- `requestId` defaults to `cf-ray` when available
+- `request.cf` is included (colo, country, asn) unless disabled
+- Use `headerAllowlist` to avoid logging sensitive headers
 
 ## Standalone TypeScript
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "evlog-monorepo",

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -1,0 +1,8 @@
+# Cloudflare Workers Example
+
+```bash
+pnpm add evlog
+pnpm dlx wrangler dev
+```
+
+This example uses `evlog/workers` and disables invocation logs to avoid duplicate request logs.

--- a/examples/workers/package.json
+++ b/examples/workers/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "evlog-workers-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "evlog": "file:../../packages/evlog"
+  },
+  "devDependencies": {
+    "wrangler": "^3.101.0"
+  }
+}

--- a/examples/workers/src/index.ts
+++ b/examples/workers/src/index.ts
@@ -1,0 +1,22 @@
+import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({
+  env: { service: 'workers-example' },
+})
+
+export default {
+  async fetch(request: Request) {
+    const log = createWorkersLogger(request)
+
+    try {
+      log.set({ route: 'health' })
+      const response = new Response('ok', { status: 200 })
+      log.emit({ status: response.status })
+      return response
+    } catch (error) {
+      log.error(error as Error)
+      log.emit({ status: 500 })
+      throw error
+    }
+  },
+}

--- a/examples/workers/wrangler.toml
+++ b/examples/workers/wrangler.toml
@@ -1,0 +1,7 @@
+name = "evlog-workers-example"
+main = "src/index.ts"
+compatibility_date = "2026-02-03"
+
+[observability.logs]
+enabled = true
+invocation_logs = false

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -346,6 +346,49 @@ async function processSyncJob(job: Job) {
 }
 ```
 
+## Cloudflare Workers
+
+Use the Workers adapter for structured logs and correct platform severity.
+
+```typescript
+// src/index.ts
+import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({
+  env: { service: 'edge-api' },
+})
+
+export default {
+  async fetch(request: Request) {
+    const log = createWorkersLogger(request)
+
+    try {
+      log.set({ route: 'health' })
+      const response = new Response('ok', { status: 200 })
+      log.emit({ status: response.status })
+      return response
+    } catch (error) {
+      log.error(error as Error)
+      log.emit({ status: 500 })
+      throw error
+    }
+  },
+}
+```
+
+Disable invocation logs to avoid duplicate request logs:
+
+```toml
+# wrangler.toml
+[observability.logs]
+invocation_logs = false
+```
+
+Notes:
+- `requestId` defaults to `cf-ray` when available
+- `request.cf` is included (colo, country, asn) unless disabled
+- Use `headerAllowlist` to avoid logging sensitive headers
+
 ## API Reference
 
 ### `initLogger(config)`
@@ -362,6 +405,7 @@ initLogger({
     region?: string      // Deployment region
   },
   pretty?: boolean       // Pretty print (default: true in dev)
+  stringify?: boolean    // JSON.stringify output (default: true, false for Workers)
   include?: string[]     // Route patterns to log (glob), e.g. ['/api/**']
   sampling?: {
     rates?: {            // Head sampling (random per level)
@@ -477,6 +521,34 @@ log.set({ user: { id: '123' } })  // Add context
 log.error(error, { step: 'x' })   // Log error with context
 log.emit()                         // Emit final event
 log.getContext()                   // Get current context
+```
+
+### `initWorkersLogger(options?)`
+
+Initialize evlog for Cloudflare Workers (object logs + correct severity).
+
+```typescript
+import { initWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({
+  env: { service: 'edge-api' },
+})
+```
+
+### `createWorkersLogger(request, options?)`
+
+Create a request-scoped logger for Workers. Auto-extracts `cf-ray`, `request.cf`, method, and path.
+
+```typescript
+import { createWorkersLogger } from 'evlog/workers'
+
+const log = createWorkersLogger(request, {
+  requestId: 'custom-id',      // Override cf-ray (default: cf-ray header)
+  headers: ['x-request-id'],   // Headers to include (default: none)
+})
+
+log.set({ user: { id: '123' } })
+log.emit({ status: 200 })
 ```
 
 ### `createError(options)`

--- a/packages/evlog/build.config.ts
+++ b/packages/evlog/build.config.ts
@@ -14,6 +14,7 @@ export default defineBuildConfig({
     { input: 'src/logger', name: 'logger' },
     { input: 'src/utils', name: 'utils' },
     { input: 'src/types', name: 'types' },
+    { input: 'src/workers/index', name: 'workers' },
   ],
   declaration: true,
   clean: true,

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -34,6 +34,10 @@
     "./nitro": {
       "types": "./dist/nitro/plugin.d.mts",
       "import": "./dist/nitro/plugin.mjs"
+    },
+    "./workers": {
+      "types": "./dist/workers.d.mts",
+      "import": "./dist/workers.mjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -48,6 +52,9 @@
       ],
       "nitro": [
         "./dist/nitro/plugin.d.mts"
+      ],
+      "workers": [
+        "./dist/workers.d.mts"
       ]
     }
   },

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -9,6 +9,7 @@ let globalEnv: EnvironmentContext = {
 
 let globalPretty = isDev()
 let globalSampling: SamplingConfig = {}
+let globalStringify = true
 
 /**
  * Initialize the logger with configuration.
@@ -27,6 +28,7 @@ export function initLogger(config: LoggerConfig = {}): void {
 
   globalPretty = config.pretty ?? isDev()
   globalSampling = config.sampling ?? {}
+  globalStringify = config.stringify ?? true
 }
 
 /**
@@ -87,8 +89,10 @@ function emitWideEvent(level: LogLevel, event: Record<string, unknown>, skipSamp
 
   if (globalPretty) {
     prettyPrintWideEvent(formatted)
-  } else {
+  } else if (globalStringify) {
     console[getConsoleMethod(level)](JSON.stringify(formatted))
+  } else {
+    console[getConsoleMethod(level)](formatted)
   }
 
   return formatted
@@ -102,9 +106,9 @@ function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
     const color = getLevelColor(level)
     const timestamp = new Date().toISOString().slice(11, 23)
     console.log(`${colors.dim}${timestamp}${colors.reset} ${color}[${tag}]${colors.reset} ${message}`)
-  } else {
-    emitWideEvent(level, { tag, message })
+    return
   }
+  emitWideEvent(level, { tag, message })
 }
 
 function formatValue(value: unknown): string {

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -197,6 +197,12 @@ export interface LoggerConfig {
   pretty?: boolean
   /** Sampling configuration for filtering logs */
   sampling?: SamplingConfig
+  /**
+   * When pretty is disabled, emit JSON strings (default) or raw objects.
+   * Set to false for environments like Cloudflare Workers that expect objects.
+   * @default true
+   */
+  stringify?: boolean
 }
 
 /**

--- a/packages/evlog/src/utils.ts
+++ b/packages/evlog/src/utils.ts
@@ -16,17 +16,21 @@ export function isClient(): boolean {
 }
 
 export function isDev(): boolean {
-  if (typeof process !== 'undefined' && process.env.NODE_ENV) {
+  if (typeof process !== 'undefined') {
     return process.env.NODE_ENV !== 'production'
   }
-  return true
+  if (typeof window !== 'undefined') {
+    return true
+  }
+  return false
 }
 
 export function detectEnvironment(): Partial<EnvironmentContext> {
   const env = typeof process !== 'undefined' ? process.env : {}
+  const defaultEnvironment = isDev() ? 'development' : 'production'
 
   return {
-    environment: env.NODE_ENV || 'development',
+    environment: env.NODE_ENV || defaultEnvironment,
     service: env.SERVICE_NAME || 'app',
     version: env.APP_VERSION,
     commitHash: env.COMMIT_SHA
@@ -40,8 +44,8 @@ export function detectEnvironment(): Partial<EnvironmentContext> {
   }
 }
 
-export function getConsoleMethod(level: LogLevel): 'log' | 'error' | 'warn' {
-  return level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'log'
+export function getConsoleMethod(level: LogLevel): LogLevel {
+  return level
 }
 
 export const colors = {

--- a/packages/evlog/src/workers/index.ts
+++ b/packages/evlog/src/workers/index.ts
@@ -1,0 +1,100 @@
+import { initLogger, createRequestLogger } from '../logger'
+import type { LoggerConfig, RequestLogger } from '../types'
+
+/**
+ * Options for createWorkersLogger
+ */
+export interface WorkersLoggerOptions {
+  /** Override the request ID (default: cf-ray header) */
+  requestId?: string
+  /** Headers to include in logs (default: none) */
+  headers?: string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function collectHeaders(headers: Headers, include: string[] | undefined): Record<string, string> | undefined {
+  if (!include || include.length === 0) return undefined
+
+  const normalized = new Set(include.map(h => h.toLowerCase()))
+  const result: Record<string, string> = {}
+
+  headers.forEach((value, key) => {
+    if (normalized.has(key.toLowerCase())) {
+      result[key] = value
+    }
+  })
+
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+/**
+ * Initialize evlog for Cloudflare Workers.
+ * Call once at module scope.
+ *
+ * @example
+ * ```ts
+ * initWorkersLogger({
+ *   env: { service: 'my-api' },
+ * })
+ * ```
+ */
+export function initWorkersLogger(options: LoggerConfig = {}): void {
+  initLogger({
+    ...options,
+    pretty: false,
+    stringify: false,
+  })
+}
+
+function pickCfContext(request: Request): Record<string, unknown> {
+  const cf = Reflect.get(request, 'cf')
+  if (!isRecord(cf)) return {}
+
+  const out: Record<string, unknown> = {}
+  if (typeof cf.colo === 'string') out.colo = cf.colo
+  if (typeof cf.country === 'string') out.country = cf.country
+  if (typeof cf.asn === 'number') out.asn = cf.asn
+  return out
+}
+
+/**
+ * Create a request-scoped logger for Cloudflare Workers.
+ * Auto-extracts cf-ray, request.cf context, method, and path.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(request: Request) {
+ *     const log = createWorkersLogger(request)
+ *
+ *     log.set({ user: { id: '123' } })
+ *     log.emit({ status: 200 })
+ *
+ *     return new Response('ok')
+ *   }
+ * }
+ * ```
+ */
+export function createWorkersLogger(request: Request, options: WorkersLoggerOptions = {}): RequestLogger {
+  const url = new URL(request.url)
+  const cfRay = request.headers.get('cf-ray') ?? undefined
+  const traceparent = request.headers.get('traceparent') ?? undefined
+
+  const log = createRequestLogger({
+    method: request.method,
+    path: url.pathname,
+    requestId: options.requestId ?? cfRay,
+  })
+
+  log.set({
+    cfRay,
+    traceparent,
+    ...pickCfContext(request),
+    ...(options.headers ? { requestHeaders: collectHeaders(request.headers, options.headers) } : {}),
+  })
+
+  return log
+}

--- a/packages/evlog/test/logger.test.ts
+++ b/packages/evlog/test/logger.test.ts
@@ -60,10 +60,10 @@ describe('initLogger', () => {
 })
 
 describe('log', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let infoSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     initLogger({ pretty: false })
@@ -75,8 +75,8 @@ describe('log', () => {
 
   it('logs tagged message with info level', () => {
     log.info('auth', 'User logged in')
-    expect(consoleSpy).toHaveBeenCalled()
-    const [[output]] = consoleSpy.mock.calls
+    expect(infoSpy).toHaveBeenCalled()
+    const [[output]] = infoSpy.mock.calls
     expect(output).toContain('"level":"info"')
     expect(output).toContain('"tag":"auth"')
     expect(output).toContain('"message":"User logged in"')
@@ -84,8 +84,8 @@ describe('log', () => {
 
   it('logs wide event object', () => {
     log.info({ action: 'checkout', items: 3 })
-    expect(consoleSpy).toHaveBeenCalled()
-    const [[output]] = consoleSpy.mock.calls
+    expect(infoSpy).toHaveBeenCalled()
+    const [[output]] = infoSpy.mock.calls
     expect(output).toContain('"action":"checkout"')
     expect(output).toContain('"items":3')
   })
@@ -104,10 +104,10 @@ describe('log', () => {
 })
 
 describe('createRequestLogger', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let infoSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     initLogger({ pretty: false })
   })
@@ -249,8 +249,8 @@ describe('createRequestLogger', () => {
     logger.set({ user: { id: '123' } })
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalled()
-    const [[output]] = consoleSpy.mock.calls
+    expect(infoSpy).toHaveBeenCalled()
+    const [[output]] = infoSpy.mock.calls
     expect(output).toContain('"level":"info"')
     expect(output).toContain('"method":"GET"')
     expect(output).toContain('"path":"/api/test"')
@@ -275,7 +275,7 @@ describe('createRequestLogger', () => {
     await new Promise(resolve => setTimeout(resolve, 50))
     logger.emit()
 
-    const [[output]] = consoleSpy.mock.calls
+    const [[output]] = infoSpy.mock.calls
     expect(output).toMatch(/"duration":"[0-9]+ms"/)
   })
 
@@ -284,7 +284,7 @@ describe('createRequestLogger', () => {
     logger.set({ original: true })
     logger.emit({ override: true })
 
-    const [[output]] = consoleSpy.mock.calls
+    const [[output]] = infoSpy.mock.calls
     expect(output).toContain('"original":true')
     expect(output).toContain('"override":true')
   })
@@ -339,12 +339,12 @@ describe('createRequestLogger', () => {
 })
 
 describe('sampling', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let infoSpy: ReturnType<typeof vi.spyOn>
   let errorSpy: ReturnType<typeof vi.spyOn>
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
@@ -360,7 +360,7 @@ describe('sampling', () => {
     log.warn('test', 'warn message')
     log.error('test', 'error message')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
@@ -377,7 +377,7 @@ describe('sampling', () => {
     log.warn('test', 'warn message')
     log.error('test', 'error message')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
@@ -395,7 +395,7 @@ describe('sampling', () => {
     log.debug('test', 'debug message')
     log.error('test', 'error message')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
     expect(warnSpy).toHaveBeenCalledTimes(0)
     expect(errorSpy).toHaveBeenCalledTimes(0)
   })
@@ -412,7 +412,7 @@ describe('sampling', () => {
     log.warn('test', 'warn message')
     log.error('test', 'error message')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
     expect(warnSpy).toHaveBeenCalledTimes(0)
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
@@ -428,7 +428,7 @@ describe('sampling', () => {
     const logger = createRequestLogger({ method: 'GET', path: '/test' })
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
   })
 
   it('respects error rate for request logger with errors', () => {
@@ -460,17 +460,19 @@ describe('sampling', () => {
     // Simulate random returning 0.3 (30%) - should log (30 < 50)
     randomSpy.mockReturnValueOnce(0.3)
     log.info('test', 'should log')
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
 
     // Simulate random returning 0.7 (70%) - should not log (70 >= 50)
     randomSpy.mockReturnValueOnce(0.7)
     log.info('test', 'should not log')
-    expect(consoleSpy).toHaveBeenCalledTimes(1) // Still 1, not logged
+    expect(infoSpy).toHaveBeenCalledTimes(1) // Still 1, not logged
 
     randomSpy.mockRestore()
   })
 
   it('applies sampling to tagged logs in pretty mode', () => {
+    // Pretty mode uses console.log for formatted output
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     initLogger({
       pretty: true,
       sampling: {
@@ -479,10 +481,12 @@ describe('sampling', () => {
     })
 
     log.info('test', 'should not log')
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(logSpy).toHaveBeenCalledTimes(0)
   })
 
   it('logs tagged messages in pretty mode when sampling rate is 100%', () => {
+    // Pretty mode uses console.log for formatted output
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     initLogger({
       pretty: true,
       sampling: {
@@ -491,16 +495,16 @@ describe('sampling', () => {
     })
 
     log.info('test', 'should log')
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(logSpy).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('tail sampling', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let infoSpy: ReturnType<typeof vi.spyOn>
   let errorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -521,7 +525,7 @@ describe('tail sampling', () => {
     logger.set({ status: 500 }) // Error status
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('does not keep logs when status is below threshold', () => {
@@ -537,7 +541,7 @@ describe('tail sampling', () => {
     logger.set({ status: 200 }) // Success status
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
   })
 
   it('keeps logs when duration meets threshold', async () => {
@@ -553,7 +557,7 @@ describe('tail sampling', () => {
     await new Promise(resolve => setTimeout(resolve, 60)) // Wait longer than threshold
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('does not keep logs when duration is below threshold', () => {
@@ -569,7 +573,7 @@ describe('tail sampling', () => {
     // Emit immediately (duration < 1000ms)
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
   })
 
   it('keeps logs when path matches pattern', () => {
@@ -584,7 +588,7 @@ describe('tail sampling', () => {
     const logger = createRequestLogger({ method: 'GET', path: '/api/critical/checkout' })
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('does not keep logs when path does not match pattern', () => {
@@ -599,7 +603,7 @@ describe('tail sampling', () => {
     const logger = createRequestLogger({ method: 'GET', path: '/api/normal/users' })
     logger.emit()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(0)
+    expect(infoSpy).toHaveBeenCalledTimes(0)
   })
 
   it('uses OR logic for multiple conditions', () => {
@@ -618,14 +622,14 @@ describe('tail sampling', () => {
     const logger1 = createRequestLogger({ method: 'GET', path: '/api/critical/test' })
     logger1.set({ status: 200 })
     logger1.emit()
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
 
     // Only status matches, path doesn't
-    consoleSpy.mockClear()
+    infoSpy.mockClear()
     const logger2 = createRequestLogger({ method: 'GET', path: '/api/normal' })
     logger2.set({ status: 500 })
     logger2.emit()
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('force keeps logs via _forceKeep override', () => {
@@ -640,7 +644,7 @@ describe('tail sampling', () => {
     const logger = createRequestLogger({ method: 'GET', path: '/test' })
     logger.emit({ _forceKeep: true })
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('head sampling still works when no tail conditions match', () => {
@@ -657,7 +661,7 @@ describe('tail sampling', () => {
     logger.emit()
 
     // Should be logged because head sampling rate is 100%
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
   })
 
   it('combines head and tail sampling correctly', () => {
@@ -677,14 +681,14 @@ describe('tail sampling', () => {
     const logger1 = createRequestLogger({ method: 'GET', path: '/test' })
     logger1.set({ status: 400 })
     logger1.emit()
-    expect(consoleSpy).toHaveBeenCalledTimes(1) // Kept by tail sampling
+    expect(infoSpy).toHaveBeenCalledTimes(1) // Kept by tail sampling
 
     // Random returns 0.9 (would fail 50% head sampling), status is 200
-    consoleSpy.mockClear()
+    infoSpy.mockClear()
     const logger2 = createRequestLogger({ method: 'GET', path: '/test' })
     logger2.set({ status: 200 })
     logger2.emit()
-    expect(consoleSpy).toHaveBeenCalledTimes(0) // Dropped by head sampling
+    expect(infoSpy).toHaveBeenCalledTimes(0) // Dropped by head sampling
 
     randomSpy.mockRestore()
   })

--- a/packages/evlog/tsconfig.json
+++ b/packages/evlog/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "evlog": ["./src/index.ts"],
       "evlog/nuxt": ["./src/nuxt/module.ts"],
-      "evlog/nitro": ["./src/nitro/plugin.ts"]
+      "evlog/nitro": ["./src/nitro/plugin.ts"],
+      "evlog/workers": ["./src/workers/index.ts"]
     }
   },
   "include": ["src/**/*", "test/**/*"],


### PR DESCRIPTION
## Summary

Adds first-class Cloudflare Workers support for evlog, addressing:
- PR #21: `process` undefined in Workers breaks env detection
- Issue #18: Duplicate logs and requestId mismatch

## Changes

- **New Workers adapter** (`evlog/workers`):
  - `initWorkersLogger(options)` - initialize with `stringify: false` for structured objects
  - `createWorkersLogger(request, options)` - request-scoped logger with auto-extracted context
  - Emits objects via `console[level](event)` for proper platform severity mapping

- **Auto-extracted context**:
  - `cf-ray` header as requestId
  - `request.cf` properties (colo, country, asn)
  - Method, path from request

- **Core changes**:
  - `isDev()` returns `false` in Workers (no process/window)
  - Added `stringify?: boolean` option to skip JSON.stringify (for Workers)
  - Simplified `getConsoleMethod` to identity function

## Usage

```typescript
import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'

initWorkersLogger({ env: { service: 'my-api' } })

export default {
  async fetch(request: Request) {
    const log = createWorkersLogger(request)
    log.set({ user: { id: '123' } })
    log.emit({ status: 200 })
    return new Response('ok')
  }
}
```