### PR TITLE
fix: capture status/statusText from H3 v2+ errors

### DIFF
--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -307,6 +307,8 @@ export function createRequestLogger<T extends object = Record<string, unknown>>(
           name: err.name,
           message: err.message,
           stack: err.stack,
+          ...('status' in err && { status: (err as Record<string, unknown>).status }),
+          ...('statusText' in err && { statusText: (err as Record<string, unknown>).statusText }),
           ...('statusCode' in err && { statusCode: (err as Record<string, unknown>).statusCode }),
           ...('statusMessage' in err && { statusMessage: (err as Record<string, unknown>).statusMessage }),
           ...('data' in err && { data: (err as Record<string, unknown>).data }),

--- a/packages/evlog/test/logger.test.ts
+++ b/packages/evlog/test/logger.test.ts
@@ -314,6 +314,25 @@ describe('createRequestLogger', () => {
     })
   })
 
+  it('captures status/statusText from new-style H3 errors (Nuxt v4.3+)', () => {
+    const logger = createRequestLogger({})
+    const error = Object.assign(new Error('Not Found'), {
+      status: 404,
+      statusText: 'Not Found',
+    })
+
+    logger.error(error)
+
+    const context = logger.getContext()
+    expect(context.error).toEqual({
+      name: 'Error',
+      message: 'Not Found',
+      stack: expect.any(String),
+      status: 404,
+      statusText: 'Not Found',
+    })
+  })
+
   it('does not include custom properties when absent', () => {
     const logger = createRequestLogger({})
     logger.error(new Error('Plain error'))
@@ -325,6 +344,7 @@ describe('createRequestLogger', () => {
       stack: expect.any(String),
     })
     expect(context.error).not.toHaveProperty('statusCode')
+    expect(context.error).not.toHaveProperty('status')
     expect(context.error).not.toHaveProperty('data')
     expect(context.error).not.toHaveProperty('cause')
   })


### PR DESCRIPTION
This pull request enhances error logging in the `evlog` package to support new-style H3 errors (introduced in Nuxt v4.3+), ensuring that `status` and `statusText` properties are captured when present. It also adds comprehensive tests to verify this behavior and confirms that custom properties are not included when absent.