### PR TITLE
feat(workers): add defineWorkerFetch and waitUntil for async drains

### DIFF
--- a/apps/docs/content/0.landing.md
+++ b/apps/docs/content/0.landing.md
@@ -427,22 +427,18 @@ Wide events and structured errors for TypeScript. One log per request, full cont
 
   #cloudflare
   ```ts [src/worker.ts]
-  import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+  import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
   initWorkersLogger({ env: { service: 'checkout-worker' } })
 
-  export default {
-    async fetch(request, env) {
-      const log = createWorkersLogger(request)
+  export default defineWorkerFetch(async (request, env, _ctx, log) => {
+    const { cartId } = await request.json()
+    const cart = await env.DB.findCart(cartId)
+    log.set({ cart: { items: cart.items.length, total: cart.total } })
 
-      const { cartId } = await request.json()
-      const cart = await env.DB.findCart(cartId)
-      log.set({ cart: { items: cart.items.length, total: cart.total } })
-
-      log.emit()
-      return Response.json({ orderId: cart.id })
-    },
-  }
+    log.emit()
+    return Response.json({ orderId: cart.id })
+  })
   ```
 
   #bun

--- a/apps/docs/content/4.frameworks/12.cloudflare-workers.md
+++ b/apps/docs/content/4.frameworks/12.cloudflare-workers.md
@@ -14,9 +14,9 @@ The `evlog/workers` adapter provides factory functions for creating request-scop
 Set up evlog in my Cloudflare Worker.
 
 - Install evlog: pnpm add evlog
-- Import initWorkersLogger and createWorkersLogger from 'evlog/workers'
+- Import initWorkersLogger and defineWorkerFetch from 'evlog/workers'
 - Call initWorkersLogger({ env: { service: 'my-worker' } }) at the top level
-- In the fetch handler, create a logger with createWorkersLogger(request)
+- In the fetch handler, use **defineWorkerFetch** (recommended) or createWorkersLogger(request, { executionCtx: ctx })
 - Use log.set() to accumulate context throughout the request
 - Call log.emit() manually before returning the response (no middleware lifecycle)
 
@@ -37,30 +37,28 @@ bun add evlog
 ### 2. Initialize and create request loggers
 
 ```typescript [src/worker.ts]
-import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
 initWorkersLogger({
   env: { service: 'my-worker' },
 })
 
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const log = createWorkersLogger(request)
+export default defineWorkerFetch(async (request, _env, _ctx, log) => {
+  log.set({ action: 'handle_request' })
 
-    log.set({ action: 'handle_request' })
+  // ... your handler logic
 
-    // ... your handler logic
-
-    log.emit()
-    return Response.json({ ok: true })
-  },
-}
+  log.emit()
+  return Response.json({ ok: true })
+})
 ```
 
-`createWorkersLogger(request)` automatically extracts `method`, `path`, and `cf-ray` from the request.
+`defineWorkerFetch` passes `ExecutionContext` into `createWorkersLogger` for you, so async **`drain`** calls (PostHog, Axiom, …) stay alive via `waitUntil` after the response is returned. Use raw `export default { fetch }` + `createWorkersLogger(request, { executionCtx: ctx })` only if you prefer not to use the wrapper.
+
+`createWorkersLogger` still auto-extracts `method`, `path`, and `cf-ray` from the request.
 
 ::callout{icon="i-lucide-info" color="info"}
-You must call `log.emit()` manually before returning a response. Workers don't have a request lifecycle hook to auto-emit.
+You must call `log.emit()` manually before returning a response. Workers don't have a request lifecycle hook to auto-emit. With **`defineWorkerFetch`**, async `drain` work is tied to `waitUntil` automatically; with a raw `{ fetch }` handler, pass `{ executionCtx: ctx }` to `createWorkersLogger`.
 ::
 
 ## Wide Events
