### PR TITLE
fix(better-auth): narrow getSession headers type to Headers

### DIFF
--- a/packages/evlog/src/better-auth/index.ts
+++ b/packages/evlog/src/better-auth/index.ts
@@ -26,18 +26,21 @@ export interface BetterAuthInstance {
  */
 export type HeadersInput = Headers | Record<string, string | string[] | undefined>
 
-function toHeaders(input: HeadersInput): Headers {
-  if (input instanceof Headers) return input
-  const headers = new Headers()
-  for (const key in input) {
-    const value = input[key]
-    if (value === undefined) continue
-    if (Array.isArray(value)) {
-      for (const item of value) headers.append(key, item)
-    } else {
-      headers.set(key, value)
-    }
-  }
+ function toHeaders(input: HeadersInput): Headers {
+   if (input instanceof Headers) return input
+   const headers = new Headers()
+-  for (const key in input) {
+-    const value = input[key]
++  for (const [key, value] of Object.entries(input)) {
+     if (value === undefined) continue
+     if (Array.isArray(value)) {
+       for (const item of value) headers.append(key, item)
+     } else {
+       headers.set(key, value)
+     }
+   }
+   return headers
+ }
   return headers
 }
 

--- a/packages/evlog/src/better-auth/index.ts
+++ b/packages/evlog/src/better-auth/index.ts
@@ -4,16 +4,41 @@ import { matchesPattern } from '../utils'
 /**
  * Minimal type for the Better Auth instance.
  * Only requires `api.getSession` — compatible with any Better Auth configuration.
+ *
+ * Headers are typed as `Headers` (not a wider union) so a real Better Auth
+ * instance is assignable. Record-style headers are normalized internally
+ * before being passed to `auth.api.getSession`.
  */
 export interface BetterAuthInstance {
   api: {
     getSession: (opts: {
-      headers: Headers | Record<string, string | string[] | undefined>
+      headers: Headers
     }) => Promise<{
       user: Record<string, unknown>
       session: Record<string, unknown>
     } | null>
   }
+}
+
+/**
+ * Headers in any shape commonly produced by HTTP frameworks.
+ * Normalized internally to a `Headers` instance before calling Better Auth.
+ */
+export type HeadersInput = Headers | Record<string, string | string[] | undefined>
+
+function toHeaders(input: HeadersInput): Headers {
+  if (input instanceof Headers) return input
+  const headers = new Headers()
+  for (const key in input) {
+    const value = input[key]
+    if (value === undefined) continue
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item)
+    } else {
+      headers.set(key, value)
+    }
+  }
+  return headers
 }
 
 /**
@@ -280,13 +305,13 @@ function shouldResolve(path: string, options?: { exclude?: string[], include?: s
 export function createAuthMiddleware(
   auth: BetterAuthInstance,
   options?: AuthMiddlewareOptions,
-): (log: RequestLogger, headers: Headers | Record<string, string | string[] | undefined>, path?: string) => Promise<boolean> {
+): (log: RequestLogger, headers: HeadersInput, path?: string) => Promise<boolean> {
   return async (log, headers, path?) => {
     if (path && !shouldResolve(path, options)) return false
 
     const start = Date.now()
     try {
-      const session = await auth.api.getSession({ headers })
+      const session = await auth.api.getSession({ headers: toHeaders(headers) })
       const resolvedIn = Date.now() - start
 
       if (session) {
@@ -340,11 +365,11 @@ export function createAuthMiddleware(
 export function createAuthIdentifier(
   auth: BetterAuthInstance,
   options?: AuthIdentifierOptions,
-): (event: { path: string, headers: Headers | { get(name: string): string | null }, context: { log?: RequestLogger } }) => Promise<void> {
+): (event: { path: string, headers: HeadersInput, context: { log?: RequestLogger } }) => Promise<void> {
   const middleware = createAuthMiddleware(auth, options)
 
   return async (event) => {
     if (!event.context.log) return
-    await middleware(event.context.log, event.headers as Headers, event.path)
+    await middleware(event.context.log, event.headers, event.path)
   }
 }

--- a/packages/evlog/src/better-auth/index.ts
+++ b/packages/evlog/src/better-auth/index.ts
@@ -26,21 +26,17 @@ export interface BetterAuthInstance {
  */
 export type HeadersInput = Headers | Record<string, string | string[] | undefined>
 
- function toHeaders(input: HeadersInput): Headers {
-   if (input instanceof Headers) return input
-   const headers = new Headers()
--  for (const key in input) {
--    const value = input[key]
-+  for (const [key, value] of Object.entries(input)) {
-     if (value === undefined) continue
-     if (Array.isArray(value)) {
-       for (const item of value) headers.append(key, item)
-     } else {
-       headers.set(key, value)
-     }
-   }
-   return headers
- }
+function toHeaders(input: HeadersInput): Headers {
+  if (input instanceof Headers) return input
+  const headers = new Headers()
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined) continue
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item)
+    } else {
+      headers.set(key, value)
+    }
+  }
   return headers
 }
 

--- a/packages/evlog/test/better-auth/better-auth.test.ts
+++ b/packages/evlog/test/better-auth/better-auth.test.ts
@@ -245,6 +245,38 @@ describe('createAuthMiddleware', () => {
     expect(log.setCalls[0].userId).toBe('usr_123')
   })
 
+  it('normalizes record-style headers to a Headers instance', async () => {
+    const log = createMockLogger()
+    const auth = createMockAuth()
+    const identify = createAuthMiddleware(auth)
+
+    const result = await identify(log, {
+      cookie: 'session=abc',
+      'x-forwarded-for': ['1.2.3.4', '5.6.7.8'],
+      'x-empty': undefined,
+    })
+
+    expect(result).toBe(true)
+    expect(auth.api.getSession).toHaveBeenCalledOnce()
+    const passed = (auth.api.getSession.mock.calls[0]![0] as { headers: Headers }).headers
+    expect(passed).toBeInstanceOf(Headers)
+    expect(passed.get('cookie')).toBe('session=abc')
+    expect(passed.get('x-forwarded-for')).toBe('1.2.3.4, 5.6.7.8')
+    expect(passed.has('x-empty')).toBe(false)
+  })
+
+  it('passes through Headers instances unchanged', async () => {
+    const log = createMockLogger()
+    const auth = createMockAuth()
+    const identify = createAuthMiddleware(auth)
+
+    const headers = new Headers({ cookie: 'session=abc' })
+    await identify(log, headers)
+
+    const passed = (auth.api.getSession.mock.calls[0]![0] as { headers: Headers }).headers
+    expect(passed).toBe(headers)
+  })
+
   it('returns false when session is null', async () => {
     const log = createMockLogger()
     const auth = createMockAuth(null)


### PR DESCRIPTION
Resolves #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication middleware now normalizes different header formats into a consistent headers object before session lookup, preserving multi-value headers and handling missing entries.
  * If a native headers object is provided, it is passed through unchanged to the session lookup.

* **Tests**
  * Added tests verifying both record-style headers and native headers are handled correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/333)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->