### PR TITLE
feat(fs): add readFsLogs and tailFsLogs readers

### DIFF
--- a/apps/docs/content/5.build-on-top/4.fs-reader.md
+++ b/apps/docs/content/5.build-on-top/4.fs-reader.md
@@ -1,0 +1,65 @@
+---
+title: Reading FS logs
+description: Replay and tail the local NDJSON drain with readFsLogs and tailFsLogs — works in-process or from any external Node tool.
+navigation:
+  title: FS reader
+  icon: i-lucide-folder-search
+---
+
+The [filesystem drain](/adapters/self-hosted/fs) writes wide events as NDJSON files in `.evlog/logs/` (one file per day, optional rotation). The `evlog/fs` module also ships **readers** that let any Node tool replay or follow that history without hooking into the running app.
+
+## Replay history
+
+```ts
+import { readFsLogs } from 'evlog/fs'
+
+for await (const event of readFsLogs({ since: '2026-03-01', level: 'error' })) {
+  console.log(event.timestamp, event.action ?? event.message)
+}
+```
+
+`readFsLogs(options)` walks the NDJSON files in chronological order, parses them line by line, and yields events that pass all filters. Files outside the date window are skipped entirely.
+
+### Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `dir` | `string` | Directory to read from. Default: `.evlog/logs`. |
+| `since` | `Date \| string` | Yield events with `timestamp >= since`. |
+| `until` | `Date \| string` | Yield events with `timestamp <= until`. |
+| `level` | `LogLevel \| LogLevel[]` | Filter by event level. |
+| `filter` | `(event) => boolean` | Custom predicate. |
+
+Malformed lines (partial writes, manual edits) are silently skipped — your script never crashes on a bad line.
+
+## Live tail
+
+```ts
+import { tailFsLogs } from 'evlog/fs'
+
+const ac = new AbortController()
+process.on('SIGINT', () => ac.abort())
+
+for await (const event of tailFsLogs({ signal: ac.signal })) {
+  console.log('live:', event.action ?? event.message)
+}
+```
+
+`tailFsLogs(options)` first yields existing events (unless `fromEnd: true`), then keeps yielding new ones as they're appended — including events written into newly created daily files. Partial writes split across polls are recombined transparently.
+
+### Tail-specific options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `pollIntervalMs` | `number` | Polling interval. Default: 500ms (minimum 50ms). |
+| `fromEnd` | `boolean` | Skip existing events; only yield future ones. Default: false. |
+| `signal` | `AbortSignal` | Stop tailing when aborted. |
+
+All [`readFsLogs`](#options) options also apply.
+
+## Use cases
+
+- A local Electron / Tauri dashboard reading `.evlog/logs/` from a target project directory.
+- A CI report aggregator that scans logs after a test run.
+- A `grep`-style CLI that pipes filtered events into `jq`.
+- Replaying historic events into a dashboard before switching to a live in-process subscription.

--- a/packages/evlog/src/adapters/fs.ts
+++ b/packages/evlog/src/adapters/fs.ts
@@ -1,6 +1,8 @@
-import { appendFile, mkdir, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
+import { appendFile, mkdir, open, readdir, stat, unlink, writeFile } from 'node:fs/promises'
 import { join, sep } from 'node:path'
-import type { WideEvent } from '../types'
+import { createInterface } from 'node:readline'
+import type { LogLevel, WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { resolveAdapterConfig } from '../shared/config'
 import { defineDrain } from '../shared/drain'
@@ -147,4 +149,286 @@ export function createFsDrain(overrides?: Partial<FsConfig>) {
     },
     send: writeBatchToFs,
   })
+}
+
+/** Options accepted by {@link readFsLogs}. */
+export interface ReadFsLogsOptions {
+  /** Directory to read from. Default: `.evlog/logs` */
+  dir?: string
+  /** Only yield events with `event.timestamp >= since`. */
+  since?: Date | string
+  /** Only yield events with `event.timestamp <= until`. */
+  until?: Date | string
+  /** Filter by event level. */
+  level?: LogLevel | LogLevel[]
+  /** Custom predicate — return `false` to skip the event. */
+  filter?: (event: WideEvent) => boolean
+}
+
+/** Options accepted by {@link tailFsLogs}. */
+export interface TailFsLogsOptions extends ReadFsLogsOptions {
+  /**
+   * Polling interval (ms) used to detect new bytes / new files.
+   * @default 500
+   */
+  pollIntervalMs?: number
+  /**
+   * Skip existing events and only yield events appended after the tailer
+   * starts. Useful for "live tail" UX.
+   * @default false
+   */
+  fromEnd?: boolean
+  /** Stop tailing when this signal aborts. */
+  signal?: AbortSignal
+}
+
+interface ParsedFilename {
+  date: string
+  index: number
+}
+
+function isLogFilename(filename: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}(\.\d+)?\.jsonl$/.test(filename)
+}
+
+function compareLogFiles(a: string, b: string): number {
+  const pa = parseLogFilename(a)
+  const pb = parseLogFilename(b)
+  return pa.date.localeCompare(pb.date) || pa.index - pb.index
+}
+
+function normalizeTimestamp(value: Date | string | undefined): number | undefined {
+  if (!value) return undefined
+  const date = value instanceof Date ? value : new Date(value)
+  const ts = date.getTime()
+  return Number.isNaN(ts) ? undefined : ts
+}
+
+function buildFilter(options: ReadFsLogsOptions): (event: WideEvent) => boolean {
+  const since = normalizeTimestamp(options.since)
+  const until = normalizeTimestamp(options.until)
+  const levels = options.level
+    ? new Set<LogLevel>(Array.isArray(options.level) ? options.level : [options.level])
+    : undefined
+  const custom = options.filter
+
+  return (event: WideEvent) => {
+    if (levels && !levels.has(event.level)) return false
+    if (since !== undefined || until !== undefined) {
+      const ts = typeof event.timestamp === 'string' ? Date.parse(event.timestamp) : Number.NaN
+      if (Number.isNaN(ts)) return false
+      if (since !== undefined && ts < since) return false
+      if (until !== undefined && ts > until) return false
+    }
+    if (custom && !custom(event)) return false
+    return true
+  }
+}
+
+async function listLogFiles(dir: string): Promise<string[]> {
+  let files: string[]
+  try {
+    files = await readdir(dir)
+  } catch {
+    return []
+  }
+  return files.filter(isLogFilename).sort(compareLogFiles)
+}
+
+function fileDateMs(filename: string): number {
+  const { date } = parseLogFilename(filename)
+  return date ? Date.parse(`${date}T00:00:00.000Z`) : Number.NaN
+}
+
+function fileWithinRange(filename: string, since?: number, until?: number): boolean {
+  if (since === undefined && until === undefined) return true
+  const dayStart = fileDateMs(filename)
+  if (Number.isNaN(dayStart)) return true
+  const dayEnd = dayStart + 24 * 60 * 60 * 1000 - 1
+  if (since !== undefined && dayEnd < since) return false
+  if (until !== undefined && dayStart > until) return false
+  return true
+}
+
+async function* iterateFile(filePath: string): AsyncGenerator<WideEvent> {
+  const stream = createReadStream(filePath, { encoding: 'utf-8' })
+  const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try {
+        yield JSON.parse(trimmed) as WideEvent
+      } catch {
+        // Skip malformed lines (partial writes, manual edits) silently.
+      }
+    }
+  } finally {
+    rl.close()
+    stream.destroy()
+  }
+}
+
+/**
+ * Read past events from the local file system drain (NDJSON). Files are
+ * iterated in chronological order; events are yielded as they appear in
+ * each file.
+ *
+ * @example
+ * ```ts
+ * import { readFsLogs } from 'evlog/fs'
+ *
+ * for await (const event of readFsLogs({ since: '2026-01-01', level: 'error' })) {
+ *   console.log(event)
+ * }
+ * ```
+ */
+export async function* readFsLogs(options: ReadFsLogsOptions = {}): AsyncGenerator<WideEvent> {
+  const dir = options.dir ?? '.evlog/logs'
+  const sinceMs = normalizeTimestamp(options.since)
+  const untilMs = normalizeTimestamp(options.until)
+  const predicate = buildFilter(options)
+
+  const files = await listLogFiles(dir)
+  for (const filename of files) {
+    if (!fileWithinRange(filename, sinceMs, untilMs)) continue
+    for await (const event of iterateFile(join(dir, filename))) {
+      if (predicate(event)) yield event
+    }
+  }
+}
+
+async function safeStatSize(filePath: string): Promise<number> {
+  try {
+    const s = await stat(filePath)
+    return s.size
+  } catch {
+    return 0
+  }
+}
+
+async function readAppendedLines(
+  filePath: string,
+  fromOffset: number,
+  carry: string,
+): Promise<{ events: string[]; offset: number; carry: string }> {
+  const size = await safeStatSize(filePath)
+  if (size <= fromOffset) return { events: [], offset: fromOffset, carry }
+
+  const handle = await open(filePath, 'r')
+  try {
+    const length = size - fromOffset
+    const buf = Buffer.alloc(length)
+    await handle.read(buf, 0, length, fromOffset)
+    const chunk = carry + buf.toString('utf-8')
+    const newlineIdx = chunk.lastIndexOf('\n')
+    if (newlineIdx === -1) {
+      return { events: [], offset: size, carry: chunk }
+    }
+    const complete = chunk.slice(0, newlineIdx)
+    const remainder = chunk.slice(newlineIdx + 1)
+    const lines = complete.split('\n').map(l => l.trim()).filter(Boolean)
+    return { events: lines, offset: size, carry: remainder }
+  } finally {
+    await handle.close()
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      if (signal) signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timer)
+        resolve()
+        return
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
+  })
+}
+
+/**
+ * Follow the local file system drain in real time. Yields existing events
+ * (unless `fromEnd: true`) then keeps yielding new events as they are
+ * appended. Automatically picks up newly created daily files.
+ *
+ * @example
+ * ```ts
+ * import { tailFsLogs } from 'evlog/fs'
+ *
+ * const ac = new AbortController()
+ * setTimeout(() => ac.abort(), 60_000)
+ *
+ * for await (const event of tailFsLogs({ signal: ac.signal })) {
+ *   console.log('live:', event.action ?? event.message)
+ * }
+ * ```
+ */
+export async function* tailFsLogs(options: TailFsLogsOptions = {}): AsyncGenerator<WideEvent> {
+  const dir = options.dir ?? '.evlog/logs'
+  const interval = Math.max(50, options.pollIntervalMs ?? 500)
+  const { signal } = options
+  const predicate = buildFilter(options)
+
+  const offsets = new Map<string, number>()
+  const carries = new Map<string, string>()
+
+  if (options.fromEnd) {
+    const files = await listLogFiles(dir)
+    for (const filename of files) {
+      offsets.set(filename, await safeStatSize(join(dir, filename)))
+      carries.set(filename, '')
+    }
+  } else {
+    for await (const event of readFsLogs(options)) {
+      if (signal?.aborted) return
+      yield event
+    }
+    const files = await listLogFiles(dir)
+    for (const filename of files) {
+      if (!offsets.has(filename)) {
+        offsets.set(filename, await safeStatSize(join(dir, filename)))
+        carries.set(filename, '')
+      }
+    }
+  }
+
+  while (true) {
+    if (signal?.aborted) return
+    await delay(interval, signal)
+    if (signal?.aborted) return
+
+    const files = await listLogFiles(dir)
+
+    for (const filename of files) {
+      if (!offsets.has(filename)) {
+        offsets.set(filename, 0)
+        carries.set(filename, '')
+      }
+      const filePath = join(dir, filename)
+      const fromOffset = offsets.get(filename)!
+      const carry = carries.get(filename) ?? ''
+      const { events, offset, carry: newCarry } = await readAppendedLines(filePath, fromOffset, carry)
+      offsets.set(filename, offset)
+      carries.set(filename, newCarry)
+
+      for (const line of events) {
+        if (signal?.aborted) return
+        try {
+          const event = JSON.parse(line) as WideEvent
+          if (predicate(event)) yield event
+        } catch {
+          // Skip malformed lines.
+        }
+      }
+    }
+  }
 }

