### PR TITLE
docs: update skill files to keep user-facing docs in sync

### DIFF
--- a/.agents/skills/create-adapter/SKILL.md
+++ b/.agents/skills/create-adapter/SKILL.md
@@ -27,7 +27,7 @@ The exact wording may vary depending on the adapter (e.g., `feat: add OTLP adapt
 | 4 | `packages/evlog/test/adapters/{name}.test.ts` | Create tests |
 | 5 | `apps/docs/content/3.adapters/{n}.{name}.md` | Create adapter doc page (before `custom.md`) |
 | 6 | `apps/docs/content/3.adapters/1.overview.md` | Add adapter to overview (links, card, env vars) |
-| 7 | `AGENTS.md` | Add adapter to the "Built-in Adapters" table |
+| 7 | `skills/evlog/SKILL.md` | Add adapter row in the Drain Adapters table |
 | 8 | Renumber `custom.md` | Ensure `custom.md` stays last after the new adapter |
 
 **Important**: Do NOT consider the task complete until all 8 touchpoints have been addressed.
@@ -123,14 +123,15 @@ Edit `apps/docs/content/3.adapters/1.overview.md` to add the new adapter in **th
 2. **`::card-group` section** -- add a card block before the Custom card
 3. **Zero-Config Setup `.env` example** -- add the adapter's env vars
 
-## Step 7: Update AGENTS.md
+## Step 7: Update `skills/evlog/SKILL.md`
 
-In the root `AGENTS.md` file, "Log Draining & Adapters" section:
+In `skills/evlog/SKILL.md` (the public skill distributed to users), find the **Drain Adapters** table and add a new row:
 
-1. Add a row to the **"Built-in Adapters"** table
-2. Add a **"Using {Name} Adapter"** usage example block with `create{Name}Drain()` and env vars
+```markdown
+| {Name} | `evlog/{name}` | `{NAME}_TOKEN`, `{NAME}_DATASET` (or equivalent) |
+```
 
-Follow the pattern of existing adapters in the file.
+Follow the pattern of the existing rows (Axiom, OTLP, PostHog, Sentry, Better Stack). No additional usage example block is needed — the table entry is sufficient.
 
 ## Step 8: Renumber `custom.md`
 

--- a/.agents/skills/create-enricher/SKILL.md
+++ b/.agents/skills/create-enricher/SKILL.md
@@ -25,7 +25,7 @@ The exact wording may vary depending on the enricher (e.g., `feat: add user agen
 | 2 | `packages/evlog/test/enrichers.test.ts` | Add tests |
 | 3 | `apps/docs/content/4.enrichers/2.built-in.md` | Add enricher to built-in docs |
 | 4 | `apps/docs/content/4.enrichers/1.overview.md` | Add enricher to overview cards |
-| 5 | `AGENTS.md` | Add enricher to the "Built-in Enrichers" table |
+| 5 | `skills/evlog/SKILL.md` | Add enricher to the Built-in line in the Enrichers section |
 | 6 | `README.md` + `packages/evlog/README.md` | Add enricher to README enrichers section |
 
 **Important**: Do NOT consider the task complete until all 6 touchpoints have been addressed.
@@ -124,12 +124,12 @@ Edit `apps/docs/content/4.enrichers/1.overview.md` to add a card for the new enr
   :::
 ```
 
-## Step 5: Update AGENTS.md
+## Step 5: Update `skills/evlog/SKILL.md`
 
-Add the new enricher to the **"Built-in Enrichers"** table in the root `AGENTS.md` file, in the "Event Enrichment" section:
+In `skills/evlog/SKILL.md` (the public skill distributed to users), find the **Enrichers** section and add the new enricher to the `Built-in:` line:
 
 ```markdown
-| {DISPLAY} | `evlog/enrichers` | `{name}` | [Description] |
+Built-in: `createUserAgentEnricher()`, `createGeoEnricher()`, ..., `create{Name}Enricher()` — all from `evlog/enrichers`.
 ```
 
 ## Step 6: Update README

--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -27,14 +27,15 @@ feat({framework}): add {Framework} middleware integration
 | 6 | `apps/docs/content/6.examples/{N}.{framework}.md` | Create dedicated example page |
 | 7 | `apps/docs/content/0.landing.md` | Add framework code snippet |
 | 8 | `apps/docs/app/components/features/FeatureFrameworks.vue` | Add framework tab |
-| 9 | `AGENTS.md` | Add framework to integration section |
-| 10 | `examples/{framework}/` | Create example app with test UI |
-| 11 | `package.json` (root) | Add `example:{framework}` script |
-| 12 | `.changeset/{framework}-integration.md` | Create changeset (`minor`) |
-| 13 | `.github/workflows/semantic-pull-request.yml` | Add `{framework}` scope |
-| 14 | `.github/pull_request_template.md` | Add `{framework}` scope |
+| 9 | `skills/evlog/SKILL.md` | Add framework setup section + update frontmatter description |
+| 10 | `packages/evlog/README.md` | Add framework section + add row to Framework Support table |
+| 11 | `examples/{framework}/` | Create example app with test UI |
+| 12 | `package.json` (root) | Add `example:{framework}` script |
+| 13 | `.changeset/{framework}-integration.md` | Create changeset (`minor`) |
+| 14 | `.github/workflows/semantic-pull-request.yml` | Add `{framework}` scope |
+| 15 | `.github/pull_request_template.md` | Add `{framework}` scope |
 
-**Important**: Do NOT consider the task complete until all 14 touchpoints have been addressed.
+**Important**: Do NOT consider the task complete until all 15 touchpoints have been addressed.
 
 ## Naming Conventions
 
@@ -334,15 +335,32 @@ Update `apps/docs/app/components/features/FeatureFrameworks.vue`:
 
 Icons use Simple Icons format: `i-simple-icons-{name}` (e.g., `i-simple-icons-express`, `i-simple-icons-hono`).
 
-## Step 9: Update AGENTS.md
+## Step 9: Update `skills/evlog/SKILL.md`
 
-In the root `AGENTS.md` file:
+In `skills/evlog/SKILL.md` (the public skill distributed to users):
 
-1. Add the framework to the **"Framework Integration"** section
-2. Add import path and basic setup example (showing both `req.log` and `useLogger()`)
-3. Show drain/enrich/keep usage
+1. Add `### {Framework}` in the **"Framework Setup"** section, after the last existing framework entry and before "Cloudflare Workers"
+2. Include:
+   - Import + `initLogger` + middleware/plugin setup
+   - Logger access in route handlers (`req.log`, `c.get('log')`, or `{ log }` destructuring)
+   - `useLogger()` snippet with a short service function example
+   - Full pipeline example showing `drain`, `enrich`, and `keep` options
+3. Update the `description:` line in the YAML frontmatter to mention the new framework name
 
-## Step 10: Example App
+## Step 10: Update `packages/evlog/README.md`
+
+In the root `packages/evlog/README.md`:
+
+1. Add a `## {Framework}` section after the Elysia section (before `## Browser`), with a minimal setup snippet and a link to the example app
+2. Add a row to the **"Framework Support"** table:
+
+```markdown
+| **{Framework}** | `{registration pattern}` with `import { evlog } from 'evlog/{framework}'` ([example](./examples/{framework})) |
+```
+
+Keep the snippet short — just init, register/use middleware, and one route handler showing logger access. No need to repeat drain/enrich/keep here.
+
+## Step 11: Example App
 
 Create `examples/{framework}/` with a runnable app that demonstrates all evlog features.
 
@@ -406,7 +424,7 @@ Reference: `examples/hono/src/ui.ts` for the canonical pattern. Copy and adapt f
 }
 ```
 
-## Step 11: Root Package Script
+## Step 12: Root Package Script
 
 Add a root-level script in the monorepo `package.json`:
 
@@ -416,7 +434,7 @@ Add a root-level script in the monorepo `package.json`:
 
 The `dotenv --` prefix loads the root `.env` file (containing `POSTHOG_API_KEY` and other adapter keys) into the process before turbo starts. Turborepo does not load `.env` files — `dotenv-cli` handles this at the root level so individual examples need no env configuration.
 
-## Step 12: Changeset
+## Step 13: Changeset
 
 Create `.changeset/{framework}-integration.md`:
 
@@ -428,7 +446,7 @@ Create `.changeset/{framework}-integration.md`:
 Add {Framework} middleware integration (`evlog/{framework}`) with automatic wide-event logging, drain, enrich, and tail sampling support
 ```
 
