### PR TITLE
fix: group otlp batch by resource identity instead of using first event

### DIFF
--- a/packages/evlog/src/adapters/otlp.ts
+++ b/packages/evlog/src/adapters/otlp.ts
@@ -289,25 +289,28 @@ export async function sendBatchToOTLP(events: WideEvent[], config: OTLPConfig): 
 
   const url = `${config.endpoint.replace(/\/$/, '')}/v1/logs`
 
-  // Group events by service for proper resource attribution
-  // For simplicity, we use the first event's resource attributes
-  const [firstEvent] = events
-  const resourceAttributes = buildResourceAttributes(firstEvent, config)
-
-  const logRecords = events.map(toOTLPLogRecord)
+  // Group events by (service, environment) so each gets correct OTLP resource attributes
+  const grouped = new Map<string, WideEvent[]>()
+  for (const event of events) {
+    const key = `${event.service}::${event.environment}`
+    const group = grouped.get(key)
+    if (group) {
+      group.push(event)
+    } else {
+      grouped.set(key, [event])
+    }
+  }
 
   const payload: ExportLogsServiceRequest = {
-    resourceLogs: [
-      {
-        resource: { attributes: resourceAttributes },
-        scopeLogs: [
-          {
-            scope: { name: 'evlog', version: '1.0.0' },
-            logRecords,
-          },
-        ],
-      },
-    ],
+    resourceLogs: Array.from(grouped.values()).map((groupEvents) => ({
+      resource: { attributes: buildResourceAttributes(groupEvents[0]!, config) },
+      scopeLogs: [
+        {
+          scope: { name: 'evlog', version: '1.0.0' },
+          logRecords: groupEvents.map(toOTLPLogRecord),
+        },
+      ],
+    })),
   }
 
   const headers: Record<string, string> = {

--- a/packages/evlog/test/adapters/otlp.test.ts
+++ b/packages/evlog/test/adapters/otlp.test.ts
@@ -330,6 +330,64 @@ describe('otlp adapter', () => {
       expect(payload.resourceLogs[0].scopeLogs[0].logRecords).toHaveLength(3)
     })
 
+    it('groups events by service into separate resourceLogs', async () => {
+      const events = [
+        createTestEvent({ service: 'auth', environment: 'production', requestId: '1' }),
+        createTestEvent({ service: 'payments', environment: 'production', requestId: '2' }),
+        createTestEvent({ service: 'auth', environment: 'production', requestId: '3' }),
+      ]
+
+      await sendBatchToOTLP(events, {
+        endpoint: 'http://localhost:4318',
+      })
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+      const payload = JSON.parse(options.body as string)
+
+      // Should create 2 resourceLogs: one for auth, one for payments
+      expect(payload.resourceLogs).toHaveLength(2)
+
+      const authAttrs = payload.resourceLogs[0].resource.attributes
+      const paymentsAttrs = payload.resourceLogs[1].resource.attributes
+
+      const authService = authAttrs.find((a: { key: string }) => a.key === 'service.name')
+      expect(authService?.value).toEqual({ stringValue: 'auth' })
+
+      const paymentsService = paymentsAttrs.find((a: { key: string }) => a.key === 'service.name')
+      expect(paymentsService?.value).toEqual({ stringValue: 'payments' })
+
+      expect(payload.resourceLogs[0].scopeLogs[0].logRecords).toHaveLength(2)
+      expect(payload.resourceLogs[1].scopeLogs[0].logRecords).toHaveLength(1)
+    })
+
+    it('groups events by environment into separate resourceLogs', async () => {
+      const events = [
+        createTestEvent({ service: 'api', environment: 'production', requestId: '1' }),
+        createTestEvent({ service: 'api', environment: 'staging', requestId: '2' }),
+      ]
+
+      await sendBatchToOTLP(events, {
+        endpoint: 'http://localhost:4318',
+      })
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+      const payload = JSON.parse(options.body as string)
+
+      expect(payload.resourceLogs).toHaveLength(2)
+
+      const prodAttrs = payload.resourceLogs[0].resource.attributes
+      const stagingAttrs = payload.resourceLogs[1].resource.attributes
+
+      const prodEnv = prodAttrs.find((a: { key: string }) => a.key === 'deployment.environment')
+      expect(prodEnv?.value).toEqual({ stringValue: 'production' })
+
+      const stagingEnv = stagingAttrs.find((a: { key: string }) => a.key === 'deployment.environment')
+      expect(stagingEnv?.value).toEqual({ stringValue: 'staging' })
+
+      expect(payload.resourceLogs[0].scopeLogs[0].logRecords).toHaveLength(1)
+      expect(payload.resourceLogs[1].scopeLogs[0].logRecords).toHaveLength(1)
+    })
+
     it('does not send request for empty events array', async () => {
       await sendBatchToOTLP([], {
         endpoint: 'http://localhost:4318',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- evlog (the evlog package)
- nuxthub (the nuxthub package)
- deps (the dependencies)
- repo (the repository)
- nuxt (Nuxt module)
- nitro (Nitro plugin)
- next (Next.js integration)
- tanstack-start (TanStack Start integration)
- hono (Hono middleware)
- express (Express middleware)
- elysia (Elysia plugin)
- fastify (Fastify plugin)
- nestjs (NestJS middleware)
- sveltekit (SvelteKit integration)
- workers (Cloudflare Workers adapter)
- dx (developer experience improvements)
-->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

`sendBatchToOTLP` uses the first event's resource attributes for all events in the batch. When a batch contains events from multiple services or environments (e.g. a queue consumer or telemetry relay) every event gets the first event's `service.name` and `deployment.environment` — so logs from `payments` show up as `auth`.

We hit this in production running a workers queue consumer that aggregates events from multiple services and flushes them in a single `sendBatchToOTLP` call. We had to inline the otlp adapter in our app to work around it.

This PR groups events by (service, environment) before building the payload, so each group gets its own `resourceLogs` entry with correct resource attributes. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

> [!NOTE]
> This PR was written with AI assistance.
