### PR TITLE
feat(evlog): tag drain requests with User-Agent + X-Evlog-Source

### DIFF
--- a/apps/docs/content/5.build-on-top/.navigation.yml
+++ b/apps/docs/content/5.build-on-top/.navigation.yml
@@ -1,0 +1,1 @@
+title: Build on top

--- a/apps/docs/content/5.build-on-top/1.identity-headers.md
+++ b/apps/docs/content/5.build-on-top/1.identity-headers.md
@@ -1,0 +1,54 @@
+---
+title: Identity headers
+description: Every drain request sent by evlog is tagged with a User-Agent and an X-Evlog-Source header so receivers can identify the traffic.
+navigation:
+  title: Identity headers
+  icon: i-lucide-fingerprint
+---
+
+All built-in adapters send two identity headers on every outgoing request:
+
+| Header | Value |
+| --- | --- |
+| `User-Agent` | `evlog/<version>` (Node / server runtimes only — browsers strip this header) |
+| `X-Evlog-Source` | The adapter name (`axiom`, `datadog`, `otlp`, `posthog`, `sentry`, `better-stack`, `client`, ...) |
+
+The browser-side `evlog/http` drain (used by the client transport) sets `X-Evlog-Source: client` instead, since browsers cannot override `User-Agent`.
+
+## Why
+
+- Quickly distinguish evlog traffic from other clients in the receiving system's logs.
+- Track adapter usage / version drift centrally.
+- Identify the source when debugging a specific drain.
+
+## Reading the version
+
+Both constants are exported from `evlog/toolkit`:
+
+```ts
+import { EVLOG_USER_AGENT, EVLOG_VERSION } from 'evlog/toolkit'
+
+console.log(EVLOG_VERSION)    // → "2.16.0"
+console.log(EVLOG_USER_AGENT) // → "evlog/2.16.0"
+```
+
+## Custom drains
+
+When you build a drain on top of `httpPost` from `evlog/toolkit`, identity headers are injected automatically. To override or suppress them:
+
+```ts
+import { httpPost } from 'evlog/toolkit'
+
+await httpPost({
+  url: 'https://my-platform.example.com/ingest',
+  headers: { 'Content-Type': 'application/json' },
+  body: '[]',
+  timeout: 5000,
+  label: 'my-platform',
+  source: 'my-platform',           // sent as X-Evlog-Source
+  userAgent: 'my-fork/1.0',        // overrides the default User-Agent
+  // userAgent: false,             // suppress the header entirely
+})
+```
+
+Adapters built with `defineHttpDrain()` automatically pass the drain `name` as `source`.

--- a/packages/evlog/src/adapters/axiom.ts
+++ b/packages/evlog/src/adapters/axiom.ts
@@ -154,6 +154,7 @@ export async function sendBatchToAxiom(events: WideEvent[], config: AxiomConfig)
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'Axiom',
+    source: 'axiom',
   })
 }
 

--- a/packages/evlog/src/adapters/better-stack.ts
+++ b/packages/evlog/src/adapters/better-stack.ts
@@ -115,5 +115,6 @@ export async function sendBatchToBetterStack(events: WideEvent[], config: Better
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'Better Stack',
+    source: 'better-stack',
   })
 }

--- a/packages/evlog/src/adapters/datadog.ts
+++ b/packages/evlog/src/adapters/datadog.ts
@@ -202,5 +202,6 @@ export async function sendBatchToDatadog(events: WideEvent[], config: DatadogCon
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'Datadog',
+    source: 'datadog',
   })
 }

--- a/packages/evlog/src/adapters/otlp.ts
+++ b/packages/evlog/src/adapters/otlp.ts
@@ -324,5 +324,6 @@ export async function sendBatchToOTLP(events: WideEvent[], config: OTLPConfig): 
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'OTLP',
+    source: 'otlp',
   })
 }

--- a/packages/evlog/src/adapters/posthog.ts
+++ b/packages/evlog/src/adapters/posthog.ts
@@ -206,5 +206,6 @@ export async function sendBatchToPostHogEvents(events: WideEvent[], config: Post
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'PostHog',
+    source: 'posthog',
   })
 }

