### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,8 +28,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
 
       - uses: actions/setup-node@v6
         with:
@@ -110,8 +108,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -36,8 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -58,8 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -79,8 +73,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -106,8 +98,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,8 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.2
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "HugoRCD",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "dev": "turbo run dev --filter=evlog-playground",
     "dev:prepare": "turbo run dev:prepare",
@@ -74,11 +74,5 @@
     "apps/*",
     "packages/*",
     "examples/*"
-  ],
-  "pnpm": {
-    "overrides": {
-      "minimark": "0.2.0",
-      "@nuxtjs/mcp-toolkit": "^0.16.1"
-    }
-  }
+  ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,9 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
   vue-demi: false
+  '@nestjs/core': false
+  '@swc/core': false
+  workerd: false
   better-sqlite3: true
   isolated-vm: true
   sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,13 +3,18 @@ packages:
   - packages/*
   - examples/*
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - unrs-resolver
-  - vue-demi
+shamefullyHoist: true
+strictPeerDependencies: false
 
-onlyBuiltDependencies:
-  - better-sqlite3
-  - isolated-vm
-  - sharp
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false
+  vue-demi: false
+  better-sqlite3: true
+  isolated-vm: true
+  sharp: true
+
+overrides:
+  minimark: 0.2.0
+  '@nuxtjs/mcp-toolkit': ^0.16.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,16 @@ allowBuilds:
 overrides:
   minimark: 0.2.0
   '@nuxtjs/mcp-toolkit': ^0.16.1
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Migrate `onlyBuiltDependencies` + `ignoredBuiltDependencies` → unified `allowBuilds` map (required in v11)
- Move `overrides` from `package.json` → `pnpm-workspace.yaml` (the `pnpm` field in `package.json` is no longer recognized in v11)
- Move `shamefullyHoist` and `strictPeerDependencies` from `.npmrc` → `pnpm-workspace.yaml` (in v11, `.npmrc` only holds auth/registry)
- Delete `.npmrc` (now empty)

CI already runs on Node 22 and `pnpm/action-setup@v6`, which read `packageManager` from `package.json` — no workflow changes needed.

### 2. Add `minimumReleaseAge` to harden supply chain

Sets a 2-day minimum age (2880 minutes) before any newly published dependency can resolve. Mitigates compromised-package attacks where a malicious version is pushed and pulled into installs within hours.

Trusted-source allowlist exempts the Nuxt and Vercel ecosystems:
- `@nuxt/*`, `@nuxtjs/*`, `nuxt`, `nuxt-*`
- `@vercel/*`, `@ai-sdk/*`, `ai`

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (lockfile already verified via `--lockfile-only`)
- [ ] CI passes: ci.yml, e2e.yml, autofix.yml
- [ ] No regression in `pnpm dev:prepare` and `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded package manager to pnpm 11.1.3.
  * Refined workspace build allowances and dependency overrides.
  * Removed legacy npm installation flags from repository config.
  * Stopped pinning a specific pnpm version in CI and workflow setup steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->