--- a/packages/evlog/test/adapters/fs-reader.test.ts
+++ b/packages/evlog/test/adapters/fs-reader.test.ts
@@ -1,0 +1,333 @@
+import { mkdtemp, rm, writeFile, appendFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readFsLogs, tailFsLogs } from '../../src/adapters/fs'
+import type { WideEvent } from '../../src/types'
+
+function makeEvent(id: number, overrides?: Partial<WideEvent>): WideEvent {
+  return {
+    timestamp: '2026-03-14T10:00:00.000Z',
+    level: 'info',
+    service: 'test',
+    environment: 'test',
+    id,
+    ...overrides,
+  }
+}
+
+function ndjson(events: WideEvent[]): string {
+  return `${events.map(e => JSON.stringify(e)).join('\n')}\n`
+}
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'evlog-fs-reader-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('readFsLogs', () => {
+  it('returns empty when directory does not exist', async () => {
+    const events: WideEvent[] = []
+    for await (const event of readFsLogs({ dir: join(dir, 'missing') })) {
+      events.push(event)
+    }
+    expect(events).toEqual([])
+  })
+
+  it('iterates events from a single file in NDJSON order', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([makeEvent(1), makeEvent(2), makeEvent(3)]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1, 2, 3])
+  })
+
+  it('iterates files in chronological order', async () => {
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(3), makeEvent(4)]))
+    await writeFile(join(dir, '2026-03-13.jsonl'), ndjson([makeEvent(1), makeEvent(2)]))
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1, 2, 3, 4])
+  })
+
+  it('handles rotated suffix files in correct order', async () => {
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(1)]))
+    await writeFile(join(dir, '2026-03-14.1.jsonl'), ndjson([makeEvent(2)]))
+    await writeFile(join(dir, '2026-03-14.2.jsonl'), ndjson([makeEvent(3)]))
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1, 2, 3])
+  })
+
+  it('skips malformed lines without throwing', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      `${JSON.stringify(makeEvent(1))}\nnot-json\n${JSON.stringify(makeEvent(2))}\n`,
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1, 2])
+  })
+
+  it('filters by level (single value)', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([
+        makeEvent(1, { level: 'info' }),
+        makeEvent(2, { level: 'error' }),
+        makeEvent(3, { level: 'warn' }),
+      ]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, level: 'error' })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([2])
+  })
+
+  it('filters by level (multiple values)', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([
+        makeEvent(1, { level: 'info' }),
+        makeEvent(2, { level: 'error' }),
+        makeEvent(3, { level: 'warn' }),
+      ]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, level: ['error', 'warn'] })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([2, 3])
+  })
+
+  it('filters by since timestamp', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([
+        makeEvent(1, { timestamp: '2026-03-14T08:00:00.000Z' }),
+        makeEvent(2, { timestamp: '2026-03-14T10:00:00.000Z' }),
+        makeEvent(3, { timestamp: '2026-03-14T12:00:00.000Z' }),
+      ]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, since: '2026-03-14T09:00:00.000Z' })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([2, 3])
+  })
+
+  it('filters by until timestamp', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([
+        makeEvent(1, { timestamp: '2026-03-14T08:00:00.000Z' }),
+        makeEvent(2, { timestamp: '2026-03-14T10:00:00.000Z' }),
+        makeEvent(3, { timestamp: '2026-03-14T12:00:00.000Z' }),
+      ]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, until: new Date('2026-03-14T10:00:00.000Z') })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1, 2])
+  })
+
+  it('skips entire files outside the date window', async () => {
+    await writeFile(join(dir, '2026-03-13.jsonl'), ndjson([makeEvent(1)]))
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(2)]))
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, since: '2026-03-14T00:00:00.000Z' })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([2])
+  })
+
+  it('applies a custom filter predicate', async () => {
+    await writeFile(
+      join(dir, '2026-03-14.jsonl'),
+      ndjson([
+        makeEvent(1, { service: 'api' }),
+        makeEvent(2, { service: 'web' }),
+      ]),
+    )
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir, filter: e => e.service === 'web' })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([2])
+  })
+
+  it('ignores non-jsonl files', async () => {
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(1)]))
+    await writeFile(join(dir, 'README.md'), '# nope')
+    await writeFile(join(dir, 'corrupted.txt'), 'noise')
+
+    const events: number[] = []
+    for await (const event of readFsLogs({ dir })) {
+      events.push(event.id as number)
+    }
+    expect(events).toEqual([1])
+  })
+})
+
+describe('tailFsLogs', () => {
+  it('yields existing events then waits for new ones', async () => {
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(1), makeEvent(2)]))
+
+    const ac = new AbortController()
+    const collected: number[] = []
+
+    const consumer = (async () => {
+      for await (const event of tailFsLogs({ dir, pollIntervalMs: 50, signal: ac.signal })) {
+        collected.push(event.id as number)
+        if (collected.length === 4) {
+          ac.abort()
+          break
+        }
+      }
+    })()
+
+    await new Promise(r => setTimeout(r, 100))
+    await appendFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(3), makeEvent(4)]))
+
+    await consumer
+    expect(collected).toEqual([1, 2, 3, 4])
+  })
+
+  it('skips existing events when fromEnd is true', async () => {
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(1), makeEvent(2)]))
+
+    const ac = new AbortController()
+    const collected: number[] = []
+
+    const consumer = (async () => {
+      for await (const event of tailFsLogs({
+        dir,
+        pollIntervalMs: 50,
+        signal: ac.signal,
+        fromEnd: true,
+      })) {
+        collected.push(event.id as number)
+        if (collected.length === 1) {
+          ac.abort()
+          break
+        }
+      }
+    })()
+
+    await new Promise(r => setTimeout(r, 100))
+    await appendFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(99)]))
+
+    await consumer
+    expect(collected).toEqual([99])
+  })
+
+  it('detects newly appearing log files', async () => {
+    const ac = new AbortController()
+    const collected: number[] = []
+
+    const consumer = (async () => {
+      for await (const event of tailFsLogs({
+        dir,
+        pollIntervalMs: 50,
+        signal: ac.signal,
+      })) {
+        collected.push(event.id as number)
+        if (collected.length === 2) {
+          ac.abort()
+          break
+        }
+      }
+    })()
+
+    await new Promise(r => setTimeout(r, 100))
+    await writeFile(join(dir, '2026-03-14.jsonl'), ndjson([makeEvent(10)]))
+    await new Promise(r => setTimeout(r, 200))
+    await writeFile(join(dir, '2026-03-15.jsonl'), ndjson([makeEvent(11)]))
+
+    await consumer
+    expect(collected).toEqual([10, 11])
+  })
+
+  it('handles partial line writes across polls', async () => {
+    const file = join(dir, '2026-03-14.jsonl')
+    await writeFile(file, '')
+
+    const ac = new AbortController()
+    const collected: number[] = []
+
+    const consumer = (async () => {
+      for await (const event of tailFsLogs({
+        dir,
+        pollIntervalMs: 50,
+        signal: ac.signal,
+        fromEnd: true,
+      })) {
+        collected.push(event.id as number)
+        if (collected.length === 1) {
+          ac.abort()
+          break
+        }
+      }
+    })()
+
+    await new Promise(r => setTimeout(r, 100))
+    const json = JSON.stringify(makeEvent(42))
+    await appendFile(file, json.slice(0, 10))
+    await new Promise(r => setTimeout(r, 100))
+    await appendFile(file, `${json.slice(10)}\n`)
+
+    await consumer
+    expect(collected).toEqual([42])
+  })
+
+  it('aborts cleanly via AbortSignal', async () => {
+    const ac = new AbortController()
+    const start = Date.now()
+
+    const consumer = (async () => {
+      const out: WideEvent[] = []
+      for await (const event of tailFsLogs({
+        dir,
+        pollIntervalMs: 50,
+        signal: ac.signal,
+        fromEnd: true,
+      })) {
+        out.push(event)
+      }
+      return out
+    })()
+
+    setTimeout(() => ac.abort(), 100)
+    const result = await consumer
+
+    expect(result).toEqual([])
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+})


