### PR TITLE
feat: add memory adapter

### DIFF
--- a/.changeset/add-memory-drain-adapter.md
+++ b/.changeset/add-memory-drain-adapter.md
@@ -5,13 +5,14 @@
 Add `evlog/memory` — an in-memory ring buffer drain that works in any runtime, including Cloudflare Workers (workerd) where Node's `fs` module is unavailable.
 
 ```ts
-import { createMemoryDrain, readMemoryLogs, clearMemoryLogs } from 'evlog/memory'
+import { createMemoryDrain, readMemoryLogs, clearMemoryLogs, parseReadMemoryLogsQuery } from 'evlog/memory'
 
 // Wire the drain
 app.use(evlog({ drain: createMemoryDrain() }))
 
-// Expose a dev-only endpoint for agent retrieval
-app.get('/_evlog/logs', (c) => c.json(readMemoryLogs({ limit: 200 })))
+// Expose a dev-only endpoint — agents can filter via query params
+app.get('/_evlog/logs', (c) =>
+  c.json(readMemoryLogs(parseReadMemoryLogsQuery(c.req.query()))))
 ```
 
 Key features:
@@ -19,6 +20,7 @@ Key features:
 - **Bounded ring buffer** — configurable `maxEvents` (default `1000`) prevents unbounded memory growth
 - **Named stores** — isolate buffers per service or test suite via the `store` option
 - **Filtering API** — `readMemoryLogs` accepts `since`, `until`, `level`, `filter`, and `limit` options, matching the `readFsLogs` interface
