### PR TITLE
fix(nuxthub): add retry with backoff to drain insert

### DIFF
--- a/.changeset/ninety-ties-care.md
+++ b/.changeset/ninety-ties-care.md
@@ -1,0 +1,5 @@
+---
+"@evlog/nuxthub": patch
+---
+
+add retry logic to nuxthub module

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,8 @@ Here are the available types and scopes:
 ### Scopes
 - docs (the documentation)
 - playground (the playground)
-- module (the module)
+- evlog (the evlog package)
+- nuxthub (the nuxthub package)
 - deps (the dependencies)
 - repo (the repository)
 -->

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -24,7 +24,8 @@ jobs:
           scopes: |
             docs
             playground
-            module
+            evlog
+            nuxthub
             deps
             repo
           types: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ apps/chat/.data
 .codex/environments/
 .claude/
 apps/nuxthub-playground/.data
+.next/

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "evlog-monorepo",
@@ -3662,6 +3661,8 @@
     "globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "h3-next/crossws": ["crossws@0.4.4", "", { "peerDependencies": { "srvx": ">=0.7.1" }, "optionalPeers": ["srvx"] }, "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 


### PR DESCRIPTION
This pull request introduces retry logic to the `nuxthub` module, improving resilience when inserting event rows into the database. It also updates project documentation and workflow configuration to reflect the new scope for the `nuxthub` package.