### PR TITLE
fix(docs): use valid frameworks docs url in adapters prompts

### DIFF
--- a/apps/docs/content/4.adapters/2.axiom.md
+++ b/apps/docs/content/4.adapters/2.axiom.md
@@ -33,7 +33,7 @@ Add the Axiom drain adapter to send evlog wide events to Axiom.
 6. Test by triggering a request and checking the Axiom dataset
 
 Adapter docs: https://www.evlog.dev/adapters/axiom
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/4.adapters/3.otlp.md
+++ b/apps/docs/content/4.adapters/3.otlp.md
@@ -42,7 +42,7 @@ Add the OTLP drain adapter to send evlog wide events via OpenTelemetry Protocol.
 7. Test by triggering a request and checking your OTLP backend (Grafana, Datadog, Honeycomb, etc.)
 
 Adapter docs: https://www.evlog.dev/adapters/otlp
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/4.adapters/4.posthog.md
+++ b/apps/docs/content/4.adapters/4.posthog.md
@@ -34,7 +34,7 @@ Add the PostHog drain adapter to send evlog wide events to PostHog Logs.
 7. Test by triggering a request and checking PostHog > Logs
 
 Adapter docs: https://www.evlog.dev/adapters/posthog
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/4.adapters/5.sentry.md
+++ b/apps/docs/content/4.adapters/5.sentry.md
@@ -33,7 +33,7 @@ Add the Sentry drain adapter to send evlog wide events to Sentry Logs.
 6. Test by triggering a request and checking Sentry > Explore > Logs
 
 Adapter docs: https://www.evlog.dev/adapters/sentry
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/4.adapters/6.better-stack.md
+++ b/apps/docs/content/4.adapters/6.better-stack.md
@@ -33,7 +33,7 @@ Add the Better Stack drain adapter to send evlog wide events to Better Stack.
 6. Test by triggering a request and checking the Better Stack logs dashboard
 
 Adapter docs: https://www.evlog.dev/adapters/better-stack
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/4.adapters/7.fs.md
+++ b/apps/docs/content/4.adapters/7.fs.md
@@ -38,7 +38,7 @@ Add the file system drain adapter to write evlog wide events locally as NDJSON f
 7. Test by triggering a request and checking .evlog/logs/*.jsonl
 
 Adapter docs: https://www.evlog.dev/adapters/fs
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::

--- a/apps/docs/content/5.enrichers/2.built-in.md
+++ b/apps/docs/content/5.enrichers/2.built-in.md
@@ -31,7 +31,7 @@ Add all built-in enrichers to my evlog setup.
 5. All enrichers accept { overwrite?: boolean } - defaults to false to preserve user-set data
 
 Enricher docs: https://www.evlog.dev/enrichers/built-in
-Framework setup: https://www.evlog.dev/frameworks
+Framework setup: https://www.evlog.dev/frameworks/overview
 ```
 
 ::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- evlog (the evlog package)
- nuxthub (the nuxthub package)
- deps (the dependencies)
- repo (the repository)
- nuxt (Nuxt module)
- nitro (Nitro plugin)
- next (Next.js integration)
- tanstack-start (TanStack Start integration)
- hono (Hono middleware)
- express (Express middleware)
- elysia (Elysia plugin)
- fastify (Fastify plugin)
- nestjs (NestJS middleware)
- sveltekit (SvelteKit integration)
- workers (Cloudflare Workers adapter)
- fs (File System adapter)
- ai (AI SDK integration)
- dx (developer experience improvements)
-->

### 📚 Description

Fixing broken urls in the Adapters docs prompts, issue similar to #211.