### PR TITLE
fix: emit wide event on client disconnect in express and nestjs

### DIFF
--- a/.changeset/express-nestjs-emit-on-disconnect.md
+++ b/.changeset/express-nestjs-emit-on-disconnect.md
@@ -1,0 +1,11 @@
+---
+'evlog': patch
+---
+
+Fix wide event never being emitted when the client disconnects mid-request in `evlog/express` and `evlog/nestjs`.
+
+Both integrations now listen for the underlying socket `close` event in addition to `finish`. When the client aborts before `res.end()` resolves, the wide event is still emitted (with the same `status`, `duration`, and accumulated context) and tagged with `connectionClosed: true` so disconnects are observable in your drain. The first event to fire wins, so successful responses are unaffected.
+
+For background work that must outlive the HTTP response (resumable streams, post-response usage accounting), continue to use `req.log.fork('label', fn)` — once the request logger has been emitted it is sealed.
+
+Closes [#305](https://github.com/HugoRCD/evlog/issues/305).

--- a/packages/evlog/src/express/index.ts
+++ b/packages/evlog/src/express/index.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction, RequestHandler } from 'express'
 import type { RequestLogger } from '../types'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
+import { bindNodeResponseLifecycle } from '../shared/nodeResponse'
 import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
@@ -52,16 +53,14 @@ const integration = defineFrameworkIntegration<Request>({
  */
 export function evlog(options: EvlogExpressOptions = {}): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    const { finish, skipped, runWith } = integration.start(req, options)
+    const { logger, finish, skipped, runWith } = integration.start(req, options)
 
     if (skipped) {
       next()
       return
     }
 
-    res.on('finish', () => {
-      finish({ status: res.statusCode }).catch(() => {})
-    })
+    bindNodeResponseLifecycle(res, logger, finish)
 
     void runWith(() => next())
   }

--- a/packages/evlog/src/nestjs/index.ts
+++ b/packages/evlog/src/nestjs/index.ts
@@ -5,6 +5,7 @@ import type { RequestLogger } from '../types'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 import { extractSafeNodeHeaders } from '../shared/headers'
+import { bindNodeResponseLifecycle } from '../shared/nodeResponse'
 import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
@@ -59,9 +60,7 @@ function createEvlogMiddleware(getOptions: () => EvlogNestJSOptions) {
     attachForkToLogger(storage, logger, middlewareOpts)
     req.log = logger
 
-    res.on('finish', () => {
-      finish({ status: res.statusCode }).catch(() => {})
-    })
+    bindNodeResponseLifecycle(res, logger, finish)
 
     storage.run(logger, () => next())
   }

--- a/packages/evlog/src/shared/nodeResponse.ts
+++ b/packages/evlog/src/shared/nodeResponse.ts
@@ -1,0 +1,48 @@
+import type { ServerResponse } from 'node:http'
+import type { RequestLogger } from '../types'
+import type { MiddlewareLoggerResult } from './middleware'
+
+/**
+ * Bind an evlog middleware {@link MiddlewareLoggerResult.finish | `finish()`}
+ * to a Node {@link ServerResponse} lifecycle.
+ *
+ * Listens to **both** `finish` (response fully transmitted) and `close`
+ * (underlying socket closed — including client disconnects mid-response).
+ * Idempotent: only the first event to fire calls `finish()`.
+ *
+ * When `close` fires before `finish`, the client disconnected before the
+ * response could complete. In that case the wide event is marked with
+ * `connectionClosed: true` so disconnects are observable in the drain.
+ *
+ * @remarks
+ * For background work that must outlive the HTTP response (e.g. resumable
+ * streams, post-response usage accounting), use
+ * {@link RequestLogger.fork | `req.log.fork(label, fn)`} instead of mutating
+ * the request logger after the response has closed — once `finish()` has run,
+ * the request logger is sealed.
+ *
+ * @internal Used by the Express and NestJS integrations.
+ */
+export function bindNodeResponseLifecycle(
+  res: ServerResponse,
+  logger: RequestLogger,
+  finish: MiddlewareLoggerResult['finish'],
+): void {
+  let settled = false
+
+  const onFinish = (): void => {
+    if (settled) return
+    settled = true
+    finish({ status: res.statusCode }).catch(() => {})
+  }
+
+  const onClose = (): void => {
+    if (settled) return
+    settled = true
+    logger.set({ connectionClosed: true })
+    finish({ status: res.statusCode }).catch(() => {})
+  }
+
+  res.once('finish', onFinish)
+  res.once('close', onClose)
+}

--- a/packages/evlog/test/express.test.ts
+++ b/packages/evlog/test/express.test.ts
@@ -424,8 +424,13 @@ describe('evlog/express', () => {
      */
     async function abortMidRequest(app: express.Express, path: string, abortAfterMs: number): Promise<void> {
       const server = app.listen(0)
+      await new Promise<void>(resolve => server.once('listening', resolve))
       try {
-        const { port } = server.address() as AddressInfo
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+          throw new Error('Failed to bind test server to an ephemeral port')
+        }
+        const { port } = address as AddressInfo
         const req = http.request({ host: '127.0.0.1', port, path, method: 'GET' })
         req.on('error', () => {})
         req.end()

--- a/packages/evlog/test/express.test.ts
+++ b/packages/evlog/test/express.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
@@ -411,6 +413,89 @@ describe('evlog/express', () => {
         typeof call[0] === 'string' && call[0].includes('"asyncWork":"done"'),
       )
       expect(lastCall).toBeDefined()
+    })
+  })
+
+  describe('client disconnect', () => {
+    /**
+     * Boot a real HTTP server, fire a request, abort it before the handler
+     * finishes, then wait for the listener to settle. Avoids supertest, which
+     * always lets the handler complete.
+     */
+    async function abortMidRequest(app: express.Express, path: string, abortAfterMs: number): Promise<void> {
+      const server = app.listen(0)
+      try {
+        const { port } = server.address() as AddressInfo
+        const req = http.request({ host: '127.0.0.1', port, path, method: 'GET' })
+        req.on('error', () => {})
+        req.end()
+        await new Promise(resolve => setTimeout(resolve, abortAfterMs))
+        req.destroy()
+        await new Promise(resolve => setTimeout(resolve, 60))
+      } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()))
+      }
+    }
+
+    it('emits the wide event with connectionClosed=true when the client aborts mid-handler', async () => {
+      const app = express()
+      app.use(evlog())
+      app.get('/api/slow', async (req, res) => {
+        req.log.set({ step: 'before-sleep' })
+        await new Promise(resolve => setTimeout(resolve, 100))
+        req.log.set({ step: 'after-sleep' })
+        res.json({ ok: true })
+      })
+
+      const consoleSpy = vi.mocked(console.info)
+      await abortMidRequest(app, '/api/slow', 20)
+
+      const lastCall = consoleSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('"path":"/api/slow"'),
+      )
+      expect(lastCall).toBeDefined()
+
+      const event = JSON.parse(lastCall![0] as string)
+      expect(event.connectionClosed).toBe(true)
+      expect(event.method).toBe('GET')
+      expect(event.path).toBe('/api/slow')
+      expect(event.step).toBe('before-sleep')
+    })
+
+    it('does not flag connectionClosed when the response completes normally', async () => {
+      const app = express()
+      app.use(evlog())
+      app.get('/api/fast', (_req, res) => res.json({ ok: true }))
+
+      const consoleSpy = vi.mocked(console.info)
+      await request(app).get('/api/fast')
+
+      const lastCall = consoleSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('"path":"/api/fast"'),
+      )
+      expect(lastCall).toBeDefined()
+
+      const event = JSON.parse(lastCall![0] as string)
+      expect(event.connectionClosed).toBeUndefined()
+      expect(event.status).toBe(200)
+    })
+
+    it('runs drain exactly once when the client aborts mid-handler', async () => {
+      const { drain } = createPipelineSpies()
+
+      const app = express()
+      app.use(evlog({ drain }))
+      app.get('/api/slow', async (_req, res) => {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        res.json({ ok: true })
+      })
+
+      await abortMidRequest(app, '/api/slow', 20)
+
+      expect(drain).toHaveBeenCalledTimes(1)
+      const [[ctx]] = drain.mock.calls
+      expect(ctx.event.connectionClosed).toBe(true)
+      expect(ctx.event.path).toBe('/api/slow')
     })
   })
 })

