### PR TITLE
feat: `requestId` override in a worker environment

### DIFF
--- a/packages/evlog/src/nitro/plugin.ts
+++ b/packages/evlog/src/nitro/plugin.ts
@@ -149,7 +149,6 @@ export default defineNitroPlugin((nitroApp) => {
     e.context._evlogStartTime = Date.now()
     
     let requestIdOverride: string | undefined = undefined
-    // Are we in a cloudflare environment? Use cf-ray for requestId
     if (globalThis.navigator?.userAgent === 'Cloudflare-Workers') {
       const cfRay = getSafeHeaders(event)?.['cf-ray']
       if (cfRay) requestIdOverride = cfRay


### PR DESCRIPTION
Very simple pull request to allow for a requestId override in a Worker environment.

## WHY

Using Nuxt framework on a Cloudflare Workers env means the logs will have a UUID for resultId, not matching the requestId in Workers Observability.

This will look for a ```workerd``` environment and use the ```cf-ray``` headers in place of the UUID request ID.

Currently testing for durability.