### PR DESCRIPTION
## Summary

The filesystem drain has always been write-only. This adds two readers so any external tool (CLI, local dashboard, CI report scraper) can consume the NDJSON history without hooking into the running app.

- `readFsLogs({ dir, since, until, level, filter })` — async iterator that walks `.jsonl` files in chronological order, parses line by line, skips malformed lines, and yields events passing all filters. Files outside the date window are skipped entirely.
- `tailFsLogs({ ..., pollIntervalMs, fromEnd, signal })` — first yields existing events (unless \`fromEnd: true\`), then keeps yielding new ones as they're appended. Detects newly created daily files and recombines partial-write chunks across polls. Aborts cleanly via \`AbortSignal\`.

Both helpers ship under the existing \`evlog/fs\` entrypoint — no new public export, no new dependency.

## Why

Independent of the running app: useful for `grep`-style CLIs, post-CI report aggregation, Electron/Tauri dashboards reading `.evlog/logs/` from a target directory, and replay-then-live patterns where historic events seed a UI before switching to a live in-process subscription.

## Test plan

- [x] `pnpm --filter evlog run lint`
- [x] `pnpm --filter evlog run test` — 18 new tests in `test/adapters/fs-reader.test.ts` cover ordering, level filter, since/until window, malformed lines, partial-write reassembly, new-file detection, and signal abort
- [x] `pnpm --filter evlog run build`