### PR TITLE
docs(tanstack-start): improve TanStack Start documentation coverage

### DIFF
--- a/.changeset/improve-tanstack-start-docs.md
+++ b/.changeset/improve-tanstack-start-docs.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Improve TanStack Start documentation with route filtering, pipeline (batching & retry), tail sampling sections, Vite plugin callout, and TanStack Router vs TanStack Start disambiguation

--- a/apps/docs/content/2.frameworks/00.overview.md
+++ b/apps/docs/content/2.frameworks/00.overview.md
@@ -17,6 +17,7 @@ evlog provides native integrations for every major TypeScript framework. The sam
 | [SvelteKit](/frameworks/sveltekit) | `evlog/sveltekit` | Hooks | `event.locals.log` / `useLogger()` | Stable |
 | [Nitro](/frameworks/nitro) | `evlog/nitro` | Module | `useLogger(event)` | Stable |
 | [TanStack Start](/frameworks/tanstack-start) | `evlog/nitro/v3` | Module | `useRequest().context.log` | Stable |
+| [TanStack Router](/frameworks/tanstack-start) | `evlog/nitro/v3` | Module | Via TanStack Start (uses Nitro v3) | Stable |
 | [React Router](/frameworks/react-router) | `evlog/react-router` | Middleware | `context.get(loggerContext)` / `useLogger()` | Stable |
 | [NestJS](/frameworks/nestjs) | `evlog/nestjs` | Module | `useLogger()` | Stable |
 | [Express](/frameworks/express) | `evlog/express` | Middleware | `req.log` / `useLogger()` | Stable |
@@ -74,7 +75,7 @@ evlog provides native integrations for every major TypeScript framework. The sam
   to: /frameworks/tanstack-start
   color: neutral
   ---
-  Uses Nitro v3 module with async context for seamless logging in server functions.
+  Uses Nitro v3 module with async context for seamless logging in server functions. Also covers TanStack Router (full-stack mode).
   :::
   :::card
   ---

--- a/apps/docs/content/2.frameworks/05.tanstack-start.md
+++ b/apps/docs/content/2.frameworks/05.tanstack-start.md
@@ -12,7 +12,11 @@ links:
     variant: subtle
 ---
 
-TanStack Start uses Nitro v3 as its server layer, so evlog integrates via the `evlog/nitro/v3` module. The same plugin-based hooks system applies.
+TanStack Start uses [Nitro v3](/frameworks/nitro) as its server layer, so evlog integrates via the `evlog/nitro/v3` module. The same plugin-based hooks system applies.
+
+::callout{icon="i-lucide-info" color="info"}
+**TanStack Router vs TanStack Start** — TanStack Router is a client-side router and doesn't need server-side logging. This page covers **TanStack Start**, the full-stack framework. If you're using TanStack Router in SPA mode, see [Client Logging](/core-concepts/client-logging) instead.
+::
 
 ::code-collapse
 
@@ -82,6 +86,10 @@ export const Route = createRootRoute({
 ```
 
 That's it. evlog automatically captures every request as a wide event with method, path, status, and duration.
+
+::callout{color="info" icon="i-custom-vite"}
+**Using Vite?** TanStack Start is Vite-based. The [`evlog/vite`](/core-concepts/vite-plugin) plugin strips `log.debug()` from production builds and injects source locations — add it to your `vite.config.ts` alongside the TanStack Start plugin.
+::
 
 ## Wide Events
 
@@ -196,6 +204,30 @@ try {
 
 See the [Configuration reference](/core-concepts/configuration) for all available options (`initLogger`, middleware options, sampling, silent mode, etc.).
 
+## Route Filtering
+
+Control which routes are logged with `include` and `exclude` in the module options:
+
+```typescript [nitro.config.ts]
+import { defineConfig } from 'nitro'
+import evlog from 'evlog/nitro/v3'
+
+export default defineConfig({
+  experimental: { asyncContext: true },
+  modules: [
+    evlog({
+      env: { service: 'my-app' },
+      include: ['/api/**'],
+      exclude: ['/_internal/**', '/health'],
+      routes: {
+        '/api/auth/**': { service: 'auth-service' },
+        '/api/payment/**': { service: 'payment-service' },
+      },
+    }),
+  ],
+})
+```
+
 ## Drain & Enrichers
 
 Since TanStack Start uses Nitro v3, configure drains and enrichers via Nitro plugins. Create a `server/plugins/` directory and register hooks:
@@ -227,6 +259,46 @@ export default definePlugin((nitroApp) => {
 ::callout{icon="i-lucide-info" color="info"}
 See the [Adapters](/adapters/overview) and [Enrichers](/enrichers/overview) docs for all available drain adapters and enrichers.
 ::
+
+### Pipeline (Batching & Retry)
+
+For production, wrap your adapter with `createDrainPipeline` to batch events and retry on failure:
+
+```typescript [server/plugins/evlog-drain.ts]
+import { definePlugin } from 'nitro'
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+export default definePlugin((nitroApp) => {
+  const pipeline = createDrainPipeline<DrainContext>({
+    batch: { size: 50, intervalMs: 5000 },
+    retry: { maxAttempts: 3 },
+  })
+  const drain = pipeline(createAxiomDrain())
+
+  nitroApp.hooks.hook('evlog:drain', drain)
+})
+```
+
+::callout{color="info" icon="i-lucide-info"}
+Call `drain.flush()` on server shutdown to ensure all buffered events are sent. See the [Pipeline docs](/adapters/pipeline) for all options.
+::
+
+## Tail Sampling
+
+Use the `evlog:emit:keep` hook to force-retain specific events regardless of head sampling:
+
+```typescript [server/plugins/evlog-keep.ts]
+import { definePlugin } from 'nitro'
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:emit:keep', (ctx) => {
+    if (ctx.duration && ctx.duration > 2000) ctx.shouldKeep = true
+    if (ctx.status && ctx.status >= 500) ctx.shouldKeep = true
+  })
+})
+```
 
 ## Run Locally
 


### PR DESCRIPTION
## Summary

- Add missing sections to TanStack Start docs: **Route Filtering**, **Pipeline (Batching & Retry)**, and **Tail Sampling**, bringing it to parity with React Router docs
- Add **TanStack Router vs TanStack Start** callout to disambiguate for users searching "TanStack support"
- Add **Vite plugin** callout since TanStack Start is Vite-based
- Add TanStack Router row to overview table for discoverability

Closes #137