--- a/packages/evlog/test/nestjs.test.ts
+++ b/packages/evlog/test/nestjs.test.ts
@@ -469,8 +469,13 @@ describe('evlog/nestjs', () => {
   describe('client disconnect', () => {
     async function abortMidRequest(app: express.Express, path: string, abortAfterMs: number): Promise<void> {
       const server = app.listen(0)
+      await new Promise<void>(resolve => server.once('listening', resolve))
       try {
-        const { port } = server.address() as AddressInfo
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+          throw new Error('Failed to bind test server to an ephemeral port')
+        }
+        const { port } = address
         const req = http.request({ host: '127.0.0.1', port, path, method: 'GET' })
         req.on('error', () => {})
         req.end()

--- a/packages/evlog/test/nestjs.test.ts
+++ b/packages/evlog/test/nestjs.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
@@ -461,6 +463,66 @@ describe('evlog/nestjs', () => {
         typeof call[0] === 'string' && call[0].includes('"asyncWork":"done"'),
       )
       expect(lastCall).toBeDefined()
+    })
+  })
+
+  describe('client disconnect', () => {
+    async function abortMidRequest(app: express.Express, path: string, abortAfterMs: number): Promise<void> {
+      const server = app.listen(0)
+      try {
+        const { port } = server.address() as AddressInfo
+        const req = http.request({ host: '127.0.0.1', port, path, method: 'GET' })
+        req.on('error', () => {})
+        req.end()
+        await new Promise(resolve => setTimeout(resolve, abortAfterMs))
+        req.destroy()
+        await new Promise(resolve => setTimeout(resolve, 60))
+      } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()))
+      }
+    }
+
+    it('emits the wide event with connectionClosed=true when the client aborts mid-handler', async () => {
+      const app = express()
+      app.use(getMiddleware())
+      app.get('/api/slow', async (req, res) => {
+        req.log!.set({ step: 'before-sleep' })
+        await new Promise(resolve => setTimeout(resolve, 100))
+        req.log!.set({ step: 'after-sleep' })
+        res.json({ ok: true })
+      })
+
+      const consoleSpy = vi.mocked(console.info)
+      await abortMidRequest(app, '/api/slow', 20)
+
+      const lastCall = consoleSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('"path":"/api/slow"'),
+      )
+      expect(lastCall).toBeDefined()
+
+      const event = JSON.parse(lastCall![0] as string)
+      expect(event.connectionClosed).toBe(true)
+      expect(event.method).toBe('GET')
+      expect(event.path).toBe('/api/slow')
+      expect(event.step).toBe('before-sleep')
+    })
+
+    it('runs drain exactly once when the client aborts mid-handler', async () => {
+      const drain = vi.fn()
+
+      const app = express()
+      app.use(getMiddleware({ drain }))
+      app.get('/api/slow', async (_req, res) => {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        res.json({ ok: true })
+      })
+
+      await abortMidRequest(app, '/api/slow', 20)
+
+      expect(drain).toHaveBeenCalledTimes(1)
+      const [[ctx]] = drain.mock.calls
+      expect(ctx.event.connectionClosed).toBe(true)
+      expect(ctx.event.path).toBe('/api/slow')
     })
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

Resolves #305

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Express and NestJS integrations now reliably emit request events when a client disconnects mid-request; emitted events include metadata flagging the connection as closed.
* **Chores**
  * Added a release note entry documenting the patch bump and the disconnect-emission fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/336)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->