--- a/packages/evlog/src/adapters/sentry.ts
+++ b/packages/evlog/src/adapters/sentry.ts
@@ -289,5 +289,6 @@ export async function sendBatchToSentry(events: WideEvent[], config: SentryConfi
     timeout: config.timeout ?? 5000,
     retries: config.retries,
     label: 'Sentry',
+    source: 'sentry',
   })
 }

--- a/packages/evlog/src/http.ts
+++ b/packages/evlog/src/http.ts
@@ -68,7 +68,7 @@ export function createHttpDrain(config: HttpDrainConfig): (batch: DrainContext[]
     try {
       const response = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...customHeaders },
+        headers: { 'Content-Type': 'application/json', 'X-Evlog-Source': 'client', ...customHeaders },
         body,
         signal: controller.signal,
         keepalive: true,

--- a/packages/evlog/src/shared/drain.ts
+++ b/packages/evlog/src/shared/drain.ts
@@ -117,6 +117,7 @@ export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): (c
         timeout,
         retries,
         label: options.name,
+        source: options.name,
       })
     },
   })

--- a/packages/evlog/src/shared/http.ts
+++ b/packages/evlog/src/shared/http.ts
@@ -1,7 +1,19 @@
 /**
  * Minimal HTTP transport for drain adapters: abort-based timeouts, exponential
  * backoff on `5xx` / network errors, response bodies truncated in error messages.
+ *
+ * Identifies every outgoing request as coming from evlog via:
+ * - `User-Agent: evlog/<version>` (Node / server runtimes only — browsers strip this)
+ * - `X-Evlog-Source: <source>` when {@link HttpPostOptions.source} is set
  */
