### PR TITLE
fix: resolve typecheck and lint errors across the codebase

### DIFF
--- a/examples/tanstack-start/nitro.config.ts
+++ b/examples/tanstack-start/nitro.config.ts
@@ -1,12 +1,11 @@
-import { defineConfig } from 'nitro'
+import type { NitroConfig } from 'nitro/types'
 import evlog from 'evlog/nitro/v3'
 
 /* `evlog/nitro/v3` may resolve a different `nitro` version than this example's
  * `nitro-nightly`. Runtime behavior matches; align the module slot for tsc. */
-type NitroUserConfig = Parameters<typeof defineConfig>[0]
-type NitroModuleSlot = NonNullable<NitroUserConfig['modules']>[number]
+type NitroModuleSlot = NonNullable<NitroConfig['modules']>[number]
 
-export default defineConfig({
+export default {
   experimental: {
     asyncContext: true,
   },
@@ -15,4 +14,4 @@ export default defineConfig({
       env: { service: 'tanstack-start-example' },
     }) as unknown as NitroModuleSlot,
   ],
-})
+} satisfies NitroConfig

--- a/examples/tanstack-start/vite.config.ts
+++ b/examples/tanstack-start/vite.config.ts
@@ -13,7 +13,7 @@ import { nitro } from 'nitro/vite'
  * app's `vite` — assert once here instead of drowning in TS2769 chains. */
 const plugins = [
   devtools(),
-  nitro({ rollupConfig: { external: [/^@sentry\//] } }),
+  nitro(),
   tsconfigPaths({ projects: ['./tsconfig.json'] }),
   tailwindcss(),
   tanstackStart(),

--- a/packages/evlog/src/adapters/axiom.ts
+++ b/packages/evlog/src/adapters/axiom.ts
@@ -65,7 +65,7 @@ const AXIOM_FIELDS: ConfigField<ResolvedAxiomConfig>[] = [
 
 let warnedAboutToken = false
 
-function applyApiKeyAlias(config: ResolvedAxiomConfig): ResolvedAxiomConfig {
+function applyApiKeyAlias(config: Partial<ResolvedAxiomConfig>): Partial<ResolvedAxiomConfig> {
   if (!config.apiKey && config.token) {
     if (!warnedAboutToken) {
       warnedAboutToken = true

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -134,7 +134,7 @@ function decorateAudit(audit: AuditFields, timestamp: string): AuditFields {
  */
 export function withAuditMethods<T extends object = Record<string, unknown>>(logger: RequestLogger<T>): AuditableLogger<T> {
   const target = logger as AuditableLogger<T>
-  if (target.audit) return target
+  if ((target as { audit?: AuditMethod<T> }).audit) return target
 
   const audit = function audit(input: AuditInput): void {
     const fields = buildAuditFields(input)
@@ -424,11 +424,11 @@ export function defineAuditAction<TTargetType extends string | undefined = undef
   const targetType = options?.target
   return (input) => {
     const merged: AuditInput = {
-      ...input,
+      ...(input as AuditInput),
       action,
     }
     if (targetType && input.target && !input.target.type) {
-      merged.target = { ...input.target, type: targetType }
+      merged.target = { ...input.target, type: targetType } as AuditTarget
     }
     return merged
   }
@@ -511,7 +511,7 @@ function matchesAudit(event: AuditFields, matcher: AuditMatcher): boolean {
   if (matcher.outcome !== undefined && event.outcome !== matcher.outcome) return false
   if (matcher.actor) {
     for (const [k, v] of Object.entries(matcher.actor)) {
-      if ((event.actor as Record<string, unknown>)[k] !== v) return false
+      if ((event.actor as unknown as Record<string, unknown>)[k] !== v) return false
     }
   }
   if (matcher.target) {

--- a/packages/evlog/src/catalog.ts
+++ b/packages/evlog/src/catalog.ts
@@ -167,7 +167,7 @@ export function defineError<
   const TEntry extends ErrorCatalogEntry,
 >(code: TCode, entry: TEntry): DefinedError<TCode, TEntry> {
   const factory = ((...args: unknown[]) =>
-    buildEvlogError(code, entry, args[0] as Record<string, unknown> | undefined)) as DefinedError<TCode, TEntry>
+    buildEvlogError(code, entry, args[0] as Record<string, unknown> | undefined)) as unknown as DefinedError<TCode, TEntry>
 
   Object.defineProperties(factory, {
     code: { value: code, enumerable: true },

--- a/packages/evlog/src/express/index.ts
+++ b/packages/evlog/src/express/index.ts
@@ -15,7 +15,7 @@ export { useLogger }
 
 declare module 'express-serve-static-core' {
   interface Request {
-    log: RequestLogger
+    log?: RequestLogger
   }
 }
 

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify'
+import type { RequestLogger } from '../types'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
@@ -13,8 +14,8 @@ export { useLogger }
 
 declare module 'fastify' {
   interface FastifyRequest {
-    // Overrides Fastify's built-in pino logger on the request with evlog's RequestLogger.
-    log: any
+    // @ts-expect-error intentionally overrides Fastify's built-in pino logger with evlog's RequestLogger
+    log: RequestLogger
   }
 }
 

--- a/packages/evlog/src/next/instrumentation.ts
+++ b/packages/evlog/src/next/instrumentation.ts
@@ -143,7 +143,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
           patching = false
         }
       }
-      return originalStdoutWrite(chunk, ...args as [])
+      return originalStdoutWrite(chunk as string, ...args as [])
     } as typeof process.stdout.write
 
     proc.stderr.write = function(chunk: unknown, ...args: unknown[]): boolean {
@@ -155,7 +155,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
           patching = false
         }
       }
-      return originalStderrWrite(chunk, ...args as [])
+      return originalStderrWrite(chunk as string, ...args as [])
     } as typeof process.stderr.write
   }
 

--- a/packages/evlog/src/next/middleware.ts
+++ b/packages/evlog/src/next/middleware.ts
@@ -7,7 +7,10 @@ type NextRequest = {
 }
 
 type NextResponse = {
-  headers: { set(name: string, value: string): void }
+  headers: {
+    set(name: string, value: string): void
+    get(name: string): string | null
+  }
 }
 
 type NextResponseStatic = {

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -53,6 +53,7 @@ const noopResult: MiddlewareLoggerResult = {
     error() {},
     info() {},
     warn() {},
+    setLevel() {},
     emit() {
       return null 
     },

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -19,7 +19,7 @@ export { useLogger }
  */
 type SvelteKitHandle = (input: {
   event: { request: Request; url: URL; locals: Record<string, any> }
-  resolve: (event: any) => Promise<Response>
+  resolve: (...args: any[]) => Response | Promise<Response>
 }) => Promise<Response>
 
 /**

--- a/packages/evlog/src/utils.ts
+++ b/packages/evlog/src/utils.ts
@@ -124,11 +124,20 @@ export const SENSITIVE_HEADERS = [
   'proxy-authorization',
 ]
 
-export function filterSafeHeaders(headers: Record<string, string>): Record<string, string> {
+/**
+ * Filter out undefined values and sensitive headers from a raw header map.
+ *
+ * @param headers - Flat header map where values may be `undefined`
+ *   (e.g. from `IncomingMessage.headers` or a framework's header accessor).
+ * @returns A new object containing only the headers whose values are defined
+ *   and whose lowercased key is not in the built-in sensitive-header list
+ *   (e.g. `authorization`, `cookie`, `x-api-key`).
+ */
+export function filterSafeHeaders(headers: Partial<Record<string, string | undefined>>): Record<string, string> {
   const safeHeaders: Record<string, string> = {}
 
   for (const [key, value] of Object.entries(headers)) {
-    if (!SENSITIVE_HEADERS.includes(key.toLowerCase())) {
+    if (value !== undefined && !SENSITIVE_HEADERS.includes(key.toLowerCase())) {
       safeHeaders[key] = value
     }
   }

--- a/packages/evlog/test/adapters/axiom.test.ts
+++ b/packages/evlog/test/adapters/axiom.test.ts
@@ -29,7 +29,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -42,7 +42,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
         baseUrl: 'https://custom.axiom.co',
       })
 
@@ -55,7 +55,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
         edgeUrl: 'https://eu-central-1.aws.edge.axiom.co',
       })
 
@@ -68,7 +68,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
         edgeUrl: 'http://localhost:3400/custom/ingest/',
       })
 
@@ -81,7 +81,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my dataset/test',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [url] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -93,7 +93,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my dataset/test',
-        token: 'test-token',
+        apiKey: 'test-token',
         edgeUrl: 'https://eu-central-1.aws.edge.axiom.co',
       })
 
@@ -106,7 +106,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'my-secret-token',
+        apiKey: 'my-secret-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -120,7 +120,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
         orgId: 'my-org-123',
       })
 
@@ -135,7 +135,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -148,7 +148,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -162,7 +162,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -179,7 +179,7 @@ describe('axiom adapter', () => {
 
       await expect(sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })).rejects.toThrow('Axiom API error: 400 Bad Request')
     })
   })
@@ -194,7 +194,7 @@ describe('axiom adapter', () => {
 
       await sendBatchToAxiom(events, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -207,7 +207,7 @@ describe('axiom adapter', () => {
     it('sends empty array when no events', async () => {
       await sendBatchToAxiom([], {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -225,7 +225,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
@@ -237,7 +237,7 @@ describe('axiom adapter', () => {
 
       await sendToAxiom(event, {
         dataset: 'my-dataset',
-        token: 'test-token',
+        apiKey: 'test-token',
         timeout: 10000,
       })
 

--- a/packages/evlog/test/adapters/better-stack.test.ts
+++ b/packages/evlog/test/adapters/better-stack.test.ts
@@ -50,7 +50,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -62,7 +62,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
         endpoint: 'https://custom.betterstack.com',
       })
 
@@ -74,7 +74,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
         endpoint: 'https://custom.betterstack.com/',
       })
 
@@ -86,7 +86,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await sendToBetterStack(event, {
-        sourceToken: 'my-secret-token',
+        apiKey: 'my-secret-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -99,7 +99,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -112,7 +112,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent({ action: 'test-action', userId: '123' })
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -137,7 +137,7 @@ describe('better-stack adapter', () => {
       const event = createTestEvent()
 
       await expect(sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })).rejects.toThrow('Better Stack API error: 400 Bad Request')
     })
   })
@@ -151,7 +151,7 @@ describe('better-stack adapter', () => {
       ]
 
       await sendBatchToBetterStack(events, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -164,7 +164,7 @@ describe('better-stack adapter', () => {
 
     it('sends empty array when no events', async () => {
       await sendBatchToBetterStack([], {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit]
@@ -179,7 +179,7 @@ describe('better-stack adapter', () => {
       const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
       })
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
@@ -190,7 +190,7 @@ describe('better-stack adapter', () => {
       const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
 
       await sendToBetterStack(event, {
-        sourceToken: 'test-token',
+        apiKey: 'test-token',
         timeout: 10000,
       })
 

--- a/packages/evlog/test/ai/ai.test.ts
+++ b/packages/evlog/test/ai/ai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { LanguageModelV3, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type { LanguageModelV3, LanguageModelV3FinishReason, LanguageModelV3StreamPart } from '@ai-sdk/provider'
 import type { RequestLogger } from '../../src/types'
 import { createAILogger, createAIMiddleware, createEvlogIntegration } from '../../src/ai'
 import { createLogger } from '../../src/logger'
@@ -56,6 +56,7 @@ function createMockLogger(): MockLogger {
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
+    setLevel: vi.fn(),
     emit: vi.fn(() => null),
     getContext: vi.fn(() => ({})),
   }
@@ -94,7 +95,7 @@ function createMockModel(overrides?: Partial<{ provider: string, modelId: string
   } as unknown as LanguageModelV3
 }
 
-function createFinishReason(unified = 'stop') {
+function createFinishReason(unified: LanguageModelV3FinishReason['unified'] = 'stop'): LanguageModelV3FinishReason {
   return { unified, raw: undefined }
 }
 

--- a/packages/evlog/test/better-auth/better-auth.test.ts
+++ b/packages/evlog/test/better-auth/better-auth.test.ts
@@ -17,6 +17,7 @@ function createMockLogger(): RequestLogger & { setCalls: Array<Record<string, un
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
+    setLevel: vi.fn(),
     emit: vi.fn(() => null),
     getContext: vi.fn(() => ({})),
   }
@@ -258,7 +259,7 @@ describe('createAuthMiddleware', () => {
 
     expect(result).toBe(true)
     expect(auth.api.getSession).toHaveBeenCalledOnce()
-    const passed = (auth.api.getSession.mock.calls[0]![0] as { headers: Headers }).headers
+    const passed = ((auth.api.getSession.mock.calls[0]! as unknown as [{ headers: Headers }])[0]).headers
     expect(passed).toBeInstanceOf(Headers)
     expect(passed.get('cookie')).toBe('session=abc')
     expect(passed.get('x-forwarded-for')).toBe('1.2.3.4, 5.6.7.8')
@@ -273,7 +274,7 @@ describe('createAuthMiddleware', () => {
     const headers = new Headers({ cookie: 'session=abc' })
     await identify(log, headers)
 
-    const passed = (auth.api.getSession.mock.calls[0]![0] as { headers: Headers }).headers
+    const passed = ((auth.api.getSession.mock.calls[0]! as unknown as [{ headers: Headers }])[0]).headers
     expect(passed).toBe(headers)
   })
 

--- a/packages/evlog/test/core/logger-request-logger.test.ts
+++ b/packages/evlog/test/core/logger-request-logger.test.ts
@@ -43,11 +43,11 @@ describe('createRequestLogger', () => {
   it('overwrites existing primitive keys with set()', () => {
     const logger = createRequestLogger({})
 
-    logger.set({ status: 'pending' })
-    logger.set({ status: 'complete' })
+    logger.set({ phase: 'pending' })
+    logger.set({ phase: 'complete' })
 
     const context = logger.getContext()
-    expect(context.status).toBe('complete')
+    expect(context.phase).toBe('complete')
   })
 
   it('deep merges nested objects with set()', () => {
@@ -222,9 +222,9 @@ describe('createRequestLogger', () => {
 
     const context = logger.getContext()
     expect(context.requestLogs).toHaveLength(3)
-    expect(context.requestLogs[0].message).toBe('First entry')
-    expect(context.requestLogs[1].message).toBe('Second entry')
-    expect(context.requestLogs[2].message).toBe('Third entry')
+    expect((context.requestLogs as Array<{ message: string }>)[0]!.message).toBe('First entry')
+    expect((context.requestLogs as Array<{ message: string }>)[1]!.message).toBe('Second entry')
+    expect((context.requestLogs as Array<{ message: string }>)[2]!.message).toBe('Third entry')
   })
 
   it('captures custom error properties (statusCode, data, cause)', () => {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -239,8 +239,8 @@ describe('createLogger', () => {
 
     const context = logger.getContext()
     expect(context.requestLogs).toHaveLength(2)
-    expect(context.requestLogs[0].message).toBe('Extracting data')
-    expect(context.requestLogs[1].message).toBe('Slow downstream query')
+    expect((context.requestLogs as Array<{ message: string }>)[0]!.message).toBe('Extracting data')
+    expect((context.requestLogs as Array<{ message: string }>)[1]!.message).toBe('Slow downstream query')
   })
 
   it('returns WideEvent on emit', () => {

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -15,7 +15,7 @@ function delay(ms = 1) {
   })
 }
 
-function request(app: Elysia, path: string, init?: RequestInit) {
+function request(app: { handle: (req: Request) => Promise<Response> }, path: string, init?: RequestInit) {
   return app.handle(new Request(`http://localhost${path}`, init)).then(async (response) => {
     // using Elysia.afterResponse is scheduled to run
     // after response is sent but not immediately

--- a/packages/evlog/test/frameworks/fastify.test.ts
+++ b/packages/evlog/test/frameworks/fastify.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Fastify from 'fastify'
+import type { RequestLogger } from '../../src/types'
 import { initLogger } from '../../src/logger'
 import { evlog, useLogger } from '../../src/fastify/index'
 import {
@@ -34,7 +35,7 @@ describe('evlog/fastify', () => {
 
     let hasLogger = false
     app.get('/api/test', (request) => {
-      hasLogger = request.log !== null && typeof request.log.set === 'function'
+      hasLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
       return { ok: true }
     })
 
@@ -65,7 +66,7 @@ describe('evlog/fastify', () => {
     const app = Fastify({ logger: false })
     await app.register(evlog, { drain })
     app.get('/api/users', (request) => {
-      request.log.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+      ((request.log) as unknown as RequestLogger).set({ user: { id: 'u-1' }, db: { queries: 3 } })
       return { users: [] }
     })
 
@@ -83,7 +84,7 @@ describe('evlog/fastify', () => {
     const app = Fastify({ logger: false })
     await app.register(evlog, { drain })
     app.get('/api/fail', (request) => {
-      request.log.error(new Error('Something broke'))
+      ((request.log) as unknown as RequestLogger).error(new Error('Something broke'))
       const error = new Error('Something broke') as Error & { statusCode?: number }
       error.statusCode = 500
       throw error
@@ -101,7 +102,7 @@ describe('evlog/fastify', () => {
 
     let isEvlogLogger = false
     app.get('/health', (request) => {
-      isEvlogLogger = typeof request.log.set === 'function'
+      isEvlogLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
       return { ok: true }
     })
 
@@ -114,7 +115,7 @@ describe('evlog/fastify', () => {
     const app = Fastify({ logger: false })
     await app.register(evlog, { include: ['/api/**'], drain })
     app.get('/api/data', (request) => {
-      request.log.set({ data: true })
+      ((request.log) as unknown as RequestLogger).set({ data: true })
       return { ok: true }
     })
 
@@ -160,7 +161,7 @@ describe('evlog/fastify', () => {
 
     let isEvlogLogger = false
     app.get('/_internal/probe', (request) => {
-      isEvlogLogger = typeof request.log.set === 'function'
+      isEvlogLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
       return { ok: true }
     })
 
@@ -192,7 +193,7 @@ describe('evlog/fastify', () => {
       const app = Fastify({ logger: false })
       await app.register(evlog, { drain })
       app.get('/api/test', (request) => {
-        request.log.set({ user: { id: 'u-1' } })
+        ((request.log) as unknown as RequestLogger).set({ user: { id: 'u-1' } })
         return { ok: true }
       })
 
@@ -272,7 +273,7 @@ describe('evlog/fastify', () => {
       const app = Fastify({ logger: false })
       await app.register(evlog, { keep, drain })
       app.get('/api/test', (request) => {
-        request.log.set({ important: true })
+        ((request.log) as unknown as RequestLogger).set({ important: true })
         return { ok: true }
       })
 
@@ -361,7 +362,7 @@ describe('evlog/fastify', () => {
 
       let isSame = false
       app.get('/api/test', (request) => {
-        isSame = useLogger() === request.log
+        isSame = useLogger() === (request.log as unknown as RequestLogger)
         return { ok: true }
       })
 

--- a/packages/evlog/test/frameworks/nestjs.test.ts
+++ b/packages/evlog/test/frameworks/nestjs.test.ts
@@ -86,7 +86,7 @@ describe('evlog/nestjs', () => {
       module.configure(consumer)
 
       expect(apply).toHaveBeenCalledOnce()
-      expect(apply.mock.calls[0][0]).toBeTypeOf('function')
+      expect((apply.mock.calls[0] as unknown as [unknown])[0]).toBeTypeOf('function')
       expect(forRoutes).toHaveBeenCalledWith('*')
     })
   })
@@ -131,7 +131,7 @@ describe('evlog/nestjs', () => {
       const app = express()
       app.use(getMiddleware())
       app.get('/api/users', (req, res) => {
-        req.log.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+        req.log!.set({ user: { id: 'u-1' }, db: { queries: 3 } })
         res.json({ users: [] })
       })
 
@@ -152,7 +152,7 @@ describe('evlog/nestjs', () => {
       const app = express()
       app.use(getMiddleware())
       app.get('/api/fail', (req, res) => {
-        req.log.error(new Error('Something broke'))
+        req.log!.error(new Error('Something broke'))
         res.status(500).json({ error: 'fail' })
       })
 
@@ -187,7 +187,7 @@ describe('evlog/nestjs', () => {
       const app = express()
       app.use(getMiddleware({ include: ['/api/**'] }))
       app.get('/api/data', (req, res) => {
-        req.log.set({ data: true })
+        req.log!.set({ data: true })
         res.json({ ok: true })
       })
 
@@ -269,7 +269,7 @@ describe('evlog/nestjs', () => {
       const app = express()
       app.use(getMiddleware({ drain }))
       app.get('/api/test', (req, res) => {
-        req.log.set({ user: { id: 'u-1' } })
+        req.log!.set({ user: { id: 'u-1' } })
         res.json({ ok: true })
       })
 
@@ -341,7 +341,7 @@ describe('evlog/nestjs', () => {
       const app = express()
       app.use(getMiddleware({ keep, drain }))
       app.get('/api/test', (req, res) => {
-        req.log.set({ important: true })
+        req.log!.set({ important: true })
         res.json({ ok: true })
       })
 

--- a/packages/evlog/test/frameworks/sveltekit.test.ts
+++ b/packages/evlog/test/frameworks/sveltekit.test.ts
@@ -18,8 +18,8 @@ function createMockEvent(method = 'GET', path = '/api/test', headers: Record<str
   }
 }
 
-function createMockResolve(status = 200) {
-  return vi.fn(() => new Response(JSON.stringify({ ok: true }), { status }))
+function createMockResolve(status = 200): (event: any) => Promise<Response> {
+  return vi.fn((_ev: any) => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status })))
 }
 
 describe('evlog/sveltekit', () => {

--- a/packages/evlog/test/helpers/framework.ts
+++ b/packages/evlog/test/helpers/framework.ts
@@ -26,9 +26,9 @@ export async function waitForDrainCalls(
  */
 export function createPipelineSpies() {
   return {
-    drain: vi.fn<[DrainContext], void | Promise<void>>(),
-    enrich: vi.fn<[EnrichContext], void | Promise<void>>(),
-    keep: vi.fn<[TailSamplingContext], void | Promise<void>>(),
+    drain: vi.fn<(ctx: DrainContext) => void | Promise<void>>(),
+    enrich: vi.fn<(ctx: EnrichContext) => void | Promise<void>>(),
+    keep: vi.fn<(ctx: TailSamplingContext) => void | Promise<void>>(),
   }
 }
 

--- a/packages/evlog/test/http/http.test.ts
+++ b/packages/evlog/test/http/http.test.ts
@@ -116,7 +116,7 @@ describe('createHttpDrain', () => {
       if (originalVisibilityState) {
         Object.defineProperty(document, 'visibilityState', originalVisibilityState)
       } else {
-        delete (document as Record<string, unknown>).visibilityState
+        delete (document as unknown as Record<string, unknown>).visibilityState
       }
     })
 

--- a/packages/evlog/test/next/handler.test.ts
+++ b/packages/evlog/test/next/handler.test.ts
@@ -60,7 +60,7 @@ describe('withEvlog', () => {
   it('captures response status from Response object', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       return new Response('created', { status: 201 })
     })
 
@@ -76,7 +76,7 @@ describe('withEvlog', () => {
   it('allows setting context via the logger', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       const logger = evlogStorage.getStore()!
       logger.set({ user: { id: '123', plan: 'enterprise' } })
       logger.set({ cart: { items: 5 } })
@@ -96,7 +96,7 @@ describe('withEvlog', () => {
   it('captures errors and re-throws them', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       throw new Error('Something broke')
     })
 
@@ -115,7 +115,7 @@ describe('withEvlog', () => {
   it('extracts error status from error object', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       const error = new Error('Not found') as Error & { status: number }
       error.status = 404
       throw error
@@ -133,7 +133,7 @@ describe('withEvlog', () => {
     const drainMock = vi.fn()
     const withEvlog = createWithEvlog({ pretty: false, drain: drainMock })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       return new Response('ok')
     })
 
@@ -162,7 +162,7 @@ describe('withEvlog', () => {
       },
     })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
     const request = new Request('http://localhost/api/test', { method: 'GET' })
     await handler(request)
 
@@ -177,7 +177,7 @@ describe('withEvlog', () => {
       drain: drainMock,
     })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
 
     await handler(new Request('http://localhost/api/health', { method: 'GET' }))
     expect(drainMock).not.toHaveBeenCalled()
@@ -193,7 +193,7 @@ describe('withEvlog', () => {
       },
     })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
     await handler(new Request('http://localhost/api/auth/login', { method: 'POST' }))
 
     const [[output]] = consoleSpy.mock.calls
@@ -204,7 +204,7 @@ describe('withEvlog', () => {
   it('reuses x-request-id header from middleware', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
 
     const request = new Request('http://localhost/api/test', {
       method: 'GET',
@@ -237,7 +237,7 @@ describe('withEvlog', () => {
   it('passes through when logging is disabled', async () => {
     const withEvlog = createWithEvlog({ enabled: false, pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       const store = evlogStorage.getStore()
       // Logger exists but is a noop when disabled
       return new Response('ok')
@@ -253,7 +253,7 @@ describe('withEvlog', () => {
   it('generates a requestId when none is provided', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
     await handler(new Request('http://localhost/api/test', { method: 'GET' }))
 
     const [[output]] = consoleSpy.mock.calls
@@ -266,7 +266,7 @@ describe('withEvlog', () => {
   it('includes duration in emitted event', async () => {
     const withEvlog = createWithEvlog({ pretty: false })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       return new Response('ok')
     })
 
@@ -285,7 +285,7 @@ describe('withEvlog', () => {
       },
     })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
     // Should not throw even when drain fails
     await expect(handler(new Request('http://localhost/api/test'))).resolves.toBeInstanceOf(Response)
   })
@@ -306,7 +306,7 @@ describe('withEvlog', () => {
       drain: drainMock,
     })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       const logger = evlogStorage.getStore()!
       logger.set({ user: { premium: true } })
       return new Response('ok')
@@ -333,7 +333,7 @@ describe('withEvlog', () => {
       drain: drainMock,
     })
 
-    const handler = withEvlog(() => {
+    const handler = withEvlog((_: Request) => {
       throw new Error('Server error')
     })
 
@@ -347,7 +347,7 @@ describe('withEvlog', () => {
     const drainMock = vi.fn()
     const withEvlog = createWithEvlog({ pretty: false, drain: drainMock })
 
-    const handler = withEvlog(() => new Response('ok'))
+    const handler = withEvlog((_: Request) => new Response('ok'))
 
     const request = new Request('http://localhost/api/test', {
       method: 'GET',

--- a/packages/evlog/test/next/middleware.test.ts
+++ b/packages/evlog/test/next/middleware.test.ts
@@ -65,9 +65,9 @@ describe('evlogMiddleware', () => {
 
     expect(mockNextResponse.next).toHaveBeenCalled()
     const [[callArgs]] = mockNextResponse.next.mock.calls
-    expect(callArgs.request.headers).toBeInstanceOf(Headers)
+    expect(callArgs!.request!.headers).toBeInstanceOf(Headers)
 
-    const { headers } = callArgs.request
+    const { headers } = callArgs!.request!
     expect(headers.get('x-request-id')).toBeDefined()
     expect(headers.get('x-evlog-start')).toBeDefined()
   })
@@ -78,7 +78,7 @@ describe('evlogMiddleware', () => {
     await middleware(request as any)
 
     const [[callArgs2]] = mockNextResponse.next.mock.calls
-    const startTime = Number(callArgs2.request.headers.get('x-evlog-start'))
+    const startTime = Number(callArgs2!.request!.headers.get('x-evlog-start'))
     expect(startTime).toBeGreaterThan(0)
     expect(startTime).toBeLessThanOrEqual(Date.now())
   })
@@ -103,7 +103,7 @@ describe('evlogMiddleware', () => {
     await middleware(apiRequest as any)
     expect(mockNextResponse.next).toHaveBeenCalledTimes(1)
     const [[apiCallArgs]] = mockNextResponse.next.mock.calls
-    expect(apiCallArgs.request.headers.get('x-request-id')).toBeDefined()
+    expect(apiCallArgs!.request!.headers.get('x-request-id')).toBeDefined()
 
     vi.clearAllMocks()
 

--- a/packages/evlog/test/next/stream.test.ts
+++ b/packages/evlog/test/next/stream.test.ts
@@ -73,7 +73,7 @@ describe('defineStreamedInstrumentation', () => {
     await register()
 
     expect(createInstrumentation).toHaveBeenCalled()
-    const lastCall = createInstrumentation.mock.calls.at(-1)![0] as { drain?: (ctx: unknown) => Promise<void> }
+    const lastCall = ((createInstrumentation.mock.calls.at(-1)!) as unknown as [unknown])[0] as unknown as { drain?: (ctx: unknown) => Promise<void> }
     const composed = lastCall.drain
     expect(composed).toBeDefined()
 
@@ -88,7 +88,7 @@ describe('defineStreamedInstrumentation', () => {
     const { register } = defineStreamedInstrumentation({ drain: userDrain })
     await register()
 
-    const lastCall = createInstrumentation.mock.calls.at(-1)![0] as { drain?: (ctx: unknown) => Promise<void> }
+    const lastCall = ((createInstrumentation.mock.calls.at(-1)!) as unknown as [unknown])[0] as unknown as { drain?: (ctx: unknown) => Promise<void> }
     const composed = lastCall.drain
     expect(composed).toBe(userDrain)
   })
@@ -100,7 +100,7 @@ describe('defineStreamedInstrumentation', () => {
     const { register } = defineStreamedInstrumentation({ stream: true })
     await register()
 
-    const lastCall = createInstrumentation.mock.calls.at(-1)![0] as { drain?: (ctx: unknown) => Promise<void> }
+    const lastCall = ((createInstrumentation.mock.calls.at(-1)!) as unknown as [unknown])[0] as unknown as { drain?: (ctx: unknown) => Promise<void> }
     const composed = lastCall.drain
     expect(composed).toBeDefined()
 
@@ -112,7 +112,7 @@ describe('defineStreamedInstrumentation', () => {
     const { register } = defineStreamedInstrumentation()
     await register()
 
-    const lastCall = createInstrumentation.mock.calls.at(-1)![0] as { drain?: unknown }
+    const lastCall = ((createInstrumentation.mock.calls.at(-1)!) as unknown as [unknown])[0] as unknown as { drain?: unknown }
     expect(lastCall.drain).toBeUndefined()
   })
 

--- a/packages/evlog/test/nitro-v3/cloudflare-durable-build.test.ts
+++ b/packages/evlog/test/nitro-v3/cloudflare-durable-build.test.ts
@@ -15,7 +15,7 @@ if (!distExists) {
  * Static or Rollup-resolvable `import("nitro/runtime-config")` from published
  * dist used to fail with "Cannot resolve ... externals are not allowed".
  */
-describe.sequential.skipIf(!distExists)('Nitro cloudflare-durable build with evlog dist', () => {
+describe.skipIf(!distExists).sequential('Nitro cloudflare-durable build with evlog dist', () => {
   let nitro: Awaited<ReturnType<typeof createNitro>>
 
   afterAll(async () => {

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -7,10 +7,10 @@ const mockSend = vi.fn()
 const mockGetRequestURL = vi.fn(() => ({ pathname: '/api/test' }))
 
 vi.mock('h3', () => ({
-  setResponseStatus: (...args: unknown[]) => mockSetResponseStatus(...args),
-  setResponseHeader: (...args: unknown[]) => mockSetResponseHeader(...args),
-  send: (...args: unknown[]) => mockSend(...args),
-  getRequestURL: (...args: unknown[]) => mockGetRequestURL(...args),
+  setResponseStatus: (...args: any[]) => mockSetResponseStatus(...args),
+  setResponseHeader: (...args: any[]) => mockSetResponseHeader(...args),
+  send: (...args: any[]) => mockSend(...args),
+  getRequestURL: (...args: any[]) => (mockGetRequestURL as (...a: any[]) => unknown)(...args),
 }))
 
 // Mock nitropack/runtime
@@ -45,7 +45,7 @@ describe('errorHandler', () => {
         },
       }
 
-      errorHandler(evlogError as Error, mockEvent)
+      errorHandler(evlogError as any, mockEvent as any, {} as any)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 402)
       expect(mockSetResponseHeader).toHaveBeenCalledWith(mockEvent, 'Content-Type', 'application/json')
@@ -79,7 +79,7 @@ describe('errorHandler', () => {
         cause: evlogError,
       }
 
-      errorHandler(wrapperError as Error, mockEvent)
+      errorHandler(wrapperError as any, mockEvent as any, {} as any)
 
       // HTTP status should come from evlogError, not wrapper
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 404)
@@ -95,7 +95,7 @@ describe('errorHandler', () => {
         message: 'Unknown error',
       }
 
-      errorHandler(evlogError as Error, mockEvent)
+      errorHandler(evlogError as any, mockEvent as any, {} as any)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 500)
     })
@@ -108,7 +108,7 @@ describe('errorHandler', () => {
         internal: { userId: 'u-internal', rawPolicy: 'deny:admin' },
       })
 
-      errorHandler(err, mockEvent)
+      errorHandler(err as any, mockEvent as any, {} as any)
 
       const sentBody = JSON.parse(mockSend.mock.calls[0][1])
       expect(sentBody.internal).toBeUndefined()
@@ -130,7 +130,7 @@ describe('errorHandler', () => {
         statusCode: 400,
       }
 
-      errorHandler(error as Error, mockEvent)
+      errorHandler(error as any, mockEvent as any, {} as any)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 400)
 
@@ -150,7 +150,7 @@ describe('errorHandler', () => {
         message: 'Generic error',
       }
 
-      errorHandler(error as Error, mockEvent)
+      errorHandler(error as any, mockEvent as any, {} as any)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 500)
     })
@@ -161,7 +161,7 @@ describe('errorHandler', () => {
         message: '',
       }
 
-      errorHandler(error as Error, mockEvent)
+      errorHandler(error as any, mockEvent as any, {} as any)
 
       const sentBody = JSON.parse(mockSend.mock.calls[0][1])
       expect(sentBody.message).toBe('Internal Server Error')
@@ -177,7 +177,7 @@ describe('errorHandler', () => {
         statusCode: 500,
       }
 
-      errorHandler(error as Error, mockEvent)
+      errorHandler(error as any, mockEvent as any, {} as any)
 
       const sentBody = JSON.parse(mockSend.mock.calls[0][1])
       expect(sentBody.message).toBe('Internal Server Error')
@@ -193,7 +193,7 @@ describe('errorHandler', () => {
         statusCode: 400,
       }
 
-      errorHandler(error as Error, mockEvent)
+      errorHandler(error as any, mockEvent as any, {} as any)
 
       const sentBody = JSON.parse(mockSend.mock.calls[0][1])
       expect(sentBody.message).toBe('Invalid email format')

--- a/packages/evlog/test/nitro/plugin-enrichment.test.ts
+++ b/packages/evlog/test/nitro/plugin-enrichment.test.ts
@@ -8,7 +8,7 @@ vi.mock('h3', () => ({
   getHeaders: vi.fn(),
 }))
 
-function getSafeHeaders(allHeaders: Record<string, string>): Record<string, string> {
+function getSafeHeaders(allHeaders: Partial<Record<string, string | undefined>>): Record<string, string> {
   return filterSafeHeaders(allHeaders)
 }
 

--- a/packages/evlog/test/nitro/plugin.test.ts
+++ b/packages/evlog/test/nitro/plugin.test.ts
@@ -9,7 +9,7 @@ vi.mock('h3', () => ({
   getHeaders: vi.fn(),
 }))
 
-function getSafeHeaders(allHeaders: Record<string, string>): Record<string, string> {
+function getSafeHeaders(allHeaders: Partial<Record<string, string | undefined>>): Record<string, string> {
   return filterSafeHeaders(allHeaders)
 }
 
@@ -48,7 +48,7 @@ describe('nitro plugin - drain hook headers', () => {
     }
 
     // Simulate what callDrainHook does
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: mockEmittedEvent,
       request: {
@@ -108,7 +108,7 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/api/users', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
@@ -155,7 +155,7 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/api/users', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
@@ -184,7 +184,7 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
@@ -226,7 +226,7 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'POST', path: '/api/checkout', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
@@ -264,7 +264,7 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
@@ -594,6 +594,9 @@ describe('nitro plugin - useLogger service parameter', () => {
   it('service parameter overrides default service', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({ service: 'default-service' }),
@@ -619,6 +622,9 @@ describe('nitro plugin - useLogger service parameter', () => {
   it('calling useLogger without service parameter preserves existing service', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({ service: 'existing-service' }),
@@ -643,6 +649,9 @@ describe('nitro plugin - useLogger service parameter', () => {
   it('explicit service parameter takes precedence over route-based config', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({}),
@@ -670,6 +679,9 @@ describe('nitro plugin - useLogger service parameter', () => {
   it('service parameter can override any existing service configuration', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({ service: 'default-service' }),
@@ -697,6 +709,9 @@ describe('nitro plugin - service resolution priority', () => {
   it('explicit service parameter has highest priority', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({
@@ -734,6 +749,9 @@ describe('nitro plugin - service resolution priority', () => {
   it('route-based config applies when no explicit service provided', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({
@@ -765,6 +783,9 @@ describe('nitro plugin - service resolution priority', () => {
   it('env.service fallback when no route matches and no explicit service', () => {
     const mockLog = {
       set: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
       error: vi.fn(),
       emit: vi.fn(),
       getContext: vi.fn().mockReturnValue({

--- a/packages/evlog/test/toolkit/toolkit.test.ts
+++ b/packages/evlog/test/toolkit/toolkit.test.ts
@@ -385,7 +385,7 @@ describe('plugin runner', () => {
       {
         name: 'audit',
         extendLogger: (logger) => {
-          (logger as Record<string, unknown>).custom = () => 'hi'
+          (logger as unknown as Record<string, unknown>).custom = () => 'hi'
         },
       },
     ])

--- a/packages/evlog/tsconfig.json
+++ b/packages/evlog/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved TypeScript type safety and casting consistency across adapters, middleware, and framework integrations.
  * Made request logger typing optional in Express to handle cases where middleware may not be present.
  * Enhanced handler and middleware type signatures for better compatibility.

* **Tests**
  * Updated test mocks and assertions to align with improved type signatures and logger interfaces.

* **Chores**
  * Enabled experimental TypeScript decorator support in compiler options.
  * Updated configuration examples for Nitro and Vite builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->