-## Step 13 & 14: PR Scopes
+## Step 14 & 15: PR Scopes
 
 Add the framework name as a valid scope in **both** files so PR title validation passes:
 

--- a/skills/evlog/SKILL.md
+++ b/skills/evlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-logging-patterns
-description: Review code for logging patterns and suggest evlog adoption. Guides setup on Nuxt, Next.js, TanStack Start, Nitro, Hono, Cloudflare Workers, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, PostHog, Sentry, Better Stack), sampling, and enrichers.
+description: Review code for logging patterns and suggest evlog adoption. Guides setup on Nuxt, Next.js, TanStack Start, Nitro, Hono, Express, Fastify, Elysia, Cloudflare Workers, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, PostHog, Sentry, Better Stack), sampling, and enrichers.
 license: MIT
 metadata:
   author: HugoRCD
@@ -292,36 +292,171 @@ Import `useLogger` from `evlog/nitro` in routes.
 ### Hono
 
 ```typescript
-import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
-import { createRequestLogger, initLogger, createError, parseError } from 'evlog'
+import { initLogger } from 'evlog'
+import { evlog, type EvlogVariables } from 'evlog/hono'
 
-initLogger({ env: { service: 'hono-api' } })
+initLogger({ env: { service: 'my-api' } })
 
-const app = new Hono()
+const app = new Hono<EvlogVariables>()
+app.use(evlog())
 
-app.use('*', async (c, next) => {
-  const startedAt = Date.now()
-  const log = createRequestLogger({ method: c.req.method, path: c.req.path })
-  c.set('log', log)
-  try {
-    await next()
-  } catch (error) {
-    log.error(error as Error)
-    throw error
-  } finally {
-    log.emit({ status: c.res.status, duration: Date.now() - startedAt })
-  }
+app.get('/api/users', (c) => {
+  const log = c.get('log')
+  log.set({ users: { count: 42 } })
+  return c.json({ users: [] })
 })
+```
 
