### PR TITLE
feat(stream): add evlog/stream in-process drain primitive

### DIFF
--- a/apps/docs/content/5.build-on-top/2.stream-api.md
+++ b/apps/docs/content/5.build-on-top/2.stream-api.md
@@ -6,7 +6,16 @@ navigation:
   icon: i-lucide-radio-tower
 ---
 
-`createStreamDrain()` exposes the events flowing through evlog as an in-process pub/sub. It's the primitive any local consumer can subscribe to — dashboards, devtools, CLIs, custom UIs — without re-implementing a drain.
+`createStreamDrain()` exposes the events flowing through evlog as an **in-process** pub/sub. It's the primitive any local consumer can subscribe to — dashboards, devtools, CLIs, custom UIs — without re-implementing a drain.
+
+::callout
+---
+icon: i-lucide-info
+---
+**Scope:** the stream lives inside a single Node / Bun / Deno process. It sees events emitted from that process only — like the [filesystem drain](/adapters/self-hosted/fs). It is **not** a cross-process bus.
+
+That means it works perfectly during local development, on long-lived self-hosted servers, and inside containers. On serverless platforms (Vercel Functions, Cloudflare Workers, AWS Lambda…), each invocation is a separate isolate, so a subscriber in one invocation will not see events emitted from another. Use a real broker (Redis Streams, NATS, Pub/Sub…) when you need cross-instance fan-out.
+::
 
 ```ts
 import { createStreamDrain } from 'evlog/stream'

--- a/apps/docs/content/5.build-on-top/2.stream-api.md
+++ b/apps/docs/content/5.build-on-top/2.stream-api.md
@@ -1,0 +1,87 @@
+---
+title: Stream API
+description: Subscribe to wide events flowing through evlog, in-process, with createStreamDrain — sync listeners, async iterators, and a ring buffer.
+navigation:
+  title: Stream API
+  icon: i-lucide-radio-tower
+---
+
+`createStreamDrain()` exposes the events flowing through evlog as an in-process pub/sub. It's the primitive any local consumer can subscribe to — dashboards, devtools, CLIs, custom UIs — without re-implementing a drain.
+
+```ts
+import { createStreamDrain } from 'evlog/stream'
+
+const stream = createStreamDrain({ buffer: 200 })
+
+// Register as a normal evlog drain (Nitro hook or plugin runner):
+nitroApp.hooks.hook('evlog:drain', stream.drain)
+```
+
+## Subscribing
+
+Two consumption styles are supported.
+
+### Sync listener
+
+```ts
+const unsubscribe = stream.subscribe((event) => {
+  if (event.level === 'error') notifyOps(event)
+})
+
+// Later:
+unsubscribe()
+```
+
+Listener errors are caught and logged — they never affect other subscribers or the drain.
+
+### Async iterator
+
+```ts
+for await (const event of stream.events()) {
+  console.log(event.timestamp, event.action ?? event.message)
+  if (shouldStop(event)) break  // breaking cleanly unsubscribes
+}
+```
+
+Each call to `events()` returns a fresh independent iterator. Past buffered events are **not** replayed; pair with `stream.recent()` to seed history.
+
+## Replay buffer
+
+`stream.recent()` returns a defensive copy of the most recent events (oldest first). The default buffer holds 500 events; pass `buffer: 0` to disable, or set it explicitly:
+
+```ts
+const stream = createStreamDrain({ buffer: 1000 })
+
+const initial = stream.recent()
+for (const past of initial) seedDashboard(past)
+
+stream.subscribe(liveEvent => updateDashboard(liveEvent))
+```
+
+## Backpressure
+
+A slow async-iterator consumer never blocks the drain. Each iterator has a per-subscriber queue (default 1000); when it overflows, the oldest queued events are dropped and `stream.droppedCount` increments.
+
+## Filter
+
+Events that fail the optional `filter` predicate are not buffered nor delivered:
+
+```ts
+const errors = createStreamDrain({
+  filter: event => event.level === 'error' || event.status >= 500,
+})
+```
+
+## Default singleton
+
+When several pieces of code in the same process need to share a single stream — typically a framework integration that wires the drain on one side and a consumer (UI, route, plugin) on the other — use the singleton accessors instead of passing references around:
+
+```ts
+import { getDefaultStream, setDefaultStream } from 'evlog/stream'
+
+// Lazily creates a singleton on first call
+const stream = getDefaultStream({ buffer: 500 })
+
+// Reset (mostly useful in tests)
+setDefaultStream(null)
+```

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -110,6 +110,11 @@
       "import": "./dist/pipeline.mjs",
       "default": "./dist/pipeline.mjs"
     },
+    "./stream": {
+      "types": "./dist/stream.d.mts",
+      "import": "./dist/stream.mjs",
+      "default": "./dist/stream.mjs"
+    },
     "./http": {
       "types": "./dist/http.d.mts",
       "import": "./dist/http.mjs",
@@ -244,6 +249,9 @@
       ],
       "pipeline": [
         "./dist/pipeline.d.mts"
+      ],
+      "stream": [
+        "./dist/stream.d.mts"
       ],
       "http": [
         "./dist/http.d.mts"

--- a/packages/evlog/src/stream.ts
+++ b/packages/evlog/src/stream.ts
@@ -1,0 +1,259 @@
+/**
+ * In-process event stream — the foundation for any local consumer (devtools,
+ * dashboards, CLIs, SSE/WebSocket bridges) to observe events flowing through
+ * the drain pipeline without re-implementing one.
+ *
+ * @example
+ * ```ts
+ * import { createStreamDrain } from 'evlog/stream'
+ *
+ * const stream = createStreamDrain({ buffer: 200 })
+ * nitroApp.hooks.hook('evlog:drain', stream.drain)
+ *
+ * stream.subscribe((event) => {
+ *   if (event.level === 'error') notifyOps(event)
+ * })
+ *
+ * for await (const event of stream.events()) {
+ *   console.log(event.timestamp, event.action ?? event.message)
+ * }
+ * ```
+ */
+
+import type { DrainContext, WideEvent } from './types'
+
+/** Configuration accepted by {@link createStreamDrain}. */
+export interface StreamDrainOptions {
+  /**
+   * Number of recent events kept in the ring buffer and replayed to new
+   * subscribers via {@link StreamDrain.recent}. Set to `0` to disable
+   * replay.
+   * @default 500
+   */
+  buffer?: number
+  /**
+   * Optional predicate run on each drained event — return `false` to skip
+   * the event entirely (it is neither buffered nor delivered).
+   */
+  filter?: (event: WideEvent) => boolean
+  /**
+   * Per-subscriber queue size for the {@link StreamDrain.events} async
+   * iterator. When the consumer falls behind by more than this many events,
+   * the oldest queued events are dropped — the drain is never blocked.
+   * @default 1000
+   */
+  perSubscriberQueue?: number
+}
+
+/** Live drain that exposes its events to in-process subscribers. */
+export interface StreamDrain {
+  /**
+   * Drain callback. Pass to `nitroApp.hooks.hook('evlog:drain', stream.drain)`
+   * or to a plugin via `drainPlugin('stream', stream.drain)`.
+   */
+  drain: (ctx: DrainContext | DrainContext[]) => Promise<void>
+  /**
+   * Register a synchronous listener. Errors thrown by the listener are
+   * caught and logged — they never affect other subscribers or the drain.
+   * @returns Unsubscribe function.
+   */
+  subscribe: (listener: (event: WideEvent) => void) => () => void
+  /**
+   * Async iterator over live events. Each call returns a fresh iterator —
+   * past events from the ring buffer are NOT replayed. Combine with
+   * {@link StreamDrain.recent} to seed history.
+   *
+   * Calling `return()` (e.g. via `break`) cleanly unsubscribes.
+   */
+  events: () => AsyncIterableIterator<WideEvent>
+  /**
+   * Snapshot of buffered events (oldest first, most recent last). Useful
+   * to seed a new connection / UI panel before switching to live updates.
+   */
+  recent: () => readonly WideEvent[]
+  /** Number of currently active subscribers (sync + async iterators). */
+  readonly subscriberCount: number
+  /** Number of events dropped because the buffer was disabled or wrapped. */
+  readonly droppedCount: number
+  /**
+   * Disconnect all subscribers and end any pending async iterators. The
+   * stream itself remains usable — new subscriptions still work.
+   */
+  close: () => void
+}
+
+const DEFAULT_BUFFER = 500
+const DEFAULT_QUEUE = 1000
+
+interface AsyncSubscriber {
+  push: (event: WideEvent) => void
+  end: () => void
+}
+
+/**
+ * Create an in-process {@link StreamDrain}. Multiple stream drains can
+ * coexist in the same process — they are fully independent.
+ */
+export function createStreamDrain(options: StreamDrainOptions = {}): StreamDrain {
+  const bufferSize = Math.max(0, Math.floor(options.buffer ?? DEFAULT_BUFFER))
+  const queueLimit = Math.max(1, Math.floor(options.perSubscriberQueue ?? DEFAULT_QUEUE))
+  const { filter } = options
+
+  const buffer: WideEvent[] = []
+  const syncListeners = new Set<(event: WideEvent) => void>()
+  const asyncSubscribers = new Set<AsyncSubscriber>()
+  let dropped = 0
+
+  function publish(event: WideEvent): void {
+    if (filter && !filter(event)) return
+
+    if (bufferSize > 0) {
+      buffer.push(event)
+      while (buffer.length > bufferSize) {
+        buffer.shift()
+        dropped++
+      }
+    }
+
+    for (const listener of syncListeners) {
+      try {
+        listener(event)
+      } catch (err) {
+        console.error('[evlog/stream] subscriber threw:', err)
+      }
+    }
+
+    for (const sub of asyncSubscribers) {
+      sub.push(event)
+    }
+  }
+
+  const drain: StreamDrain['drain'] = (ctx) => {
+    const contexts = Array.isArray(ctx) ? ctx : [ctx]
+    for (const c of contexts) {
+      if (c?.event) publish(c.event)
+    }
+    return Promise.resolve()
+  }
+
+  const subscribe: StreamDrain['subscribe'] = (listener) => {
+    syncListeners.add(listener)
+    return () => {
+      syncListeners.delete(listener)
+    }
+  }
+
+  function createAsyncIterator(): AsyncIterableIterator<WideEvent> {
+    const queue: WideEvent[] = []
+    let pendingResolve: ((result: IteratorResult<WideEvent>) => void) | null = null
+    let closed = false
+
+    const subscriber: AsyncSubscriber = {
+      push(event) {
+        if (closed) return
+        if (pendingResolve) {
+          const resolve = pendingResolve
+          pendingResolve = null
+          resolve({ value: event, done: false })
+          return
+        }
+        queue.push(event)
+        while (queue.length > queueLimit) {
+          queue.shift()
+          dropped++
+        }
+      },
+      end() {
+        if (closed) return
+        closed = true
+        if (pendingResolve) {
+          const resolve = pendingResolve
+          pendingResolve = null
+          resolve({ value: undefined, done: true })
+        }
+      },
+    }
+
+    asyncSubscribers.add(subscriber)
+
+    const iterator: AsyncIterableIterator<WideEvent> = {
+      [Symbol.asyncIterator]() {
+        return iterator
+      },
+      next(): Promise<IteratorResult<WideEvent>> {
+        if (queue.length > 0) {
+          return Promise.resolve({ value: queue.shift()!, done: false })
+        }
+        if (closed) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+        return new Promise((resolve) => {
+          pendingResolve = resolve
+        })
+      },
+      return(): Promise<IteratorResult<WideEvent>> {
+        closed = true
+        asyncSubscribers.delete(subscriber)
+        if (pendingResolve) {
+          const resolve = pendingResolve
+          pendingResolve = null
+          resolve({ value: undefined, done: true })
+        }
+        return Promise.resolve({ value: undefined, done: true })
+      },
+    }
+
+    return iterator
+  }
+
+  return {
+    drain,
+    subscribe,
+    events: createAsyncIterator,
+    recent: () => buffer.slice(),
+    get subscriberCount() {
+      return syncListeners.size + asyncSubscribers.size
+    },
+    get droppedCount() {
+      return dropped
+    },
+    close() {
+      syncListeners.clear()
+      for (const sub of asyncSubscribers) {
+        sub.end()
+      }
+      asyncSubscribers.clear()
+    },
+  }
+}
+
+let defaultStream: StreamDrain | null = null
+
+/**
+ * Lazily create / return the process-wide default {@link StreamDrain}.
+ *
+ * Used by built-in framework integrations (Nuxt SSE bridge, devtools panel)
+ * so they share a single buffer. Custom code can subscribe to this stream
+ * to observe everything draining through evlog without registering a new
+ * drain.
+ *
+ * @example
+ * ```ts
+ * import { getDefaultStream } from 'evlog/stream'
+ *
+ * getDefaultStream().subscribe((event) => console.log(event.action))
+ * ```
+ */
+export function getDefaultStream(options?: StreamDrainOptions): StreamDrain {
+  if (!defaultStream) defaultStream = createStreamDrain(options)
+  return defaultStream
+}
+
+/**
+ * Replace or clear the default stream. Pass `null` to reset (mostly useful
+ * in tests).
+ */
+export function setDefaultStream(stream: StreamDrain | null): void {
+  defaultStream?.close()
+  defaultStream = stream
+}

--- a/packages/evlog/test/stream.test.ts
+++ b/packages/evlog/test/stream.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createStreamDrain, getDefaultStream, setDefaultStream } from '../src/stream'
+import type { DrainContext, WideEvent } from '../src/types'
+
+function makeEvent(id: number, overrides?: Partial<WideEvent>): WideEvent {
+  return {
+    timestamp: '2024-01-01T00:00:00.000Z',
+    level: 'info',
+    service: 'test',
+    environment: 'test',
+    id,
+    ...overrides,
+  }
+}
+
+function makeContext(event: WideEvent): DrainContext {
+  return { event }
+}
+
+describe('createStreamDrain', () => {
+  describe('drain', () => {
+    it('accepts a single DrainContext', async () => {
+      const stream = createStreamDrain()
+      const listener = vi.fn()
+      stream.subscribe(listener)
+
+      await stream.drain(makeContext(makeEvent(1)))
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }))
+    })
+
+    it('accepts an array of DrainContexts', async () => {
+      const stream = createStreamDrain()
+      const listener = vi.fn()
+      stream.subscribe(listener)
+
+      await stream.drain([makeContext(makeEvent(1)), makeContext(makeEvent(2))])
+
+      expect(listener).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips events that fail the filter', async () => {
+      const stream = createStreamDrain({
+        filter: event => event.level === 'error',
+      })
+      const listener = vi.fn()
+      stream.subscribe(listener)
+
+      await stream.drain([
+        makeContext(makeEvent(1, { level: 'info' })),
+        makeContext(makeEvent(2, { level: 'error' })),
+      ])
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }))
+    })
+  })
+
+  describe('subscribe', () => {
+    it('returns an unsubscribe function', async () => {
+      const stream = createStreamDrain()
+      const listener = vi.fn()
+      const unsubscribe = stream.subscribe(listener)
+
+      await stream.drain(makeContext(makeEvent(1)))
+      unsubscribe()
+      await stream.drain(makeContext(makeEvent(2)))
+
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('isolates listener errors from siblings', async () => {
+      const stream = createStreamDrain()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const goodListener = vi.fn()
+
+      stream.subscribe(() => {
+        throw new Error('boom')
+      })
+      stream.subscribe(goodListener)
+
+      await stream.drain(makeContext(makeEvent(1)))
+
+      expect(goodListener).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalledWith('[evlog/stream] subscriber threw:', expect.any(Error))
+      errorSpy.mockRestore()
+    })
+
+    it('reports subscriberCount accurately', () => {
+      const stream = createStreamDrain()
+      expect(stream.subscriberCount).toBe(0)
+
+      const u1 = stream.subscribe(() => {})
+      const u2 = stream.subscribe(() => {})
+      expect(stream.subscriberCount).toBe(2)
+
+      u1()
+      expect(stream.subscriberCount).toBe(1)
+      u2()
+      expect(stream.subscriberCount).toBe(0)
+    })
+  })
+
+  describe('recent', () => {
+    it('keeps a ring buffer of the configured size', async () => {
+      const stream = createStreamDrain({ buffer: 3 })
+
+      for (let i = 1; i <= 5; i++) {
+        await stream.drain(makeContext(makeEvent(i)))
+      }
+
+      const recent = stream.recent()
+      expect(recent.map(e => e.id)).toEqual([3, 4, 5])
+    })
+
+    it('returns an empty array when buffer is disabled', async () => {
+      const stream = createStreamDrain({ buffer: 0 })
+      await stream.drain(makeContext(makeEvent(1)))
+
+      expect(stream.recent()).toEqual([])
+    })
+
+    it('returns a defensive copy', async () => {
+      const stream = createStreamDrain({ buffer: 5 })
+      await stream.drain(makeContext(makeEvent(1)))
+
+      const snap = stream.recent() as WideEvent[]
+      snap.length = 0
+      expect(stream.recent()).toHaveLength(1)
+    })
+
+    it('counts dropped events when the buffer wraps', async () => {
+      const stream = createStreamDrain({ buffer: 2 })
+
+      for (let i = 1; i <= 5; i++) {
+        await stream.drain(makeContext(makeEvent(i)))
+      }
+
+      expect(stream.droppedCount).toBe(3)
+    })
+  })
+
+  describe('events (async iterator)', () => {
+    it('yields drained events to the consumer', async () => {
+      const stream = createStreamDrain()
+      const iter = stream.events()
+      const collected: number[] = []
+
+      const consumer = (async () => {
+        for await (const event of iter) {
+          collected.push(event.id as number)
+          if (collected.length === 2) break
+        }
+      })()
+
+      await stream.drain(makeContext(makeEvent(1)))
+      await stream.drain(makeContext(makeEvent(2)))
+
+      await consumer
+      expect(collected).toEqual([1, 2])
+    })
+
+    it('does not replay buffered events', async () => {
+      const stream = createStreamDrain()
+      await stream.drain(makeContext(makeEvent(1)))
+
+      const iter = stream.events()
+      const collected: number[] = []
+
+      const consumer = (async () => {
+        for await (const event of iter) {
+          collected.push(event.id as number)
+          break
+        }
+      })()
+
+      await stream.drain(makeContext(makeEvent(2)))
+      await consumer
+
+      expect(collected).toEqual([2])
+    })
+
+    it('cleanly unsubscribes when consumer breaks', async () => {
+      const stream = createStreamDrain()
+      const iter = stream.events()
+
+      const consumer = (async () => {
+        for await (const _event of iter) {
+          break
+        }
+      })()
+
+      await stream.drain(makeContext(makeEvent(1)))
+      await consumer
+
+      expect(stream.subscriberCount).toBe(0)
+    })
+
+    it('drops events when a consumer falls behind', async () => {
+      const stream = createStreamDrain({ perSubscriberQueue: 2 })
+      const iter = stream.events()
+
+      for (let i = 1; i <= 5; i++) {
+        await stream.drain(makeContext(makeEvent(i)))
+      }
+
+      const collected: number[] = []
+      for (let i = 0; i < 2; i++) {
+        const result = await iter.next()
+        if (!result.done) collected.push(result.value.id as number)
+      }
+      await iter.return!()
+
+      expect(collected).toEqual([4, 5])
+      expect(stream.droppedCount).toBeGreaterThanOrEqual(3)
+    })
+
+    it('supports multiple concurrent iterators', async () => {
+      const stream = createStreamDrain()
+      const a = stream.events()
+      const b = stream.events()
+
+      await stream.drain(makeContext(makeEvent(1)))
+
+      const aResult = await a.next()
+      const bResult = await b.next()
+
+      expect((aResult.value as WideEvent).id).toBe(1)
+      expect((bResult.value as WideEvent).id).toBe(1)
+
+      await a.return!()
+      await b.return!()
+    })
+  })
+
+  describe('close', () => {
+    it('disconnects sync listeners and ends async iterators', async () => {
+      const stream = createStreamDrain()
+      const listener = vi.fn()
+      stream.subscribe(listener)
+      const iter = stream.events()
+
+      stream.close()
+
+      const result = await iter.next()
+      expect(result.done).toBe(true)
+      expect(stream.subscriberCount).toBe(0)
+
+      await stream.drain(makeContext(makeEvent(1)))
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('still allows new subscriptions after close', async () => {
+      const stream = createStreamDrain()
+      stream.close()
+
+      const listener = vi.fn()
+      stream.subscribe(listener)
+      await stream.drain(makeContext(makeEvent(1)))
+
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('getDefaultStream / setDefaultStream', () => {
+  afterEach(() => {
+    setDefaultStream(null)
+  })
+
+  it('returns the same instance across calls', () => {
+    const a = getDefaultStream()
+    const b = getDefaultStream()
+    expect(a).toBe(b)
+  })
+
+  it('honours buffer option only on first call', async () => {
+    const stream = getDefaultStream({ buffer: 2 })
+    for (let i = 1; i <= 5; i++) {
+      await stream.drain({ event: makeEvent(i) })
+    }
+    expect(stream.recent().map(e => e.id)).toEqual([4, 5])
+  })
+
+  it('setDefaultStream(null) resets the singleton', () => {
+    const a = getDefaultStream()
+    setDefaultStream(null)
+    const b = getDefaultStream()
+    expect(a).not.toBe(b)
+  })
+
+  it('setDefaultStream(custom) replaces the singleton', () => {
+    const custom = createStreamDrain()
+    setDefaultStream(custom)
+    expect(getDefaultStream()).toBe(custom)
+  })
+})

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     'adapters/fs': 'src/adapters/fs.ts',
     'enrichers': 'src/enrichers/index.ts',
     'pipeline': 'src/pipeline.ts',
+    'stream': 'src/stream.ts',
     'http': 'src/http.ts',
     'browser': 'src/browser.ts',
     'next/index': 'src/next/index.ts',


### PR DESCRIPTION
## Summary

Expose the events flowing through the evlog drain pipeline as an in-process pub/sub. The new \`evlog/stream\` entrypoint is the foundation any local consumer (devtools, dashboards, CLIs, custom UIs) can subscribe to without re-implementing a drain.

This PR intentionally ships the **primitive only** so the API surface can be reviewed in isolation. Wiring it into the Nitro plugin / Nuxt module / a network bridge (SSE, WebSocket, ...) is left to follow-up PRs — that part still deserves discussion.

## API

\`\`\`ts
import { createStreamDrain } from 'evlog/stream'

const stream = createStreamDrain({ buffer: 500 })

// Register on any evlog drain hook:
nitroApp.hooks.hook('evlog:drain', stream.drain)

// Subscribe synchronously
const unsubscribe = stream.subscribe(event => console.log(event))

// Or with an async iterator
for await (const event of stream.events()) {
  if (shouldStop(event)) break  // breaking cleanly unsubscribes
}

// Recent buffered events, oldest first
stream.recent()
\`\`\`

\`getDefaultStream()\` / \`setDefaultStream()\` provide a process-wide singleton so several pieces of code can share one stream without threading references around.

## Behavior

- A slow async consumer never blocks the drain — each iterator has a per-subscriber queue (default 1000) that drops oldest on overflow.
- Sync listener errors are caught and logged; they never affect siblings or the drain.
- \`droppedCount\` and \`subscriberCount\` are exposed for observability.
- Optional \`filter\` predicate skips events at ingest (not buffered, not delivered).
- \`close()\` disconnects all subscribers and ends pending iterators; new subscriptions still work after close.

## Files

- \`packages/evlog/src/stream.ts\` — the module
- \`packages/evlog/test/stream.test.ts\` — 21 tests (subscribe, async iterator, ring buffer, backpressure drop, default singleton, close semantics)
- \`packages/evlog/package.json\` + \`packages/evlog/tsdown.config.ts\` — register \`./stream\` export
- \`apps/docs/content/5.build-on-top/2.stream-api.md\` — docs

## Discussion points

Worth reviewing before we layer SSE / consumer SDK on top:

1. **Buffer policy** — fixed-size ring (current) vs time-based vs both?
2. **Per-subscriber queue size** — drop-oldest on overflow (current) is the safest default for live UIs, but some consumers may prefer back-pressure (block) or drop-newest. Worth exposing?
3. **\`getDefaultStream\` singleton** — convenient but couples consumers to a global. Acceptable trade-off?
4. **Filter at ingest** — currently the predicate skips both buffer and listeners. Should we keep two filters (one for buffer, one per-subscriber)?

## Test plan

- [x] \`pnpm --filter evlog run lint\`
- [x] \`pnpm --filter evlog run test\` — 21 new tests
- [x] \`pnpm --filter evlog run build\` — \`./stream\` dist files emitted