@@ -68,23 +66,26 @@ You must call `log.emit()` manually before returning a response. Workers don't h
 Build up context progressively, then emit at the end:
 
 ```typescript [src/worker.ts]
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const log = createWorkersLogger(request)
-    const url = new URL(request.url)
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
-    log.set({ route: url.pathname })
+initWorkersLogger({
+  env: { service: 'my-worker' },
+})
 
-    const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(url.searchParams.get('userId')).first()
-    log.set({ user: { id: user.id, plan: user.plan } })
+export default defineWorkerFetch(async (request, env, _ctx, log) => {
+  const url = new URL(request.url)
 
-    const orders = await env.DB.prepare('SELECT COUNT(*) as count FROM orders WHERE user_id = ?').bind(user.id).first()
-    log.set({ orders: { count: orders.count } })
+  log.set({ route: url.pathname })
 
-    log.emit()
-    return Response.json({ user, orders })
-  },
-}
+  const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(url.searchParams.get('userId')).first()
+  log.set({ user: { id: user.id, plan: user.plan } })
+
+  const orders = await env.DB.prepare('SELECT COUNT(*) as count FROM orders WHERE user_id = ?').bind(user.id).first()
+  log.set({ orders: { count: orders.count } })
+
+  log.emit()
+  return Response.json({ user, orders })
+})
 ```
 
 ```bash [Terminal output]
@@ -101,39 +102,38 @@ Use `createError` for structured errors and handle them with try/catch:
 
 ```typescript [src/worker.ts]
 import { createError, parseError } from 'evlog'
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const log = createWorkersLogger(request)
+initWorkersLogger({ env: { service: 'my-worker' } })
 