-app.get('/health', (c) => c.json({ ok: true }))
+Access the logger via `c.get('log')` in handlers. No `useLogger()` — use `c.get('log')` and pass it down explicitly, or use Express/Fastify/Elysia if you need `useLogger()` across async boundaries.
 
-app.onError((error, c) => {
-  const parsed = parseError(error)
-  return c.json(parsed, { status: parsed.status || 500 })
+Full pipeline with drain, enrich, and tail sampling:
+
+```typescript
+import { createAxiomDrain } from 'evlog/axiom'
+
+app.use(evlog({
+  include: ['/api/**'],
+  drain: createAxiomDrain(),
+  enrich: (ctx) => { ctx.event.region = process.env.FLY_REGION },
+  keep: (ctx) => {
+    if (ctx.duration && ctx.duration > 2000) ctx.shouldKeep = true
+  },
+}))
+```
+
+### Express
+
+```typescript
+import express from 'express'
+import { initLogger } from 'evlog'
+import { evlog, useLogger } from 'evlog/express'
+
+initLogger({ env: { service: 'my-api' } })
+
+const app = express()
+app.use(evlog())
+
+app.get('/api/users', (req, res) => {
+  req.log.set({ users: { count: 42 } })
+  res.json({ users: [] })
 })
+```
 
-serve({ fetch: app.fetch, port: 3000 })
+Use `useLogger()` to access the logger from anywhere in the call stack without passing `req`:
+
+```typescript
+import { useLogger } from 'evlog/express'
+
+async function findUsers() {
+  const log = useLogger()
+  log.set({ db: { query: 'SELECT * FROM users' } })
+}
+```
+
+Full pipeline with drain, enrich, and tail sampling:
+
+```typescript
+import { createAxiomDrain } from 'evlog/axiom'
+
+app.use(evlog({
+  include: ['/api/**'],
+  drain: createAxiomDrain(),
+  enrich: (ctx) => { ctx.event.region = process.env.FLY_REGION },
+  keep: (ctx) => {
+    if (ctx.duration && ctx.duration > 2000) ctx.shouldKeep = true
+  },
+}))
+```
+
+### Fastify
+
+```typescript
+import Fastify from 'fastify'
+import { initLogger } from 'evlog'
+import { evlog, useLogger } from 'evlog/fastify'
+
+initLogger({ env: { service: 'my-api' } })
+
+const app = Fastify({ logger: false })
+await app.register(evlog)
+
+app.get('/api/users', async (request) => {
+  request.log.set({ users: { count: 42 } })
+  return { users: [] }
+})
+```
+
+`request.log` is the evlog wide-event logger (shadows Fastify's built-in pino logger on the request). Fastify's pino logger remains accessible via `fastify.log`.
+
+Use `useLogger()` to access the logger from anywhere in the call stack without passing `request`:
+
+```typescript
+import { useLogger } from 'evlog/fastify'
+
+async function findUsers() {
+  const log = useLogger()
+  log.set({ db: { query: 'SELECT * FROM users' } })
+}
+```
+
+Full pipeline with drain, enrich, and tail sampling:
+
+```typescript
+import { createAxiomDrain } from 'evlog/axiom'
+
+await app.register(evlog, {
+  include: ['/api/**'],
+  drain: createAxiomDrain(),
+  enrich: (ctx) => { ctx.event.region = process.env.FLY_REGION },
+  keep: (ctx) => {
+    if (ctx.duration && ctx.duration > 2000) ctx.shouldKeep = true
+  },
+})
+```
+
+### Elysia
+
+```typescript
+import { Elysia } from 'elysia'
+import { initLogger } from 'evlog'
+import { evlog, useLogger } from 'evlog/elysia'
+
+initLogger({ env: { service: 'my-api' } })
+
+const app = new Elysia()
+  .use(evlog())
+  .get('/api/users', ({ log }) => {
+    log.set({ users: { count: 42 } })
+    return { users: [] }
+  })
+  .listen(3000)
+```
+
+Use `useLogger()` to access the logger from anywhere in the call stack:
+
+```typescript
+import { useLogger } from 'evlog/elysia'
+
+async function findUsers() {
+  const log = useLogger()
+  log.set({ db: { query: 'SELECT * FROM users' } })
+}
+```
+
+Full pipeline with drain, enrich, and tail sampling:
+
+```typescript
+import { createAxiomDrain } from 'evlog/axiom'
+
+app.use(evlog({
+  include: ['/api/**'],
+  drain: createAxiomDrain(),
+  enrich: (ctx) => { ctx.event.region = process.env.FLY_REGION },
+  keep: (ctx) => {
+    if (ctx.duration && ctx.duration > 2000) ctx.shouldKeep = true
+  },
+}))
 ```
 
 ### Cloudflare Workers


### PR DESCRIPTION
## Summary

- **`skills/evlog/SKILL.md`**: fix Hono section (replace old `createRequestLogger` manual approach with `evlog/hono` middleware, remove incorrect `useLogger` import since Hono doesn't export it), add Express, Fastify, and Elysia sections with setup snippet + `useLogger()` + drain/enrich/keep pipeline, update frontmatter description
- **`create-framework-integration/SKILL.md`**: Step 9 now targets `skills/evlog/SKILL.md` instead of `AGENTS.md`; new Step 10 added for `packages/evlog/README.md`; steps renumbered to 15 total
- **`create-adapter/SKILL.md`**: Step 7 now targets `skills/evlog/SKILL.md` Drain Adapters table
- **`create-enricher/SKILL.md`**: Step 5 now targets `skills/evlog/SKILL.md` Built-in enrichers line

## Context

Since the last few framework integrations (Hono middleware, Express, Elysia, Fastify), new content was being added to `AGENTS.md` instead of the public user-facing skill. This PR fixes the root cause (internal dev skills now point to the right file) and catches up the public skill with all missing frameworks.

Note: `AGENTS.md` and `packages/evlog/README.md` fixes (Hono update, Express/Fastify/Elysia additions, self-updating guidelines) were committed directly to `main` in b93d6db.