### PR TITLE
fix(nitro): normalize module paths for windows virtual modules

### DIFF
--- a/.changeset/fix-windows-nitro-module-paths.md
+++ b/.changeset/fix-windows-nitro-module-paths.md
@@ -1,0 +1,7 @@
+---
+'evlog': patch
+---
+
+Fix `evlog/nitro` and `evlog/nitro/v3` on Windows. The module passed native `path.resolve()` paths to `nitro.options.plugins` and `nitro.options.errorHandler`. Nitro raw-interpolates those into the `#nitro/virtual/plugins` and `#nitro/virtual/error-handler` JS string literals, so Windows backslashes were parsed as escape sequences (`\n`, `\v`, …) and broke module resolution — surfacing as `Cannot find module … imported from '#nitro/virtual/error-handler'`. Paths are now normalized to forward slashes before being handed to Nitro.
+
+Closes [#345](https://github.com/HugoRCD/evlog/issues/345).

--- a/packages/evlog/src/nitro-v3/module.ts
+++ b/packages/evlog/src/nitro-v3/module.ts
@@ -7,13 +7,21 @@ export type { NitroModuleOptions }
 
 const _dir = dirname(fileURLToPath(import.meta.url))
 
+// Nitro raw-interpolates these paths into JS string literals when generating
+// the #nitro/virtual/plugins and #nitro/virtual/error-handler modules, so
+// Windows backslashes would be parsed as escape sequences (\n, \v, …) and
+// break module resolution. Normalize to POSIX separators.
+function resolveModulePath(name: string): string {
+  return resolve(_dir, name).replace(/\\/g, '/')
+}
+
 export default function evlog(options?: NitroModuleOptions) {
   return {
     name: 'evlog',
     setup(nitro: Nitro) {
       // Push the plugin (no extension — Nitro's bundler resolves it)
       nitro.options.plugins = nitro.options.plugins || []
-      nitro.options.plugins.push(resolve(_dir, 'plugin'))
+      nitro.options.plugins.push(resolveModulePath('plugin'))
 
       // explicitly tell nitro to bundle evlog's files to correctly resolve nitro dependencies
       if (!nitro.options.noExternals) {
@@ -21,15 +29,15 @@ export default function evlog(options?: NitroModuleOptions) {
       } else if (Array.isArray(nitro.options.noExternals)) {
         nitro.options.noExternals.push('evlog')
       }
-      
+
 
       // Set error handler only if not already configured by user
       if (!nitro.options.errorHandler) {
-        nitro.options.errorHandler = [resolve(_dir, 'errorHandler')]
+        nitro.options.errorHandler = [resolveModulePath('errorHandler')]
       } else if (Array.isArray(nitro.options.errorHandler)) {
-        nitro.options.errorHandler.unshift(resolve(_dir, 'errorHandler'))
+        nitro.options.errorHandler.unshift(resolveModulePath('errorHandler'))
       } else if (typeof nitro.options.errorHandler === 'string') {
-        nitro.options.errorHandler = [resolve(_dir, 'errorHandler'), nitro.options.errorHandler]
+        nitro.options.errorHandler = [resolveModulePath('errorHandler'), nitro.options.errorHandler]
       }
 
       // Inject config into runtimeConfig — works in production where the

--- a/packages/evlog/src/nitro/module.ts
+++ b/packages/evlog/src/nitro/module.ts
@@ -7,17 +7,25 @@ export type { NitroModuleOptions }
 
 const _dir = dirname(fileURLToPath(import.meta.url))
 
+// Nitro raw-interpolates these paths into JS string literals when generating
+// the #nitro/virtual/plugins and #nitro/virtual/error-handler modules, so
+// Windows backslashes would be parsed as escape sequences (\n, \v, …) and
+// break module resolution. Normalize to POSIX separators.
+function resolveModulePath(name: string): string {
+  return resolve(_dir, name).replace(/\\/g, '/')
+}
+
 export default function evlog(options?: NitroModuleOptions) {
   return {
     name: 'evlog',
     setup(nitro: Nitro) {
       // Push the plugin (no extension — Nitro's bundler resolves it)
       nitro.options.plugins = nitro.options.plugins || []
-      nitro.options.plugins.push(resolve(_dir, 'plugin'))
+      nitro.options.plugins.push(resolveModulePath('plugin'))
 
       // Set error handler only if not already configured by user
       if (!nitro.options.errorHandler) {
-        nitro.options.errorHandler = resolve(_dir, 'errorHandler')
+        nitro.options.errorHandler = resolveModulePath('errorHandler')
       }
 
       // explicitly tell nitro to bundle evlog's files to correctly resolve nitro dependencies

--- a/packages/evlog/test/nitro/module-paths.test.ts
+++ b/packages/evlog/test/nitro/module-paths.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import nitroV2Module from '../../src/nitro/module'
+import nitroV3Module from '../../src/nitro-v3/module'
+
+// Nitro builds its #nitro/virtual/plugins and #nitro/virtual/error-handler
+// virtual modules by raw-interpolating these paths into JS string literals:
+//   import _abc from "${plugin}"
+//   import errorHandler$0 from "${h}"
+// On Windows, path.resolve() returns paths with backslashes (e.g. C:\…\plugin).
+// Those backslashes would then be parsed as JS escape sequences (\n, \v, …),
+// silently corrupting the specifier. Regression test for evlog#345.
+describe('nitro modules avoid backslash paths', () => {
+  function makeNitroStub() {
+    return {
+      options: {
+        plugins: [] as string[],
+        errorHandler: undefined as string | string[] | undefined,
+        noExternals: undefined as undefined | true | string[],
+        runtimeConfig: {} as Record<string, unknown>,
+      },
+    }
+  }
+
+  it('nitro v2 module pushes POSIX-style plugin and errorHandler paths', () => {
+    const nitro = makeNitroStub()
+    nitroV2Module({ env: { service: 'test' } }).setup(nitro as never)
+
+    expect(nitro.options.plugins).toHaveLength(1)
+    expect(nitro.options.plugins[0]).not.toMatch(/\\/)
+    expect(nitro.options.plugins[0]).toMatch(/\/nitro\/plugin$/)
+
+    expect(nitro.options.errorHandler).toBeTypeOf('string')
+    expect(nitro.options.errorHandler).not.toMatch(/\\/)
+    expect(nitro.options.errorHandler).toMatch(/\/nitro\/errorHandler$/)
+  })
+
+  it('nitro v3 module pushes POSIX-style plugin and errorHandler paths', () => {
+    const nitro = makeNitroStub()
+    nitroV3Module({ env: { service: 'test' } }).setup(nitro as never)
+
+    expect(nitro.options.plugins).toHaveLength(1)
+    expect(nitro.options.plugins[0]).not.toMatch(/\\/)
+    expect(nitro.options.plugins[0]).toMatch(/\/nitro-v3\/plugin$/)
+
+    expect(Array.isArray(nitro.options.errorHandler)).toBe(true)
+    const handlers = nitro.options.errorHandler as string[]
+    expect(handlers).toHaveLength(1)
+    expect(handlers[0]).not.toMatch(/\\/)
+    expect(handlers[0]).toMatch(/\/nitro-v3\/errorHandler$/)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows module resolution errors in Nitro integration that caused "Cannot find module" failures by normalizing internal path separators.

* **Tests**
  * Added regression tests validating that Nitro module virtual import paths are properly generated on Windows for both v2 and v3 implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->