### PR TITLE
feat(stream): expose evlog/stream over SSE for local consumers

### DIFF
--- a/apps/docs/content/5.build-on-top/3.sse-bridge.md
+++ b/apps/docs/content/5.build-on-top/3.sse-bridge.md
@@ -1,0 +1,124 @@
+---
+title: SSE bridge
+description: Expose the in-process evlog stream over Server-Sent Events for local devtools, dashboards, and any browser tab. Local development and self-hosted only.
+navigation:
+  title: SSE bridge
+  icon: i-lucide-wifi
+---
+
+The Nuxt module ships an opt-in Server-Sent Events endpoint that exposes the [in-process default stream](/build-on-top/stream-api#default-singleton) over HTTP. Anything that speaks SSE — a browser tab, a Tauri app, a CLI using `fetch`, a curl one-liner — can subscribe to live wide events.
+
+::callout
+---
+icon: i-lucide-alert-triangle
+color: warning
+---
+**Local development and long-lived self-hosted servers only.**
+
+The bridge is built on the in-process stream. On serverless platforms (**Vercel Functions**, **Cloudflare Workers**, **AWS Lambda**…), each request is a separate isolate — the SSE consumer in one isolate will not see events emitted by other isolates, so the stream looks empty in production. Use a real broker (Redis Streams, NATS, Pub/Sub…) when you need cross-instance fan-out in serverless.
+
+It works perfectly in `pnpm dev`, on a Node / Bun / Deno container, on a long-lived VM, or on Fly / Railway-style instances.
+::
+
+## Enable
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['evlog/nuxt'],
+  evlog: {
+    transport: {
+      stream: {
+        enabled: true,
+        // optional:
+        // endpoint: '/api/_evlog/stream',
+        // token: process.env.EVLOG_STREAM_TOKEN,
+        // heartbeatMs: 15_000,
+        // buffer: 500,
+      },
+    },
+  },
+})
+```
+
+The Nitro plugin auto-hooks the default in-process stream into `evlog:drain`, so every wide event also flows into any subscriber connected to the SSE route.
+
+## Try it in the playground
+
+`apps/playground` ships a live demo. Run:
+
+```bash
+pnpm dev
+# open http://localhost:3000/stream
+```
+
+You get a live event table with filters, a JSON inspector for each event, and buttons to fire demo requests. Useful to read the page source (`apps/playground/app/pages/stream.vue`) — it's ~25 lines of `EventSource` glue.
+
+## Endpoint
+
+`GET /api/_evlog/stream`
+
+| Header | Note |
+| --- | --- |
+| `Authorization: Bearer <token>` | Required when `token` is configured |
+| `Accept: text/event-stream` | Set automatically by the browser `EventSource` |
+
+Query parameters:
+- `?since=<iso>` — replay buffered events with `event.timestamp >= since` before switching to live mode
+
+Response:
+- `Content-Type: text/event-stream; charset=utf-8`
+- `X-Evlog-Version: <package version>`
+
+## Wire format
+
+Every SSE `data:` line is a versioned JSON envelope:
+
+```text
+data: {"evlog":"1","type":"hello","data":{"evlogVersion":"2.16.0","bufferSize":500,"heartbeatMs":15000}}
+
+data: {"evlog":"1","type":"replay","data":{...wide event...}}
+
+data: {"evlog":"1","type":"event","data":{...wide event...}}
+
+event: ping
+data: {"evlog":"1","type":"ping","data":{"t":1730000000000}}
+```
+
+| Type | When |
+| --- | --- |
+| `hello` | First frame — server version + stream config |
+| `replay` | Each buffered event flushed when the client passed `?since=` |
+| `event` | Each new event drained after the connection opened |
+| `ping` | Heartbeat every `heartbeatMs` (default 15s), sent with `event: ping` |
+
+The `evlog: "1"` discriminant is the protocol version; future incompatible changes will bump it.
+
+## Security
+
+| Mode | Behavior |
+| --- | --- |
+| `token` set | `Authorization: Bearer <token>` is required |
+| `token` unset, host is `localhost` | Connection allowed (dev convenience) |
+| `token` unset, host is non-`localhost` | `Origin` must match `Host` (mirrors the ingest endpoint policy) |
+
+The endpoint always returns `404` when `transport.stream.enabled !== true` so it's a no-op in environments where you didn't opt in.
+
+## Minimal browser consumer
+
+```ts
+const es = new EventSource('/api/_evlog/stream')
+
+es.onmessage = (e) => {
+  const envelope = JSON.parse(e.data)
+  if (envelope.evlog !== '1') return
+  if (envelope.type === 'event' || envelope.type === 'replay') {
+    handle(envelope.data)
+  }
+}
+
+es.addEventListener('ping', () => {
+  // heartbeat — connection alive
+})
+```
+
+That's it — no SDK needed, the browser ships `EventSource`. For Node / Bun consumers, use `fetch` with streaming response and parse the same envelope.

--- a/apps/playground/app/pages/stream.vue
+++ b/apps/playground/app/pages/stream.vue
@@ -1,0 +1,311 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
+import type { WideEvent } from 'evlog'
+
+definePageMeta({ layout: false })
+useHead({ title: 'evlog stream — live events' })
+
+interface Envelope {
+  evlog: '1'
+  type: 'event' | 'replay' | 'ping' | 'hello'
+  data: unknown
+}
+
+const events = shallowRef<WideEvent[]>([])
+const status = ref<'connecting' | 'connected' | 'error'>('connecting')
+const helloPayload = ref<{ evlogVersion: string; bufferSize?: number; heartbeatMs?: number } | null>(null)
+const search = ref('')
+const levelFilter = ref<'' | 'info' | 'warn' | 'error' | 'debug'>('')
+const paused = ref(false)
+const droppedWhilePaused = ref(0)
+const selected = ref<WideEvent | null>(null)
+const lastPing = ref<number | null>(null)
+
+let es: EventSource | null = null
+
+function pushEvent(event: WideEvent) {
+  if (paused.value) {
+    droppedWhilePaused.value++
+    return
+  }
+  events.value = [event, ...events.value].slice(0, 500)
+}
+
+function actionLabel(event: WideEvent) {
+  const e = event as Record<string, unknown>
+  return (e.action as string) ?? (e.message as string) ?? (e.path as string) ?? ''
+}
+
+function eventMatches(event: WideEvent) {
+  if (levelFilter.value && event.level !== levelFilter.value) return false
+  const q = search.value.trim().toLowerCase()
+  if (!q) return true
+  try {
+    return JSON.stringify(event).toLowerCase().includes(q)
+  } catch {
+    return false
+  }
+}
+
+const filtered = computed(() => events.value.filter(eventMatches))
+
+function fireDemoRequest(path: string) {
+  $fetch(path).catch(() => {})
+}
+
+onMounted(() => {
+  es = new EventSource('/api/_evlog/stream')
+
+  es.onopen = () => {
+    status.value = 'connected' 
+  }
+  es.onerror = () => {
+    status.value = 'error' 
+  }
+  es.onmessage = (e) => {
+    let envelope: Envelope
+    try {
+      envelope = JSON.parse(e.data)
+    } catch {
+      return
+    }
+    if (envelope.evlog !== '1') return
+    if (envelope.type === 'hello') {
+      helloPayload.value = envelope.data as typeof helloPayload.value
+      return
+    }
+    if (envelope.type === 'event' || envelope.type === 'replay') {
+      pushEvent(envelope.data as WideEvent)
+    }
+  }
+
+  es.addEventListener('ping', () => {
+    lastPing.value = Date.now()
+  })
+})
+
+onBeforeUnmount(() => {
+  es?.close()
+})
+</script>
+
+<template>
+  <div class="flex h-dvh bg-default text-default text-[13px]">
+    <aside class="w-72 shrink-0 border-r border-default flex flex-col">
+      <div class="px-4 pt-5 pb-3">
+        <NuxtLink to="/" class="text-[11px] text-muted hover:text-default">
+          ← back
+        </NuxtLink>
+        <h1 class="mt-2 text-sm font-semibold tracking-tight">
+          evlog stream
+        </h1>
+        <p class="text-[11px] text-muted mt-0.5">
+          Live SSE feed
+        </p>
+      </div>
+
+      <div class="px-4 pb-3 space-y-2 text-[11px] text-muted">
+        <div class="flex items-center gap-2">
+          <span
+            class="size-2 rounded-full"
+            :class="{
+              'bg-green-500': status === 'connected',
+              'bg-yellow-500': status === 'connecting',
+              'bg-red-500': status === 'error',
+            }"
+          />
+          <span class="capitalize">{{ status }}</span>
+          <span v-if="helloPayload" class="ml-auto opacity-60">v{{ helloPayload.evlogVersion }}</span>
+        </div>
+        <div class="grid grid-cols-2 gap-2 tabular-nums">
+          <div class="rounded border border-default px-2 py-1">
+            <div class="opacity-60">
+              total
+            </div>
+            <div class="text-default text-sm">
+              {{ events.length }}
+            </div>
+          </div>
+          <div class="rounded border border-default px-2 py-1">
+            <div class="opacity-60">
+              visible
+            </div>
+            <div class="text-default text-sm">
+              {{ filtered.length }}
+            </div>
+          </div>
+        </div>
+        <div v-if="lastPing" class="text-[10px] opacity-60">
+          last ping: {{ new Date(lastPing).toLocaleTimeString() }}
+        </div>
+      </div>
+
+      <div class="px-4 pb-3 border-t border-default pt-3 space-y-2">
+        <div class="text-[10px] uppercase tracking-wider text-muted">
+          Fire demo events
+        </div>
+        <button
+          class="w-full text-left text-[12px] px-2 py-1 rounded border border-default hover:bg-elevated"
+          @click="fireDemoRequest('/api/test/wide-event')"
+        >
+          GET /api/test/wide-event
+        </button>
+        <button
+          class="w-full text-left text-[12px] px-2 py-1 rounded border border-default hover:bg-elevated"
+          @click="fireDemoRequest('/api/test/error')"
+        >
+          GET /api/test/error
+        </button>
+        <button
+          class="w-full text-left text-[12px] px-2 py-1 rounded border border-default hover:bg-elevated"
+          @click="fireDemoRequest('/api/test/h3-error')"
+        >
+          GET /api/test/h3-error
+        </button>
+        <button
+          class="w-full text-left text-[12px] px-2 py-1 rounded border border-default hover:bg-elevated"
+          @click="fireDemoRequest('/api/test/catalog/payment-declined')"
+        >
+          GET /api/test/catalog/payment-declined
+        </button>
+      </div>
+
+      <div class="mt-auto px-4 pb-4 pt-3 border-t border-default">
+        <div class="text-[10px] uppercase tracking-wider text-muted mb-2">
+          API
+        </div>
+        <pre class="text-[10px] leading-relaxed bg-elevated rounded p-2 overflow-x-auto"><code>// Subscribe via fetch
+const es = new EventSource(
+  '/api/_evlog/stream'
+)
+es.onmessage = (e) =&gt; {
+  const env = JSON.parse(e.data)
+  if (env.type === 'event')
+    handle(env.data)
+}</code></pre>
+      </div>
+    </aside>
+
+    <main class="flex-1 flex flex-col min-w-0">
+      <div class="flex items-center gap-2 px-4 py-2 border-b border-default">
+        <input
+          v-model="search"
+          type="search"
+          placeholder="filter events…"
+          class="flex-1 px-2 py-1 text-[12px] bg-elevated border border-default rounded outline-none focus:border-primary"
+        >
+        <select
+          v-model="levelFilter"
+          class="px-2 py-1 text-[12px] bg-elevated border border-default rounded outline-none focus:border-primary"
+        >
+          <option value="">
+            all levels
+          </option>
+          <option value="info">
+            info
+          </option>
+          <option value="warn">
+            warn
+          </option>
+          <option value="error">
+            error
+          </option>
+          <option value="debug">
+            debug
+          </option>
+        </select>
+        <button
+          class="px-2 py-1 text-[12px] border border-default rounded hover:bg-elevated"
+          :class="{ 'bg-primary/10 text-primary border-primary': paused }"
+          @click="paused = !paused"
+        >
+          {{ paused ? `paused (${droppedWhilePaused})` : 'pause' }}
+        </button>
+        <button
+          class="px-2 py-1 text-[12px] border border-default rounded hover:bg-elevated"
+          @click="events = []; selected = null; droppedWhilePaused = 0"
+        >
+          clear
+        </button>
+      </div>
+
+      <div class="flex flex-1 min-h-0">
+        <div class="flex-1 overflow-y-auto">
+          <table class="w-full">
+            <thead class="text-[10px] uppercase tracking-wider text-muted">
+              <tr>
+                <th class="text-left px-3 py-2 font-normal w-24">
+                  time
+                </th>
+                <th class="text-left px-3 py-2 font-normal w-16">
+                  level
+                </th>
+                <th class="text-left px-3 py-2 font-normal w-32">
+                  service
+                </th>
+                <th class="text-left px-3 py-2 font-normal w-16">
+                  status
+                </th>
+                <th class="text-left px-3 py-2 font-normal">
+                  action / path
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(event, idx) in filtered"
+                :key="`${event.timestamp}-${idx}`"
+                class="border-t border-default cursor-pointer hover:bg-elevated"
+                :class="{ 'bg-primary/5': selected === event }"
+                @click="selected = event"
+              >
+                <td class="px-3 py-1.5 text-[11px] tabular-nums text-muted">
+                  {{ new Date(event.timestamp).toLocaleTimeString() }}
+                </td>
+                <td class="px-3 py-1.5">
+                  <span
+                    class="text-[10px] px-1.5 py-0.5 rounded"
+                    :class="{
+                      'bg-blue-500/10 text-blue-500': event.level === 'info',
+                      'bg-yellow-500/10 text-yellow-500': event.level === 'warn',
+                      'bg-red-500/10 text-red-500': event.level === 'error',
+                      'bg-purple-500/10 text-purple-500': event.level === 'debug',
+                    }"
+                  >
+                    {{ event.level }}
+                  </span>
+                </td>
+                <td class="px-3 py-1.5 text-[11px] truncate max-w-32 text-muted">
+                  {{ event.service }}
+                </td>
+                <td class="px-3 py-1.5 text-[11px] tabular-nums text-muted">
+                  {{ (event as Record<string, unknown>).status ?? '' }}
+                </td>
+                <td class="px-3 py-1.5 text-[11px] truncate">
+                  {{ actionLabel(event) }}
+                </td>
+              </tr>
+              <tr v-if="filtered.length === 0">
+                <td colspan="5" class="text-center text-muted py-12 text-[12px]">
+                  Waiting for events… click a demo button on the left or hit any route to generate one.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <aside v-if="selected" class="w-96 shrink-0 border-l border-default overflow-y-auto p-4">
+          <div class="flex items-center justify-between mb-2">
+            <h2 class="text-[10px] uppercase tracking-wider text-muted">
+              Wide event
+            </h2>
+            <button class="text-[11px] text-muted hover:text-default" @click="selected = null">
+              ✕
+            </button>
+          </div>
+          <pre class="text-[11px] leading-relaxed font-mono whitespace-pre-wrap wrap-break-word"><code>{{ JSON.stringify(selected, null, 2) }}</code></pre>
+        </aside>
+      </div>
+    </main>
+  </div>
+</template>

--- a/apps/playground/nuxt.config.ts
+++ b/apps/playground/nuxt.config.ts
@@ -13,6 +13,10 @@ export default defineNuxtConfig({
     },
     transport: {
       enabled: true,
+      stream: {
+        enabled: true,
+        heartbeatMs: 5000,
+      },
     },
     redact: true,
     routes: {

--- a/packages/evlog/src/nitro/plugin.ts
+++ b/packages/evlog/src/nitro/plugin.ts
@@ -9,6 +9,7 @@ import { createRequestLogger, getGlobalPluginRunner, initLogger, isEnabled } fro
 import { shouldLog, getServiceForPath, extractErrorStatus } from '../nitro'
 import { normalizeRedactConfig } from '../redact'
 import { resolveEvlogConfigForNitroPlugin } from '../shared/nitroConfigBridge'
+import { getDefaultStream } from '../stream'
 import type { EnrichContext, RequestLogger, ServerEvent, TailSamplingContext, WideEvent } from '../types'
 import { filterSafeHeaders } from '../utils'
 
@@ -133,6 +134,17 @@ export default defineNitroPlugin(async (nitroApp) => {
     redact,
     _suppressDrainWarning: true,
   })
+
+  // When `transport.stream.enabled`, hook the default in-process stream
+  // into `evlog:drain` so the SSE route (and any other in-process consumer)
+  // can subscribe to live events.
+  const streamConfig = (evlogConfig as { transport?: { stream?: { enabled?: boolean; buffer?: number } } } | undefined)?.transport?.stream
+  if (streamConfig?.enabled === true) {
+    const stream = getDefaultStream({ buffer: streamConfig.buffer })
+    nitroApp.hooks.hook('evlog:drain', (ctx) => {
+      if (ctx?.event) stream.drain(ctx)
+    })
+  }
 
   // When globally disabled, createRequestLogger returns a no-op logger — still
   // attach it so handlers can call useLogger(event) without throwing.

--- a/packages/evlog/src/nuxt/module.ts
+++ b/packages/evlog/src/nuxt/module.ts
@@ -293,6 +293,8 @@ export default defineNuxtModule<ModuleOptions>({
     const transportEnabled = options.transport?.enabled ?? false
     const transportEndpoint = options.transport?.endpoint ?? '/api/_evlog/ingest'
     const transportCredentials = options.transport?.credentials ?? 'same-origin'
+    const streamEnabled = options.transport?.stream?.enabled === true
+    const streamEndpoint = options.transport?.stream?.endpoint ?? '/api/_evlog/stream'
 
     nuxt.options.runtimeConfig.evlog = options
 
@@ -327,6 +329,14 @@ export default defineNuxtModule<ModuleOptions>({
         route: transportEndpoint,
         method: 'post',
         handler: resolver.resolve('../runtime/server/routes/_evlog/ingest.post'),
+      })
+    }
+
+    if (streamEnabled) {
+      addServerHandler({
+        route: streamEndpoint,
+        method: 'get',
+        handler: resolver.resolve('../runtime/server/routes/_evlog/stream.get'),
       })
     }
 

--- a/packages/evlog/src/runtime/server/routes/_evlog/stream.get.ts
+++ b/packages/evlog/src/runtime/server/routes/_evlog/stream.get.ts
@@ -1,0 +1,134 @@
+import { createError, defineEventHandler, getHeader, getQuery, getRequestHost, setResponseHeaders } from 'h3'
+import type { WideEvent } from '../../../../types'
+import { getDefaultStream } from '../../../../stream'
+import { EVLOG_VERSION } from '../../../../shared/http'
+import { resolveEvlogConfigForNitroPlugin } from '../../../../shared/nitroConfigBridge'
+
+/**
+ * Server-Sent Events bridge for the in-process default stream drain.
+ *
+ * Designed for local development and long-lived self-hosted servers — the
+ * stream lives inside one process. On serverless platforms (Vercel
+ * Functions, Cloudflare Workers, Lambda) each invocation is isolated, so a
+ * subscriber on one isolate never sees events emitted from another one;
+ * there the bridge effectively just observes the current invocation.
+ */
+
+interface ResolvedStreamConfig {
+  token?: string
+  heartbeatMs: number
+  buffer: number
+}
+
+async function resolveStreamConfig(): Promise<ResolvedStreamConfig | null> {
+  const evlog = (await resolveEvlogConfigForNitroPlugin()) as
+    | { transport?: { stream?: { enabled?: boolean; token?: string; heartbeatMs?: number; buffer?: number } } }
+    | undefined
+  const stream = evlog?.transport?.stream
+  if (!stream || stream.enabled !== true) return null
+  return {
+    token: typeof stream.token === 'string' ? stream.token : undefined,
+    heartbeatMs: typeof stream.heartbeatMs === 'number' ? stream.heartbeatMs : 15_000,
+    buffer: typeof stream.buffer === 'number' ? stream.buffer : 500,
+  }
+}
+
+function isLocalHost(host: string | undefined): boolean {
+  if (!host) return false
+  const lower = host.toLowerCase()
+  return lower.startsWith('localhost') || lower.startsWith('127.0.0.1') || lower.startsWith('[::1]')
+}
+
+function envelope(type: 'event' | 'replay' | 'hello', data: unknown): string {
+  return `data: ${JSON.stringify({ evlog: '1', type, data })}\n\n`
+}
+
+export default defineEventHandler(async (event) => {
+  const config = await resolveStreamConfig()
+  if (!config) {
+    throw createError({ statusCode: 404, message: 'evlog stream is not enabled' })
+  }
+
+  if (config.token) {
+    const auth = getHeader(event, 'authorization')
+    if (auth !== `Bearer ${config.token}`) {
+      throw createError({ statusCode: 401, message: 'Unauthorized' })
+    }
+  } else {
+    const host = getRequestHost(event)
+    const origin = getHeader(event, 'origin')
+    if (!isLocalHost(host) && origin) {
+      let originHost: string | null = null
+      try {
+        originHost = new URL(origin).host
+      } catch {
+        originHost = null
+      }
+      if (originHost !== host) {
+        throw createError({ statusCode: 403, message: 'Invalid origin' })
+      }
+    }
+  }
+
+  setResponseHeaders(event, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-cache, no-transform',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+    'X-Evlog-Version': EVLOG_VERSION,
+  })
+
+  const stream = getDefaultStream({ buffer: config.buffer })
+  const { res } = event.node
+
+  res.write(envelope('hello', {
+    evlogVersion: EVLOG_VERSION,
+    bufferSize: config.buffer,
+    heartbeatMs: config.heartbeatMs,
+  }))
+
+  const query = getQuery(event)
+  const sinceRaw = typeof query.since === 'string' ? query.since : undefined
+  const sinceMs = sinceRaw ? Date.parse(sinceRaw) : Number.NaN
+  if (Number.isFinite(sinceMs)) {
+    for (const past of stream.recent()) {
+      const ts = typeof past.timestamp === 'string' ? Date.parse(past.timestamp) : Number.NaN
+      if (Number.isFinite(ts) && ts >= sinceMs) {
+        res.write(envelope('replay', past))
+      }
+    }
+  }
+
+  let closed = false
+
+  const unsubscribe = stream.subscribe((wideEvent: WideEvent) => {
+    if (closed) return
+    res.write(envelope('event', wideEvent))
+  })
+
+  const heartbeat = setInterval(() => {
+    if (closed) return
+    res.write(`event: ping\ndata: ${JSON.stringify({ evlog: '1', type: 'ping', data: { t: Date.now() } })}\n\n`)
+  }, config.heartbeatMs)
+
+  const cleanup = () => {
+    if (closed) return
+    closed = true
+    clearInterval(heartbeat)
+    unsubscribe()
+    try {
+      res.end()
+    } catch {
+      // noop
+    }
+  }
+
+  event.node.req.on('close', cleanup)
+  event.node.req.on('error', cleanup)
+  event.node.res.on('close', cleanup)
+  event.node.res.on('error', cleanup)
+
+  return new Promise<void>(() => {
+    // Resolves when the connection closes — h3 keeps the response open.
+  })
+})

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -59,7 +59,52 @@ declare module 'nitro/types' {
 }
 
 /**
- * Transport configuration for sending client logs to the server
+ * Configuration for the evlog SSE stream bridge — exposes the in-process
+ * default {@link import('./stream').StreamDrain} as an HTTP endpoint that
+ * any local tool, dashboard, or browser tab can subscribe to.
+ *
+ * Designed for local development and long-lived self-hosted servers. Does
+ * not work on serverless platforms (Vercel Functions, Cloudflare Workers,
+ * Lambda) because each invocation is an isolated process and the
+ * subscriber will not see events emitted by other invocations.
+ */
+export interface TransportStreamConfig {
+  /**
+   * Enable the SSE stream endpoint.
+   * @default false
+   */
+  enabled?: boolean
+
+  /**
+   * SSE endpoint path.
+   * @default '/api/_evlog/stream'
+   */
+  endpoint?: string
+
+  /**
+   * Bearer token required to subscribe. When unset, the route still
+   * rejects requests whose `Origin` does not match the request host
+   * (mirrors the ingest endpoint policy).
+   */
+  token?: string
+
+  /**
+   * Heartbeat interval (ms) sent as `event: ping` to keep the connection
+   * alive through proxies and detect disconnects.
+   * @default 15000
+   */
+  heartbeatMs?: number
+
+  /**
+   * Ring buffer size kept for late-joining clients (replayed via
+   * `?since=<iso>`).
+   * @default 500
+   */
+  buffer?: number
+}
+
+/**
+ * Transport configuration for sending client logs to the server.
  */
 export interface TransportConfig {
   /**
@@ -79,6 +124,13 @@ export interface TransportConfig {
    * @default 'same-origin'
    */
   credentials?: RequestCredentials
+
+  /**
+   * Optional SSE stream that exposes the in-process
+   * {@link import('./stream').StreamDrain} over HTTP. Local development
+   * and self-hosted only — see {@link TransportStreamConfig}.
+   */
+  stream?: TransportStreamConfig
 }
 
 /**

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     'runtime/client/plugin': 'src/runtime/client/plugin.ts',
     'runtime/server/useLogger': 'src/runtime/server/useLogger.ts',
     'runtime/server/routes/_evlog/ingest.post': 'src/runtime/server/routes/_evlog/ingest.post.ts',
+    'runtime/server/routes/_evlog/stream.get': 'src/runtime/server/routes/_evlog/stream.get.ts',
     'runtime/utils/parseError': 'src/runtime/utils/parseError.ts',
     'error': 'src/error.ts',
     'logger': 'src/logger.ts',


### PR DESCRIPTION
> **Draft, stacked on #330** (`feat/stream-primitive`). Don't merge until #330 lands — GitHub will retarget this PR onto `main` automatically once the parent merges.

## Summary

Opt-in HTTP bridge that exposes the in-process default \`StreamDrain\` over Server-Sent Events. Anything speaking SSE — a browser tab, a Tauri app, a CLI using \`fetch\`, even \`curl\` — can subscribe to live wide events.

## Scope: local dev and self-hosted only

The bridge is built on the [in-process stream](https://github.com/HugoRCD/evlog/pull/330) — it lives inside one Node / Bun / Deno process. On **serverless platforms (Vercel Functions, Cloudflare Workers, Lambda)** each invocation is isolated, so an SSE consumer in one isolate would not see events emitted by other isolates. Documented as a callout on top of both the stream API page (#330) and the new SSE bridge page (this PR).

It works perfectly in:
- \`pnpm dev\`
- A long-lived Node container (Fly, Railway, Coolify, raw VM, etc.)
- A self-hosted Nuxt server behind any reverse proxy that doesn't buffer SSE

It does **not** work as a cross-instance bus on Vercel & co. Use a real broker (Redis Streams, NATS, Pub/Sub) for that.

## Try it on the playground

\`\`\`bash
pnpm dev
# open http://localhost:3000/stream
\`\`\`

You get a live event table with filters, pause/clear, a JSON inspector, and a side panel that fires existing demo routes (\`/api/test/wide-event\`, \`/api/test/error\`, \`/api/test/h3-error\`, \`/api/test/catalog/payment-declined\`). Useful to read the page source — it's ~25 lines of \`EventSource\` glue, no SDK needed.

## What's in the PR

- **\`transport.stream.{enabled,endpoint,token,heartbeatMs,buffer}\`** option on the Nuxt module config (\`TransportStreamConfig\` type).
- **\`runtime/server/routes/_evlog/stream.get.ts\`** — the SSE handler. 404s when not enabled. Bearer auth when token is set, same-origin fallback on non-localhost. Emits \`hello\` then optional \`replay\` (via \`?since=<iso>\`) then live \`event\` envelopes + heartbeat \`ping\`s.
- **Nitro plugin** auto-hooks \`getDefaultStream()\` into \`evlog:drain\` when stream transport is on.
- **Nuxt module** registers the SSE route conditionally.
- **Wire format**: every SSE \`data:\` line is a versioned JSON envelope:
  \`\`\`json
  { "evlog": "1", "type": "event"|"replay"|"hello"|"ping", "data": ... }
  \`\`\`
- **Playground demo** (\`apps/playground/app/pages/stream.vue\`) — minimal Vue page, vanilla \`EventSource\` glue. No new deps.
- **Doc** \`apps/docs/content/5.build-on-top/3.sse-bridge.md\` with the local-only callout up top.

## Discussion points before un-drafting

1. **Local-first framing OK?** Doc + JSDoc + the in-product 404 should make it hard to misuse on Vercel, but I want your read on whether the warnings are loud enough.
2. **Auto-enable in dev?** Currently strictly opt-in. We could auto-enable when \`nuxt.options.dev\` is true so \`pnpm dev\` always exposes the stream — convenient, but adds a little surprise.
3. **Wire protocol shape** — happy with \`{ evlog: "1", type, data }\` or want something else? This becomes a public API the moment anyone writes a consumer.
4. **Auth policy when no token** — currently same-origin on non-localhost. Should we instead 401 outright on prod-like hosts unless a token is set?

## Test plan

- [x] \`pnpm --filter evlog run lint\`
- [x] \`pnpm --filter evlog run test\` (1229 tests)
- [x] \`pnpm --filter evlog run build\` — new \`stream.get\` chunk emitted
- [x] \`pnpm --filter evlog-playground run lint\`
- [x] Manual e2e on playground: \`hello\` envelope received on connect, live \`event\` envelope on \`/api/test/wide-event\` request, heartbeats every 5s
- [ ] Try a same-origin policy violation (curl from non-localhost) → expect 403
- [ ] Try with a token mismatch → expect 401