### PR TITLE
enhancement(elysia): use afterResponse instead of afterHandle

### DIFF
--- a/examples/elysia/src/index.ts
+++ b/examples/elysia/src/index.ts
@@ -41,14 +41,16 @@ const app = new Elysia()
     const result = findUserWithOrders(params.id)
     return result
   })
-  .get('/checkout', () => {
-    throw createError({
-      message: 'Payment failed',
-      status: 402,
-      why: 'Card declined by issuer',
-      fix: 'Try a different card or payment method',
-      link: 'https://docs.example.com/payments/declined',
-    })
+  .get('/checkout', ({ status, log }) => {
+    return status(
+      402,
+      createError({
+        message: 'Payment failed',
+        why: 'Card declined by issuer',
+        fix: 'Try a different card or payment method',
+        link: 'https://docs.example.com/payments/declined',
+      })
+    )
   })
   .onError(({ error, set }) => {
     const parsed = parseError(error)

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -3,6 +3,7 @@ import { Elysia } from 'elysia'
 import type { RequestLogger } from '../types'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { extractSafeHeaders } from '../shared/headers'
+import { filterSafeHeaders } from '../utils'
 
 const storage = new AsyncLocalStorage<RequestLogger>()
 
@@ -77,14 +78,14 @@ export function evlog(options: EvlogElysiaOptions = {}) {
   const requestState = new WeakMap<Request, RequestState>()
 
   return new Elysia({ name: 'evlog' })
-    .derive({ as: 'global' }, ({ request }) => {
-      const url = new URL(request.url)
-
+    .derive({ as: 'global' }, ({ request, path, headers }) => {
       const { logger, finish, skipped } = createMiddlewareLogger({
         method: request.method,
-        path: url.pathname,
-        requestId: request.headers.get('x-request-id') || crypto.randomUUID(),
-        headers: extractSafeHeaders(request.headers),
+        path,
+        requestId: headers['x-request-id'] || crypto.randomUUID(),
+        // It's recommended to use context.headers instead of context.request.headers
+        // because Elysia has fast path for getting headers on Bun
+        headers: filterSafeHeaders(headers as Record<string, string>),
         ...options,
       })
 
@@ -94,7 +95,7 @@ export function evlog(options: EvlogElysiaOptions = {}) {
 
       return { log: logger }
     })
-    .onAfterHandle({ as: 'global' }, async ({ request, set }) => {
+    .onAfterResponse({ as: 'global' }, async ({ request, set }) => {
       const state = requestState.get(request)
       if (!state || state.skipped || emitted.has(request)) return
       emitted.add(request)

--- a/packages/evlog/test/elysia.test.ts
+++ b/packages/evlog/test/elysia.test.ts
@@ -9,8 +9,20 @@ import {
   createPipelineSpies,
 } from './helpers/framework'
 
+function delay(ms = 1) {
+  return new Promise((resolve) => {
+    setImmediate(resolve)
+  })
+}
+
 function request(app: Elysia, path: string, init?: RequestInit) {
-  return app.handle(new Request(`http://localhost${path}`, init))
+  return app.handle(new Request(`http://localhost${path}`, init)).then(async (response) => {
+    // using Elysia.afterResponse is scheduled to run
+    // after response is sent but not immediately
+    await delay()
+
+    return response
+  })
 }
 
 describe('evlog/elysia', () => {
@@ -60,6 +72,27 @@ describe('evlog/elysia', () => {
     expect(event.method).toBe('GET')
     expect(event.path).toBe('/api/users')
     expect(event.status).toBe(200)
+    expect(event.level).toBe('info')
+    expect(event.duration).toBeDefined()
+  })
+
+  it('emits event with correct status when using Elysia.status', async () => {
+    const app = new Elysia()
+      .use(evlog())
+      .get('/api/users', ({ status }) => status(422, ({ users: [] })))
+
+    const consoleSpy = vi.mocked(console.info)
+    await request(app, '/api/users')
+
+    const lastCall = consoleSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
+    )
+    expect(lastCall).toBeDefined()
+
+    const event = JSON.parse(lastCall![0] as string)
+    expect(event.method).toBe('GET')
+    expect(event.path).toBe('/api/users')
+    expect(event.status).toBe(422)
     expect(event.level).toBe('info')
     expect(event.duration).toBeDefined()
   })


### PR DESCRIPTION
### Types
- enhancement (improving an existing functionality) 🌈

### Scopes
- elysia (Elysia plugin)

### 🔗 Linked issue
https://github.com/HugoRCD/evlog/issues/206

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

This PR refactors Elysia integration to use [Elysia.afterResponse](https://elysiajs.com/essential/life-cycle.html#after-response) instead of [Elysia.afterHandle](https://elysiajs.com/essential/life-cycle.html#after-handle) to correctly log status

I also included 1 additional test to verify if it works

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
