### PR TITLE
feat: adds `waitUntil` support for edge environments

### DIFF
--- a/apps/docs/content/3.adapters/1.overview.md
+++ b/apps/docs/content/3.adapters/1.overview.md
@@ -27,6 +27,10 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
+::callout{icon="i-lucide-cloud" color="info"}
+**Serverless Support:** On Cloudflare Workers and Vercel Edge, evlog automatically uses `waitUntil()` to ensure drains complete before the runtime terminates. No additional configuration needed.
+::
+
 ## Available Adapters
 
 ::card-group

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -354,7 +354,16 @@ export interface H3EventContext {
 export interface ServerEvent {
   method: string
   path: string
-  context: H3EventContext
+  context: H3EventContext & {
+    /** Cloudflare Workers context (available when deployed to CF Workers) */
+    cloudflare?: {
+      context: {
+        waitUntil: (promise: Promise<unknown>) => void
+      }
+    }
+    /** Vercel Edge context (available when deployed to Vercel Edge) */
+    waitUntil?: (promise: Promise<unknown>) => void
+  }
   node?: { res?: { statusCode?: number } }
   response?: Response
 }


### PR DESCRIPTION
This pull request adds robust support for serverless environments (Cloudflare Workers and Vercel Edge) by ensuring that log drain operations are completed before the runtime terminates. This is achieved by detecting and utilizing the `waitUntil()` API provided by these platforms. The changes also include comprehensive tests to verify this behavior and update the documentation to highlight the new feature.