### PR TITLE
feat(evlog): add deterministic minLevel for log api

### DIFF
--- a/.changeset/minlevel-log-threshold.md
+++ b/.changeset/minlevel-log-threshold.md
@@ -1,0 +1,7 @@
+---
+'evlog': minor
+---
+
+Add `minLevel` for a deterministic severity threshold on the global `log` API and client `initLog`, plus `setMinLevel()` for runtime toggling in the browser. Orthogonal to probabilistic `sampling.rates`; request wide events from `useLogger` / `createLogger().emit()` are unchanged. Includes `isLevelEnabled()` helper and wiring for Nuxt, Vite, and Next.js.
+
+**2026-04-11** — Playground: interactive panel to try client `minLevel` / `setMinLevel` and trigger logs per level.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -985,6 +985,8 @@ log.error({ action: 'payment', error: 'validation_failed' })
 
 Client logs output to the browser console with colored tags in development.
 
+`setMinLevel` is auto-imported in Nuxt (from `evlog/client`) — call it to change the client severity threshold at runtime (same as `initLog({ minLevel })`).
+
 #### Client Transport
 
 To send client logs to your server for centralized logging, enable the transport:

--- a/apps/docs/content/2.logging/4.client-logging.md
+++ b/apps/docs/content/2.logging/4.client-logging.md
@@ -56,6 +56,14 @@ log.info({ action: 'app_init', path: window.location.pathname })
 
 The `log` object works anywhere in your client code: components, composables, event handlers.
 
