### PR TITLE
fix: include h3 createError custom properties in wide event

### DIFF
--- a/apps/playground/server/api/test/h3-error.get.ts
+++ b/apps/playground/server/api/test/h3-error.get.ts
@@ -1,0 +1,11 @@
+export default defineEventHandler(() => {
+  throw createError({
+    status: 500,
+    message: 'Something went wrong',
+    data: {
+      code: 'VALIDATION_ERROR',
+      why: 'The input format was invalid',
+      fix: 'Ensure the input matches the expected schema',
+    },
+  })
+})

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -259,6 +259,10 @@ export function createRequestLogger(options: RequestLoggerOptions = {}): Request
           name: err.name,
           message: err.message,
           stack: err.stack,
+          ...('statusCode' in err && { statusCode: (err as Record<string, unknown>).statusCode }),
+          ...('statusMessage' in err && { statusMessage: (err as Record<string, unknown>).statusMessage }),
+          ...('data' in err && { data: (err as Record<string, unknown>).data }),
+          ...('cause' in err && { cause: (err as unknown as Record<string, unknown>).cause }),
         },
       }
       context = deepDefaults(errorData, context) as Record<string, unknown>


### PR DESCRIPTION
This pull request enhances error logging in the `evlog` package by ensuring that custom error properties such as `statusCode`, `statusMessage`, `data`, and `cause` are captured and logged when present. It also adds comprehensive tests to verify this behavior. Additionally, a new API route is introduced in the playground server to throw a structured error for testing purposes.