### PR TITLE
fix(evlog): support primitive values in defineEnricher

### DIFF
--- a/packages/evlog/src/shared/enricher.ts
+++ b/packages/evlog/src/shared/enricher.ts
@@ -9,7 +9,7 @@ export interface EnricherOptions {
   overwrite?: boolean
 }
 
-export interface EnricherDefinition<T extends object> {
+export interface EnricherDefinition<T> {
   /** Stable identifier used in error logs. */
   name: string
   /**
@@ -38,7 +38,7 @@ export interface EnricherDefinition<T extends object> {
  * })
  * ```
  */
-export function defineEnricher<T extends object>(
+export function defineEnricher<T>(
   def: EnricherDefinition<T>,
   options: EnricherOptions = {},
 ): (ctx: EnrichContext) => void {

--- a/packages/evlog/src/shared/event.ts
+++ b/packages/evlog/src/shared/event.ts
@@ -7,12 +7,16 @@
  * object values win over computed ones — so `log.set({ geo: ... })` keeps
  * precedence over an enricher's automatic detection.
  */
-export function mergeEventField<T extends object>(
+export function mergeEventField<T>(
   existing: unknown,
   computed: T,
   overwrite?: boolean,
 ): T {
-  if (overwrite || existing === undefined || existing === null || typeof existing !== 'object') {
+  if (overwrite) return computed
+  if (typeof computed !== 'object' || computed === null) {
+    return existing === undefined || existing === null ? computed : existing as T
+  }
+  if (existing === undefined || existing === null || typeof existing !== 'object') {
     return computed
   }
   return { ...computed, ...(existing as T) }

--- a/packages/evlog/test/toolkit.test.ts
+++ b/packages/evlog/test/toolkit.test.ts
@@ -77,6 +77,24 @@ describe('event helpers', () => {
     expect(merged).toEqual({ id: 'computed' })
   })
 
+  it('mergeEventField writes primitive value when no existing value', () => {
+    expect(mergeEventField(undefined, 'fast')).toBe('fast')
+    expect(mergeEventField(null, 42)).toBe(42)
+  })
+
+  it('mergeEventField preserves primitive value over computed primitive', () => {
+    expect(mergeEventField('user', 'computed')).toBe('user')
+    expect(mergeEventField(50, 37)).toBe(50)
+  })
+
+  it('mergeEventField overwrites primitive value when requested', () => {
+    expect(mergeEventField('user', 'computed', true)).toBe('computed')
+  })
+
+  it('mergeEventField preserves user values when computed is primitive', () => {
+    expect(mergeEventField({ foo: 'bar' }, 'fast')).toEqual({ foo: 'bar' })
+  })
+
   it('toTypedAttributeValue distinguishes integers and doubles', () => {
     expect(toTypedAttributeValue(42)).toEqual({ value: 42, type: 'integer' })
     expect(toTypedAttributeValue(3.14)).toEqual({ value: 3.14, type: 'double' })
@@ -147,6 +165,51 @@ describe('defineEnricher', () => {
       expect.stringContaining('[evlog/tenant]'),
       expect.any(Error),
     )
+  })
+
+  it('writes primitive values to the event field', () => {
+    const enricher = defineEnricher<string>({
+      name: 'performance-tier',
+      field: 'performanceTier',
+      compute: ({ event }) => {
+        const duration = event.duration as number | undefined
+        if (duration === undefined) return undefined
+        if (duration < 100) return 'fast'
+        if (duration < 500) return 'normal'
+        return 'slow'
+      },
+    })
+    const event = baseEvent()
+    event.duration = 50
+    const ctx = enrichCtx(event)
+    enricher(ctx)
+    expect(ctx.event.performanceTier).toBe('fast')
+  })
+
+  it('preserves existing primitive value over enricher output', () => {
+    const enricher = defineEnricher<string>({
+      name: 'performance-tier',
+      field: 'performanceTier',
+      compute: () => 'fast',
+    })
+    const event = baseEvent()
+    event.performanceTier = 'user-set'
+    const ctx = enrichCtx(event)
+    enricher(ctx)
+    expect(ctx.event.performanceTier).toBe('user-set')
+  })
+
+  it('overwrites existing primitive when overwrite is true', () => {
+    const enricher = defineEnricher<string>({
+      name: 'performance-tier',
+      field: 'performanceTier',
+      compute: () => 'fast',
+    }, { overwrite: true })
+    const event = baseEvent()
+    event.performanceTier = 'user-set'
+    const ctx = enrichCtx(event)
+    enricher(ctx)
+    expect(ctx.event.performanceTier).toBe('fast')
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

The [docs](https://www.evlog.dev/enrichers/custom#response-time-classification) show `defineEnricher<string>` as a supported pattern for custom enrichers, but the current implementation only accepts object types:

- `EnricherDefinition<T extends object>` and `defineEnricher<T extends object>` prevent primitive type parameters at the type level.
- `mergeEventField<T extends object>` was written around object spreading and didn't cleanly handle primitive computed values.

This change aligns the implementation with the documented behavior:

- Remove the `T extends object` constraint on `EnricherDefinition`, `defineEnricher`, and `mergeEventField`.
- Rework `mergeEventField` to handle primitives; object-merge semantics are unchanged.
- Add tests covering primitive merge paths and primitive enrichers.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