+## Minimum level (`minLevel`)
+
+Use `initLog({ minLevel: 'warn' })` to keep the browser console quiet (warnings and errors only). Severity order: `debug` < `info` < `warn` < `error`. Default is `'debug'` (all levels).
+
+For a **debug toggle** without reloading, call `setMinLevel('debug')` or `setMinLevel('warn')` from `evlog/client` when the user opts in or out of verbose logs.
+
+`minLevel` applies to both console output and [server transport](#sending-logs-to-the-server) payloads.
+
 ## Two Call Signatures
 
 The `log` API accepts two forms depending on the context.
@@ -88,6 +96,8 @@ log.info('auth', 'User logged in')
 
 Both forms support four levels: `log.info()`, `log.warn()`, `log.error()`, and `log.debug()`.
 
+In the browser, `log.debug()` is emitted with `console.log` (not `console.debug`) so lines stay visible with the default DevTools **Info** filter; the structured event still has `level: 'debug'`.
+
 ## Identity Context
 
 Track which user generated a log with `setIdentity()`:
@@ -116,6 +126,7 @@ Identity fields are automatically merged into every log event until cleared. Thi
 | `enabled` | `true` | Enable or disable all client logging |
 | `console` | `true` | Output logs to the browser console |
 | `pretty` | `true` | Use colored, formatted console output |
+| `minLevel` | `'debug'` | Minimum severity: `debug` < `info` < `warn` < `error` |
 | `service` | `'client'` | Service name included in every log event |
 | `transport` | - | Send logs to a server endpoint (see below) |
 

--- a/apps/docs/content/3.core-concepts/1.configuration.md
+++ b/apps/docs/content/3.core-concepts/1.configuration.md
@@ -32,6 +32,7 @@ initLogger({
   pretty: false,
   silent: false,
   stringify: true,
+  minLevel: 'info',
   sampling: { rates: { info: 10 }, keep: [{ status: 400 }] },
   drain: createAxiomDrain(),
 })
@@ -44,8 +45,16 @@ initLogger({
 | `pretty` | `boolean` | `true` in dev | Pretty print with tree formatting. Auto-detected based on `NODE_ENV` |
 | `silent` | `boolean` | `false` | Suppress console output. Events are still built, sampled, and passed to drains |
 | `stringify` | `boolean` | `true` | Emit JSON strings when `pretty` is disabled. Set to `false` for Cloudflare Workers |
+| `minLevel` | `'debug' \| 'info' \| 'warn' \| 'error'` | `'debug'` | Minimum severity for the global `log` API only (not `createLogger` / request wide events). Order: debug < info < warn < error |
 | `sampling` | `SamplingConfig` | `undefined` | Head and tail sampling configuration. See [Sampling](/core-concepts/sampling) |
 | `drain` | `(ctx: DrainContext) => void` | `undefined` | Drain callback for sending events to external services |
+
+### `minLevel` vs sampling
+
+- **`minLevel`** is a **hard threshold** on the simple `log.*` API: levels below the threshold are never emitted. It does **not** apply to wide events from `useLogger` / `createLogger().emit()` — use **`sampling.rates`** (and tail `keep`) for request volume.
+- **Head sampling** (`sampling.rates`) is **probabilistic** on what is already allowed by `minLevel` for simple logs.
+
+Evaluation order for `log.info` / `log.debug` / etc.: `enabled` → `minLevel` → head sampling → output.
 
 ### Environment Context
 

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -720,6 +720,7 @@ All options work in Nuxt (`evlog` key), Nitro (passed to `evlog()`), Next.js (`c
 | `include` | `string[]` | All routes | Route glob patterns to log |
 | `exclude` | `string[]` | None | Route patterns to exclude (takes precedence) |
 | `routes` | `Record<string, { service }>` | -- | Route-specific service names |
+| `minLevel` | `'debug' \| 'info' \| 'warn' \| 'error'` | `'debug'` | Hard threshold for the global `log` API and client `log` (not request wide events). Use `sampling.rates` for probabilistic volume on requests |
 | `sampling.rates` | `object` | -- | Head sampling: `{ info: 10, warn: 50 }` (0-100%) |
 | `sampling.keep` | `array` | -- | Tail sampling: `[{ status: 400 }, { duration: 1000 }]` |
 | `drain` | `(ctx) => void` | -- | Drain callback (Next.js, standalone) |

--- a/apps/playground/app/components/playground/MinLevelPanel.vue
+++ b/apps/playground/app/components/playground/MinLevelPanel.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import type { LogLevel } from 'evlog'
+import { log, setMinLevel } from 'evlog/client'
+
+const levels: LogLevel[] = ['debug', 'info', 'warn', 'error']
+
+const minLevel = ref<LogLevel>('debug')
+
+const order: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+}
+
+function passes(level: LogLevel): boolean {
+  return order[level] >= order[minLevel.value]
+}
+
+function applyMinLevel(level: LogLevel) {
+  minLevel.value = level
+  setMinLevel(level)
+}
+
+function emitAt(level: LogLevel) {
+  const payload = { panel: 'min-level', ts: Date.now() }
+  if (level === 'debug') {
+    log.debug(payload)
+  } else if (level === 'info') {
+    log.info(payload)
+  } else if (level === 'warn') {
+    log.warn('playground', 'warn sample')
+  } else {
+    log.error('playground', 'error sample')
+  }
+}
+
+onMounted(() => {
+  const raw = useRuntimeConfig().public.evlog as { minLevel?: LogLevel } | undefined
+  const fromConfig = raw?.minLevel
+  if (fromConfig && levels.includes(fromConfig)) {
+    minLevel.value = fromConfig
+    setMinLevel(fromConfig)
+  }
+})
+</script>
+
+<template>
+  <ClientOnly>
+    <div class="max-w-3xl space-y-6">
+      <div
+        class="rounded-lg border border-[var(--ui-border)] bg-elevated p-5 space-y-4"
+      >
+        <div>
+          <p class="text-xs font-medium text-highlighted uppercase tracking-wide">
+            Minimum level
+          </p>
+          <p class="text-xs text-muted mt-1 leading-relaxed">
+            Only the global client <code class="text-[11px]">log.*</code> API is filtered. Open DevTools and watch the console: levels below the threshold produce no output and no transport when ingest is enabled.
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <UButton
+            v-for="lvl in levels"
+            :key="lvl"
+            size="sm"
+            :variant="minLevel === lvl ? 'solid' : 'outline'"
+            :color="minLevel === lvl ? 'primary' : 'neutral'"
+            @click="applyMinLevel(lvl)"
+          >
+            {{ lvl }}
+          </UButton>
+        </div>
+
+        <p class="text-[11px] text-muted leading-relaxed">
+          <span class="text-highlighted">Passes:</span>
+          {{ levels.filter(l => passes(l)).join(', ') }}
+        </p>
+        <p class="text-[11px] text-muted leading-relaxed">
+          <code class="text-[11px]">log.debug()</code> uses <code class="text-[11px]">console.log</code> in the browser so lines show with the default console filter (payload still has <code class="text-[11px]">level: &quot;debug&quot;</code>).
+        </p>
+      </div>
+
+      <div
+        class="rounded-lg border border-[var(--ui-border)] bg-elevated p-5 space-y-4"
+      >
+        <p class="text-xs font-medium text-highlighted uppercase tracking-wide">
+          Trigger logs
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <UButton
+            v-for="lvl in levels"
+            :key="`emit-${lvl}`"
+            size="sm"
+            variant="soft"
+            :color="lvl === 'error' ? 'error' : lvl === 'warn' ? 'warning' : lvl === 'info' ? 'primary' : 'neutral'"
+            @click="emitAt(lvl)"
+          >
+            log.{{ lvl }}()
+          </UButton>
+        </div>
+        <p class="text-[11px] text-muted">
+          Set minimum to <code class="text-[11px]">warn</code>, then trigger <code class="text-[11px]">log.info</code> — nothing should appear. Switch back to <code class="text-[11px]">debug</code> and trigger again to verify.
+        </p>
+      </div>
+    </div>
+    <template #fallback>
+      <p class="text-sm text-muted">
+        Loading…
+      </p>
+    </template>
+  </ClientOnly>
+</template>

--- a/apps/playground/app/config/tests.config.ts
+++ b/apps/playground/app/config/tests.config.ts
@@ -52,6 +52,15 @@ function makeDrainEvent(action: string, extra?: Record<string, unknown>) {
 export const testConfig = {
   sections: [
     {
+      id: 'min-level',
+      label: 'Min level',
+      icon: 'i-lucide-sliders-horizontal',
+      title: 'Minimum log level (client)',
+      description:
+        'Deterministic filter for the client `log` API: choose a minimum severity, trigger each level, and confirm blocked lines never reach the console or ingest. Use `setMinLevel` at runtime without reload.',
+      tests: [],
+    } as TestSection,
+    {
       id: 'client-logging',
       label: 'Client Logging',
       icon: 'i-lucide-laptop',

--- a/apps/playground/app/pages/index.vue
+++ b/apps/playground/app/pages/index.vue
@@ -46,7 +46,11 @@ const currentSection = computed(() =>
         :title="currentSection.title"
         :description="currentSection.description"
       >
-        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <PlaygroundMinLevelPanel v-if="currentSection.id === 'min-level'" />
+        <div
+          v-else
+          class="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
+        >
           <PlaygroundTestCard
             v-for="test in currentSection.tests"
             :key="test.id"

--- a/bun.lock
+++ b/bun.lock
@@ -293,7 +293,7 @@
     },
     "packages/evlog": {
       "name": "evlog",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "devDependencies": {
         "@codspeed/vitest-plugin": "^5.2.0",
         "@nestjs/common": "^11.1.18",

--- a/packages/evlog/src/client.ts
+++ b/packages/evlog/src/client.ts
@@ -1,1 +1,1 @@
-export { initLog, log, setIdentity, clearIdentity } from './runtime/client/log'
+export { initLog, log, setIdentity, clearIdentity, setMinLevel } from './runtime/client/log'

--- a/packages/evlog/src/index.ts
+++ b/packages/evlog/src/index.ts
@@ -1,5 +1,6 @@
 export { EvlogError, createError, createEvlogError } from './error'
 export { createLogger, createRequestLogger, getEnvironment, initLogger, isEnabled, log, shouldKeep } from './logger'
+export { isLevelEnabled } from './utils'
 export { useLogger } from './runtime/server/useLogger'
 export { parseError } from './runtime/utils/parseError'
 

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -1,5 +1,5 @@
 import type { DrainContext, EnvironmentContext, FieldContext, Log, LogLevel, LoggerConfig, RequestLogger, RequestLoggerOptions, SamplingConfig, TailSamplingContext, WideEvent } from './types'
-import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isClient, isDev, matchesPattern } from './utils'
+import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isClient, isDev, isLevelEnabled, matchesPattern } from './utils'
 
 function isPlainObject(val: unknown): val is Record<string, unknown> {
   return val !== null && typeof val === 'object' && !Array.isArray(val)
@@ -35,6 +35,8 @@ let globalStringify = true
 let globalDrain: ((ctx: DrainContext) => void | Promise<void>) | undefined
 let globalEnabled = true
 let globalSilent = false
+/** Minimum level for the global `log` API only (`ownsEvent === false`). Default: all levels. */
+let globalMinLevel: LogLevel = 'debug'
 let _locked = false
 
 /**
@@ -58,6 +60,7 @@ export function initLogger(config: LoggerConfig = {}): void {
   globalStringify = config.stringify ?? true
   globalDrain = config.drain
   globalSilent = config.silent ?? false
+  globalMinLevel = config.minLevel ?? 'debug'
 
   if (globalSilent && !globalDrain && !config._suppressDrainWarning) {
     console.warn('[evlog] silent mode is enabled but no drain is configured. Events will be built and sampled but not output anywhere. Set a drain via initLogger({ drain }) or a framework hook (evlog:drain).')
@@ -143,8 +146,13 @@ export function shouldKeep(ctx: TailSamplingContext): boolean {
 function emitWideEvent(level: LogLevel, event: Record<string, unknown>, deferDrain = false, ownsEvent = false): WideEvent | null {
   if (!globalEnabled) return null
 
-  if (!ownsEvent && !shouldSample(level)) {
-    return null
+  if (!ownsEvent) {
+    if (!isLevelEnabled(level, globalMinLevel)) {
+      return null
+    }
+    if (!shouldSample(level)) {
+      return null
+    }
   }
 
   let formatted: WideEvent
@@ -189,6 +197,9 @@ function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
   if (!globalEnabled) return
 
   if (globalPretty && !globalSilent) {
+    if (!isLevelEnabled(level, globalMinLevel)) {
+      return
+    }
     if (!shouldSample(level)) {
       return
     }

--- a/packages/evlog/src/next/client.ts
+++ b/packages/evlog/src/next/client.ts
@@ -1,10 +1,10 @@
 'use client'
 
 import { useEffect } from 'react'
-import type { TransportConfig } from '../types'
+import type { LogLevel, TransportConfig } from '../types'
 import { initLog, log, setIdentity, clearIdentity } from '../runtime/client/log'
 
-export { log, setIdentity, clearIdentity } from '../runtime/client/log'
+export { log, setIdentity, clearIdentity, setMinLevel } from '../runtime/client/log'
 
 export interface EvlogProviderProps {
   /**
@@ -38,6 +38,12 @@ export interface EvlogProviderProps {
    */
   console?: boolean
 
+  /**
+   * Minimum severity for client `log` calls (debug < info < warn < error).
+   * @default 'debug'
+   */
+  minLevel?: LogLevel
+
   children: React.ReactNode
 }
 
@@ -60,16 +66,17 @@ export interface EvlogProviderProps {
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function EvlogProvider({ service, pretty, transport, enabled, console: consoleOutput, children }: EvlogProviderProps) {
+export function EvlogProvider({ service, pretty, transport, enabled, console: consoleOutput, minLevel, children }: EvlogProviderProps) {
   useEffect(() => {
     initLog({
       enabled,
       console: consoleOutput,
       pretty,
+      minLevel,
       service,
       transport,
     })
-  }, [enabled, consoleOutput, pretty, service, transport])
+  }, [enabled, consoleOutput, pretty, minLevel, service, transport])
 
   return children
 }

--- a/packages/evlog/src/next/handler.ts
+++ b/packages/evlog/src/next/handler.ts
@@ -36,6 +36,7 @@ export function configureHandler(options: NextEvlogOptions): void {
     pretty: options.pretty,
     silent: options.silent,
     sampling: options.sampling,
+    minLevel: options.minLevel,
     stringify: options.stringify,
     _suppressDrainWarning: true,
   })

--- a/packages/evlog/src/next/instrumentation.ts
+++ b/packages/evlog/src/next/instrumentation.ts
@@ -1,4 +1,4 @@
-import type { DrainContext, EnvironmentContext, SamplingConfig } from '../types'
+import type { DrainContext, EnvironmentContext, LogLevel, SamplingConfig } from '../types'
 import { initLogger, log, lockLogger } from '../logger'
 
 /** Request payload passed to Next.js `onRequestError` (App Router). */
@@ -81,6 +81,8 @@ export interface InstrumentationOptions {
   silent?: boolean
   /** Sampling configuration for filtering logs. */
   sampling?: SamplingConfig
+  /** Minimum severity for the global `log` API. @default 'debug' */
+  minLevel?: LogLevel
   /** When pretty is disabled, emit JSON strings or raw objects. @default true */
   stringify?: boolean
   /** Drain callback called with every emitted event. */
@@ -116,6 +118,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
       pretty: options.pretty,
       silent: options.silent,
       sampling: options.sampling,
+      minLevel: options.minLevel,
       stringify: options.stringify,
       drain: options.drain,
     })

--- a/packages/evlog/src/next/types.ts
+++ b/packages/evlog/src/next/types.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentContext, SamplingConfig } from '../types'
+import type { EnvironmentContext, LogLevel, SamplingConfig } from '../types'
 import type { BaseEvlogOptions } from '../shared/middleware'
 
 export interface NextEvlogOptions extends BaseEvlogOptions {
@@ -29,6 +29,12 @@ export interface NextEvlogOptions extends BaseEvlogOptions {
    * Sampling configuration for filtering logs.
    */
   sampling?: SamplingConfig
+
+  /**
+   * Minimum severity for the global `log` API (not request wide events).
+   * @default 'debug'
+   */
+  minLevel?: LogLevel
 
   /**
    * When pretty is disabled, emit JSON strings (default) or raw objects.

--- a/packages/evlog/src/nitro-v3/plugin.ts
+++ b/packages/evlog/src/nitro-v3/plugin.ts
@@ -139,6 +139,7 @@ export default definePlugin(async (nitroApp) => {
     pretty: evlogConfig?.pretty,
     silent: evlogConfig?.silent,
     sampling: evlogConfig?.sampling,
+    minLevel: evlogConfig?.minLevel,
     _suppressDrainWarning: true,
   })
 

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentContext, RouteConfig, SamplingConfig } from './types'
+import type { EnvironmentContext, LogLevel, RouteConfig, SamplingConfig } from './types'
 import { extractErrorStatus } from './shared/errors'
 
 export { shouldLog, getServiceForPath } from './shared/routes'
@@ -53,6 +53,13 @@ export interface NitroModuleOptions {
    * Sampling configuration for filtering logs.
    */
   sampling?: SamplingConfig
+
+  /**
+   * Minimum severity for the global `log` API (not request wide events).
+   * Order: debug < info < warn < error.
+   * @default 'debug'
+   */
+  minLevel?: LogLevel
 }
 
 export interface EvlogConfig {
@@ -64,6 +71,7 @@ export interface EvlogConfig {
   exclude?: string[]
   routes?: Record<string, RouteConfig>
   sampling?: SamplingConfig
+  minLevel?: LogLevel
 }
 
 /**

--- a/packages/evlog/src/nitro/plugin.ts
+++ b/packages/evlog/src/nitro/plugin.ts
@@ -114,6 +114,7 @@ export default defineNitroPlugin(async (nitroApp) => {
     pretty: evlogConfig?.pretty,
     silent: evlogConfig?.silent,
     sampling: evlogConfig?.sampling,
+    minLevel: evlogConfig?.minLevel,
     _suppressDrainWarning: true,
   })
 

--- a/packages/evlog/src/nuxt/module.ts
+++ b/packages/evlog/src/nuxt/module.ts
@@ -131,6 +131,13 @@ export interface ModuleOptions {
   sampling?: SamplingConfig
 
   /**
+   * Minimum severity for the global `log` API on server and client (not request wide events).
+   * Order: debug < info < warn < error.
+   * @default 'debug'
+   */
+  minLevel?: LogLevel
+
+  /**
    * Transport configuration for sending client logs to the server.
    *
    * @example
@@ -287,6 +294,7 @@ export default defineNuxtModule<ModuleOptions>({
       enabled: options.enabled ?? true,
       console: options.console,
       pretty: options.pretty,
+      minLevel: options.minLevel,
       transport: {
         enabled: transportEnabled,
         endpoint: transportEndpoint,
@@ -320,6 +328,10 @@ export default defineNuxtModule<ModuleOptions>({
       },
       {
         name: 'clearIdentity',
+        from: resolver.resolve('../runtime/client/log'),
+      },
+      {
+        name: 'setMinLevel',
         from: resolver.resolve('../runtime/client/log'),
       },
       {

--- a/packages/evlog/src/runtime/client/log.ts
+++ b/packages/evlog/src/runtime/client/log.ts
@@ -1,11 +1,20 @@
 import type { Log, LogLevel, TransportConfig } from '../../types'
-import { cssColors, escapeFormatString, getConsoleMethod, getCssLevelColor } from '../../utils'
+import { cssColors, escapeFormatString, getCssLevelColor, isLevelEnabled } from '../../utils'
 
-const isClient = typeof window !== 'undefined'
+/**
+ * Browser DevTools often hide or bucket `console.debug` under "Verbose" in a way that looks like
+ * nothing happened. Use `console.log` for debug-level client output so it shows with the default
+ * Info filter; the structured payload still has `level: 'debug'`.
+ */
+function browserConsoleMethod(level: LogLevel): 'log' | 'info' | 'warn' | 'error' {
+  if (level === 'debug') return 'log'
+  return level as 'info' | 'warn' | 'error'
+}
 
 let clientEnabled = true
 let clientConsole = true
 let clientPretty = true
+let clientMinLevel: LogLevel = 'debug'
 let clientService = 'client'
 let transportEnabled = false
 let transportEndpoint = '/api/_evlog/ingest'
@@ -21,14 +30,22 @@ export function clearIdentity(): void {
 }
 
 
-export function initLog(options: { enabled?: boolean, console?: boolean, pretty?: boolean, service?: string, transport?: TransportConfig } = {}): void {
+export function initLog(options: { enabled?: boolean, console?: boolean, pretty?: boolean, minLevel?: LogLevel, service?: string, transport?: TransportConfig } = {}): void {
   clientEnabled = typeof options.enabled === 'boolean' ? options.enabled : true
   clientConsole = typeof options.console === 'boolean' ? options.console : true
   clientPretty = typeof options.pretty === 'boolean' ? options.pretty : true
+  clientMinLevel = options.minLevel ?? 'debug'
   clientService = options.service ?? 'client'
   transportEnabled = options.transport?.enabled ?? false
   transportEndpoint = options.transport?.endpoint ?? '/api/_evlog/ingest'
   transportCredentials = options.transport?.credentials ?? 'same-origin'
+}
+
+/**
+ * Update the minimum log level at runtime (e.g. enable verbose client logs from a debug toggle).
+ */
+export function setMinLevel(level: LogLevel): void {
+  clientMinLevel = level
 }
 
 async function sendToServer(event: Record<string, unknown>): Promise<void> {
@@ -49,6 +66,7 @@ async function sendToServer(event: Record<string, unknown>): Promise<void> {
 
 function emitLog(level: LogLevel, event: Record<string, unknown>): void {
   if (!clientEnabled) return
+  if (!isLevelEnabled(level, clientMinLevel)) return
 
   const formatted = {
     timestamp: new Date().toISOString(),
@@ -59,7 +77,7 @@ function emitLog(level: LogLevel, event: Record<string, unknown>): void {
   }
 
   if (clientConsole) {
-    const method = getConsoleMethod(level)
+    const method = browserConsoleMethod(level)
     if (clientPretty) {
       const { level: lvl, service, ...rest } = formatted
       console[method](`%c[${escapeFormatString(String(service))}]%c ${lvl}`, getCssLevelColor(lvl), cssColors.reset, rest)
@@ -73,9 +91,10 @@ function emitLog(level: LogLevel, event: Record<string, unknown>): void {
 
 function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
   if (!clientEnabled) return
+  if (!isLevelEnabled(level, clientMinLevel)) return
   if (clientPretty) {
     if (clientConsole) {
-      console[getConsoleMethod(level)](`%c[${escapeFormatString(tag)}]%c ${escapeFormatString(message)}`, getCssLevelColor(level), cssColors.reset)
+      console[browserConsoleMethod(level)](`%c[${escapeFormatString(tag)}]%c ${escapeFormatString(message)}`, getCssLevelColor(level), cssColors.reset)
     }
     sendToServer({
       timestamp: new Date().toISOString(),
@@ -92,7 +111,8 @@ function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
 
 function createLogMethod(level: LogLevel) {
   return function logMethod(tagOrEvent: string | Record<string, unknown>, message?: string): void {
-    if (!(import.meta.client ?? isClient)) {
+    // Call-time check: avoid relying on import.meta.client (can be false in some mixed bundles).
+    if (typeof window === 'undefined') {
       return
     }
 

--- a/packages/evlog/src/runtime/client/plugin.ts
+++ b/packages/evlog/src/runtime/client/plugin.ts
@@ -1,4 +1,4 @@
-import type { TransportConfig } from '../../types'
+import type { LogLevel, TransportConfig } from '../../types'
 import { initLog } from './log'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
@@ -6,6 +6,7 @@ interface EvlogPublicConfig {
   enabled?: boolean
   console?: boolean
   pretty?: boolean
+  minLevel?: LogLevel
   transport?: TransportConfig
 }
 
@@ -17,6 +18,7 @@ export default defineNuxtPlugin(() => {
     enabled: evlogConfig?.enabled,
     console: evlogConfig?.console,
     pretty: evlogConfig?.pretty ?? import.meta.dev,
+    minLevel: evlogConfig?.minLevel,
     service: 'client',
     transport: evlogConfig?.transport,
   })

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -263,6 +263,13 @@ export interface LoggerConfig {
   /** Sampling configuration for filtering logs */
   sampling?: SamplingConfig
   /**
+   * Minimum severity for the global `log` API (tagged and object form).
+   * Does not apply to `createLogger().emit()` / request wide events (use `sampling` for volume).
+   * Order: debug < info < warn < error.
+   * @default 'debug' (all levels)
+   */
+  minLevel?: LogLevel
+  /**
    * When pretty is disabled, emit JSON strings (default) or raw objects.
    * Set to false for environments like Cloudflare Workers that expect objects.
    * @default true

--- a/packages/evlog/src/utils.ts
+++ b/packages/evlog/src/utils.ts
@@ -44,6 +44,20 @@ export function detectEnvironment(): Partial<EnvironmentContext> {
   }
 }
 
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+}
+
+/**
+ * True if `level` is at least as severe as `minLevel` (debug < info < warn < error).
+ */
+export function isLevelEnabled(level: LogLevel, minLevel: LogLevel): boolean {
+  return LEVEL_ORDER[level] >= LEVEL_ORDER[minLevel]
+}
+
 export function getConsoleMethod(level: LogLevel): LogLevel {
   return level
 }

--- a/packages/evlog/src/vite/auto-init.ts
+++ b/packages/evlog/src/vite/auto-init.ts
@@ -27,6 +27,7 @@ function buildConfig(options: EvlogViteOptions): Record<string, unknown> {
   if (options.pretty !== undefined) config.pretty = options.pretty
   if (options.silent !== undefined) config.silent = options.silent
   if (options.sampling) config.sampling = options.sampling
+  if (options.minLevel !== undefined) config.minLevel = options.minLevel
   if (options.stringify !== undefined) config.stringify = options.stringify
 
   return config

--- a/packages/evlog/src/vite/client-inject.ts
+++ b/packages/evlog/src/vite/client-inject.ts
@@ -16,6 +16,7 @@ export function createClientInjectPlugin(clientOptions: ClientOptions): Plugin {
       config.service = clientOptions.service ?? 'client'
       if (clientOptions.console !== undefined) config.console = clientOptions.console
       config.pretty = clientOptions.pretty ?? isDev
+      if (clientOptions.minLevel !== undefined) config.minLevel = clientOptions.minLevel
       if (clientOptions.transport) config.transport = clientOptions.transport
 
       const configJson = JSON.stringify(config)

--- a/packages/evlog/src/vite/types.ts
+++ b/packages/evlog/src/vite/types.ts
@@ -14,6 +14,8 @@ export interface ClientOptions {
   pretty?: boolean
   /** Enable console output on client @default true */
   console?: boolean
+  /** Minimum severity for client `log` calls (debug < info < warn < error) @default 'debug' */
+  minLevel?: LogLevel
   /** Transport configuration for sending client logs to the server */
   transport?: TransportConfig
 }
@@ -31,6 +33,8 @@ export interface EvlogViteOptions {
   silent?: boolean
   /** Sampling configuration */
   sampling?: SamplingConfig
+  /** Minimum severity for the global `log` API (not request wide events) @default 'debug' */
+  minLevel?: LogLevel
   /** Emit JSON strings or raw objects @default true */
   stringify?: boolean
   /** Opt-in auto-imports for log, createEvlogError, parseError */

--- a/packages/evlog/test/client-console.test.ts
+++ b/packages/evlog/test/client-console.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { initLog, log } from '../src/runtime/client/log'
+import { initLog, log, setMinLevel } from '../src/runtime/client/log'
 
 describe('client console option', () => {
   let infoSpy: ReturnType<typeof vi.spyOn>
@@ -26,6 +26,14 @@ describe('client console option', () => {
     log.info({ action: 'test' })
 
     expect(infoSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses console.log for debug level (not console.debug) for DevTools visibility', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    initLog({ enabled: true, pretty: false, minLevel: 'debug' })
+    log.debug({ action: 'dbg' })
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).not.toHaveBeenCalled()
   })
 
   it('suppresses console output when console is false', () => {
@@ -112,6 +120,45 @@ describe('client console option', () => {
     expect(infoSpy).not.toHaveBeenCalled()
 
     initLog({ enabled: true, console: true, pretty: false })
+    log.info({ action: 'visible' })
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('client minLevel', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('suppresses console and transport below minLevel', () => {
+    initLog({
+      enabled: true,
+      pretty: false,
+      minLevel: 'warn',
+      transport: { enabled: true, endpoint: '/api/_evlog/ingest' },
+    })
+    log.info({ action: 'x' })
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('setMinLevel enables verbose logs at runtime', () => {
+    initLog({ enabled: true, pretty: false, minLevel: 'warn' })
+    log.info({ action: 'hidden' })
+    expect(infoSpy).not.toHaveBeenCalled()
+
+    setMinLevel('debug')
     log.info({ action: 'visible' })
     expect(infoSpy).toHaveBeenCalledTimes(1)
   })

--- a/packages/evlog/test/logger.test.ts
+++ b/packages/evlog/test/logger.test.ts
@@ -104,6 +104,63 @@ describe('log', () => {
   })
 })
 
+describe('minLevel', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('suppresses simple log calls below minLevel', () => {
+    initLogger({ pretty: false, minLevel: 'warn' })
+    log.info({ action: 'x' })
+    log.debug({ action: 'y' })
+    expect(infoSpy).not.toHaveBeenCalled()
+    log.warn({ action: 'z' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not apply minLevel to createLogger.emit wide events', () => {
+    initLogger({ pretty: false, minLevel: 'warn' })
+    const logger = createRequestLogger({ method: 'GET', path: '/ok' })
+    logger.set({ ok: true })
+    logger.emit()
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    const [[output]] = infoSpy.mock.calls
+    expect(String(output)).toContain('"level":"info"')
+  })
+
+  it('filters by minLevel even when sampling would keep the level', () => {
+    initLogger({
+      pretty: false,
+      minLevel: 'warn',
+      sampling: { rates: { info: 100, warn: 100 } },
+    })
+    log.info({ n: 1 })
+    expect(infoSpy).not.toHaveBeenCalled()
+    log.warn({ n: 2 })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('still applies head sampling when minLevel allows the level', () => {
+    initLogger({
+      pretty: false,
+      minLevel: 'debug',
+      sampling: { rates: { info: 0 } },
+    })
+    log.info({ n: 1 })
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+})
+
 describe('createRequestLogger', () => {
   let infoSpy: ReturnType<typeof vi.spyOn>
 

--- a/packages/evlog/test/utils.test.ts
+++ b/packages/evlog/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { colors, formatDuration, getLevelColor, isClient, isDev, isServer, matchesPattern } from '../src/utils'
+import { colors, formatDuration, getLevelColor, isClient, isDev, isLevelEnabled, isServer, matchesPattern } from '../src/utils'
 
 // Helper to test shouldLog logic (mirrors plugin.ts implementation)
 function shouldLog(path: string, include?: string[], exclude?: string[]): boolean {
@@ -87,6 +87,19 @@ describe('getLevelColor', () => {
 
   it('returns white for unknown level', () => {
     expect(getLevelColor('unknown')).toBe(colors.white)
+  })
+})
+
+describe('isLevelEnabled', () => {
+  it('treats debug as least severe', () => {
+    expect(isLevelEnabled('debug', 'debug')).toBe(true)
+    expect(isLevelEnabled('debug', 'info')).toBe(false)
+  })
+
+  it('allows levels at or above minLevel', () => {
+    expect(isLevelEnabled('info', 'warn')).toBe(false)
+    expect(isLevelEnabled('warn', 'warn')).toBe(true)
+    expect(isLevelEnabled('error', 'warn')).toBe(true)
   })
 })
 

--- a/packages/evlog/test/vite/auto-init.test.ts
+++ b/packages/evlog/test/vite/auto-init.test.ts
@@ -44,6 +44,16 @@ describe('vite auto-init plugin', () => {
     expect(config.env.environment).toBe('staging')
   })
 
+  it('includes minLevel', () => {
+    const plugin = createAutoInitPlugin({
+      service: 'my-app',
+      minLevel: 'warn',
+    })
+    const define = getDefineConfig(plugin)
+    const config = JSON.parse(define.__EVLOG_CONFIG__)
+    expect(config.minLevel).toBe('warn')
+  })
+
   it('includes all serializable options', () => {
     const plugin = createAutoInitPlugin({
       service: 'api',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- evlog (the evlog package)
- nuxthub (the nuxthub package)
- deps (the dependencies)
- repo (the repository)
- nuxt (Nuxt module)
- nitro (Nitro plugin)
- next (Next.js integration)
- tanstack-start (TanStack Start integration)
- hono (Hono middleware)
- express (Express middleware)
- elysia (Elysia plugin)
- fastify (Fastify plugin)
- nestjs (NestJS middleware)
- react-router (React Router integration)
- sveltekit (SvelteKit integration)
- workers (Cloudflare Workers adapter)
- fs (File System adapter)
- ai (AI SDK integration)
- dx (developer experience improvements)
-->

### 🔗 Linked issue

Resolves #265

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