+- **`parseReadMemoryLogsQuery(query)`** — coerce HTTP query-string params (`Record<string, string>`) into typed `ReadMemoryLogsOptions`; works with Hono, h3/Nitro, Express, Fastify, Next.js, Elysia, NestJS
 - **`clearMemoryLogs(store?)`** — reset a store, useful in tests
 
 Closes [#349](https://github.com/HugoRCD/evlog/issues/349).

--- a/.changeset/add-memory-drain-adapter.md
+++ b/.changeset/add-memory-drain-adapter.md
@@ -1,0 +1,24 @@
+---
+'evlog': minor
+---
+
+Add `evlog/memory` — an in-memory ring buffer drain that works in any runtime, including Cloudflare Workers (workerd) where Node's `fs` module is unavailable.
+
+```ts
+import { createMemoryDrain, readMemoryLogs, clearMemoryLogs } from 'evlog/memory'
+
+// Wire the drain
+app.use(evlog({ drain: createMemoryDrain() }))
+
+// Expose a dev-only endpoint for agent retrieval
+app.get('/_evlog/logs', (c) => c.json(readMemoryLogs({ limit: 200 })))
+```
+
+Key features:
+- **Zero runtime dependencies** — pure in-memory, no `fs`, no network
+- **Bounded ring buffer** — configurable `maxEvents` (default `1000`) prevents unbounded memory growth
+- **Named stores** — isolate buffers per service or test suite via the `store` option
+- **Filtering API** — `readMemoryLogs` accepts `since`, `until`, `level`, `filter`, and `limit` options, matching the `readFsLogs` interface
+- **`clearMemoryLogs(store?)`** — reset a store, useful in tests
+
+Closes [#349](https://github.com/HugoRCD/evlog/issues/349).

--- a/apps/docs/content/3.integrate/adapters/01.overview.md
+++ b/apps/docs/content/3.integrate/adapters/01.overview.md
@@ -50,6 +50,11 @@ links:
     to: /integrate/adapters/self-hosted/nuxthub
     color: neutral
     variant: subtle
+  - label: Memory
+    icon: i-lucide-cpu
+    to: /integrate/adapters/self-hosted/memory
+    color: neutral
+    variant: subtle
 ---
 
 Adapters let you send logs to external observability platforms. evlog provides built-in adapters for popular services, and you can create custom adapters for any destination.
@@ -200,6 +205,15 @@ initLogger({ drain: createAxiomDrain() })
   to: /integrate/adapters/self-hosted/nuxthub
   ---
   Self-hosted log storage in your NuxtHub database with automatic retention.
+  :::
+
+  :::card
+  ---
+  icon: i-lucide-cpu
+  title: Memory
+  to: /integrate/adapters/self-hosted/memory
+  ---
+  In-memory ring buffer that works in any runtime, including Cloudflare Workers.
   :::
 
   :::card

--- a/apps/docs/content/3.integrate/adapters/self-hosted/03.memory.md
+++ b/apps/docs/content/3.integrate/adapters/self-hosted/03.memory.md
@@ -122,18 +122,20 @@ initLogger({ drain: createMemoryDrain() })
 
 ## Agent Access via HTTP
 
-Expose a route so agents can retrieve structured logs during a local dev session:
+Expose a route so agents can retrieve structured logs during a local dev session. Use `parseReadMemoryLogsQuery` to let agents pass filter params directly as query strings:
 
 ```typescript [src/index.ts (Hono)]
-import { readMemoryLogs } from 'evlog/memory'
+import { readMemoryLogs, parseReadMemoryLogsQuery } from 'evlog/memory'
 
 // Restrict to dev — agents hit this endpoint to retrieve logs
 if (process.env.NODE_ENV !== 'production') {
   app.get('/_evlog/logs', (c) => {
-    return c.json(readMemoryLogs({ limit: 200 }))
+    return c.json(readMemoryLogs(parseReadMemoryLogsQuery(c.req.query())))
   })
 }
 ```
+
+An agent can now call `/_evlog/logs?level=error&limit=50&since=2026-01-01T00:00:00Z` and the query params are coerced to the correct types before being passed to `readMemoryLogs`. Supported query params: `store`, `since`, `until`, `level` (comma-separated for multiple), `limit`.
 
 The response is a JSON array of [`WideEvent`](/reference/configuration) objects — the same shape used by every other evlog adapter.
 
@@ -163,7 +165,7 @@ import { createMemoryDrain, readMemoryLogs, clearMemoryLogs } from 'evlog/memory
 
 // Two separate buffers
 const authDrain = createMemoryDrain({ store: 'auth' })
-const apiBrain = createMemoryDrain({ store: 'api' })
+const apiDrain = createMemoryDrain({ store: 'api' })
 
 // Read from a specific store
 const authErrors = readMemoryLogs({ store: 'auth', level: 'error' })
@@ -249,7 +251,7 @@ The in-memory buffer is lost when the worker/process restarts. For persistent st
 For advanced use cases, call the underlying helpers directly:
 
 ```typescript [src/index.ts]
-import { writeToMemory, readMemoryLogs, clearMemoryLogs } from 'evlog/memory'
+import { writeToMemory, readMemoryLogs, clearMemoryLogs, parseReadMemoryLogsQuery } from 'evlog/memory'
 
 // Write events directly (skips the drain pipeline)
 writeToMemory([event], { store: 'default', maxEvents: 1000 })
@@ -257,9 +259,23 @@ writeToMemory([event], { store: 'default', maxEvents: 1000 })
 // Read the current buffer
 const events = readMemoryLogs()
 
+// Parse HTTP query params into ReadMemoryLogsOptions
+const opts = parseReadMemoryLogsQuery({ level: 'error', limit: '50' })
+// → { level: 'error', limit: 50 }
+
 // Reset for tests
 clearMemoryLogs()
 ```
+
+### `parseReadMemoryLogsQuery` coercion rules
+
+| Query param | Type in `ReadMemoryLogsOptions` | Notes |
+|-------------|--------------------------------|-------|
+| `store` | `string` | Passed through as-is |
+| `since` | `string` | ISO 8601 string — parsed by `readMemoryLogs` |
+| `until` | `string` | ISO 8601 string — parsed by `readMemoryLogs` |
+| `level` | `LogLevel \| LogLevel[]` | Comma-separated (`error,warn`) or repeated array; invalid values are dropped |
+| `limit` | `number` | `parseInt`; NaN → omitted |
 
 ## Next Steps
 

--- a/apps/docs/content/3.integrate/adapters/self-hosted/03.memory.md
+++ b/apps/docs/content/3.integrate/adapters/self-hosted/03.memory.md
@@ -1,0 +1,269 @@
+---
+title: Memory Adapter
+description: Store wide events in an in-memory ring buffer. Works in any runtime — including Cloudflare Workers (workerd) — where the file system is unavailable.
+navigation:
+  title: Memory
+  icon: i-lucide-cpu
+links:
+  - label: File System Adapter
+    icon: i-lucide-hard-drive
+    to: /integrate/adapters/self-hosted/fs
+    color: neutral
+    variant: subtle
+  - label: Hono Integration
+    icon: i-lucide-zap
+    to: /integrate/frameworks/hono
+    color: neutral
+    variant: subtle
+---
+
+The Memory adapter stores wide events in a module-level ring buffer. Unlike the [File System adapter](/integrate/adapters/self-hosted/fs), it has **zero runtime dependencies** and runs anywhere — including Cloudflare Workers (workerd), Deno Deploy, and other edge runtimes that don't expose Node's `fs` module.
+
+The primary use case is **local dev agent access**: wire the drain during development, expose a lightweight HTTP endpoint, and let your AI agent fetch structured logs over HTTP without any external tooling.
+
+::prompt
+---
+description: Add the memory drain adapter
+icon: i-lucide-cpu
+actions:
+  - copy
+  - cursor
+  - windsurf
+---
+
+Add the memory drain adapter to store evlog wide events in an in-memory ring buffer.
+
+1. Identify which framework I'm using and follow its evlog integration pattern
+2. Install evlog if not already installed
+3. Import createMemoryDrain and readMemoryLogs from 'evlog/memory'
+4. Wire createMemoryDrain() into my framework's drain configuration
+5. Expose a dev-only HTTP endpoint that returns readMemoryLogs() as JSON
+6. Agents can now hit that endpoint to retrieve structured logs over HTTP
+7. Optionally configure maxEvents (default 1000) or use named stores
+
+Adapter docs: https://www.evlog.dev/integrate/adapters/self-hosted/memory
+Framework setup: https://www.evlog.dev/integrate/frameworks/overview
+
+::
+
+## Installation
+
+The Memory adapter comes bundled with evlog:
+
+```typescript [src/index.ts]
+import { createMemoryDrain, readMemoryLogs } from 'evlog/memory'
+```
+
+## Quick Start
+
+::code-group
+```typescript [Hono (Cloudflare Workers)]
+// src/index.ts
+import { Hono } from 'hono'
+import { evlog } from 'evlog/hono'
+import { createMemoryDrain, readMemoryLogs } from 'evlog/memory'
+
+const app = new Hono()
+
+app.use(evlog({ drain: createMemoryDrain() }))
+
+// Dev-only endpoint — restrict or remove in production
+app.get('/_evlog/logs', (c) => {
+  return c.json(readMemoryLogs())
+})
+```
+```typescript [Nuxt / Nitro]
+// server/plugins/evlog-drain.ts
+import { createMemoryDrain } from 'evlog/memory'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:drain', createMemoryDrain())
+})
+```
+```typescript [Next.js]
+// lib/evlog.ts
+import { createEvlog } from 'evlog/next'
+import { createMemoryDrain } from 'evlog/memory'
+
+export const { withEvlog, useLogger, log, createError } = createEvlog({
+  service: 'my-app',
+  drain: createMemoryDrain(),
+})
+```
+```typescript [Express]
+import { evlog } from 'evlog/express'
+import { createMemoryDrain } from 'evlog/memory'
+
+app.use(evlog({ drain: createMemoryDrain() }))
+```
+```typescript [Fastify]
+import { evlog } from 'evlog/fastify'
+import { createMemoryDrain } from 'evlog/memory'
+
+await app.register(evlog, { drain: createMemoryDrain() })
+```
+```typescript [Elysia]
+import { evlog } from 'evlog/elysia'
+import { createMemoryDrain } from 'evlog/memory'
+
+app.use(evlog({ drain: createMemoryDrain() }))
+```
+```typescript [NestJS]
+import { createMemoryDrain } from 'evlog/memory'
+
+EvlogModule.forRoot({ drain: createMemoryDrain() })
+```
+```typescript [Standalone]
+import { createMemoryDrain } from 'evlog/memory'
+
+initLogger({ drain: createMemoryDrain() })
+```
+::
+
+## Agent Access via HTTP
+
+Expose a route so agents can retrieve structured logs during a local dev session:
+
+```typescript [src/index.ts (Hono)]
+import { readMemoryLogs } from 'evlog/memory'
+
+// Restrict to dev — agents hit this endpoint to retrieve logs
+if (process.env.NODE_ENV !== 'production') {
+  app.get('/_evlog/logs', (c) => {
+    return c.json(readMemoryLogs({ limit: 200 }))
+  })
+}
+```
+
+The response is a JSON array of [`WideEvent`](/reference/configuration) objects — the same shape used by every other evlog adapter.
+
+## Configuration
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `maxEvents` | `number` | `1000` | Maximum events to keep in the ring buffer (oldest are dropped) |
+| `store` | `string` | `'default'` | Named buffer key — multiple drains sharing the same key share the same buffer |
+
+```typescript [server/plugins/evlog-drain.ts]
+// Keep only the last 500 events
+createMemoryDrain({ maxEvents: 500 })
+
+// Use a named store for isolation
+createMemoryDrain({ store: 'my-service' })
+```
+
+### Named Stores
+
+Use named stores to isolate events from different services or for testing:
+
+```typescript [src/index.ts]
+import { createMemoryDrain, readMemoryLogs, clearMemoryLogs } from 'evlog/memory'
+
+// Two separate buffers
+const authDrain = createMemoryDrain({ store: 'auth' })
+const apiBrain = createMemoryDrain({ store: 'api' })
+
+// Read from a specific store
+const authErrors = readMemoryLogs({ store: 'auth', level: 'error' })
+
+// Clear a store (useful in tests)
+clearMemoryLogs('auth')
+```
+
+## Querying
+
+`readMemoryLogs` supports the same filtering options as `readFsLogs`:
+
+```typescript [src/index.ts]
+import { readMemoryLogs } from 'evlog/memory'
+
+// All events
+const all = readMemoryLogs()
+
+// Errors only
+const errors = readMemoryLogs({ level: 'error' })
+
+// Last 10 minutes
+const recent = readMemoryLogs({
+  since: new Date(Date.now() - 10 * 60 * 1000),
+})
+
+// Custom predicate
+const slow = readMemoryLogs({
+  filter: e => typeof e.duration === 'string' && e.duration.endsWith('s'),
+})
+
+// Most recent 50 events
+const latest = readMemoryLogs({ limit: 50 })
+```
+
+### `readMemoryLogs` Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `store` | `string` | Named store to read from (default: `'default'`) |
+| `since` | `Date \| string` | Only events with `timestamp >= since` |
+| `until` | `Date \| string` | Only events with `timestamp <= until` |
+| `level` | `LogLevel \| LogLevel[]` | Filter by level |
+| `filter` | `(event) => boolean` | Custom predicate |
+| `limit` | `number` | Return at most N most-recent matching events |
+
+## Combining with Network Drains
+
+Use the memory adapter locally while sending to an observability platform in production:
+
+```typescript [server/plugins/evlog-drain.ts]
+import { createMemoryDrain } from 'evlog/memory'
+import { createAxiomDrain } from 'evlog/axiom'
+
+const memory = createMemoryDrain()
+const axiom = createAxiomDrain()
+
+const drain = async (ctx) => {
+  if (process.env.NODE_ENV === 'development') {
+    await memory(ctx)
+  } else {
+    await axiom(ctx)
+  }
+}
+```
+
+## Ring Buffer Behaviour
+
+The buffer is **bounded**: once it reaches `maxEvents`, the oldest events are discarded to make room for incoming ones. This means memory usage stays constant regardless of how long the service runs.
+
+```text [Ring buffer (maxEvents: 5)]
+Write events 1–5 → [1, 2, 3, 4, 5]
+Write event  6   → [2, 3, 4, 5, 6]  (1 is dropped)
+Write events 7–8 → [4, 5, 6, 7, 8]
+```
+
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+The in-memory buffer is lost when the worker/process restarts. For persistent storage, use the [File System adapter](/integrate/adapters/self-hosted/fs) (Node-based runtimes) or [NuxtHub](/integrate/adapters/self-hosted/nuxthub).
+::
+
+## Direct API Usage
+
+For advanced use cases, call the underlying helpers directly:
+
+```typescript [src/index.ts]
+import { writeToMemory, readMemoryLogs, clearMemoryLogs } from 'evlog/memory'
+
+// Write events directly (skips the drain pipeline)
+writeToMemory([event], { store: 'default', maxEvents: 1000 })
+
+// Read the current buffer
+const events = readMemoryLogs()
+
+// Reset for tests
+clearMemoryLogs()
+```
+
+## Next Steps
+
+- [File System Adapter](/integrate/adapters/self-hosted/fs) - Persistent local logs for Node-based runtimes
+- [NuxtHub Adapter](/integrate/adapters/self-hosted/nuxthub) - Database-backed storage for Cloudflare D1
+- [Pipeline](/extend/drain-pipeline) - Add batching and retry to any drain
+- [Custom Adapters](/extend/custom-drains) - Build your own adapter

--- a/examples/tanstack-start/nitro.config.ts
+++ b/examples/tanstack-start/nitro.config.ts
@@ -1,12 +1,11 @@
-import { defineConfig } from 'nitro'
+import type { NitroConfig } from 'nitro/types'
 import evlog from 'evlog/nitro/v3'
 
 /* `evlog/nitro/v3` may resolve a different `nitro` version than this example's
  * `nitro-nightly`. Runtime behavior matches; align the module slot for tsc. */
-type NitroUserConfig = Parameters<typeof defineConfig>[0]
-type NitroModuleSlot = NonNullable<NitroUserConfig['modules']>[number]
+type NitroModuleSlot = NonNullable<NitroConfig['modules']>[number]
 
-export default defineConfig({
+export default {
   experimental: {
     asyncContext: true,
   },
@@ -15,4 +14,4 @@ export default defineConfig({
       env: { service: 'tanstack-start-example' },
     }) as unknown as NitroModuleSlot,
   ],
-})
+} satisfies NitroConfig

--- a/examples/tanstack-start/vite.config.ts
+++ b/examples/tanstack-start/vite.config.ts
@@ -13,7 +13,7 @@ import { nitro } from 'nitro/vite'
  * app's `vite` — assert once here instead of drowning in TS2769 chains. */
 const plugins = [
   devtools(),
-  nitro({ rollupConfig: { external: [/^@sentry\//] } }),
+  nitro(),
   tsconfigPaths({ projects: ['./tsconfig.json'] }),
   tailwindcss(),
   tanstackStart(),

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -100,6 +100,11 @@
       "import": "./dist/adapters/fs.mjs",
       "default": "./dist/adapters/fs.mjs"
     },
+    "./memory": {
+      "types": "./dist/adapters/memory.d.mts",
+      "import": "./dist/adapters/memory.mjs",
+      "default": "./dist/adapters/memory.mjs"
+    },
     "./enrichers": {
       "types": "./dist/enrichers.d.mts",
       "import": "./dist/enrichers.mjs",
@@ -248,6 +253,9 @@
       ],
       "fs": [
         "./dist/adapters/fs.d.mts"
+      ],
+      "memory": [
+        "./dist/adapters/memory.d.mts"
       ],
       "enrichers": [
         "./dist/enrichers.d.mts"

--- a/packages/evlog/src/adapters/memory.ts
+++ b/packages/evlog/src/adapters/memory.ts
@@ -62,7 +62,7 @@ export function createMemoryDrain(overrides?: Partial<MemoryConfig>) {
   return defineDrain<MemoryConfig>({
     name: 'memory',
     resolve: () => config,
-    send: async (events, cfg) => writeToMemory(events, cfg),
+    send: (events, cfg) => Promise.resolve(writeToMemory(events, cfg)),
   })
 }
 
@@ -112,7 +112,7 @@ function normalizeTimestamp(value: Date | string | undefined): number | undefine
  */
 export function readMemoryLogs(options: ReadMemoryLogsOptions = {}): WideEvent[] {
   const storeName = options.store ?? DEFAULT_STORE
-  const events = [...getOrCreateStore(storeName)]
+  const events = [...(stores.get(storeName) ?? [])]
 
   const sinceMs = normalizeTimestamp(options.since)
   const untilMs = normalizeTimestamp(options.until)
@@ -133,8 +133,9 @@ export function readMemoryLogs(options: ReadMemoryLogsOptions = {}): WideEvent[]
     return true
   })
 
-  if (options.limit !== undefined && filtered.length > options.limit) {
-    return filtered.slice(-options.limit)
+  if (options.limit !== undefined) {
+    if (options.limit <= 0) return []
+    if (filtered.length > options.limit) return filtered.slice(-options.limit)
   }
   return filtered
 }
@@ -151,4 +152,53 @@ export function readMemoryLogs(options: ReadMemoryLogsOptions = {}): WideEvent[]
 export function clearMemoryLogs(store = DEFAULT_STORE): void {
   const s = stores.get(store)
   if (s) s.length = 0
+}
+
+const VALID_LEVELS = new Set<LogLevel>(['info', 'error', 'warn', 'debug'])
+
+/**
+ * Parse a flat query-string object (e.g. from `c.req.query()` in Hono, or
+ * `req.query` in Express) into {@link ReadMemoryLogsOptions} with proper type
+ * coercion.
+ *
+ * This lets agents discover and pass filter parameters through HTTP query
+ * strings directly:
+ *
+ * @example
+ * ```ts
+ * // Hono — zero glue
+ * app.get('/_evlog/logs', (c) =>
+ *   c.json(readMemoryLogs(parseReadMemoryLogsQuery(c.req.query()))))
+ *
+ * // Express
+ * app.get('/_evlog/logs', (req, res) =>
+ *   res.json(readMemoryLogs(parseReadMemoryLogsQuery(req.query as Record<string, string>))))
+ * ```
+ *
+ * Supported query params: `store`, `since`, `until`, `level` (comma-separated),
+ * `limit`. The `filter` predicate cannot be expressed as a query param.
+ */
+export function parseReadMemoryLogsQuery(
+  query: Record<string, string | string[] | undefined>,
+): ReadMemoryLogsOptions {
+  const opts: ReadMemoryLogsOptions = {}
+  const { store, since, until, level, limit } = query
+
+  if (typeof store === 'string' && store) opts.store = store
+  if (typeof since === 'string' && since) opts.since = since
+  if (typeof until === 'string' && until) opts.until = until
+
+  if (level !== undefined) {
+    const raw = Array.isArray(level) ? level : level.split(',')
+    const levels = raw.map((l) => l.trim()).filter((l): l is LogLevel => VALID_LEVELS.has(l as LogLevel))
+    if (levels.length === 1) [opts.level] = levels
+    else if (levels.length > 1) opts.level = levels
+  }
+
+  if (typeof limit === 'string') {
+    const n = Number.parseInt(limit, 10)
+    if (!Number.isNaN(n)) opts.limit = n
+  }
+
+  return opts
 }

--- a/packages/evlog/src/adapters/memory.ts
+++ b/packages/evlog/src/adapters/memory.ts
@@ -1,0 +1,154 @@
+import type { LogLevel, WideEvent } from '../types'
+import { defineDrain } from '../shared/drain'
+
+/**
+ * Configuration for the in-memory drain.
+ */
+export interface MemoryConfig {
+  /** Named store key. Multiple drains sharing the same key share the same buffer. Default: `'default'` */
+  store: string
+  /** Maximum number of events to keep in the ring buffer. Oldest events are discarded when the limit is exceeded. Default: `1000` */
+  maxEvents: number
+}
+
+const DEFAULT_STORE = 'default'
+const DEFAULT_MAX_EVENTS = 1000
+
+const stores = new Map<string, WideEvent[]>()
+
+function getOrCreateStore(name: string): WideEvent[] {
+  if (!stores.has(name)) stores.set(name, [])
+  return stores.get(name)!
+}
+
+/**
+ * Write events directly into the named store. Exported for direct use and
+ * easier testing without going through the drain pipeline.
+ */
+export function writeToMemory(events: WideEvent[], config: MemoryConfig): void {
+  if (events.length === 0) return
+  const store = getOrCreateStore(config.store)
+  store.push(...events)
+  if (store.length > config.maxEvents) {
+    store.splice(0, store.length - config.maxEvents)
+  }
+}
+
+/**
+ * Create a drain that stores wide events in an in-memory ring buffer.
+ *
+ * Works in **any** runtime — including Cloudflare Workers (workerd) — where
+ * the filesystem (`evlog/fs`) is not available. Pair it with a dev-only HTTP
+ * endpoint to let agents retrieve the buffer over HTTP.
+ *
+ * @example
+ * ```ts
+ * // Hono + Cloudflare Workers
+ * import { createMemoryDrain, readMemoryLogs } from 'evlog/memory'
+ *
+ * app.use(evlog({ drain: createMemoryDrain() }))
+ *
+ * // Dev-only endpoint for agent retrieval
+ * if (env.NODE_ENV === 'development') {
+ *   app.get('/_evlog/logs', (c) => c.json(readMemoryLogs()))
+ * }
+ * ```
+ */
+export function createMemoryDrain(overrides?: Partial<MemoryConfig>) {
+  const config: MemoryConfig = {
+    store: overrides?.store ?? DEFAULT_STORE,
+    maxEvents: overrides?.maxEvents ?? DEFAULT_MAX_EVENTS,
+  }
+  return defineDrain<MemoryConfig>({
+    name: 'memory',
+    resolve: () => config,
+    send: async (events, cfg) => writeToMemory(events, cfg),
+  })
+}
+
+/** Options accepted by {@link readMemoryLogs}. */
+export interface ReadMemoryLogsOptions {
+  /** Named store to read from. Default: `'default'` */
+  store?: string
+  /** Only include events with `timestamp >= since`. */
+  since?: Date | string
+  /** Only include events with `timestamp <= until`. */
+  until?: Date | string
+  /** Filter by log level. */
+  level?: LogLevel | LogLevel[]
+  /** Custom predicate — return `false` to skip the event. */
+  filter?: (event: WideEvent) => boolean
+  /** Return at most this many of the most-recent matching events. */
+  limit?: number
+}
+
+function normalizeTimestamp(value: Date | string | undefined): number | undefined {
+  if (!value) return undefined
+  const date = value instanceof Date ? value : new Date(value)
+  const ts = date.getTime()
+  return Number.isNaN(ts) ? undefined : ts
+}
+
+/**
+ * Read events from the named in-memory store. Returns a snapshot of the
+ * buffer with optional filtering, ordered oldest-first.
+ *
+ * @example
+ * ```ts
+ * import { readMemoryLogs } from 'evlog/memory'
+ *
+ * // All events
+ * const events = readMemoryLogs()
+ *
+ * // Errors in the last hour
+ * const errors = readMemoryLogs({
+ *   level: 'error',
+ *   since: new Date(Date.now() - 60 * 60 * 1000),
+ * })
+ *
+ * // Expose as a JSON endpoint
+ * app.get('/_evlog/logs', (c) => c.json(readMemoryLogs({ limit: 200 })))
+ * ```
+ */
+export function readMemoryLogs(options: ReadMemoryLogsOptions = {}): WideEvent[] {
+  const storeName = options.store ?? DEFAULT_STORE
+  const events = [...getOrCreateStore(storeName)]
+
+  const sinceMs = normalizeTimestamp(options.since)
+  const untilMs = normalizeTimestamp(options.until)
+  const levels = options.level
+    ? new Set<LogLevel>(Array.isArray(options.level) ? options.level : [options.level])
+    : undefined
+  const custom = options.filter
+
+  const filtered = events.filter((event) => {
+    if (levels && !levels.has(event.level)) return false
+    if (sinceMs !== undefined || untilMs !== undefined) {
+      const ts = typeof event.timestamp === 'string' ? Date.parse(event.timestamp) : Number.NaN
+      if (Number.isNaN(ts)) return false
+      if (sinceMs !== undefined && ts < sinceMs) return false
+      if (untilMs !== undefined && ts > untilMs) return false
+    }
+    if (custom && !custom(event)) return false
+    return true
+  })
+
+  if (options.limit !== undefined && filtered.length > options.limit) {
+    return filtered.slice(-options.limit)
+  }
+  return filtered
+}
+
+/**
+ * Clear all events from a named store (or `'default'`).
+ *
+ * @example
+ * ```ts
+ * clearMemoryLogs()           // clears the default store
+ * clearMemoryLogs('my-store') // clears a named store
+ * ```
+ */
+export function clearMemoryLogs(store = DEFAULT_STORE): void {
+  const s = stores.get(store)
+  if (s) s.length = 0
+}

--- a/packages/evlog/test/adapters/memory.test.ts
+++ b/packages/evlog/test/adapters/memory.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import type { WideEvent } from '../../src/types'
-import { clearMemoryLogs, createMemoryDrain, readMemoryLogs, writeToMemory } from '../../src/adapters/memory'
+import { clearMemoryLogs, createMemoryDrain, parseReadMemoryLogsQuery, readMemoryLogs, writeToMemory } from '../../src/adapters/memory'
 
 const createTestEvent = (overrides?: Partial<WideEvent>): WideEvent => ({
   timestamp: '2026-03-14T10:00:00.000Z',
@@ -199,6 +199,29 @@ describe('readMemoryLogs', () => {
     expect(limited.map(e => e.requestId)).toEqual(['r3', 'r4'])
   })
 
+  it('returns an empty array when limit is 0', () => {
+    populate()
+
+    expect(readMemoryLogs({ limit: 0 })).toHaveLength(0)
+  })
+
+  it('returns an empty array when limit is negative', () => {
+    populate()
+
+    expect(readMemoryLogs({ limit: -1 })).toHaveLength(0)
+  })
+
+  it('does not create a store entry when reading from an unknown store', () => {
+    const storesBefore = readMemoryLogs({ store: 'never-written' })
+    expect(storesBefore).toHaveLength(0)
+
+    writeToMemory([createTestEvent()], { store: 'default', maxEvents: 1000 })
+    clearMemoryLogs('default')
+
+    // The 'never-written' store should not exist in the map — clearing it is a no-op
+    expect(() => clearMemoryLogs('never-written')).not.toThrow()
+  })
+
   it('returns a snapshot (mutations to result do not affect the store)', () => {
     populate()
 
@@ -228,5 +251,71 @@ describe('clearMemoryLogs', () => {
 
   it('is a no-op on a store that was never written to', () => {
     expect(() => clearMemoryLogs('nonexistent')).not.toThrow()
+  })
+})
+
+describe('parseReadMemoryLogsQuery', () => {
+  it('returns empty options for an empty query', () => {
+    expect(parseReadMemoryLogsQuery({})).toEqual({})
+  })
+
+  it('passes store and string timestamp params through', () => {
+    const result = parseReadMemoryLogsQuery({
+      store: 'api',
+      since: '2026-01-01T00:00:00.000Z',
+      until: '2026-12-31T23:59:59.999Z',
+    })
+    expect(result).toEqual({
+      store: 'api',
+      since: '2026-01-01T00:00:00.000Z',
+      until: '2026-12-31T23:59:59.999Z',
+    })
+  })
+
+  it('coerces a single level string', () => {
+    expect(parseReadMemoryLogsQuery({ level: 'error' })).toEqual({ level: 'error' })
+  })
+
+  it('coerces comma-separated levels into an array', () => {
+    expect(parseReadMemoryLogsQuery({ level: 'error,warn' })).toEqual({ level: ['error', 'warn'] })
+  })
+
+  it('coerces an array of level strings', () => {
+    expect(parseReadMemoryLogsQuery({ level: ['error', 'warn'] })).toEqual({ level: ['error', 'warn'] })
+  })
+
+  it('ignores unknown level values', () => {
+    expect(parseReadMemoryLogsQuery({ level: 'critical,error' })).toEqual({ level: 'error' })
+  })
+
+  it('omits level when all values are invalid', () => {
+    expect(parseReadMemoryLogsQuery({ level: 'critical,verbose' })).toEqual({})
+  })
+
+  it('coerces limit to a number', () => {
+    expect(parseReadMemoryLogsQuery({ limit: '50' })).toEqual({ limit: 50 })
+  })
+
+  it('ignores a non-numeric limit', () => {
+    expect(parseReadMemoryLogsQuery({ limit: 'all' })).toEqual({})
+  })
+
+  it('passes a zero limit through (readMemoryLogs will return [])', () => {
+    expect(parseReadMemoryLogsQuery({ limit: '0' })).toEqual({ limit: 0 })
+  })
+
+  it('ignores empty string values', () => {
+    expect(parseReadMemoryLogsQuery({ store: '', since: '' })).toEqual({})
+  })
+
+  it('end-to-end: filters events via parsed query', () => {
+    const cfg = { store: 'default', maxEvents: 1000 }
+    writeToMemory([createTestEvent({ level: 'error', action: 'e1' })], cfg)
+    writeToMemory([createTestEvent({ level: 'info', action: 'i1' })], cfg)
+
+    const opts = parseReadMemoryLogsQuery({ level: 'error', limit: '10' })
+    const events = readMemoryLogs(opts)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.level).toBe('error')
   })
 })

--- a/packages/evlog/test/adapters/memory.test.ts
+++ b/packages/evlog/test/adapters/memory.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { WideEvent } from '../../src/types'
+import { clearMemoryLogs, createMemoryDrain, readMemoryLogs, writeToMemory } from '../../src/adapters/memory'
+
+const createTestEvent = (overrides?: Partial<WideEvent>): WideEvent => ({
+  timestamp: '2026-03-14T10:00:00.000Z',
+  level: 'info',
+  service: 'test-service',
+  environment: 'test',
+  ...overrides,
+})
+
+afterEach(() => {
+  clearMemoryLogs()
+  clearMemoryLogs('custom')
+  clearMemoryLogs('a')
+  clearMemoryLogs('b')
+})
+
+describe('writeToMemory', () => {
+  it('stores events in the default store', () => {
+    writeToMemory([createTestEvent({ action: 'req_1' })], { store: 'default', maxEvents: 1000 })
+
+    expect(readMemoryLogs()).toHaveLength(1)
+    expect(readMemoryLogs()[0]!.action).toBe('req_1')
+  })
+
+  it('appends to existing events', () => {
+    const cfg = { store: 'default', maxEvents: 1000 }
+    writeToMemory([createTestEvent({ requestId: '1' })], cfg)
+    writeToMemory([createTestEvent({ requestId: '2' })], cfg)
+
+    expect(readMemoryLogs()).toHaveLength(2)
+  })
+
+  it('skips empty arrays without touching the store', () => {
+    writeToMemory([], { store: 'default', maxEvents: 1000 })
+
+    expect(readMemoryLogs()).toHaveLength(0)
+  })
+
+  it('enforces maxEvents by dropping oldest events', () => {
+    const cfg = { store: 'default', maxEvents: 3 }
+    for (let i = 1; i <= 5; i++) {
+      writeToMemory([createTestEvent({ requestId: String(i) })], cfg)
+    }
+
+    const events = readMemoryLogs()
+    expect(events).toHaveLength(3)
+    expect(events.map(e => e.requestId)).toEqual(['3', '4', '5'])
+  })
+
+  it('writes to a named store independently', () => {
+    writeToMemory([createTestEvent({ action: 'default_event' })], { store: 'default', maxEvents: 1000 })
+    writeToMemory([createTestEvent({ action: 'custom_event' })], { store: 'custom', maxEvents: 1000 })
+
+    expect(readMemoryLogs({ store: 'default' })).toHaveLength(1)
+    expect(readMemoryLogs({ store: 'custom' })).toHaveLength(1)
+    expect(readMemoryLogs({ store: 'default' })[0]!.action).toBe('default_event')
+    expect(readMemoryLogs({ store: 'custom' })[0]!.action).toBe('custom_event')
+  })
+})
+
+describe('createMemoryDrain', () => {
+  it('writes events to the default store via drain', async () => {
+    const drain = createMemoryDrain()
+    const ctx = { event: createTestEvent({ action: 'drain_test' }), request: { method: 'GET', path: '/', requestId: 'r1' }, headers: {} }
+
+    await drain(ctx)
+
+    expect(readMemoryLogs()).toHaveLength(1)
+    expect(readMemoryLogs()[0]!.action).toBe('drain_test')
+  })
+
+  it('writes batch of contexts', async () => {
+    const drain = createMemoryDrain()
+    const ctxs = [
+      { event: createTestEvent({ requestId: '1' }), request: { method: 'GET', path: '/', requestId: '1' }, headers: {} },
+      { event: createTestEvent({ requestId: '2' }), request: { method: 'GET', path: '/', requestId: '2' }, headers: {} },
+    ]
+
+    await drain(ctxs)
+
+    expect(readMemoryLogs()).toHaveLength(2)
+  })
+
+  it('respects the maxEvents cap', async () => {
+    const drain = createMemoryDrain({ maxEvents: 2 })
+
+    for (let i = 1; i <= 4; i++) {
+      await drain({ event: createTestEvent({ requestId: String(i) }), request: { method: 'GET', path: '/', requestId: String(i) }, headers: {} })
+    }
+
+    expect(readMemoryLogs()).toHaveLength(2)
+    expect(readMemoryLogs().map(e => e.requestId)).toEqual(['3', '4'])
+  })
+
+  it('writes to a custom named store', async () => {
+    const drain = createMemoryDrain({ store: 'custom' })
+    await drain({ event: createTestEvent({ action: 'named' }), request: { method: 'GET', path: '/', requestId: 'r1' }, headers: {} })
+
+    expect(readMemoryLogs({ store: 'custom' })).toHaveLength(1)
+    expect(readMemoryLogs()).toHaveLength(0)
+  })
+
+  it('multiple drains sharing the same store key see each other\'s events', async () => {
+    const drainA = createMemoryDrain({ store: 'a' })
+    const drainB = createMemoryDrain({ store: 'a' })
+
+    await drainA({ event: createTestEvent({ action: 'from_a' }), request: { method: 'GET', path: '/', requestId: 'r1' }, headers: {} })
+    await drainB({ event: createTestEvent({ action: 'from_b' }), request: { method: 'GET', path: '/', requestId: 'r2' }, headers: {} })
+
+    expect(readMemoryLogs({ store: 'a' })).toHaveLength(2)
+  })
+})
+
+describe('readMemoryLogs', () => {
+  const populate = () => {
+    writeToMemory([
+      createTestEvent({ level: 'info', timestamp: '2026-03-14T08:00:00.000Z', requestId: 'r1' }),
+      createTestEvent({ level: 'warn', timestamp: '2026-03-14T09:00:00.000Z', requestId: 'r2' }),
+      createTestEvent({ level: 'error', timestamp: '2026-03-14T10:00:00.000Z', requestId: 'r3' }),
+      createTestEvent({ level: 'info', timestamp: '2026-03-14T11:00:00.000Z', requestId: 'r4' }),
+    ], { store: 'default', maxEvents: 1000 })
+  }
+
+  it('returns all events when no filter is provided', () => {
+    populate()
+
+    expect(readMemoryLogs()).toHaveLength(4)
+  })
+
+  it('returns an empty array when the store is empty', () => {
+    expect(readMemoryLogs()).toHaveLength(0)
+  })
+
+  it('filters by a single level', () => {
+    populate()
+
+    const errors = readMemoryLogs({ level: 'error' })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]!.requestId).toBe('r3')
+  })
+
+  it('filters by multiple levels', () => {
+    populate()
+
+    const warnAndError = readMemoryLogs({ level: ['warn', 'error'] })
+    expect(warnAndError).toHaveLength(2)
+    expect(warnAndError.map(e => e.requestId)).toEqual(['r2', 'r3'])
+  })
+
+  it('filters by since', () => {
+    populate()
+
+    const recent = readMemoryLogs({ since: '2026-03-14T09:30:00.000Z' })
+    expect(recent.map(e => e.requestId)).toEqual(['r3', 'r4'])
+  })
+
+  it('filters by until', () => {
+    populate()
+
+    const early = readMemoryLogs({ until: '2026-03-14T09:30:00.000Z' })
+    expect(early.map(e => e.requestId)).toEqual(['r1', 'r2'])
+  })
+
+  it('filters by since and until range', () => {
+    populate()
+
+    const range = readMemoryLogs({
+      since: '2026-03-14T08:30:00.000Z',
+      until: '2026-03-14T09:30:00.000Z',
+    })
+    expect(range.map(e => e.requestId)).toEqual(['r2'])
+  })
+
+  it('accepts Date objects for since/until', () => {
+    populate()
+
+    const range = readMemoryLogs({
+      since: new Date('2026-03-14T09:00:00.000Z'),
+      until: new Date('2026-03-14T10:00:00.000Z'),
+    })
+    expect(range.map(e => e.requestId)).toEqual(['r2', 'r3'])
+  })
+
+  it('applies a custom filter predicate', () => {
+    populate()
+
+    const filtered = readMemoryLogs({ filter: e => e.requestId === 'r2' })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.requestId).toBe('r2')
+  })
+
+  it('returns only the most-recent N events when limit is set', () => {
+    populate()
+
+    const limited = readMemoryLogs({ limit: 2 })
+    expect(limited.map(e => e.requestId)).toEqual(['r3', 'r4'])
+  })
+
+  it('returns a snapshot (mutations to result do not affect the store)', () => {
+    populate()
+
+    const snap = readMemoryLogs()
+    snap.splice(0)
+
+    expect(readMemoryLogs()).toHaveLength(4)
+  })
+})
+
+describe('clearMemoryLogs', () => {
+  it('empties the default store', () => {
+    writeToMemory([createTestEvent()], { store: 'default', maxEvents: 1000 })
+    clearMemoryLogs()
+
+    expect(readMemoryLogs()).toHaveLength(0)
+  })
+
+  it('empties a named store without touching the default', () => {
+    writeToMemory([createTestEvent()], { store: 'default', maxEvents: 1000 })
+    writeToMemory([createTestEvent()], { store: 'custom', maxEvents: 1000 })
+    clearMemoryLogs('custom')
+
+    expect(readMemoryLogs()).toHaveLength(1)
+    expect(readMemoryLogs({ store: 'custom' })).toHaveLength(0)
+  })
+
+  it('is a no-op on a store that was never written to', () => {
+    expect(() => clearMemoryLogs('nonexistent')).not.toThrow()
+  })
+})

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -122,6 +122,12 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "sendToHyperDX",
     "toHyperDXOTLPConfig",
   ],
+  "./memory": [
+    "clearMemoryLogs",
+    "createMemoryDrain",
+    "readMemoryLogs",
+    "writeToMemory",
+  ],
   "./nestjs": [
     "EvlogModule",
     "useLogger",

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -125,6 +125,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
   "./memory": [
     "clearMemoryLogs",
     "createMemoryDrain",
+    "parseReadMemoryLogsQuery",
     "readMemoryLogs",
     "writeToMemory",
   ],

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     'adapters/hyperdx': 'src/adapters/hyperdx.ts',
     'adapters/datadog': 'src/adapters/datadog.ts',
     'adapters/fs': 'src/adapters/fs.ts',
+    'adapters/memory': 'src/adapters/memory.ts',
     'enrichers': 'src/enrichers/index.ts',
     'pipeline': 'src/pipeline.ts',
     'stream': 'src/stream.ts',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memory adapter for in-memory event logging across JS runtimes (default bounded store: 1000), with named stores, read/filter/query, and clearing helpers; includes HTTP-query coercion helper for read options.

* **Documentation**
  * New Memory adapter docs and integration examples (framework wiring, dev-only JSON endpoint pattern, config and behavior guidance).

* **Tests**
  * Comprehensive tests covering write/read/filter/eviction/clear and query parsing.

* **Chores**
  * Package exports and build entries updated to expose the adapter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->