### PR TITLE
docs: add sampling and client logging core concept pages

### DIFF
--- a/apps/docs/content/2.core-concepts/5.sampling.md
+++ b/apps/docs/content/2.core-concepts/5.sampling.md
@@ -22,8 +22,10 @@ At scale, logging everything gets expensive fast. Sampling lets you keep costs u
 
 Head sampling randomly keeps a percentage of logs per level. It runs **before** the request completes — a coin flip at emission time.
 
+::code-group
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({
+  modules: ['evlog/nuxt'],
   evlog: {
     sampling: {
       rates: {
@@ -36,6 +38,37 @@ export default defineNuxtConfig({
   },
 })
 ```
+```typescript [lib/evlog.ts (Next.js)]
+import { createEvlog } from 'evlog/next'
+
+export const { withEvlog, useLogger } = createEvlog({
+  service: 'my-app',
+  sampling: {
+    rates: {
+      info: 10,
+      warn: 50,
+      debug: 0,
+      error: 100,
+    },
+  },
+})
+```
+```typescript [index.ts (Hono / Express / Fastify)]
+import { initLogger } from 'evlog'
+
+initLogger({
+  env: { service: 'my-app' },
+  sampling: {
+    rates: {
+      info: 10,
+      warn: 50,
+      debug: 0,
+      error: 100,
+    },
+  },
+})
+```
+::
 
 Each level is a percentage from 0 to 100. Levels you don't configure default to 100% (keep everything). Error defaults to 100% even when other levels are configured — you have to explicitly set `error: 0` to drop errors.
 
@@ -47,21 +80,16 @@ Head sampling is random. A `10%` rate means roughly 1 in 10 info logs are kept �
 
 Head sampling is blind — it doesn't know if a request was slow, failed, or hit a critical path. Tail sampling fixes this by evaluating **after** the request completes and force-keeping logs that match specific conditions.
 
-```typescript [nuxt.config.ts]
-export default defineNuxtConfig({
-  evlog: {
-    sampling: {
-      rates: {
-        info: 10,
-      },
-      keep: [
-        { status: 400 },              // HTTP status >= 400
-        { duration: 1000 },           // Request took >= 1s
-        { path: '/api/payments/**' }, // Critical path (glob)
-      ],
-    },
-  },
-})
+```typescript
+// Works the same across all frameworks
+sampling: {
+  rates: { info: 10 },
+  keep: [
+    { status: 400 },              // HTTP status >= 400
+    { duration: 1000 },           // Request took >= 1s
+    { path: '/api/payments/**' }, // Critical path (glob)
+  ],
+}
 ```
 
 Conditions use **>=** comparison for `status` and `duration`, and glob matching for `path`. If **any** condition matches, the log is kept regardless of head sampling (OR logic).
@@ -105,24 +133,23 @@ POST /api/checkout  200  120ms  → 10% chance (head sampling)
 
 ## Custom Tail Sampling
 
-For conditions beyond status, duration, and path, use the `evlog:emit:keep` hook in Nuxt/Nitro or the `keep` callback in standalone frameworks.
+For conditions beyond status, duration, and path, use the `evlog:emit:keep` hook in Nuxt/Nitro or the `keep` callback in other frameworks.
 
 ::code-group
-```typescript [Nuxt / Nitro]
-// server/plugins/sampling.ts
+```typescript [server/plugins/sampling.ts (Nuxt)]
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('evlog:emit:keep', (ctx) => {
-    // Always keep logs for premium users
     if (ctx.context.user?.plan === 'enterprise') {
       ctx.shouldKeep = true
     }
   })
 })
 ```
-```typescript [Next.js / Express / Hono]
-import { withEvlog } from 'evlog/next' // or evlog/express, evlog/hono
+```typescript [lib/evlog.ts (Next.js)]
+import { createEvlog } from 'evlog/next'
 
-export default withEvlog(handler, {
+export const { withEvlog, useLogger } = createEvlog({
+  service: 'my-app',
   sampling: {
     rates: { info: 10 },
     keep: [{ status: 400 }],
@@ -133,6 +160,17 @@ export default withEvlog(handler, {
     }
   },
 })
+```
+```typescript [index.ts (Hono)]
+import { evlog } from 'evlog/hono'
+
+app.use(evlog({
+  keep(ctx) {
+    if (ctx.context.user?.plan === 'enterprise') {
+      ctx.shouldKeep = true
+    }
+  },
+}))
 ```
 ::
 
@@ -151,8 +189,10 @@ The `ctx` object contains:
 
 A typical production configuration that balances cost and visibility:
 
+::code-group
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({
+  modules: ['evlog/nuxt'],
   evlog: {
     env: { service: 'my-app' },
   },
@@ -176,9 +216,52 @@ export default defineNuxtConfig({
   },
 })
 ```
+```typescript [lib/evlog.ts (Next.js)]
+import { createEvlog } from 'evlog/next'
+
+export const { withEvlog, useLogger } = createEvlog({
+  service: 'my-app',
+  sampling: {
+    rates: {
+      info: 10,
+      warn: 50,
+      debug: 0,
+      error: 100,
+    },
+    keep: [
+      { status: 400 },
+      { duration: 1000 },
+      { path: '/api/payments/**' },
+      { path: '/api/auth/**' },
+    ],
+  },
+})
+```
+```typescript [index.ts (Hono / Express / Fastify)]
+import { initLogger } from 'evlog'
+
+initLogger({
+  env: { service: 'my-app' },
+  sampling: {
+    rates: {
+      info: 10,
+      warn: 50,
+      debug: 0,
+      error: 100,
+    },
+    keep: [
+      { status: 400 },
+      { duration: 1000 },
+      { path: '/api/payments/**' },
+      { path: '/api/auth/**' },
+    ],
+  },
+})
+```
+::
 
 ::callout{icon="i-lucide-lightbulb" color="warning"}
-Use the `$production` override to keep full logging in development while sampling in production. In dev, all logs are emitted — sampling only applies when deployed.
+In Nuxt, use the `$production` override to keep full logging in development while sampling in production. In other frameworks, use your own environment check or config system.
 ::
 
 ## Next Steps

--- a/apps/docs/content/2.core-concepts/6.client-logging.md
+++ b/apps/docs/content/2.core-concepts/6.client-logging.md
@@ -20,9 +20,10 @@ Server logs tell you what happened on the backend. Client logs complete the pict
 
 ## Quick Start
 
-evlog provides a client-side logging API that mirrors the server:
+evlog provides a client-side logging API that works in any browser environment:
 
-```typescript [app/plugins/logger.client.ts]
+::code-group
+```typescript [app/plugins/logger.client.ts (Nuxt)]
 import { initLog, log } from 'evlog/client'
 
 export default defineNuxtPlugin(() => {
@@ -31,6 +32,27 @@ export default defineNuxtPlugin(() => {
   log.info({ action: 'app_init', path: window.location.pathname })
 })
 ```
+```typescript [app/providers.tsx (React / Next.js)]
+'use client'
+import { useEffect } from 'react'
+import { initLog, log } from 'evlog/client'
+
+export function LogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    initLog({ service: 'web' })
+    log.info({ action: 'app_init', path: window.location.pathname })
+  }, [])
+
+  return <>{children}</>
+}
+```
+```typescript [src/app.ts (Any frontend)]
+import { initLog, log } from 'evlog/client'
+
+initLog({ service: 'web' })
+log.info({ action: 'app_init', path: window.location.pathname })
+```
+::
 
 The `log` object works anywhere in your client code — components, composables, event handlers.
 
@@ -117,9 +139,10 @@ By default, client logs only appear in the browser console. To persist them, you
 
 ### Built-in Transport
 
-The simplest approach — enable the built-in transport in `initLog()`:
+The simplest approach — enable the built-in transport in `initLog()`. Each log is sent individually via `fetch` with `keepalive: true`. Good for low-volume apps.
 
-```typescript [app/plugins/logger.client.ts]
+::code-group
+```typescript [app/plugins/logger.client.ts (Nuxt)]
 import { initLog } from 'evlog/client'
 
 export default defineNuxtPlugin(() => {
@@ -132,18 +155,29 @@ export default defineNuxtPlugin(() => {
   })
 })
 ```
+```typescript [src/app.ts (Any frontend)]
+import { initLog } from 'evlog/client'
 
-Each log is sent individually via `fetch` with `keepalive: true`. Good for low-volume apps.
+initLog({
+  service: 'web',
+  transport: {
+    enabled: true,
+    endpoint: '/api/_evlog/ingest',
+  },
+})
+```
+::
 
 ::callout{icon="i-lucide-info" color="info"}
-In Nuxt with the evlog module, the server ingest endpoint is auto-registered. For standalone frameworks, you need to create the endpoint yourself.
+In Nuxt with the evlog module, the server ingest endpoint is auto-registered. For other frameworks, you need to create the endpoint yourself — see the [Browser Drain](/adapters/browser#server-endpoint) docs for Express and Hono examples.
 ::
 
 ### Browser Drain Pipeline
 
-For higher volume or when you need batching, retries, and page-exit flushing, use the browser drain:
+For higher volume or when you need batching, retries, and page-exit flushing, use the browser drain. This works with any frontend — no framework dependency.
 
-```typescript [app/plugins/logger.client.ts]
+::code-group
+```typescript [app/plugins/logger.client.ts (Nuxt)]
 import { initLogger, log } from 'evlog'
 import { createBrowserLogDrain } from 'evlog/browser'
 
@@ -157,10 +191,25 @@ export default defineNuxtPlugin(() => {
   })
 
   initLogger({ drain })
-
   log.info({ action: 'app_init' })
 })
 ```
+```typescript [src/app.ts (Any frontend)]
+import { initLogger, log } from 'evlog'
+import { createBrowserLogDrain } from 'evlog/browser'
+
+const drain = createBrowserLogDrain({
+  drain: { endpoint: 'https://logs.example.com/v1/ingest' },
+  pipeline: {
+    batch: { size: 25, intervalMs: 2000 },
+    retry: { maxAttempts: 2 },
+  },
+})
+
+initLogger({ drain })
+log.info({ action: 'app_init' })
+```
+::
 
 The browser drain automatically:
 - **Batches** events by size and time interval


### PR DESCRIPTION
## Summary
- Add `core-concepts/sampling` page covering head sampling (random % per level), tail sampling (status/duration/path conditions), custom hooks, and production config
- Add `core-concepts/client-logging` page covering browser logging API, identity context, configuration, and server transport options
- Fixes Vercel build prerender errors caused by landing page linking to these missing pages