### PR TITLE
fix(nuxt): sync runtime evlog to nitro & noop logger when off

### DIFF
--- a/.changeset/nuxt-nitro-config-bridge.md
+++ b/.changeset/nuxt-nitro-config-bridge.md
@@ -1,0 +1,5 @@
+---
+'evlog': patch
+---
+
+Fix Nuxt `evlog` options not reaching the Nitro plugin in dev: the Nuxt module now mirrors standalone Nitro by setting `process.env.__EVLOG_CONFIG` during `nitro:config`. When `enabled` is `false`, the Nitro plugins still attach a no-op request logger so `useLogger(event)` does not throw.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,8 @@ export default defineConfig({
 
 The Nuxt module uses `addVitePlugin()` to add strip + source location plugins internally. Auto-imports and client init are NOT delegated (Nuxt handles those natively). This is purely additive — no breaking change.
 
+On `nitro:config`, the module serializes `runtimeConfig.evlog` into **`process.env.__EVLOG_CONFIG`** (same bridge as standalone Nitro). The Nitro plugin resolves config with **env first**, then `useRuntimeConfig().evlog`. That env injection is required because dev workers often cannot resolve the virtual Nitro runtime-config module reliably. **Do not** set `__EVLOG_CONFIG` yourself in a Nuxt app unless you mean to override the entire `evlog` block from `nuxt.config`.
+
 ## Framework Integration
 
 > **Creating a new framework integration?** Follow the skill at `.agents/skills/create-framework-integration/SKILL.md`. It covers all touchpoints: source code, build config, package exports, tests, example app, and all documentation updates.

--- a/packages/evlog/src/nitro-v3/plugin.ts
+++ b/packages/evlog/src/nitro-v3/plugin.ts
@@ -142,9 +142,27 @@ export default definePlugin(async (nitroApp) => {
     _suppressDrainWarning: true,
   })
 
-  if (!isEnabled()) return
-
   const hooks = nitroApp.hooks as unknown as Hooks
+
+  // When globally disabled, createRequestLogger returns a no-op logger — still
+  // attach it so handlers can call useLogger without throwing.
+  if (!isEnabled()) {
+    hooks.hook('request', (event) => {
+      const { pathname } = parseURL(event.req.url)
+      const ctx = getContext(event)
+      let requestIdOverride: string | undefined
+      if (globalThis.navigator?.userAgent === 'Cloudflare-Workers') {
+        const cfRay = event.req.headers.get('cf-ray')
+        if (cfRay) requestIdOverride = cfRay
+      }
+      ctx.log = createRequestLogger({
+        method: event.req.method,
+        path: pathname,
+        requestId: requestIdOverride || ctx.requestId as string | undefined || crypto.randomUUID(),
+      }, { _deferDrain: true })
+    })
+    return
+  }
 
   hooks.hook('request', (event) => {
     const { pathname } = parseURL(event.req.url)

--- a/packages/evlog/src/nitro/plugin.ts
+++ b/packages/evlog/src/nitro/plugin.ts
@@ -117,7 +117,24 @@ export default defineNitroPlugin(async (nitroApp) => {
     _suppressDrainWarning: true,
   })
 
-  if (!isEnabled()) return
+  // When globally disabled, createRequestLogger returns a no-op logger — still
+  // attach it so handlers can call useLogger(event) without throwing.
+  if (!isEnabled()) {
+    nitroApp.hooks.hook('request', (event) => {
+      const e = event as ServerEvent
+      let requestIdOverride: string | undefined
+      if (globalThis.navigator?.userAgent === 'Cloudflare-Workers') {
+        const cfRay = getSafeHeaders(e)?.['cf-ray']
+        if (cfRay) requestIdOverride = cfRay
+      }
+      e.context.log = createRequestLogger({
+        method: e.method,
+        path: e.path,
+        requestId: requestIdOverride || e.context.requestId || crypto.randomUUID(),
+      }, { _deferDrain: true })
+    })
+    return
+  }
 
   nitroApp.hooks.hook('request', (event) => {
     const e = event as ServerEvent

--- a/packages/evlog/src/nuxt/module.ts
+++ b/packages/evlog/src/nuxt/module.ts
@@ -267,14 +267,22 @@ export default defineNuxtModule<ModuleOptions>({
     const transportEndpoint = options.transport?.endpoint ?? '/api/_evlog/ingest'
     const transportCredentials = options.transport?.credentials ?? 'same-origin'
 
+    nuxt.options.runtimeConfig.evlog = options
+
     // Register custom error handler for proper EvlogError serialization
     // Only set if not already configured to avoid overwriting user's custom handler
+    // Mirror standalone Nitro modules: serialize evlog options into __EVLOG_CONFIG so
+    // resolveEvlogConfigForNitroPlugin() picks them up in dev (Nitro worker threads
+    // often cannot resolve useRuntimeConfig().evlog via dynamic import reliably).
     // @ts-expect-error nitro:config hook exists but is not in NuxtHooks type
     nuxt.hook('nitro:config', (nitroConfig: NitroConfig) => {
       nitroConfig.errorHandler = nitroConfig.errorHandler || resolver.resolve('../nitro/errorHandler')
-    })
 
-    nuxt.options.runtimeConfig.evlog = options
+      const evlogForNitro = nuxt.options.runtimeConfig.evlog ?? options
+      if (evlogForNitro !== undefined && typeof evlogForNitro === 'object') {
+        process.env.__EVLOG_CONFIG = JSON.stringify(evlogForNitro)
+      }
+    })
     nuxt.options.runtimeConfig.public.evlog = {
       enabled: options.enabled ?? true,
       console: options.console,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- evlog (the evlog package)
- nuxthub (the nuxthub package)
- deps (the dependencies)
- repo (the repository)
- nuxt (Nuxt module)
- nitro (Nitro plugin)
- next (Next.js integration)
- tanstack-start (TanStack Start integration)
- hono (Hono middleware)
- express (Express middleware)
- elysia (Elysia plugin)
- fastify (Fastify plugin)
- nestjs (NestJS middleware)
- react-router (React Router integration)
- sveltekit (SvelteKit integration)
- workers (Cloudflare Workers adapter)
- fs (File System adapter)
- ai (AI SDK integration)
- dx (developer experience improvements)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
