### PR TITLE
docs: fix Cloudflare Workers setup imports

### DIFF
--- a/apps/docs/content/0.landing.md
+++ b/apps/docs/content/0.landing.md
@@ -412,16 +412,13 @@ Wide events and structured errors for TypeScript. One log per request, full cont
 
   #cloudflare
   ```ts [src/worker.ts]
-  import { initLogger, createRequestLogger } from 'evlog'
+  import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
 
-  initLogger({ service: 'checkout-worker' })
+  initWorkersLogger({ env: { service: 'checkout-worker' } })
 
   export default {
     async fetch(request, env) {
-      const log = createRequestLogger({
-        method: request.method,
-        path: new URL(request.url).pathname,
-      })
+      const log = createWorkersLogger(request)
 
       const { cartId } = await request.json()
       const cart = await env.DB.findCart(cartId)

--- a/apps/docs/content/4.frameworks/12.cloudflare-workers.md
+++ b/apps/docs/content/4.frameworks/12.cloudflare-workers.md
@@ -14,9 +14,9 @@ The `evlog/workers` adapter provides factory functions for creating request-scop
 Set up evlog in my Cloudflare Worker.
 
 - Install evlog: pnpm add evlog
-- Import initLogger and createRequestLogger from 'evlog'
-- Call initLogger({ service: 'my-worker' }) at the top level
-- In the fetch handler, create a logger with createRequestLogger({ method, path })
+- Import initWorkersLogger and createWorkersLogger from 'evlog/workers'
+- Call initWorkersLogger({ env: { service: 'my-worker' } }) at the top level
+- In the fetch handler, create a logger with createWorkersLogger(request)
 - Use log.set() to accumulate context throughout the request
 - Call log.emit() manually before returning the response (no middleware lifecycle)
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1154,7 +1154,7 @@ try {
 | **Hono** | `app.use(evlog())` with `import { evlog } from 'evlog/hono'` ([example](./examples/hono)) |
 | **Fastify** | `app.register(evlog)` with `import { evlog } from 'evlog/fastify'` ([example](./examples/fastify)) |
 | **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([example](./examples/elysia)) |
-| **Cloudflare Workers** | Manual setup with `import { initLogger, createRequestLogger } from 'evlog'` ([example](./examples/workers)) |
+| **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([example](./examples/workers)) |
 | **Custom** | Build your own with `import { createMiddlewareLogger } from 'evlog/toolkit'` ([guide](https://evlog.dev/frameworks/custom-integration)) |
 | **Analog** | Nitro v2 module setup |
 | **Vinxi** | Nitro v2 module setup |


### PR DESCRIPTION
Cloudflare Workers docs were still showing the core `initLogger` / `createRequestLogger` setup in a few places.

This switches those references to the current `evlog/workers` API:
- Workers guide prompt
- landing page Workers example
- README framework matrix