### PR TITLE
fix: skip unnecessary Nitro adapter probes

### DIFF
--- a/.changeset/quiet-adapter-probe.md
+++ b/.changeset/quiet-adapter-probe.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Avoid unnecessary Nitro runtime-config probes when drain adapter overrides or env vars already satisfy the env-backed config fields.

--- a/packages/evlog/src/adapters/_config.ts
+++ b/packages/evlog/src/adapters/_config.ts
@@ -21,7 +21,9 @@ export async function resolveAdapterConfig<T>(
   fields: ConfigField<T>[],
   overrides?: Partial<T>,
 ): Promise<Partial<T>> {
-  const runtimeConfig = await getRuntimeConfig()
+  const runtimeConfig = shouldProbeRuntimeConfig(fields, overrides)
+    ? await getRuntimeConfig()
+    : undefined
   const evlogNs = runtimeConfig?.evlog?.[namespace]
   const rootNs = runtimeConfig?.[namespace]
 
@@ -36,6 +38,20 @@ export async function resolveAdapterConfig<T>(
   }
 
   return config as Partial<T>
+}
+
+function shouldProbeRuntimeConfig<T>(
+  fields: ConfigField<T>[],
+  overrides?: Partial<T>,
+): boolean {
+  // Optional tuning fields (e.g. timeout/retries) should not trigger Nitro
+  // virtual-module imports when env/overrides already resolve the env-backed
+  // adapter fields in non-Nitro runtimes.
+  return fields.some(({ key, env }) => {
+    if (overrides?.[key] !== undefined) return false
+    if (!env) return false
+    return resolveEnv(env) === undefined
+  })
 }
 
 function resolveEnv(envKeys?: string[]): string | undefined {

--- a/packages/evlog/test/adapters/config.test.ts
+++ b/packages/evlog/test/adapters/config.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/shared/nitroConfigBridge', () => ({
+  getNitroRuntimeConfigRecord: vi.fn(),
+}))
+
+// eslint-disable-next-line import/first -- Must import after vi.mock
+import { resolveAdapterConfig } from '../../src/adapters/_config'
+// eslint-disable-next-line import/first -- Must import after vi.mock
+import { getNitroRuntimeConfigRecord } from '../../src/shared/nitroConfigBridge'
+
+interface TestAdapterConfig {
+  apiKey?: string
+  endpoint?: string
+  site?: string
+  timeout?: number
+}
+
+describe('resolveAdapterConfig', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('skips the Nitro runtime probe when overrides and env already satisfy env-backed fields', async () => {
+    const runtimeProbe = vi.mocked(getNitroRuntimeConfigRecord)
+    runtimeProbe.mockResolvedValue({
+      evlog: {
+        test: {
+          timeout: 30_000,
+        },
+      },
+    })
+
+    const config = await resolveAdapterConfig<TestAdapterConfig>(
+      'test',
+      [
+        { key: 'apiKey', env: ['TEST_API_KEY'] },
+        { key: 'endpoint', env: ['TEST_ENDPOINT'] },
+        { key: 'timeout' },
+      ],
+      {
+        apiKey: 'override-key',
+        endpoint: 'https://override.example.com',
+      },
+    )
+
+    expect(runtimeProbe).not.toHaveBeenCalled()
+    expect(config).toEqual({
+      apiKey: 'override-key',
+      endpoint: 'https://override.example.com',
+      timeout: undefined,
+    })
+  })
+
+  it('skips the Nitro runtime probe when env alone satisfies the remaining env-backed fields', async () => {
+    vi.stubEnv('TEST_API_KEY', 'env-key')
+    vi.stubEnv('TEST_ENDPOINT', 'https://env.example.com')
+
+    const runtimeProbe = vi.mocked(getNitroRuntimeConfigRecord)
+
+    const config = await resolveAdapterConfig<TestAdapterConfig>(
+      'test',
+      [
+        { key: 'apiKey', env: ['TEST_API_KEY'] },
+        { key: 'endpoint', env: ['TEST_ENDPOINT'] },
+        { key: 'timeout' },
+      ],
+    )
+
+    expect(runtimeProbe).not.toHaveBeenCalled()
+    expect(config).toEqual({
+      apiKey: 'env-key',
+      endpoint: 'https://env.example.com',
+      timeout: undefined,
+    })
+  })
+
+  it('probes Nitro runtime config when an env-backed field is still unresolved', async () => {
+    const runtimeProbe = vi.mocked(getNitroRuntimeConfigRecord)
+    runtimeProbe.mockResolvedValue({
+      evlog: {
+        test: {
+          apiKey: 'runtime-key',
+          endpoint: 'https://runtime.example.com',
+        },
+      },
+      test: {
+        endpoint: 'https://root.example.com',
+        timeout: 15_000,
+      },
+    })
+
+    const config = await resolveAdapterConfig<TestAdapterConfig>(
+      'test',
+      [
+        { key: 'apiKey', env: ['TEST_API_KEY'] },
+        { key: 'endpoint', env: ['TEST_ENDPOINT'] },
+        { key: 'timeout' },
+      ],
+    )
+
+    expect(runtimeProbe).toHaveBeenCalledTimes(1)
+    expect(config).toEqual({
+      apiKey: 'runtime-key',
+      endpoint: 'https://runtime.example.com',
+      timeout: 15_000,
+    })
+  })
+
+  it('preserves override then runtime then env precedence when the probe is required', async () => {
+    vi.stubEnv('TEST_API_KEY', 'env-key')
+    vi.stubEnv('TEST_ENDPOINT', 'https://env.example.com')
+
+    const runtimeProbe = vi.mocked(getNitroRuntimeConfigRecord)
+    runtimeProbe.mockResolvedValue({
+      evlog: {
+        test: {
+          apiKey: 'runtime-key',
+          endpoint: 'https://runtime.example.com',
+          site: 'runtime-site',
+        },
+      },
+      test: {
+        endpoint: 'https://root.example.com',
+        timeout: 5_000,
+      },
+    })
+
+    const config = await resolveAdapterConfig<TestAdapterConfig>(
+      'test',
+      [
+        { key: 'apiKey', env: ['TEST_API_KEY'] },
+        { key: 'endpoint', env: ['TEST_ENDPOINT'] },
+        { key: 'site', env: ['TEST_SITE'] },
+        { key: 'timeout' },
+      ],
+      {
+        apiKey: 'override-key',
+      },
+    )
+
+    expect(runtimeProbe).toHaveBeenCalledTimes(1)
+    expect(config).toEqual({
+      apiKey: 'override-key',
+      endpoint: 'https://runtime.example.com',
+      site: 'runtime-site',
+      timeout: 5_000,
+    })
+  })
+})


### PR DESCRIPTION
Closes #290

This fixes the noisy Nitro stub warning when a drain adapter is used outside Nitro in a monorepo where Nitro is installed somewhere else.

The issue was that resolveAdapterConfig() always hit the Nitro runtime-config bridge first, even when the adapter was already fully configured from overrides or env. That meant evlog could touch Nitro's stub module and trigger the warning before it ever used the values the app was already given.

What changed:
- Skip the Nitro probe when overrides or env already satisfy all env-backed adapter fields.
- Still fall back to runtime config when an env-backed field is actually missing.
- Keep the same precedence once a lookup is needed: overrides, then runtime config, then env.

I also added regression coverage for both no-probe paths and the runtime-config fallback path so this stays locked down.