-    try {
-      const body = await request.json()
-      log.set({ payment: { amount: body.amount } })
+export default defineWorkerFetch(async (request, env, _ctx, log) => {
+  try {
+    const body = await request.json()
+    log.set({ payment: { amount: body.amount } })
 
-      if (body.amount <= 0) {
-        throw createError({
-          status: 400,
-          message: 'Invalid payment amount',
-          why: 'The amount must be a positive number',
-          fix: 'Pass a positive integer in cents',
-        })
-      }
-
-      log.emit()
-      return Response.json({ success: true })
-    } catch (error) {
-      log.error(error instanceof Error ? error : new Error(String(error)))
-      log.emit()
-
-      const parsed = parseError(error)
-      return Response.json({
-        message: parsed.message,
-        why: parsed.why,
-        fix: parsed.fix,
-      }, { status: parsed.status })
+    if (body.amount <= 0) {
+      throw createError({
+        status: 400,
+        message: 'Invalid payment amount',
+        why: 'The amount must be a positive number',
+        fix: 'Pass a positive integer in cents',
+      })
     }
-  },
-}
+
+    log.emit()
+    return Response.json({ success: true })
+  } catch (error) {
+    log.error(error instanceof Error ? error : new Error(String(error)))
+    log.emit()
+
+    const parsed = parseError(error)
+    return Response.json({
+      message: parsed.message,
+      why: parsed.why,
+      fix: parsed.fix,
+    }, { status: parsed.status })
+  }
+})
 ```
 
 ## Configuration

--- a/apps/docs/content/4.frameworks/14.astro.md
+++ b/apps/docs/content/4.frameworks/14.astro.md
@@ -30,6 +30,14 @@ Adapters: https://www.evlog.dev/adapters
 This is a guide-level integration. It uses the generic `createRequestLogger` API rather than a framework-specific module.
 ::
 
+::callout{icon="i-lucide-cloud" color="warning"}
+On **Cloudflare Workers** (including Astro with `@astrojs/cloudflare`), set `waitUntil` on `createRequestLogger` to your `ExecutionContext#waitUntil` (properly bound), or use [`defineWorkerFetch`](/frameworks/cloudflare-workers) / [`createWorkersLogger`](/frameworks/cloudflare-workers) with `{ executionCtx }` on a **Worker `fetch` entry**. Otherwise async drains may never finish after the response is returned.
+
+For Astro **middleware** (not the raw Worker handler), there is no `defineWorkerFetch`; you still pass `waitUntil` from the adapter-exposed context.
+
+The exact way to read `ctx` from Astro middleware depends on your adapter version — check the [Cloudflare adapter docs](https://docs.astro.build/en/guides/integrations-guide/cloudflare/).
+::
+
 ## Quick Start
 
 ### 1. Install

--- a/examples/workers/src/index.ts
+++ b/examples/workers/src/index.ts
@@ -1,22 +1,18 @@
-import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
 initWorkersLogger({
   env: { service: 'workers-example' },
 })
 
-export default {
-  async fetch(request: Request) {
-    const log = createWorkersLogger(request)
-
-    try {
-      log.set({ route: 'health' })
-      const response = new Response('ok', { status: 200 })
-      log.emit({ status: response.status })
-      return response
-    } catch (error) {
-      log.error(error as Error)
-      log.emit({ status: 500 })
-      throw error
-    }
-  },
-}
+export default defineWorkerFetch(async (request, _env, _ctx, log) => {
+  try {
+    log.set({ route: 'health' })
+    const response = new Response('ok', { status: 200 })
+    log.emit({ status: response.status })
+    return response
+  } catch (error) {
+    log.error(error as Error)
+    log.emit({ status: 500 })
+    throw error
+  }
+})

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -336,30 +336,40 @@ async function processSyncJob(job: Job) {
 
 ## Cloudflare Workers
 
-Use the Workers adapter for structured logs and correct platform severity.
+Use the Workers adapter for structured logs and correct platform severity. With `initWorkersLogger({ drain })`, use **`defineWorkerFetch`** so async drains are registered with `waitUntil` automatically (Cloudflare only passes `ExecutionContext` as the third `fetch` argument — there is no global).
 
 ```typescript
 // src/index.ts
-import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
 
 initWorkersLogger({
   env: { service: 'edge-api' },
 })
 
-export default {
-  async fetch(request: Request) {
-    const log = createWorkersLogger(request)
+export default defineWorkerFetch(async (request, _env, _ctx, log) => {
+  try {
+    log.set({ route: 'health' })
+    const response = new Response('ok', { status: 200 })
+    log.emit({ status: response.status })
+    return response
+  } catch (error) {
+    log.error(error as Error)
+    log.emit({ status: 500 })
+    throw error
+  }
+})
+```
 
-    try {
-      log.set({ route: 'health' })
-      const response = new Response('ok', { status: 200 })
-      log.emit({ status: response.status })
-      return response
-    } catch (error) {
-      log.error(error as Error)
-      log.emit({ status: 500 })
-      throw error
-    }
+If you keep a raw `export default { fetch }`, pass `{ executionCtx: ctx }` to `createWorkersLogger` or `waitUntil` on `createRequestLogger`.
+
+```typescript
+// Lower-level (equivalent)
+import { createWorkersLogger } from 'evlog/workers'
+
+export default {
+  async fetch(request: Request, _env: unknown, ctx: ExecutionContext) {
+    const log = createWorkersLogger(request, { executionCtx: ctx })
+    // ...
   },
 }
 ```
@@ -373,6 +383,7 @@ invocation_logs = false
 ```
 
 Notes:
+- Prefer **`defineWorkerFetch`** so you do not have to pass `executionCtx` yourself when using a drain
 - `requestId` defaults to `cf-ray` when available
 - `request.cf` is included (colo, country, asn) unless disabled
 - Use `headerAllowlist` to avoid logging sensitive headers
@@ -1185,6 +1196,21 @@ initWorkersLogger({
 })
 ```
 
+### `defineWorkerFetch(handler)`
+
+Recommended for Workers when using **`initWorkersLogger({ drain })`**. Wraps your handler so `createWorkersLogger` always receives `executionCtx` — you do not pass `ctx` into the factory yourself. Cloudflare does not expose `ExecutionContext` globally (only as `fetch`’s third argument), so this is the “automatic” option for plain Workers scripts.
+
+```typescript
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({ env: { service: 'edge-api' }, drain })
+
+export default defineWorkerFetch(async (request, env, ctx, log) => {
+  log.emit({ status: 200 })
+  return new Response('ok')
+})
+```
+
 ### `createWorkersLogger(request, options?)`
 
 Create a request-scoped logger for Workers. Auto-extracts `cf-ray`, `request.cf`, method, and path.
@@ -1192,10 +1218,14 @@ Create a request-scoped logger for Workers. Auto-extracts `cf-ray`, `request.cf`
 ```typescript
 import { createWorkersLogger } from 'evlog/workers'
 
+// ctx is the third argument to fetch(request, env, ctx)
 const log = createWorkersLogger(request, {
   requestId: 'custom-id',      // Override cf-ray (default: cf-ray header)
   headers: ['x-request-id'],   // Headers to include (default: none)
+  executionCtx: ctx,           // With initWorkersLogger({ drain }), registers async drain via waitUntil
 })
+
+// Or pass waitUntil directly: waitUntil: ctx.waitUntil.bind(ctx)
 
 log.set({ user: { id: '123' } })
 log.emit({ status: 200 })

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -160,7 +160,18 @@ export function shouldKeep(ctx: TailSamplingContext): boolean {
   })
 }
 
-function emitWideEvent(level: LogLevel, event: Record<string, unknown>, deferDrain = false, ownsEvent = false): WideEvent | null {
+interface EmitWideEventOptions {
+  deferDrain?: boolean
+  ownsEvent?: boolean
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+function emitWideEvent(
+  level: LogLevel,
+  event: Record<string, unknown>,
+  options: EmitWideEventOptions = {},
+): WideEvent | null {
+  const { deferDrain = false, ownsEvent = false, waitUntil } = options
   if (!globalEnabled) return null
 
   if (!ownsEvent) {
@@ -208,9 +219,12 @@ function emitWideEvent(level: LogLevel, event: Record<string, unknown>, deferDra
   }
 
   if (globalDrain && !deferDrain) {
-    Promise.resolve(globalDrain({ event: formatted })).catch((err) => {
+    const drainPromise = Promise.resolve(globalDrain({ event: formatted })).catch((err) => {
       console.error('[evlog] drain failed:', err)
     })
+    if (waitUntil) {
+      waitUntil(drainPromise)
+    }
   }
 
   return formatted
@@ -543,6 +557,10 @@ interface CreateLoggerInternalOptions {
    * Used by framework middleware that runs its own enrich+drain pipeline.
    */
   _deferDrain?: boolean
+  /**
+   * @see {@link RequestLoggerOptions.waitUntil}
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 
 /**
@@ -564,6 +582,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
   if (!globalEnabled) return noopLogger as unknown as AuditableLogger<T>
 
   const deferDrain = internalOptions?._deferDrain ?? false
+  const waitUntil = internalOptions?.waitUntil
   const startTime = Date.now()
   const context: Record<string, unknown> = { ...initialContext }
   let hasError = false
@@ -711,7 +730,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
       }
       context.duration = formatDuration(durationMs)
 
-      const wide = emitWideEvent(level, context, deferDrain, true)
+      const wide = emitWideEvent(level, context, { deferDrain, ownsEvent: true, waitUntil })
       emitted = true
       return wide
     },
@@ -733,13 +752,32 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
  * log.set({ cart: { items: 3 } })
  * log.emit()
  * ```
+ *
+ * @example Cloudflare Workers — pass `waitUntil` so `initLogger({ drain })` completes after the response:
+ * ```ts
+ * export default {
+ *   async fetch(request, env, ctx) {
+ *     const log = createRequestLogger({
+ *       method: request.method,
+ *       path: new URL(request.url).pathname,
+ *       waitUntil: ctx.waitUntil.bind(ctx),
+ *     })
+ *     log.emit()
+ *     return new Response('ok')
+ *   },
+ * }
+ * ```
  */
 export function createRequestLogger<T extends object = Record<string, unknown>>(options: RequestLoggerOptions = {}, internalOptions?: CreateLoggerInternalOptions): AuditableLogger<T> {
+  const { method, path, requestId, waitUntil: optionsWaitUntil } = options
   const initial: Record<string, unknown> = {}
-  if (options.method !== undefined) initial.method = options.method
-  if (options.path !== undefined) initial.path = options.path
-  if (options.requestId !== undefined) initial.requestId = options.requestId
-  return createLogger<T>(initial, internalOptions)
+  if (method !== undefined) initial.method = method
+  if (path !== undefined) initial.path = path
+  if (requestId !== undefined) initial.requestId = requestId
+  return createLogger<T>(initial, {
+    ...internalOptions,
+    waitUntil: internalOptions?.waitUntil ?? optionsWaitUntil,
+  })
 }
 
 /**

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -744,6 +744,16 @@ export interface RequestLoggerOptions {
   method?: string
   path?: string
   requestId?: string
+  /**
+   * Registers async drain work with the host runtime so it can finish after the
+   * HTTP response is returned. Required on **Cloudflare Workers** (and similar
+   * edge runtimes): without this, `initLogger({ drain })` + `log.emit()` may
+   * never complete outbound HTTP to observability backends.
+   *
+   * Pass the same function you would pass to `ExecutionContext#waitUntil`, e.g.
+   * `context.waitUntil.bind(context)` from a Workers `fetch` handler.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 
 /**

--- a/packages/evlog/src/workers/index.ts
+++ b/packages/evlog/src/workers/index.ts
@@ -2,6 +2,14 @@ import { initLogger, createRequestLogger } from '../logger'
 import type { LoggerConfig, RequestLogger } from '../types'
 
 /**
+ * Minimal Cloudflare Workers execution context (`fetch` third argument).
+ * Matches Cloudflare `ExecutionContext` without requiring `@cloudflare/workers-types`.
+ */
+export interface WorkerExecutionContext {
+  waitUntil(promise: Promise<unknown>): void
+}
+
+/**
  * Options for createWorkersLogger
  */
 export interface WorkersLoggerOptions {
@@ -9,6 +17,21 @@ export interface WorkersLoggerOptions {
   requestId?: string
   /** Headers to include in logs (default: none) */
   headers?: string[]
+  /**
+   * Cloudflare Workers `ExecutionContext` from the `fetch` handler
+   * (`async fetch(request, env, ctx)`). When set, async `initLogger({ drain })`
+   * work from `log.emit()` is registered with `ctx.waitUntil` so drains (HTTP to
+   * Axiom, PostHog, etc.) complete after the response is returned.
+   *
+   * Prefer {@link defineWorkerFetch} when you want this wired automatically.
+   */
+  executionCtx?: WorkerExecutionContext
+  /**
+   * Lower-level alternative to `executionCtx`: same function Cloudflare assigns to
+   * `ExecutionContext#waitUntil` (must be bound if you extract the method), e.g.
+   * `waitUntil: ctx.waitUntil.bind(ctx)`.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -49,6 +72,43 @@ export function initWorkersLogger(options: LoggerConfig = {}): void {
   })
 }
 
+/**
+ * Wraps a Workers `fetch` handler so {@link createWorkersLogger} receives
+ * `executionCtx` automatically for async drains (`initWorkersLogger({ drain })`).
+ *
+ * Cloudflare does not expose `ExecutionContext` globally — only as the third
+ * `fetch` argument — so evlog cannot discover it without either this helper or
+ * an explicit `{ executionCtx: ctx }` / `waitUntil` option.
+ *
+ * @example
+ * ```ts
+ * initWorkersLogger({ env: { service: 'my-api' }, drain: myDrain })
+ *
+ * export default defineWorkerFetch(async (request, env, ctx, log) => {
+ *   log.set({ route: '/health' })
+ *   log.emit({ status: 200 })
+ *   return new Response('ok')
+ * })
+ * ```
+ */
+export function defineWorkerFetch<TEnv = unknown>(
+  handler: (
+    request: Request,
+    env: TEnv,
+    ctx: WorkerExecutionContext,
+    log: RequestLogger,
+  ) => Response | Promise<Response>,
+): {
+  fetch: (request: Request, env: TEnv, ctx: WorkerExecutionContext) => Promise<Response>
+} {
+  return {
+    fetch(request, env, ctx) {
+      const log = createWorkersLogger(request, { executionCtx: ctx })
+      return Promise.resolve(handler(request, env, ctx, log))
+    },
+  }
+}
+
 function pickCfContext(request: Request): Record<string, unknown> {
   const cf = Reflect.get(request, 'cf')
   if (!isRecord(cf)) return {}
@@ -67,8 +127,8 @@ function pickCfContext(request: Request): Record<string, unknown> {
  * @example
  * ```ts
  * export default {
- *   async fetch(request: Request) {
- *     const log = createWorkersLogger(request)
+ *   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+ *     const log = createWorkersLogger(request, { executionCtx: ctx })
  *
  *     log.set({ user: { id: '123' } })
  *     log.emit({ status: 200 })
@@ -83,10 +143,17 @@ export function createWorkersLogger<T extends object = Record<string, unknown>>(
   const cfRay = request.headers.get('cf-ray') ?? undefined
   const traceparent = request.headers.get('traceparent') ?? undefined
 
+  const waitUntil =
+    options.waitUntil
+    ?? (options.executionCtx
+      ? options.executionCtx.waitUntil.bind(options.executionCtx)
+      : undefined)
+
   const log = createRequestLogger<T>({
     method: request.method,
     path: url.pathname,
     requestId: options.requestId ?? cfRay,
+    waitUntil,
   })
 
   // Cast needed: CF-specific enrichment fields (cfRay, traceparent, etc.) aren't in user's T

--- a/packages/evlog/test/logger.test.ts
+++ b/packages/evlog/test/logger.test.ts
@@ -858,6 +858,45 @@ describe('drain callback', () => {
     expect(ctx.event.userId).toBe('123')
   })
 
+  it('registers emit drain promise with waitUntil when provided', async () => {
+    const drain = vi.fn().mockResolvedValue(undefined)
+    const waitUntil = vi.fn()
+    initLogger({ pretty: false, drain })
+
+    const logger = createRequestLogger({
+      method: 'GET',
+      path: '/workers',
+      waitUntil,
+    })
+    logger.emit()
+
+    await vi.waitFor(() => expect(drain).toHaveBeenCalledTimes(1))
+    expect(waitUntil).toHaveBeenCalledTimes(1)
+    const [[scheduled]] = waitUntil.mock.calls
+    expect(scheduled).toBeInstanceOf(Promise)
+    await scheduled
+  })
+
+  it('does not call waitUntil when emit is sampled out', () => {
+    const drain = vi.fn()
+    const waitUntil = vi.fn()
+    initLogger({
+      pretty: false,
+      drain,
+      sampling: { rates: { info: 0 } },
+    })
+
+    const logger = createRequestLogger({
+      method: 'GET',
+      path: '/x',
+      waitUntil,
+    })
+    logger.emit()
+
+    expect(drain).not.toHaveBeenCalled()
+    expect(waitUntil).not.toHaveBeenCalled()
+  })
+
   it('does not call drain when event is sampled out', () => {
     const drain = vi.fn()
     initLogger({

--- a/packages/evlog/test/workers-logger.test.ts
+++ b/packages/evlog/test/workers-logger.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createWorkersLogger, defineWorkerFetch, initWorkersLogger } from '../src/workers'
+
+describe('createWorkersLogger + waitUntil', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('defineWorkerFetch wires executionCtx so emit registers drain with waitUntil', async () => {
+    const drain = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const waitUntil = vi.fn()
+    const executionCtx = { waitUntil }
+
+    initWorkersLogger({ pretty: false, drain })
+
+    const worker = defineWorkerFetch((_request, _env, _ctx, log) => {
+      log.emit()
+      return new Response('ok')
+    })
+
+    const request = new Request('https://example.com/api')
+    await worker.fetch(request, {}, executionCtx)
+
+    await vi.waitFor(() => expect(drain).toHaveBeenCalledTimes(1))
+    expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise))
+    const [[scheduled]] = waitUntil.mock.calls
+    await scheduled
+  })
+
+  it('binds executionCtx.waitUntil and registers drain work on emit', async () => {
+    const drain = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const waitUntil = vi.fn()
+    const executionCtx = { waitUntil }
+
+    initWorkersLogger({ pretty: false, drain })
+
+    const request = new Request('https://example.com/api')
+    const log = createWorkersLogger(request, {
+      requestId: 'test-req',
+      executionCtx,
+    })
+
+    log.emit()
+
+    await vi.waitFor(() => expect(drain).toHaveBeenCalledTimes(1))
+    expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise))
+
+    const [[scheduled]] = waitUntil.mock.calls
+    await scheduled
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- evlog (the evlog package)
- nuxthub (the nuxthub package)
- deps (the dependencies)
- repo (the repository)
- nuxt (Nuxt module)
- nitro (Nitro plugin)
- next (Next.js integration)
- tanstack-start (TanStack Start integration)
- hono (Hono middleware)
- express (Express middleware)
- elysia (Elysia plugin)
- fastify (Fastify plugin)
- nestjs (NestJS middleware)
- react-router (React Router integration)
- sveltekit (SvelteKit integration)
- workers (Cloudflare Workers adapter)
- fs (File System adapter)
- ai (AI SDK integration)
- dx (developer experience improvements)
-->

### 🔗 Linked issue

Resolves #300 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