+
+import { version as PKG_VERSION } from '../../package.json'
+
+/** Build-time evlog package version, e.g. `2.16.0`. */
+export const EVLOG_VERSION: string = PKG_VERSION
+
+/** Default `User-Agent` value injected into outgoing drain requests. */
+export const EVLOG_USER_AGENT = `evlog/${EVLOG_VERSION}`
 
 export interface HttpPostOptions {
   url: string
@@ -18,6 +30,47 @@ export interface HttpPostOptions {
    * @default 2
    */
   retries?: number
+  /**
+   * Override the default `User-Agent: evlog/<version>` header. Pass `false` or
+   * an empty string to suppress it entirely (e.g. when the underlying transport
+   * forbids overriding `User-Agent`).
+   */
+  userAgent?: string | false
+  /**
+   * When set, sends `X-Evlog-Source: <source>` so the receiving system can
+   * distinguish evlog traffic from other clients. Typically the adapter name
+   * (`axiom`, `datadog`, ...) or `client` for browser-originated drains.
+   */
+  source?: string
+}
+
+function hasHeader(headers: Record<string, string>, target: string): boolean {
+  const lower = target.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) return true
+  }
+  return false
+}
+
+/**
+ * Returns a copy of `headers` with evlog identity headers injected when
+ * absent. Caller-provided values always win.
+ *
+ * @internal Exposed for tests. Use {@link httpPost} from drains.
+ */
+export function withEvlogIdentityHeaders(
+  headers: Record<string, string>,
+  { userAgent, source }: { userAgent?: string | false; source?: string } = {},
+): Record<string, string> {
+  const out = { ...headers }
+  if (userAgent !== false && !hasHeader(out, 'user-agent')) {
+    const ua = typeof userAgent === 'string' && userAgent.length > 0 ? userAgent : EVLOG_USER_AGENT
+    out['User-Agent'] = ua
+  }
+  if (source && !hasHeader(out, 'x-evlog-source')) {
+    out['X-Evlog-Source'] = source
+  }
+  return out
 }
 
 function isRetryable(error: unknown): boolean {
@@ -34,8 +87,9 @@ function isRetryable(error: unknown): boolean {
  * POST a body with timeout + retry. Throws label-prefixed errors with a
  * truncated response body. Safe to call from any drain `send()`.
  */
-export async function httpPost({ url, headers, body, timeout, label, retries = 2 }: HttpPostOptions): Promise<void> {
+export async function httpPost({ url, headers, body, timeout, label, retries = 2, userAgent, source }: HttpPostOptions): Promise<void> {
   const normalizedRetries = Number.isFinite(retries) && retries >= 0 ? Math.floor(retries) : 2
+  const finalHeaders = withEvlogIdentityHeaders(headers, { userAgent, source })
 
   let lastError: Error | undefined
 
@@ -46,7 +100,7 @@ export async function httpPost({ url, headers, body, timeout, label, retries = 2
     try {
       const response = await fetch(url, {
         method: 'POST',
-        headers,
+        headers: finalHeaders,
         body,
         signal: controller.signal,
       })

--- a/packages/evlog/test/http.test.ts
+++ b/packages/evlog/test/http.test.ts
@@ -36,7 +36,7 @@ describe('createHttpDrain', () => {
     const [url, options] = vi.mocked(fetch).mock.calls[0]!
     expect(url).toBe('/api/logs')
     expect(options?.method).toBe('POST')
-    expect(options?.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(options?.headers).toEqual({ 'Content-Type': 'application/json', 'X-Evlog-Source': 'client' })
     expect(options?.body).toBe(JSON.stringify(batch))
     expect(options?.keepalive).toBe(true)
     expect(options?.credentials).toBe('same-origin')
@@ -53,6 +53,7 @@ describe('createHttpDrain', () => {
     const [, options] = vi.mocked(fetch).mock.calls[0]!
     expect(options?.headers).toEqual({
       'Content-Type': 'application/json',
+      'X-Evlog-Source': 'client',
       'Authorization': 'Bearer tok_123',
       'X-API-Key': 'key_456',
     })

--- a/packages/evlog/test/shared-http-identity.test.ts
+++ b/packages/evlog/test/shared-http-identity.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendBatchToAxiom } from '../src/adapters/axiom'
+import { sendBatchToDatadog } from '../src/adapters/datadog'
+import { sendBatchToOTLP } from '../src/adapters/otlp'
+import { EVLOG_USER_AGENT, EVLOG_VERSION, httpPost, withEvlogIdentityHeaders } from '../src/shared/http'
+import type { WideEvent } from '../src/types'
+
+const event: WideEvent = {
+  timestamp: '2024-01-01T12:00:00.000Z',
+  level: 'info',
+  service: 'test-service',
+  environment: 'test',
+}
+
+describe('shared/http evlog identity', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('EVLOG_VERSION / EVLOG_USER_AGENT', () => {
+    it('exposes a non-empty version string matching SemVer', () => {
+      expect(EVLOG_VERSION).toMatch(/^\d+\.\d+\.\d+/)
+    })
+
+    it('uses `evlog/<version>` as default User-Agent', () => {
+      expect(EVLOG_USER_AGENT).toBe(`evlog/${EVLOG_VERSION}`)
+    })
+  })
+
+  describe('withEvlogIdentityHeaders', () => {
+    it('injects User-Agent when missing', () => {
+      const out = withEvlogIdentityHeaders({ 'Content-Type': 'application/json' })
+      expect(out['User-Agent']).toBe(EVLOG_USER_AGENT)
+    })
+
+    it('preserves caller User-Agent (case-insensitive match)', () => {
+      const out = withEvlogIdentityHeaders({ 'user-agent': 'my-app/1.0' })
+      expect(out['User-Agent']).toBeUndefined()
+      expect(out['user-agent']).toBe('my-app/1.0')
+    })
+
+    it('respects userAgent override', () => {
+      const out = withEvlogIdentityHeaders({}, { userAgent: 'custom-ua/2.0' })
+      expect(out['User-Agent']).toBe('custom-ua/2.0')
+    })
+
+    it('suppresses User-Agent when userAgent is false', () => {
+      const out = withEvlogIdentityHeaders({}, { userAgent: false })
+      expect(out['User-Agent']).toBeUndefined()
+    })
+
+    it('adds X-Evlog-Source when source is provided', () => {
+      const out = withEvlogIdentityHeaders({}, { source: 'axiom' })
+      expect(out['X-Evlog-Source']).toBe('axiom')
+    })
+
+    it('does not overwrite caller-provided X-Evlog-Source', () => {
+      const out = withEvlogIdentityHeaders({ 'X-Evlog-Source': 'app' }, { source: 'axiom' })
+      expect(out['X-Evlog-Source']).toBe('app')
+    })
+
+    it('does not add X-Evlog-Source when source is omitted', () => {
+      const out = withEvlogIdentityHeaders({})
+      expect(out['X-Evlog-Source']).toBeUndefined()
+    })
+  })
+
+  describe('httpPost identity injection', () => {
+    it('injects User-Agent header into fetch call', async () => {
+      await httpPost({
+        url: 'https://example.com/ingest',
+        headers: { 'Content-Type': 'application/json' },
+        body: '[]',
+        timeout: 5000,
+        label: 'test',
+        source: 'test',
+      })
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+      const headers = options.headers as Record<string, string>
+      expect(headers['User-Agent']).toBe(EVLOG_USER_AGENT)
+      expect(headers['X-Evlog-Source']).toBe('test')
+    })
+  })
+})
+
+describe('drain adapters identity headers', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('axiom sends User-Agent + X-Evlog-Source headers', async () => {
+    await sendBatchToAxiom([event], { dataset: 'd', apiKey: 'k' })
+    const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const headers = options.headers as Record<string, string>
+    expect(headers['User-Agent']).toBe(EVLOG_USER_AGENT)
+    expect(headers['X-Evlog-Source']).toBe('axiom')
+  })
+
+  it('datadog sends User-Agent + X-Evlog-Source headers', async () => {
+    await sendBatchToDatadog([event], { apiKey: 'k' })
+    const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const headers = options.headers as Record<string, string>
+    expect(headers['User-Agent']).toBe(EVLOG_USER_AGENT)
+    expect(headers['X-Evlog-Source']).toBe('datadog')
+  })
+
+  it('otlp sends User-Agent + X-Evlog-Source headers', async () => {
+    await sendBatchToOTLP([event], { endpoint: 'https://otel.example.com' })
+    const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const headers = options.headers as Record<string, string>
+    expect(headers['User-Agent']).toBe(EVLOG_USER_AGENT)
+    expect(headers['X-Evlog-Source']).toBe('otlp')
+  })
+})


### PR DESCRIPTION
## Summary

Inject identity headers on every drain request emitted by built-in adapters so receiving systems (Axiom, Datadog, OTLP collectors, custom backends) can recognize evlog traffic and the originating adapter without parsing the body.

- `User-Agent: evlog/<version>` on Node / server runtimes (browsers strip `User-Agent`).
- `X-Evlog-Source: <adapter>` (`axiom`, `datadog`, `otlp`, `posthog`, `sentry`, `better-stack`, `hyperdx`, `client` for browser-originated drains).
- `httpPost` gains `userAgent?: string | false` and `source?: string` options so custom drains can override or suppress the headers.
- `EVLOG_VERSION`, `EVLOG_USER_AGENT`, and `withEvlogIdentityHeaders` exported from `evlog/toolkit`.

This is the first slice of a broader "build on top of evlog" effort — see `apps/docs/content/5.build-on-top/`. The next slices (FS reader, in-process stream primitive) will land as separate PRs.

## What changed

- `packages/evlog/src/shared/http.ts`: header injection logic + new options.
- `packages/evlog/src/shared/drain.ts`: `defineHttpDrain` forwards `name` as `source`.
- `packages/evlog/src/adapters/{axiom,better-stack,datadog,otlp,posthog,sentry}.ts`: legacy `sendBatchTo*` helpers pass `source` explicitly. `defineHttpDrain` paths inherit it for free.
- `packages/evlog/src/http.ts`: browser drain sets `X-Evlog-Source: client`.
- `packages/evlog/test/shared-http-identity.test.ts`: identity header tests on `httpPost`, axiom, datadog, otlp.
- `apps/docs/content/5.build-on-top/{.navigation.yml,1.identity-headers.md}`: docs section + page.

## Test plan

- [x] `pnpm --filter evlog run lint`
- [x] `pnpm --filter evlog run test`
- [x] `pnpm --filter evlog run build` (verifies `EVLOG_VERSION` is inlined from `package.json` at build time)
- [ ] Sanity check on a provider dashboard (Axiom / Datadog / OTLP collector) that incoming requests carry the new headers