### PR TITLE
fix(nitro): make evlogErrorHandler compatible with TanStack Start middleware API

### DIFF
--- a/.changeset/fix-evlog-error-handler-compat.md
+++ b/.changeset/fix-evlog-error-handler-compat.md
@@ -1,0 +1,7 @@
+---
+"evlog": patch
+---
+
+fix(nitro): make `evlogErrorHandler` compatible with TanStack Start's `createMiddleware().server()` API
+
+`evlogErrorHandler` now accepts both `(next)` and `({ next })` signatures, so `createMiddleware().server(evlogErrorHandler)` works directly without a wrapper in all TanStack Start versions.

--- a/packages/evlog/src/nitro-v3/middleware.ts
+++ b/packages/evlog/src/nitro-v3/middleware.ts
@@ -23,7 +23,8 @@ import { serializeEvlogErrorResponse } from '../nitro'
  * ```
  */
 
-export async function evlogErrorHandler<T>(next: (...args: any[]) => Promise<T>): Promise<T> {
+export async function evlogErrorHandler<T>(nextOrOptions: ((...args: any[]) => Promise<T>) | { next: (...args: any[]) => Promise<T> }): Promise<T> {
+  const next = typeof nextOrOptions === 'function' ? nextOrOptions : nextOrOptions.next
   try {
     return await next()
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

- `evlogErrorHandler` now accepts both `(next)` and `({ next })` signatures
- TanStack Start's `createMiddleware().server()` passes `{ next }` (an object), but `evlogErrorHandler` previously expected `next` directly as a function argument
- This caused a runtime error in newer TanStack Start versions (>= 1.166.x), requiring users to wrap the handler manually

Before (workaround needed):
```typescript
createMiddleware().server(({ next }) =>
  evlogErrorHandler(async () => await next())
)
```

After (works directly):
```typescript
createMiddleware().server(evlogErrorHandler)
```

Fixes #137