### PR TITLE
fix(docs): use valid adapters docs url in integration prompts

### DIFF
--- a/apps/docs/content/2.frameworks/01.nuxt.md
+++ b/apps/docs/content/2.frameworks/01.nuxt.md
@@ -22,7 +22,7 @@ Set up evlog in my Nuxt app with wide events and structured errors.
 - Wide events are auto-emitted when each request completes
 
 Docs: https://www.evlog.dev/frameworks/nuxt
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/02.nextjs.md
+++ b/apps/docs/content/2.frameworks/02.nextjs.md
@@ -28,7 +28,7 @@ Set up evlog in my Next.js app with wide events and structured errors.
 - Wide events are auto-emitted when each request completes
 
 Docs: https://www.evlog.dev/frameworks/nextjs
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/03.sveltekit.md
+++ b/apps/docs/content/2.frameworks/03.sveltekit.md
@@ -27,7 +27,7 @@ Set up evlog in my SvelteKit app.
 - Wide events are auto-emitted when each request completes
 
 Docs: https://www.evlog.dev/frameworks/sveltekit
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/04.nitro.md
+++ b/apps/docs/content/2.frameworks/04.nitro.md
@@ -22,7 +22,7 @@ Set up evlog in my Nitro app.
 - Wide events are auto-emitted when each request completes
 
 Docs: https://www.evlog.dev/frameworks/nitro
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/05.tanstack-start.md
+++ b/apps/docs/content/2.frameworks/05.tanstack-start.md
@@ -27,7 +27,7 @@ Set up evlog in my TanStack Start app.
 - Use log.set() to accumulate context, throw createError() for structured errors
 
 Docs: https://www.evlog.dev/frameworks/tanstack-start
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/06.nestjs.md
+++ b/apps/docs/content/2.frameworks/06.nestjs.md
@@ -27,7 +27,7 @@ Set up evlog in my NestJS app.
 - Optionally pass drain, enrich, and keep callbacks to forRoot()
 
 Docs: https://www.evlog.dev/frameworks/nestjs
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/07.express.md
+++ b/apps/docs/content/2.frameworks/07.express.md
@@ -28,7 +28,7 @@ Set up evlog in my Express app.
 - Optionally pass drain, enrich, include, and keep options to evlog()
 
 Docs: https://www.evlog.dev/frameworks/express
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/08.hono.md
+++ b/apps/docs/content/2.frameworks/08.hono.md
@@ -29,7 +29,7 @@ Set up evlog in my Hono app.
 - Optionally pass drain, enrich, include, and keep options to evlog()
 
 Docs: https://www.evlog.dev/frameworks/hono
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/09.fastify.md
+++ b/apps/docs/content/2.frameworks/09.fastify.md
@@ -28,7 +28,7 @@ Set up evlog in my Fastify app.
 - Optionally pass drain, enrich, include, and keep options when registering
 
 Docs: https://www.evlog.dev/frameworks/fastify
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/10.elysia.md
+++ b/apps/docs/content/2.frameworks/10.elysia.md
@@ -28,7 +28,7 @@ Set up evlog in my Elysia app.
 - Optionally pass drain, enrich, include, and keep options to evlog()
 
 Docs: https://www.evlog.dev/frameworks/elysia
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/11.cloudflare-workers.md
+++ b/apps/docs/content/2.frameworks/11.cloudflare-workers.md
@@ -21,7 +21,7 @@ Set up evlog in my Cloudflare Worker.
 - Call log.emit() manually before returning the response (no middleware lifecycle)
 
 Docs: https://www.evlog.dev/frameworks/cloudflare-workers
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/12.standalone.md
+++ b/apps/docs/content/2.frameworks/12.standalone.md
@@ -21,7 +21,7 @@ Set up evlog in my TypeScript project for scripts, workers, or CLI tools.
 - Call log.emit() manually when the operation completes
 
 Docs: https://www.evlog.dev/frameworks/standalone
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/2.frameworks/13.astro.md
+++ b/apps/docs/content/2.frameworks/13.astro.md
@@ -21,7 +21,7 @@ Set up evlog in my Astro app.
 - Call log.emit() before returning the response (no auto-emit lifecycle)
 
 Docs: https://www.evlog.dev/frameworks/astro
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::

--- a/apps/docs/content/3.core-concepts/11.ai-sdk.md
+++ b/apps/docs/content/3.core-concepts/11.ai-sdk.md
@@ -32,7 +32,7 @@ Add AI observability to my app with evlog.
 - Works with all frameworks: Nuxt, Express, Hono, Fastify, NestJS, Elysia, standalone
 
 Docs: https://www.evlog.dev/core-concepts/ai-sdk
-Adapters: https://www.evlog.dev/adapters
+Adapters: https://www.evlog.dev/adapters/overview
 ```
 
 ::


### PR DESCRIPTION
Minor fix to the ai prompts provided in documentation for each integration. 
All integration prompts reference Adapter docs by url. However, the used url is invalid and returns 404.

[https://www.evlog.dev/adapters](https://www.evlog.dev/adapters) - doesn't work
[https://www.evlog.dev/adapters/overview](https://www.evlog.dev/adapters/overview) - works
