### PR TITLE
feat: add console option for client-side log suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,7 @@ export default defineNuxtConfig({
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Globally enable/disable all logging. When `false`, all operations become no-ops |
+| `console` | `boolean` | `true` | Enable/disable browser console output. When `false`, client logs are suppressed in DevTools but still sent via transport |
 | `env.service` | `string` | `'app'` | Service name shown in logs |
 | `env.environment` | `string` | Auto-detected | Environment name |
 | `include` | `string[]` | `undefined` | Route patterns to log (glob). If not set, all routes are logged |

--- a/apps/docs/content/1.getting-started/2.installation.md
+++ b/apps/docs/content/1.getting-started/2.installation.md
@@ -492,6 +492,7 @@ These options apply to **Nuxt, Nitro v2, and Nitro v3**. The evlog module accept
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Globally enable/disable all logging. When `false`, all operations become no-ops |
+| `console` | `boolean` | `true` | Enable/disable browser console output. When `false`, client logs are suppressed in DevTools but still sent via transport |
 | `env.service` | `string` | `'app'` | Service name shown in logs |
 | `env.environment` | `string` | Auto-detected | Environment name |
 | `include` | `string[]` | `undefined` | Route patterns to log. Supports glob (`/api/**`). If not set, all routes are logged |
@@ -967,7 +968,7 @@ export default defineNuxtRouteMiddleware(() => {
 ```
 
 ::callout{icon="i-lucide-lightbulb" color="info"}
-**Tip:** Use Nuxt's `$production` override to sample only in production while keeping full visibility in development:
+**Tip:** Use Nuxt's `$production` override to sample and suppress browser console output in production while keeping full visibility in development:
 
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -977,6 +978,7 @@ export default defineNuxtConfig({
   },
   $production: {
     evlog: {
+      console: false, // Suppress browser DevTools console, keep transport
       sampling: {
         rates: { info: 10, warn: 50, debug: 0 },
         keep: [{ duration: 1000 }, { status: 400 }],

--- a/packages/evlog/src/next/client.ts
+++ b/packages/evlog/src/next/client.ts
@@ -30,6 +30,14 @@ export interface EvlogProviderProps {
    */
   enabled?: boolean
 
+  /**
+   * Enable or disable browser console output.
+   * When false, logs are suppressed in the browser DevTools console
+   * but still sent to the server via transport (if enabled).
+   * @default true
+   */
+  console?: boolean
+
   children: React.ReactNode
 }
 
@@ -52,15 +60,16 @@ export interface EvlogProviderProps {
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function EvlogProvider({ service, pretty, transport, enabled, children }: EvlogProviderProps) {
+export function EvlogProvider({ service, pretty, transport, enabled, console: consoleOutput, children }: EvlogProviderProps) {
   useEffect(() => {
     initLog({
       enabled,
+      console: consoleOutput,
       pretty,
       service,
       transport,
     })
-  }, [enabled, pretty, service, transport])
+  }, [enabled, consoleOutput, pretty, service, transport])
 
   return children
 }

--- a/packages/evlog/src/nuxt/module.ts
+++ b/packages/evlog/src/nuxt/module.ts
@@ -56,6 +56,14 @@ export interface ModuleOptions {
   env?: Partial<EnvironmentContext>
 
   /**
+   * Enable or disable browser console output.
+   * When false, client-side logs are suppressed in the browser DevTools console
+   * but still sent to the server via transport (if enabled).
+   * @default true
+   */
+  console?: boolean
+
+  /**
    * Enable pretty printing.
    * @default true in development, false in production
    */
@@ -241,6 +249,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.evlog = options
     nuxt.options.runtimeConfig.public.evlog = {
       enabled: options.enabled ?? true,
+      console: options.console,
       pretty: options.pretty,
       transport: {
         enabled: transportEnabled,

--- a/packages/evlog/src/runtime/client/log.ts
+++ b/packages/evlog/src/runtime/client/log.ts
@@ -4,6 +4,7 @@ import { getConsoleMethod } from '../../utils'
 const isClient = typeof window !== 'undefined'
 
 let clientEnabled = true
+let clientConsole = true
 let clientPretty = true
 let clientService = 'client'
 let transportEnabled = false
@@ -25,8 +26,9 @@ const LEVEL_COLORS: Record<string, string> = {
   debug: 'color: #6b7280; font-weight: bold',
 }
 
-export function initLog(options: { enabled?: boolean, pretty?: boolean, service?: string, transport?: TransportConfig } = {}): void {
+export function initLog(options: { enabled?: boolean, console?: boolean, pretty?: boolean, service?: string, transport?: TransportConfig } = {}): void {
   clientEnabled = typeof options.enabled === 'boolean' ? options.enabled : true
+  clientConsole = typeof options.console === 'boolean' ? options.console : true
   clientPretty = typeof options.pretty === 'boolean' ? options.pretty : true
   clientService = options.service ?? 'client'
   transportEnabled = options.transport?.enabled ?? false
@@ -60,13 +62,14 @@ function emitLog(level: LogLevel, event: Record<string, unknown>): void {
     ...event,
   }
 
-  const method = getConsoleMethod(level)
-
-  if (clientPretty) {
-    const { level: lvl, service, ...rest } = formatted
-    console[method](`%c[${service}]%c ${lvl}`, LEVEL_COLORS[lvl] || '', 'color: inherit', rest)
-  } else {
-    console[method](JSON.stringify(formatted))
+  if (clientConsole) {
+    const method = getConsoleMethod(level)
+    if (clientPretty) {
+      const { level: lvl, service, ...rest } = formatted
+      console[method](`%c[${service}]%c ${lvl}`, LEVEL_COLORS[lvl] || '', 'color: inherit', rest)
+    } else {
+      console[method](JSON.stringify(formatted))
+    }
   }
 
   sendToServer(formatted)
@@ -75,7 +78,9 @@ function emitLog(level: LogLevel, event: Record<string, unknown>): void {
 function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
   if (!clientEnabled) return
   if (clientPretty) {
-    console[getConsoleMethod(level)](`%c[${tag}]%c ${message}`, LEVEL_COLORS[level] || '', 'color: inherit')
+    if (clientConsole) {
+      console[getConsoleMethod(level)](`%c[${tag}]%c ${message}`, LEVEL_COLORS[level] || '', 'color: inherit')
+    }
     sendToServer({
       timestamp: new Date().toISOString(),
       level,

--- a/packages/evlog/src/runtime/client/plugin.ts
+++ b/packages/evlog/src/runtime/client/plugin.ts
@@ -4,6 +4,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
 interface EvlogPublicConfig {
   enabled?: boolean
+  console?: boolean
   pretty?: boolean
   transport?: TransportConfig
 }
@@ -14,6 +15,7 @@ export default defineNuxtPlugin(() => {
 
   initLog({
     enabled: evlogConfig?.enabled,
+    console: evlogConfig?.console,
     pretty: evlogConfig?.pretty ?? import.meta.dev,
     service: 'client',
     transport: evlogConfig?.transport,

--- a/packages/evlog/test/client-console.test.ts
+++ b/packages/evlog/test/client-console.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initLog, log } from '../src/runtime/client/log'
+
+describe('client console option', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('outputs to console by default', () => {
+    initLog({ enabled: true, pretty: false })
+
+    log.info({ action: 'test' })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses console output when console is false', () => {
+    initLog({ enabled: true, console: false, pretty: false })
+
+    log.info({ action: 'test' })
+    log.error({ action: 'test' })
+    log.warn({ action: 'test' })
+
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('still sends to transport when console is false', () => {
+    initLog({
+      enabled: true,
+      console: false,
+      pretty: false,
+      transport: { enabled: true, endpoint: '/api/_evlog/ingest' },
+    })
+
+    log.info({ action: 'test' })
+
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses pretty console output when console is false', () => {
+    initLog({ enabled: true, console: false, pretty: true })
+
+    log.info({ action: 'test' })
+
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+  })
+
+  it('suppresses tagged logs in pretty mode when console is false', () => {
+    initLog({
+      enabled: true,
+      console: false,
+      pretty: true,
+      transport: { enabled: true, endpoint: '/api/_evlog/ingest' },
+    })
+
+    log.info('auth', 'User logged in')
+
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops everything when enabled is false (regardless of console)', () => {
+    initLog({
+      enabled: false,
+      console: true,
+      pretty: false,
+      transport: { enabled: true, endpoint: '/api/_evlog/ingest' },
+    })
+
+    log.info({ action: 'test' })
+
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('restores console output when console is set back to true', () => {
+    initLog({ enabled: true, console: false, pretty: false })
+    log.info({ action: 'silent' })
+    expect(infoSpy).not.toHaveBeenCalled()
+
+    initLog({ enabled: true, console: true, pretty: false })
+    log.info({ action: 'visible' })
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
This pull request introduces a new option to control browser console output for client-side logging, allowing logs to be sent to the server without appearing in the browser DevTools console. The change is fully documented, implemented across Nuxt and Next integrations, and covered by new tests to verify its behavior.