### PR TITLE
refactor: replace non-null assertions / unsafe casts with helpers

### DIFF
--- a/apps/docs/app/components/HeroTerminalDemo.vue
+++ b/apps/docs/app/components/HeroTerminalDemo.vue
@@ -62,7 +62,9 @@ function ts() {
 }
 
 function addLog() {
-  const t = logTemplates[logId % logTemplates.length]!
+  const index = logId % logTemplates.length
+  const t = logTemplates[index]
+  if (!t) return
   chaosLogs.value.push({ id: logId++, ts: ts(), level: t.level, msg: t.msg, line: lineNum++ })
   if (chaosLogs.value.length > 13) chaosLogs.value.shift()
 
@@ -97,7 +99,7 @@ function resolve() {
       count++
       visibleFields.value = count
       if (count >= wideEventFields.length) {
-        clearInterval(fieldInterval!)
+        if (fieldInterval) clearInterval(fieldInterval)
       }
     }, 100)
   }, 700)

--- a/apps/docs/app/components/docs/DocsAsideLeftBody.vue
+++ b/apps/docs/app/components/docs/DocsAsideLeftBody.vue
@@ -9,8 +9,6 @@
  * visible at all times, so we render a flat recursive nav and skip the
  * accordion entirely.
  */
-import type { ContentNavigationItem } from '@nuxt/content'
-
 const { sidebarNavigation } = useSubNavigation()
 </script>
 
@@ -19,8 +17,8 @@ const { sidebarNavigation } = useSubNavigation()
     <ul class="flex flex-col">
       <DocsAsideLeftBodyItem
         v-for="(item, index) in sidebarNavigation"
-        :key="(item as ContentNavigationItem).path ?? `root-${index}`"
-        :item="(item as ContentNavigationItem)"
+        :key="item.path ?? `root-${index}`"
+        :item
         :level="0"
       />
     </ul>

--- a/apps/docs/app/components/docs/DocsAsideLeftBodyItem.vue
+++ b/apps/docs/app/components/docs/DocsAsideLeftBodyItem.vue
@@ -16,7 +16,9 @@ const route = useRoute()
 function getFirstPagePath(item: ContentNavigationItem): string {
   let current = item
   while (current.children?.length) {
-    current = current.children[0]!
+    const [first] = current.children
+    if (!first) break
+    current = first
   }
   return current.path
 }
@@ -46,8 +48,8 @@ const headerClasses = 'text-default font-medium hover:text-primary'
       ]"
     >
       <UIcon
-        v-if="item.icon"
-        :name="(item.icon as string)"
+        v-if="typeof item.icon === 'string'"
+        :name="item.icon"
         class="size-4 shrink-0"
       />
       <span class="truncate">{{ item.title }}</span>
@@ -58,8 +60,8 @@ const headerClasses = 'text-default font-medium hover:text-primary'
     >
       <DocsAsideLeftBodyItem
         v-for="(child, index) in item.children"
-        :key="(child as ContentNavigationItem).path ?? `${item.path}-${index}`"
-        :item="(child as ContentNavigationItem)"
+        :key="child.path ?? `${item.path}-${index}`"
+        :item="child"
         :level="level + 1"
       />
     </ul>

--- a/apps/docs/app/components/og-image/OgImageDocs.satori.vue
+++ b/apps/docs/app/components/og-image/OgImageDocs.satori.vue
@@ -63,10 +63,9 @@ const titleStyle = computed(() => {
 const titleBloomDuplicate = computed(() => titleLen.value <= 32)
 
 const titleStyleBloom = computed(() => {
-  const s = { ...titleStyle.value }
-  delete (s as Record<string, unknown>).textShadow
+  const { textShadow: _textShadow, ...rest } = titleStyle.value
   return {
-    ...s,
+    ...rest,
     color: 'rgba(255,255,255,0.92)',
   }
 })

--- a/apps/docs/server/routes/sitemap.xml.ts
+++ b/apps/docs/server/routes/sitemap.xml.ts
@@ -27,11 +27,10 @@ export default defineEventHandler(async (event) => {
   try {
     const pages = await queryCollection(event, 'docs').all()
 
-    for (const page of pages as unknown as Array<Record<string, unknown> & { path?: string }>) {
-      const meta = page as Record<string, unknown>
+    for (const page of pages) {
       let pagePath = page.path || '/'
 
-      if (meta.sitemap === false) continue
+      if (page.sitemap === false) continue
       if (pagePath.endsWith('.navigation') || pagePath.includes('/.navigation')) continue
 
       if (pagePath === '/landing') pagePath = '/'
@@ -41,8 +40,8 @@ export default defineEventHandler(async (event) => {
 
       const urlEntry: SitemapUrl = { loc: pagePath }
 
-      if (meta.modifiedAt && typeof meta.modifiedAt === 'string') {
-        const [datePart] = meta.modifiedAt.split('T')
+      if (page.modifiedAt && typeof page.modifiedAt === 'string') {
+        const [datePart] = page.modifiedAt.split('T')
         urlEntry.lastmod = datePart
       }
 

--- a/apps/just-use-evlog/app/pages/index.vue
+++ b/apps/just-use-evlog/app/pages/index.vue
@@ -21,7 +21,11 @@ const { public: pub } = useRuntimeConfig()
 const docsUrl = pub.docsUrl || 'https://www.evlog.dev'
 const siteUrl = pub.siteUrl || 'https://www.justfuckinguseevlog.com'
 
-const fm = page.value as unknown as Record<string, string>
+const pageData = page.value
+
+function pickString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
 
 useHead({
   htmlAttrs: { lang: 'en' },
@@ -36,7 +40,7 @@ useHead({
         '@context': 'https://schema.org',
         '@type': 'SoftwareApplication',
         'name': 'evlog',
-        'description': fm.description,
+        'description': pickString(pageData.description),
         'applicationCategory': 'DeveloperApplication',
         'operatingSystem': 'Any',
         'offers': { '@type': 'Offer', 'price': '0', 'priceCurrency': 'USD' },
@@ -49,12 +53,12 @@ useHead({
 })
 
 useSeoMeta({
-  title: fm.title,
-  description: fm.description,
+  title: pickString(pageData.title),
+  description: pickString(pageData.description),
   ogType: 'website',
   ogUrl: `${siteUrl}/`,
-  ogTitle: fm.ogTitle || fm.title,
-  ogDescription: fm.ogDescription || fm.description,
+  ogTitle: pickString(pageData.ogTitle) || pickString(pageData.title),
+  ogDescription: pickString(pageData.ogDescription) || pickString(pageData.description),
   ogImage: `${siteUrl}/og.jpg`,
   ogImageWidth: 1200,
   ogImageHeight: 630,

--- a/apps/nuxthub-playground/app/components/AiChat.vue
+++ b/apps/nuxthub-playground/app/components/AiChat.vue
@@ -37,16 +37,12 @@ function askQuick(question: string) {
 
 const isLoading = computed(() => chat.status === 'streaming' || chat.status === 'submitted')
 
-function isToolPart(part: any): boolean {
-  return typeof part.type === 'string' && (part.type.startsWith('tool-') || part.type === 'dynamic-tool')
-}
-
-function getToolInput(part: any): { query?: string } {
-  return part.input ?? {}
-}
-
-function getToolOutput(part: any): { count?: number, error?: string } | undefined {
-  return part.output
+interface ToolPart {
+  type: string
+  state?: string
+  errorText?: string
+  input?: { query?: string }
+  output?: { count?: number, error?: string }
 }
 
 interface AiMessageMetadata {
@@ -56,10 +52,33 @@ interface AiMessageMetadata {
   finishReason?: string
 }
 
-function getAiMetadata(message: any): AiMessageMetadata | undefined {
-  const meta = message?.metadata as AiMessageMetadata | undefined
+interface ChatMessage {
+  metadata?: AiMessageMetadata
+}
+
+function isToolPart(part: { type: string }): part is ToolPart {
+  return part.type.startsWith('tool-') || part.type === 'dynamic-tool'
+}
+
+function getToolInput(part: ToolPart): { query?: string } {
+  return part.input ?? {}
+}
+
+function getToolOutput(part: ToolPart): { count?: number, error?: string } | undefined {
+  return part.output
+}
+
+function getAiMetadata(message: ChatMessage): AiMessageMetadata | undefined {
+  const meta = message.metadata
   if (!meta || (meta.calls === undefined && meta.totalTokens === undefined)) return undefined
   return meta
+}
+
+function setQuickButtonHover(event: MouseEvent, active: boolean) {
+  const el = event.currentTarget
+  if (!(el instanceof HTMLElement)) return
+  el.style.borderColor = active ? '#3182ce' : '#e2e8f0'
+  el.style.background = active ? '#ebf8ff' : '#fff'
 }
 
 function formatCost(cost: number | undefined): string {
@@ -97,13 +116,13 @@ function formatCost(cost: number | undefined): string {
           v-if="message.role === 'assistant' && getAiMetadata(message)"
           style="flex-shrink: 0; align-self: flex-start; max-width: 85%; padding: 0.3rem 0.55rem; border-radius: 6px; font-size: 0.7rem; color: #4a5568; background: #edf2f7; border: 1px solid #e2e8f0; font-family: monospace; display: inline-flex; gap: 0.5rem; flex-wrap: wrap;"
         >
-          <span>step {{ getAiMetadata(message)!.calls }}</span>
+          <span>step {{ getAiMetadata(message)?.calls }}</span>
           <span>·</span>
-          <span>{{ getAiMetadata(message)!.totalTokens }} tokens</span>
+          <span>{{ getAiMetadata(message)?.totalTokens }} tokens</span>
           <span>·</span>
-          <span>{{ formatCost(getAiMetadata(message)!.estimatedCost) }}</span>
-          <span v-if="getAiMetadata(message)!.finishReason">·</span>
-          <span v-if="getAiMetadata(message)!.finishReason">{{ getAiMetadata(message)!.finishReason }}</span>
+          <span>{{ formatCost(getAiMetadata(message)?.estimatedCost) }}</span>
+          <span v-if="getAiMetadata(message)?.finishReason">·</span>
+          <span v-if="getAiMetadata(message)?.finishReason">{{ getAiMetadata(message)?.finishReason }}</span>
         </div>
         <template v-for="(part, pi) in message.parts" :key="`${message.id}-${part.type}-${pi}`">
           <!-- User text -->
@@ -136,9 +155,9 @@ function formatCost(cost: number | undefined): string {
               {{ getToolInput(part).query || JSON.stringify(getToolInput(part)) }}
             </div>
             <div style="padding: 0.3rem 0.65rem; font-size: 0.75rem;">
-              <span v-if="(part as any).state === 'output-error'" style="color: #e53e3e;">Error: {{ (part as any).errorText }}</span>
-              <span v-else-if="getToolOutput(part)?.error" style="color: #e53e3e;">Error: {{ getToolOutput(part)!.error }}</span>
-              <span v-else-if="(part as any).state === 'output-available'" style="color: #38a169;">{{ getToolOutput(part)?.count ?? 0 }} row{{ (getToolOutput(part)?.count ?? 0) !== 1 ? 's' : '' }} returned</span>
+              <span v-if="part.state === 'output-error'" style="color: #e53e3e;">Error: {{ part.errorText }}</span>
+              <span v-else-if="getToolOutput(part)?.error" style="color: #e53e3e;">Error: {{ getToolOutput(part)?.error }}</span>
+              <span v-else-if="part.state === 'output-available'" style="color: #38a169;">{{ getToolOutput(part)?.count ?? 0 }} row{{ (getToolOutput(part)?.count ?? 0) !== 1 ? 's' : '' }} returned</span>
               <span v-else style="color: #a0aec0; display: inline-flex; align-items: center; gap: 0.3rem;">
                 <span style="display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: #d69e2e; animation: pulse 1s infinite;" />
                 Querying...
@@ -154,8 +173,8 @@ function formatCost(cost: number | undefined): string {
         v-for="q in quickQuestions"
         :key="q"
         style="padding: 0.3rem 0.6rem; font-size: 0.78rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 999px; color: #4a5568; cursor: pointer; transition: border-color 0.15s, background 0.15s;"
-        @mouseenter="($event.target as HTMLElement).style.borderColor = '#3182ce'; ($event.target as HTMLElement).style.background = '#ebf8ff'"
-        @mouseleave="($event.target as HTMLElement).style.borderColor = '#e2e8f0'; ($event.target as HTMLElement).style.background = '#fff'"
+        @mouseenter="setQuickButtonHover($event, true)"
+        @mouseleave="setQuickButtonHover($event, false)"
         @click="askQuick(q)"
       >
         {{ q }}

--- a/apps/nuxthub-playground/server/api/logs.get.ts
+++ b/apps/nuxthub-playground/server/api/logs.get.ts
@@ -3,7 +3,7 @@ import { count as sqlCount, desc, eq } from 'drizzle-orm'
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
-  const level = query.level as string | undefined
+  const level = typeof query.level === 'string' ? query.level : undefined
   const limit = Math.min(Number(query.limit) || 50, 200)
 
   const conditions = level ? eq(schema.evlogEvents.level, level) : undefined

--- a/apps/playground/app/pages/stream.vue
+++ b/apps/playground/app/pages/stream.vue
@@ -45,9 +45,31 @@ function pushEvent(event: WideEvent) {
   events.value = [event, ...events.value].slice(0, 500)
 }
 
+function pickStringField(obj: WideEvent, key: string): string | undefined {
+  const value = obj[key]
+  return typeof value === 'string' ? value : undefined
+}
+
 function actionLabel(event: WideEvent) {
-  const e = event as Record<string, unknown>
-  return (e.action as string) ?? (e.message as string) ?? (e.path as string) ?? ''
+  return pickStringField(event, 'action')
+    ?? pickStringField(event, 'message')
+    ?? pickStringField(event, 'path')
+    ?? ''
+}
+
+function isHelloPayload(data: unknown): data is NonNullable<typeof helloPayload.value> {
+  return typeof data === 'object'
+    && data !== null
+    && 'evlogVersion' in data
+    && typeof Reflect.get(data, 'evlogVersion') === 'string'
+}
+
+function isWideEvent(data: unknown): data is WideEvent {
+  return typeof data === 'object'
+    && data !== null
+    && 'timestamp' in data
+    && 'level' in data
+    && 'service' in data
 }
 
 function eventMatches(event: WideEvent) {
@@ -173,11 +195,15 @@ async function connect() {
     }
     if (envelope.evlog !== '1') return
     if (envelope.type === 'hello') {
-      helloPayload.value = envelope.data as typeof helloPayload.value
+      if (isHelloPayload(envelope.data)) {
+        helloPayload.value = envelope.data
+      }
       return
     }
     if (envelope.type === 'event' || envelope.type === 'replay') {
-      pushEvent(envelope.data as WideEvent)
+      if (isWideEvent(envelope.data)) {
+        pushEvent(envelope.data)
+      }
     }
   }
 
@@ -397,7 +423,7 @@ onBeforeUnmount(() => {
                   {{ event.service }}
                 </td>
                 <td class="px-3 py-1.5 text-[11px] tabular-nums text-muted">
-                  {{ (event as Record<string, unknown>).status ?? '' }}
+                  {{ typeof event.status === 'number' ? event.status : '' }}
                 </td>
                 <td class="px-3 py-1.5 text-[11px] truncate">
                   {{ actionLabel(event) }}

--- a/apps/playground/server/api/audit/with-audit.post.ts
+++ b/apps/playground/server/api/audit/with-audit.post.ts
@@ -27,6 +27,6 @@ export default defineEventHandler(async (event) => {
     const result = await refundInvoice({ id }, { actor: { type: 'user', id: 'usr_42' } })
     return { ok: true, scenario, result }
   } catch (err) {
-    return { ok: false, scenario, error: (err as Error).message }
+    return { ok: false, scenario, error: err instanceof Error ? err.message : String(err) }
   }
 })

--- a/apps/playground/server/api/test/better-auth/whoami.get.ts
+++ b/apps/playground/server/api/test/better-auth/whoami.get.ts
@@ -3,7 +3,7 @@ export default defineEventHandler((event) => {
   log.set({ action: 'whoami' })
 
   const ctx = log.getContext()
-  const userId = ctx.userId as string | undefined
+  const userId = typeof ctx.userId === 'string' ? ctx.userId : undefined
 
   return {
     identified: !!userId,

--- a/examples/browser/src/client.ts
+++ b/examples/browser/src/client.ts
@@ -1,8 +1,20 @@
 import { initLogger, log } from 'evlog'
 import { createHttpLogDrain } from 'evlog/http'
 
+function requireElement(id: string): HTMLElement {
+  const el = document.getElementById(id)
+  if (!el) throw new Error(`Missing element #${id}`)
+  return el
+}
+
+function requireInput(id: string): HTMLInputElement {
+  const el = document.getElementById(id)
+  if (!(el instanceof HTMLInputElement)) throw new Error(`Missing input #${id}`)
+  return el
+}
+
 // Visual feedback
-const logList = document.getElementById('log-list')!
+const logList = requireElement('log-list')
 
 function notify(action: string, level: 'info' | 'error' = 'info') {
   const el = document.createElement('div')
@@ -23,15 +35,15 @@ log.info({ action: 'page_view', path: location.pathname, referrer: document.refe
 notify('page_view')
 
 // User clicks "Add to cart"
-document.getElementById('add-to-cart')!.addEventListener('click', () => {
+requireElement('add-to-cart').addEventListener('click', () => {
   log.info({ action: 'add_to_cart', product: 'T-Shirt', price: 29.99, currency: 'EUR' })
   notify('add_to_cart')
 })
 
 // User submits checkout form
-document.getElementById('checkout-form')!.addEventListener('submit', async (e) => {
+requireElement('checkout-form').addEventListener('submit', async (e) => {
   e.preventDefault()
-  const email = (document.getElementById('email') as HTMLInputElement).value
+  const email = requireInput('email').value
 
   log.info({ action: 'checkout_started', email_provided: !!email })
   notify('checkout_started')

--- a/examples/community-adapter-skeleton/test/acme.test.ts
+++ b/examples/community-adapter-skeleton/test/acme.test.ts
@@ -10,7 +10,7 @@ const baseEvent = (): WideEvent => ({
   action: 'checkout',
 })
 
-const ctx = (event: WideEvent): DrainContext => ({ event } as DrainContext)
+const ctx = (event: WideEvent): DrainContext => ({ event })
 
 describe('toAcmeEvent', () => {
   it('flattens timestamp + level + attributes', () => {
@@ -60,8 +60,13 @@ describe('createAcmeDrain', () => {
   it('honors explicit overrides over env vars', async () => {
     const drain = createAcmeDrain({ apiKey: 'override-secret' })
     await drain(ctx(baseEvent()))
-    const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
-    const headers = call[1].headers as Record<string, string>
-    expect(headers.Authorization).toBe('Bearer override-secret')
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer override-secret',
+        }),
+      }),
+    )
   })
 })

--- a/examples/community-framework-skeleton/src/index.ts
+++ b/examples/community-framework-skeleton/src/index.ts
@@ -85,7 +85,7 @@ export function evlog(options: EvlogMyFrameworkOptions = {}): MyFrameworkMiddlew
       await runWith(() => next())
       await finish({ status: ctx.res.statusCode })
     } catch (error) {
-      await finish({ error: error as Error })
+      await finish({ error: error instanceof Error ? error : new Error(String(error)) })
       throw error
     }
   }

--- a/examples/solidstart/src/entry-client.tsx
+++ b/examples/solidstart/src/entry-client.tsx
@@ -1,4 +1,7 @@
 // @refresh reload
 import { mount, StartClient } from "@solidjs/start/client"
 
-mount(() => <StartClient />, document.getElementById("app")!)
+const root = document.getElementById("app")
+if (!root) throw new Error('Missing element #app')
+
+mount(() => <StartClient />, root)

--- a/examples/tanstack-start/src/routes/api/admin.ts
+++ b/examples/tanstack-start/src/routes/api/admin.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useRequest } from 'nitro/context'
 import { createError } from 'evlog'
-import type { RequestLogger } from 'evlog'
+import { requireRequestLogger } from '@/utils/require-request-logger'
 
 export const Route = createFileRoute('/api/admin')({
   server: {
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/api/admin')({
         if (!req.context) {
           throw new Error('Missing Nitro request context')
         }
-        const log = req.context.log as RequestLogger
+        const log = requireRequestLogger(req.context)
 
         const body = await request.json() as { resourceId: string, changes: Record<string, unknown> }
 

--- a/examples/tanstack-start/src/routes/api/checkout.ts
+++ b/examples/tanstack-start/src/routes/api/checkout.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useRequest } from 'nitro/context'
 import { createError } from 'evlog'
-import type { RequestLogger } from 'evlog'
+import { requireRequestLogger } from '@/utils/require-request-logger'
 
 export const Route = createFileRoute('/api/checkout')({
   server: {
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/api/checkout')({
         if (!req.context) {
           throw new Error('Missing Nitro request context')
         }
-        const log = req.context.log as RequestLogger
+        const log = requireRequestLogger(req.context)
 
         const body = await request.json() as {
           userId: string

--- a/examples/tanstack-start/src/routes/api/hello.ts
+++ b/examples/tanstack-start/src/routes/api/hello.ts
@@ -1,13 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useRequest } from 'nitro/context'
-import type { RequestLogger } from 'evlog'
+import { requireRequestLogger } from '@/utils/require-request-logger'
 
 export const Route = createFileRoute('/api/hello')({
   server: {
     handlers: {
       GET: async () => {
         const req = useRequest()
-        const log = req?.context?.log as RequestLogger
+        const log = requireRequestLogger(req?.context)
 
         log.set({
           user: { id: 'user_789', plan: 'enterprise', role: 'admin' },

--- a/examples/tanstack-start/src/routes/api/order.ts
+++ b/examples/tanstack-start/src/routes/api/order.ts
@@ -1,13 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useRequest } from 'nitro/context'
-import type { RequestLogger } from 'evlog'
+import { requireRequestLogger } from '@/utils/require-request-logger'
 
 export const Route = createFileRoute('/api/order')({
   server: {
     handlers: {
       GET: async () => {
         const req = useRequest()
-        const log = req?.context?.log as RequestLogger
+        const log = requireRequestLogger(req?.context)
 
         log.set({
           user: {

--- a/examples/tanstack-start/src/utils/require-request-logger.ts
+++ b/examples/tanstack-start/src/utils/require-request-logger.ts
@@ -1,0 +1,24 @@
+import type { RequestLogger } from 'evlog'
+
+function isRequestLogger(value: unknown): value is RequestLogger {
+  return typeof value === 'object'
+    && value !== null
+    && 'set' in value
+    && typeof value.set === 'function'
+}
+
+function readContextLog(context: unknown): unknown {
+  if (typeof context !== 'object' || context === null || !('log' in context)) {
+    return undefined
+  }
+  return context.log
+}
+
+/** Narrow Nitro request context to evlog's request logger. */
+export function requireRequestLogger(context: unknown): RequestLogger {
+  const log = readContextLog(context)
+  if (!isRequestLogger(log)) {
+    throw new Error('Missing evlog request logger — is evlog/nitro/v3 registered?')
+  }
+  return log
+}

--- a/examples/workers/src/index.ts
+++ b/examples/workers/src/index.ts
@@ -11,7 +11,7 @@ export default defineWorkerFetch(async (request, _env, _ctx, log) => {
     log.emit({ status: response.status })
     return response
   } catch (error) {
-    log.error(error as Error)
+    log.error(error instanceof Error ? error : new Error(String(error)))
     log.emit({ status: 500 })
     throw error
   }

--- a/packages/evlog/bench/baseline/size.json
+++ b/packages/evlog/bench/baseline/size.json
@@ -2,13 +2,13 @@
   "entries": [
     {
       "entry": "framework/nitro",
-      "raw": 20269,
-      "gzip": 7335
+      "raw": 20465,
+      "gzip": 7402
     },
     {
       "entry": "framework/next",
       "raw": 15035,
-      "gzip": 5328
+      "gzip": 5329
     },
     {
       "entry": "framework/ai",
@@ -17,18 +17,18 @@
     },
     {
       "entry": "adapter/fs",
-      "raw": 10211,
-      "gzip": 3427
+      "raw": 10252,
+      "gzip": 3442
     },
     {
       "entry": "adapter/datadog",
-      "raw": 6370,
-      "gzip": 2541
+      "raw": 6411,
+      "gzip": 2555
     },
     {
       "entry": "adapter/sentry",
-      "raw": 6557,
-      "gzip": 2462
+      "raw": 6598,
+      "gzip": 2473
     },
     {
       "entry": "framework/vite",
@@ -38,12 +38,17 @@
     {
       "entry": "core (index)",
       "raw": 6458,
-      "gzip": 2206
+      "gzip": 2208
     },
     {
       "entry": "adapter/otlp",
-      "raw": 6047,
-      "gzip": 2189
+      "raw": 6088,
+      "gzip": 2200
+    },
+    {
+      "entry": "adapter/memory",
+      "raw": 5251,
+      "gzip": 2085
     },
     {
       "entry": "enrichers",
@@ -51,14 +56,14 @@
       "gzip": 2040
     },
     {
+      "entry": "utils",
+      "raw": 4327,
+      "gzip": 1823
+    },
+    {
       "entry": "framework/sveltekit",
       "raw": 5120,
       "gzip": 1628
-    },
-    {
-      "entry": "utils",
-      "raw": 3878,
-      "gzip": 1619
     },
     {
       "entry": "error",
@@ -67,13 +72,13 @@
     },
     {
       "entry": "adapter/axiom",
-      "raw": 4010,
-      "gzip": 1538
+      "raw": 4051,
+      "gzip": 1551
     },
     {
       "entry": "adapter/posthog",
-      "raw": 4497,
-      "gzip": 1505
+      "raw": 4538,
+      "gzip": 1518
     },
     {
       "entry": "pipeline",
@@ -83,22 +88,22 @@
     {
       "entry": "framework/elysia",
       "raw": 3465,
-      "gzip": 1365
+      "gzip": 1364
     },
     {
       "entry": "workers",
       "raw": 3226,
-      "gzip": 1336
+      "gzip": 1337
     },
     {
       "entry": "adapter/better-stack",
-      "raw": 3294,
-      "gzip": 1287
+      "raw": 3335,
+      "gzip": 1302
     },
     {
       "entry": "framework/nestjs",
-      "raw": 3032,
-      "gzip": 1284
+      "raw": 3073,
+      "gzip": 1288
     },
     {
       "entry": "http",
@@ -107,8 +112,8 @@
     },
     {
       "entry": "adapter/hyperdx",
-      "raw": 2930,
-      "gzip": 1205
+      "raw": 2971,
+      "gzip": 1221
     },
     {
       "entry": "framework/fastify",
@@ -117,18 +122,18 @@
     },
     {
       "entry": "toolkit",
-      "raw": 2221,
-      "gzip": 781
+      "raw": 2261,
+      "gzip": 796
     },
     {
       "entry": "framework/express",
-      "raw": 1378,
-      "gzip": 727
+      "raw": 1427,
+      "gzip": 740
     },
     {
       "entry": "framework/hono",
       "raw": 1146,
-      "gzip": 615
+      "gzip": 614
     },
     {
       "entry": "browser",
@@ -138,7 +143,7 @@
     {
       "entry": "logger",
       "raw": 430,
-      "gzip": 229
+      "gzip": 225
     },
     {
       "entry": "client",
@@ -152,7 +157,7 @@
     }
   ],
   "total": {
-    "raw": 155177,
-    "gzip": 55634
+    "raw": 161531,
+    "gzip": 58128
   }
 }

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -33,7 +33,10 @@ export interface AuditInput {
  * produces the same digest, regardless of how object keys were added.
  */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (Object.prototype.toString.call(value) !== '[object Object]') return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || value.constructor === Object
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -32,11 +32,16 @@ export interface AuditInput {
  * Used by `idempotencyKey` and `hash-chain` so the same logical event always
  * produces the same digest, regardless of how object keys were added.
  */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value)
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
-  const keys = Object.keys(value as Record<string, unknown>).sort()
-  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`).join(',')}}`
+  if (!isPlainObject(value)) return JSON.stringify(value)
+  const keys = Object.keys(value).sort()
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`
 }
 
 /**

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -32,7 +32,8 @@ const integration = defineFrameworkIntegration<FastifyRequest>({
     requestId: typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined,
   }),
   attachLogger: (req, logger) => {
-    (req as any).log = logger
+    // @ts-expect-error evlog replaces Fastify's built-in pino logger with RequestLogger
+    req.log = logger
   },
   storage,
 })
@@ -62,21 +63,19 @@ const evlogPlugin: FastifyPluginCallback<EvlogFastifyOptions> = (fastify, option
     const state = requestState.get(request)
     if (!state || emitted.has(request)) return
     emitted.add(request)
-    const logger = (request as any).log
     const err = error instanceof Error ? error : new Error(String(error))
-    if (logger && typeof logger.error === 'function') logger.error(err)
+    request.log.error(err)
     await state.finish({ error: err })
   })
 
   done()
 }
 
-const plugin = evlogPlugin as any
-plugin[Symbol.for('skip-override')] = true
-plugin[Symbol.for('fastify.display-name')] = 'evlog'
-
 /**
  * Create an evlog plugin for Fastify.
+ *
+ * Plugin metadata symbols (`skip-override`, `fastify.display-name`) are attached
+ * for @fastify/autoload — they are not part of `FastifyPluginCallback`.
  *
  * @example
  * ```ts
@@ -96,4 +95,7 @@ plugin[Symbol.for('fastify.display-name')] = 'evlog'
  * })
  * ```
  */
-export const evlog = evlogPlugin
+export const evlog = Object.assign(evlogPlugin, {
+  [Symbol.for('skip-override')]: true,
+  [Symbol.for('fastify.display-name')]: 'evlog',
+})

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -298,9 +298,9 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return String(value)
   }
-  if (typeof value === 'object') {
+  if (isPlainObject(value)) {
     const pairs: string[] = []
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    for (const [k, v] of Object.entries(value)) {
       if (v !== undefined && v !== null) {
         if (typeof v === 'object') {
           pairs.push(`${k}=${JSON.stringify(v)}`)
@@ -326,6 +326,48 @@ interface TreeEntry {
   children?: string[]
 }
 
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.every(item => typeof item === 'string') ? value : undefined
+}
+
+interface ToolUsageEntry {
+  name: string
+  durationMs: number
+  success: boolean
+  error?: string
+}
+
+function isToolUsageEntry(value: unknown): value is ToolUsageEntry {
+  return isPlainObject(value)
+    && typeof value.name === 'string'
+    && typeof value.durationMs === 'number'
+    && typeof value.success === 'boolean'
+}
+
+function asToolUsageArray(value: unknown): ToolUsageEntry[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.every(isToolUsageEntry) ? value : undefined
+}
+
+interface ToolCallEntry {
+  name: string
+  input: unknown
+}
+
+function isToolCallEntry(value: unknown): value is ToolCallEntry {
+  return isPlainObject(value) && typeof value.name === 'string' && 'input' in value
+}
+
+function asToolCallArray(value: unknown): ToolCallEntry[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.every(isToolCallEntry) ? value : undefined
+}
+
 function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
   const entries: TreeEntry[] = []
 
@@ -336,14 +378,18 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
     if (ai.provider) m += ` (${ai.provider})`
     headerParts.push(m)
   }
-  if (ai.calls) headerParts.push(`${ai.calls} call${(ai.calls as number) > 1 ? 's' : ''}`)
-  if (ai.steps && (ai.steps as number) > 1) headerParts.push(`${ai.steps} steps`)
+  if (ai.calls) {
+    const calls = asNumber(ai.calls)
+    if (calls !== undefined) headerParts.push(`${calls} call${calls > 1 ? 's' : ''}`)
+  }
+  const steps = asNumber(ai.steps)
+  if (steps !== undefined && steps > 1) headerParts.push(`${steps} steps`)
   entries.push({ key: 'ai', value: headerParts.join(' · ') })
 
   // Tokens
-  const inputTokens = ai.inputTokens as number | undefined
-  const outputTokens = ai.outputTokens as number | undefined
-  const totalTokens = ai.totalTokens as number | undefined
+  const inputTokens = asNumber(ai.inputTokens)
+  const outputTokens = asNumber(ai.outputTokens)
+  const totalTokens = asNumber(ai.totalTokens)
   if (inputTokens !== undefined && outputTokens !== undefined) {
     let tokLine = `${inputTokens} in → ${outputTokens} out`
     if (totalTokens) tokLine += ` (${totalTokens} total)`
@@ -356,9 +402,9 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
   }
 
   // Streaming
-  const msFirst = ai.msToFirstChunk as number | undefined
-  const msFinish = ai.msToFinish as number | undefined
-  const tps = ai.tokensPerSecond as number | undefined
+  const msFirst = asNumber(ai.msToFirstChunk)
+  const msFinish = asNumber(ai.msToFinish)
+  const tps = asNumber(ai.tokensPerSecond)
   if (msFirst !== undefined || msFinish !== undefined) {
     const parts: string[] = []
     if (msFirst !== undefined) parts.push(`${formatDuration(msFirst)} to first chunk`)
@@ -369,27 +415,30 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
   }
 
   // Cost
-  if (ai.estimatedCost !== undefined) {
-    entries.push({ key: 'ai.cost', value: formatCost(ai.estimatedCost as number) })
+  const estimatedCost = asNumber(ai.estimatedCost)
+  if (estimatedCost !== undefined) {
+    entries.push({ key: 'ai.cost', value: formatCost(estimatedCost) })
   }
 
   // Total duration
-  if (ai.totalDurationMs !== undefined) {
-    entries.push({ key: 'ai.totalDuration', value: formatDuration(ai.totalDurationMs as number) })
+  const totalDurationMs = asNumber(ai.totalDurationMs)
+  if (totalDurationMs !== undefined) {
+    entries.push({ key: 'ai.totalDuration', value: formatDuration(totalDurationMs) })
   }
 
   // Tools — merged from toolCalls (middleware) + tools (telemetry)
-  const toolCalls = ai.toolCalls as unknown[] | undefined
-  const tools = ai.tools as Array<{ name: string, durationMs: number, success: boolean, error?: string }> | undefined
-  const hasInputs = toolCalls?.length ? typeof toolCalls[0] === 'object' : false
+  const toolCalls = Array.isArray(ai.toolCalls) ? ai.toolCalls : undefined
+  const tools = asToolUsageArray(ai.tools)
+  const toolCallEntries = toolCalls ? asToolCallArray(toolCalls) : undefined
+  const hasInputs = toolCallEntries !== undefined && toolCallEntries.length > 0
 
   if (tools?.length) {
     const children = tools.map((t, idx) => {
       const mark = t.success ? '✓' : '✗'
       let line = `${t.name} ${formatDuration(t.durationMs)} ${mark}`
       if (t.error) line += ` ${t.error}`
-      if (hasInputs && toolCalls && idx < toolCalls.length) {
-        const tc = toolCalls[idx] as { input: unknown }
+      if (hasInputs && toolCallEntries && idx < toolCallEntries.length) {
+        const tc = toolCallEntries[idx]
         const inputStr = typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)
         const truncated = inputStr.length > 100 ? `${inputStr.slice(0, 100)}…` : inputStr
         line += ` ${truncated}`
@@ -398,36 +447,40 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
     })
     entries.push({ key: 'ai.tools', value: '', children })
   } else if (toolCalls?.length) {
-    if (hasInputs) {
-      const children = (toolCalls as Array<{ name: string, input: unknown }>).map((tc) => {
+    if (toolCallEntries?.length) {
+      const children = toolCallEntries.map((tc) => {
         const inputStr = typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)
         const truncated = inputStr.length > 100 ? `${inputStr.slice(0, 100)}…` : inputStr
         return `${tc.name}(${truncated})`
       })
       entries.push({ key: 'ai.tools', value: '', children })
     } else {
-      entries.push({ key: 'ai.tools', value: (toolCalls as string[]).join(', ') })
+      const names = asStringArray(toolCalls)
+      if (names?.length) entries.push({ key: 'ai.tools', value: names.join(', ') })
     }
   }
 
   // Steps
-  const stepsUsage = ai.stepsUsage as Array<Record<string, unknown>> | undefined
+  const stepsUsage = Array.isArray(ai.stepsUsage)
+    ? ai.stepsUsage.filter(isPlainObject)
+    : undefined
   if (stepsUsage?.length) {
-    const allSameModel = stepsUsage.every(s => s.model === stepsUsage[0]!.model)
+    const firstModel = stepsUsage[0]?.model
+    const allSameModel = firstModel !== undefined && stepsUsage.every(s => s.model === firstModel)
     const children = stepsUsage.map((s) => {
-      const prefix = allSameModel ? '' : `${s.model} `
+      const prefix = allSameModel ? '' : `${String(s.model)} `
       let line = `${prefix}${s.inputTokens} in → ${s.outputTokens} out`
-      const stepTools = s.toolCalls as string[] | undefined
+      const stepTools = asStringArray(s.toolCalls)
       if (stepTools?.length) line += ` [${stepTools.join(', ')}]`
       return line
     })
     entries.push({ key: 'ai.steps', value: '', children })
-  } else if (ai.steps && (ai.steps as number) > 1) {
-    entries.push({ key: 'ai.steps', value: String(ai.steps) })
+  } else if (steps !== undefined && steps > 1) {
+    entries.push({ key: 'ai.steps', value: String(steps) })
   }
 
   // Embedding
-  const embedding = ai.embedding as Record<string, unknown> | undefined
+  const embedding = isPlainObject(ai.embedding) ? ai.embedding : undefined
   if (embedding) {
     const parts: string[] = []
     if (embedding.model) parts.push(String(embedding.model))
@@ -446,19 +499,20 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
 
 function prettyPrintWideEvent(event: Record<string, unknown>): void {
   const { timestamp, level, service, environment, version, ...rest } = event
-  const ts = (timestamp as string).slice(11, 23)
+  const ts = typeof timestamp === 'string' ? timestamp.slice(11, 23) : ''
+  const levelLabel = typeof level === 'string' ? level : 'info'
   const browser = isBrowser()
 
   const parts: string[] = []
   const styles: string[] = []
 
   if (browser) {
-    const lc = getCssLevelColor(level as string)
-    parts.push(`%c${ts}%c %c${(level as string).toUpperCase()}%c %c[${escapeFormatString(String(service))}]%c`)
+    const lc = getCssLevelColor(levelLabel)
+    parts.push(`%c${ts}%c %c${levelLabel.toUpperCase()}%c %c[${escapeFormatString(String(service))}]%c`)
     styles.push(cssColors.dim, cssColors.reset, lc, cssColors.reset, cssColors.cyan, cssColors.reset)
   } else {
-    const lc = getLevelColor(level as string)
-    parts.push(`${colors.dim}${ts}${colors.reset} ${lc}${(level as string).toUpperCase()}${colors.reset} ${colors.cyan}[${service}]${colors.reset}`)
+    const lc = getLevelColor(levelLabel)
+    parts.push(`${colors.dim}${ts}${colors.reset} ${lc}${levelLabel.toUpperCase()}${colors.reset} ${colors.cyan}[${service}]${colors.reset}`)
   }
 
   if (rest.method && rest.path) {
@@ -468,9 +522,10 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
   }
 
   if (rest.status) {
+    const statusCode = asNumber(rest.status) ?? Number(rest.status)
     const sc = browser
-      ? ((rest.status as number) >= 400 ? cssColors.red : cssColors.green)
-      : ((rest.status as number) >= 400 ? colors.red : colors.green)
+      ? (statusCode >= 400 ? cssColors.red : cssColors.green)
+      : (statusCode >= 400 ? colors.red : colors.green)
     if (browser) {
       parts.push(` %c${rest.status}%c`)
       styles.push(sc, cssColors.reset)
@@ -492,8 +547,8 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
 
   console.log(parts.join(''), ...styles)
 
-  const aiData = rest.ai as Record<string, unknown> | undefined
-  if (aiData && typeof aiData === 'object') {
+  const aiData = isPlainObject(rest.ai) ? rest.ai : undefined
+  if (aiData) {
     delete rest.ai
   }
 
@@ -505,8 +560,10 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
   ]
 
   for (let i = 0; i < allEntries.length; i++) {
-    const entry = allEntries[i]!
-    const hasChildren = entry.children && entry.children.length > 0
+    const entry = allEntries[i]
+    if (!entry) continue
+    const { children } = entry
+    const hasChildren = children !== undefined && children.length > 0
     const isLast = i === allEntries.length - 1 && !hasChildren
     const prefix = isLast ? '└─' : '├─'
 
@@ -518,12 +575,13 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
       console.log(`  ${colors.dim}${prefix}${colors.reset} ${colors.cyan}${entry.key}:${colors.reset}${val}`)
     }
 
-    if (hasChildren) {
+    if (hasChildren && children) {
       const isLastEntry = i === allEntries.length - 1
       const connector = isLastEntry ? ' ' : '│'
-      for (let j = 0; j < entry.children!.length; j++) {
-        const child = entry.children![j]!
-        const isLastChild = j === entry.children!.length - 1
+      for (let j = 0; j < children.length; j++) {
+        const child = children[j]
+        if (child === undefined) continue
+        const isLastChild = j === children.length - 1
         const childPrefix = isLastChild ? '└─' : '├─'
         if (browser) {
           console.log(`  %c${connector}  ${childPrefix}%c ${escapeFormatString(child)}`, cssColors.dim, cssColors.reset)

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -41,6 +41,11 @@ function mergeInto(target: Record<string, unknown>, source: Record<string, unkno
   }
 }
 
+/**
+ * @internal Wide-event field merge — exported for test mocks that mirror emit accumulation.
+ */
+export { mergeInto as mergeWideEventFields }
+
 let globalEnv: EnvironmentContext = {
   service: 'app',
   environment: 'development',
@@ -359,6 +364,11 @@ interface ToolCallEntry {
   input: unknown
 }
 
+function serializeToolInput(input: unknown): string {
+  if (typeof input === 'string') return input
+  return JSON.stringify(input) ?? ''
+}
+
 function isToolCallEntry(value: unknown): value is ToolCallEntry {
   return isPlainObject(value) && typeof value.name === 'string' && 'input' in value
 }
@@ -439,7 +449,7 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
       if (t.error) line += ` ${t.error}`
       if (hasInputs && toolCallEntries && idx < toolCallEntries.length) {
         const tc = toolCallEntries[idx]
-        const inputStr = typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)
+        const inputStr = serializeToolInput(tc.input)
         const truncated = inputStr.length > 100 ? `${inputStr.slice(0, 100)}…` : inputStr
         line += ` ${truncated}`
       }
@@ -449,7 +459,7 @@ function buildAIEntries(ai: Record<string, unknown>): TreeEntry[] {
   } else if (toolCalls?.length) {
     if (toolCallEntries?.length) {
       const children = toolCallEntries.map((tc) => {
-        const inputStr = typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)
+        const inputStr = serializeToolInput(tc.input)
         const truncated = inputStr.length > 100 ? `${inputStr.slice(0, 100)}…` : inputStr
         return `${tc.name}(${truncated})`
       })

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -366,7 +366,20 @@ interface ToolCallEntry {
 
 function serializeToolInput(input: unknown): string {
   if (typeof input === 'string') return input
-  return JSON.stringify(input) ?? ''
+  const seen = new WeakSet<object>()
+  try {
+    const serialized = JSON.stringify(input, (_key, value) => {
+      if (typeof value === 'bigint') return value.toString()
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]'
+        seen.add(value)
+      }
+      return value
+    })
+    return serialized ?? ''
+  } catch {
+    return '[unserializable tool input]'
+  }
 }
 
 function isToolCallEntry(value: unknown): value is ToolCallEntry {

--- a/packages/evlog/src/runtime/server/routes/_evlog/ingest.post.ts
+++ b/packages/evlog/src/runtime/server/routes/_evlog/ingest.post.ts
@@ -6,6 +6,14 @@ import { filterSafeHeaders } from '../../../../utils'
 
 const VALID_LEVELS = ['info', 'error', 'warn', 'debug'] as const
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isLogLevel(value: string): value is IngestPayload['level'] {
+  return (VALID_LEVELS as readonly string[]).includes(value)
+}
+
 function validateOrigin(event: Parameters<typeof defineEventHandler>[0] extends (e: infer E) => unknown ? E : never): void {
   const origin = getHeader(event, 'origin')
   const referer = getHeader(event, 'referer')
@@ -34,17 +42,15 @@ function isValidISOTimestamp(value: string): boolean {
 }
 
 function validatePayload(body: unknown): IngestPayload {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+  if (!isRecord(body)) {
     throw createError({ statusCode: 400, message: 'Invalid request body' })
   }
 
-  const payload = body as Record<string, unknown>
-
-  if (payload.timestamp === undefined || payload.timestamp === null) {
+  if (body.timestamp === undefined || body.timestamp === null) {
     throw createError({ statusCode: 400, message: 'Missing required field: timestamp' })
   }
 
-  const { timestamp: rawTimestamp } = payload
+  const { timestamp: rawTimestamp } = body
   let timestamp: string
   if (typeof rawTimestamp === 'number') {
     const minTimestamp = new Date('2000-01-01').getTime()
@@ -62,24 +68,44 @@ function validatePayload(body: unknown): IngestPayload {
     throw createError({ statusCode: 400, message: 'Invalid timestamp: must be string or number' })
   }
 
-  if (!payload.level || typeof payload.level !== 'string') {
+  if (!body.level || typeof body.level !== 'string') {
     throw createError({ statusCode: 400, message: 'Missing required field: level' })
   }
 
-  if (!VALID_LEVELS.includes(payload.level as typeof VALID_LEVELS[number])) {
+  if (!isLogLevel(body.level)) {
     throw createError({ statusCode: 400, message: `Invalid level: must be one of ${VALID_LEVELS.join(', ')}` })
   }
 
   return {
-    ...payload,
+    ...body,
     timestamp,
-    level: payload.level as IngestPayload['level'],
+    level: body.level,
   }
 }
 
 function getSafeHeaders(event: Parameters<typeof defineEventHandler>[0] extends (e: infer E) => unknown ? E : never): Record<string, string> {
   const allHeaders = getHeaders(event as Parameters<typeof getHeaders>[0])
   return filterSafeHeaders(allHeaders)
+}
+
+interface WaitUntilHost {
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+function hasWaitUntil(value: unknown): value is WaitUntilHost & { waitUntil: (promise: Promise<unknown>) => void } {
+  return isRecord(value) && typeof value.waitUntil === 'function'
+}
+
+/** Resolve platform waitUntil from Nitro event context (Cloudflare Workers, Vercel Edge). */
+function resolveWaitUntilContext(event: unknown): WaitUntilHost | undefined {
+  if (!isRecord(event)) return undefined
+  const { context } = event
+  if (!isRecord(context)) return undefined
+  const { cloudflare } = context
+  if (isRecord(cloudflare) && isRecord(cloudflare.context)) {
+    return cloudflare.context
+  }
+  return context
 }
 
 export default defineEventHandler(async (event) => {
@@ -90,7 +116,7 @@ export default defineEventHandler(async (event) => {
   const nitroApp = useNitroApp()
   const env = getEnvironment()
 
-  const { service: _clientService, ...sanitizedPayload } = payload as IngestPayload & { service?: unknown }
+  const { service: _clientService, ...sanitizedPayload } = payload
 
   const wideEvent: WideEvent = {
     ...sanitizedPayload,
@@ -104,7 +130,7 @@ export default defineEventHandler(async (event) => {
 
   if (runner.hasClientLog) {
     runner.runOnClientLog({
-      payload: payload as Record<string, unknown>,
+      payload,
       request,
       headers,
     })
@@ -142,10 +168,9 @@ export default defineEventHandler(async (event) => {
 
   // Use waitUntil if available (Cloudflare Workers, Vercel Edge)
   // Otherwise, await the drain to prevent lost logs in serverless environments
-  const waitUntilCtx = (event as unknown as { context: Record<string, unknown> }).context
-  const cfCtx = (waitUntilCtx as { cloudflare?: { context?: { waitUntil?: (p: Promise<unknown>) => void } } }).cloudflare?.context ?? waitUntilCtx
-  if (typeof (cfCtx as { waitUntil?: unknown }).waitUntil === 'function') {
-    (cfCtx as { waitUntil: (p: Promise<unknown>) => void }).waitUntil(drainPromise)
+  const waitUntilCtx = resolveWaitUntilContext(event)
+  if (waitUntilCtx && hasWaitUntil(waitUntilCtx)) {
+    waitUntilCtx.waitUntil(drainPromise)
   } else {
     await drainPromise
   }

--- a/packages/evlog/src/shared/define.ts
+++ b/packages/evlog/src/shared/define.ts
@@ -1,6 +1,5 @@
-import type { DrainContext, EnrichContext, EnvironmentContext, LoggerConfig, RedactConfig, SamplingConfig, TailSamplingContext } from '../types'
+import type { EnvironmentContext, LoggerConfig, SamplingConfig } from '../types'
 import type { BaseEvlogOptions } from './middleware'
-import type { EvlogPlugin } from './plugin'
 
 /**
  * Single-config shape accepted everywhere evlog is bootstrapped: at
@@ -71,7 +70,7 @@ export function toLoggerConfig(config: EvlogConfig): LoggerConfig {
   if (config.minLevel !== undefined) out.minLevel = config.minLevel
   if (config.stringify !== undefined) out.stringify = config.stringify
   if (config.silent !== undefined) out.silent = config.silent
-  if (config.redact !== undefined) out.redact = config.redact as boolean | RedactConfig | undefined
+  if (config.redact !== undefined) out.redact = config.redact
   if (config.drain) out.drain = config.drain
   if (config.plugins) out.plugins = config.plugins
   return out
@@ -83,10 +82,10 @@ export function toMiddlewareOptions<T extends BaseEvlogOptions>(config: EvlogCon
   if (config.include) out.include = config.include
   if (config.exclude) out.exclude = config.exclude
   if (config.routes) out.routes = config.routes
-  if (config.drain) out.drain = config.drain as (ctx: DrainContext) => void | Promise<void>
-  if (config.enrich) out.enrich = config.enrich as (ctx: EnrichContext) => void | Promise<void>
-  if (config.keep) out.keep = config.keep as (ctx: TailSamplingContext) => void | Promise<void>
-  if (config.redact !== undefined) out.redact = config.redact as boolean | RedactConfig | undefined
-  if (config.plugins) out.plugins = config.plugins as EvlogPlugin[]
+  if (config.drain) out.drain = config.drain
+  if (config.enrich) out.enrich = config.enrich
+  if (config.keep) out.keep = config.keep
+  if (config.redact !== undefined) out.redact = config.redact
+  if (config.plugins) out.plugins = config.plugins
   return out as T
 }

--- a/packages/evlog/src/shared/storage.ts
+++ b/packages/evlog/src/shared/storage.ts
@@ -20,6 +20,7 @@ export function createLoggerStorage(contextHint: string) {
         `[evlog] useLogger() was called outside of an evlog ${contextHint}`,
       )
     }
+    /** @internal ALS store is untyped; cast satisfies the caller's generic `T`. */
     return logger as RequestLogger<T>
   }
 

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -40,6 +40,61 @@ interface AppError {
   [key: string]: unknown
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isRequestLogger(value: unknown): value is RequestLogger {
+  return isPlainObject(value)
+    && typeof value.error === 'function'
+    && typeof value.emit === 'function'
+}
+
+interface ContextEvlogError {
+  name: 'EvlogError'
+  status: number
+  message: string
+  why?: string
+  fix?: string
+  link?: string
+  code?: string
+}
+
+function isContextEvlogError(value: unknown): value is Record<string, unknown> & ContextEvlogError {
+  return isPlainObject(value)
+    && value.name === 'EvlogError'
+    && typeof value.status === 'number'
+    && typeof value.message === 'string'
+}
+
+function evlogErrorFromContext(errorData: Record<string, unknown>): EvlogError {
+  const nested = isPlainObject(errorData.data) ? errorData.data : undefined
+  const readString = (key: string): string | undefined => {
+    const direct = errorData[key]
+    if (typeof direct === 'string') return direct
+    const fromNested = nested?.[key]
+    return typeof fromNested === 'string' ? fromNested : undefined
+  }
+  return new EvlogError({
+    message: String(errorData.message),
+    status: errorData.status as number,
+    code: readString('code'),
+    why: readString('why'),
+    fix: readString('fix'),
+    link: readString('link'),
+  })
+}
+
+function readEvlogResponseData(response: Record<string, unknown>): { why?: string, fix?: string, link?: string } {
+  const { data } = response
+  if (!isPlainObject(data)) return {}
+  return {
+    why: typeof data.why === 'string' ? data.why : undefined,
+    fix: typeof data.fix === 'string' ? data.fix : undefined,
+    link: typeof data.link === 'string' ? data.link : undefined,
+  }
+}
+
 /**
  * Create an evlog handle hook for SvelteKit.
  *
@@ -98,11 +153,11 @@ export function evlog(options: EvlogSvelteKitOptions = {}): SvelteKitHandle {
         // If handleError already logged an EvlogError with a specific status,
         // return a structured JSON response instead of SvelteKit's generic 500.
         const ctx = logger.getContext()
-        const errorData = ctx.error as { name?: string; status?: number; message?: string; data?: unknown } | undefined
-        if (response.status >= 500 && errorData?.name === 'EvlogError' && errorData.status) {
+        const errorData = ctx.error
+        if (response.status >= 500 && isContextEvlogError(errorData)) {
           const { status } = errorData
           await finish({ status })
-          const body = serializeEvlogErrorResponse(errorData as EvlogError, event.url.pathname)
+          const body = serializeEvlogErrorResponse(evlogErrorFromContext(errorData), event.url.pathname)
           return new Response(JSON.stringify(body), {
             status,
             headers: { 'content-type': 'application/json' },
@@ -112,7 +167,7 @@ export function evlog(options: EvlogSvelteKitOptions = {}): SvelteKitHandle {
         await finish({ status: response.status })
         return response
       } catch (error) {
-        await finish({ error: error as Error })
+        await finish({ error: error instanceof Error ? error : new Error(String(error)) })
 
         // Return structured JSON for EvlogError (like NextJS withEvlog / Nuxt errorHandler)
         if (error instanceof EvlogError) {
@@ -148,7 +203,7 @@ export function evlog(options: EvlogSvelteKitOptions = {}): SvelteKitHandle {
  */
 export function evlogHandleError(): SvelteKitHandleServerError {
   return ({ error, event, status, message }) => {
-    const logger = event.locals.log as RequestLogger | undefined
+    const logger = isRequestLogger(event.locals.log) ? event.locals.log : undefined
 
     if (logger && error instanceof Error) {
       logger.error(error)
@@ -160,15 +215,13 @@ export function evlogHandleError(): SvelteKitHandleServerError {
       const errorStatus = extractErrorStatus(evlogError)
       const response = serializeEvlogErrorResponse(evlogError, event.url.pathname)
       return {
-        message: response.message as string,
+        message: typeof response.message === 'string' ? response.message : message,
         status: errorStatus,
-        why: (response.data as { why?: string })?.why,
-        fix: (response.data as { fix?: string })?.fix,
-        link: (response.data as { link?: string })?.link,
-      } as AppError
+        ...readEvlogResponseData(response),
+      }
     }
 
-    return { message, status } as AppError
+    return { message, status }
   }
 }
 

--- a/packages/evlog/test/README.md
+++ b/packages/evlog/test/README.md
@@ -10,6 +10,8 @@ Goals: fast (full suite < 2s locally), deterministic, no fake-greens, no console
 | A drain spy was called within a few microtasks of a request returning | `await waitForDrainCalls(drain)` before drilling into `drain.mock.calls` |
 | A specific event field is set after `log.set(...)` | `findEventViaDrain(drain, e => e.path === ...)` then assert on the returned event |
 | A duration / threshold-based behavior | `vi.useFakeTimers()` + `vi.advanceTimersByTime(N)` + `vi.useRealTimers()` (do *not* `await new Promise(setTimeout)`) |
+| Narrowing after `expect(x).toBeDefined()` | `defined(x, 'label')` from `helpers/defined.ts` — not `x!` |
+| Accessing the request logger inside a route handler test | `useLogger()` — not `req.log!` (keep one test per framework that asserts `req.log` is attached) |
 | An adapter posts the right URL / body / headers | `mockFetch()` from `helpers/fetch.ts` + `getFetchCall` / `getFetchJson` / `getFetchHeaders` |
 | A wide event factory for adapter tests | `makeWideEvent(overrides?)` from `helpers/events.ts` |
 | The sweep of HTTP framework specs ("emits event", "x-request-id", "route service") | `describeStandardHttpMatrix({ name, mount })` from `helpers/frameworkMatrix.ts` |
@@ -53,6 +55,7 @@ the real-runtime version catches integration regressions.
 3. `await new Promise(r => setTimeout(r, N))` for timing assertions. Use fake timers; `setTimeout` couples the test to wall-clock and CI load.
 4. `expect(x).toBeDefined()` as the *only* assertion. Always drill at least one level deeper.
 5. Adding a new export to `package.json` without updating `tsdown.config.ts` and re-running `pnpm test` so `api-surface.test.ts` snapshots the new surface.
+6. Non-null assertions (`!`) and type casts (`as`) when a helper or guard can express the same intent — use `defined()`, `getDrainCallArg()`, `useLogger()`, or `expect(...).toEqual(...)`.
 
 ## File layout
 
@@ -64,6 +67,7 @@ test/
     events.ts              # makeEvent / makeWideEvent / makeContext / makeError
     fetch.ts               # mockFetch / getFetchCall / getFetchJson / getFetchHeaders
     framework.ts           # createPipelineSpies / assertHttpEventEmitted / waitForDrainCalls / findEventViaDrain / ...
+    defined.ts             # defined() / getDrainCallArg() — type-safe narrowing without `!`
     frameworkMatrix.ts     # describeStandardHttpMatrix(adapter)
     slowReporter.ts        # CI-only reporter for tests > EVLOG_SLOW_TEST_BUDGET_MS (default 500ms)
     timers.ts              # withFakeTimers / flushMicrotasks

--- a/packages/evlog/test/adapters/fs.test.ts
+++ b/packages/evlog/test/adapters/fs.test.ts
@@ -1,7 +1,9 @@
+import type { Stats } from 'node:fs'
 import { join } from 'node:path'
-import { mkdir, appendFile, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { readdir, mkdir, appendFile, stat, unlink, writeFile } from 'node:fs/promises'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WideEvent } from '../../src/types'
+import { defined } from '../helpers/defined'
 
 import { writeBatchToFs, writeToFs } from '../../src/adapters/fs'
 
@@ -17,6 +19,15 @@ vi.mock('node:fs/promises', () => ({
 const mockedMkdir = vi.mocked(mkdir)
 const mockedAppendFile = vi.mocked(appendFile)
 const mockedReaddir = vi.mocked(readdir)
+
+function mockReaddirNames(names: string[]) {
+  mockedReaddir.mockResolvedValueOnce(names as unknown as Awaited<ReturnType<typeof readdir>>)
+}
+
+function getAppendFileContent(callIndex = 0): string {
+  const args = defined(mockedAppendFile.mock.calls[callIndex], 'appendFile call')
+  return String(args[1])
+}
 const mockedStat = vi.mocked(stat)
 const mockedUnlink = vi.mocked(unlink)
 const mockedWriteFile = vi.mocked(writeFile)
@@ -78,7 +89,7 @@ describe('fs adapter', () => {
     })
 
     it('skips .gitignore creation when it already exists', async () => {
-      mockedStat.mockResolvedValueOnce({} as any)
+      mockedStat.mockResolvedValueOnce({ size: 0 } as Stats)
 
       await writeToFs(createTestEvent(), { dir: 'other/.evlog/logs', pretty: false })
 
@@ -95,7 +106,8 @@ describe('fs adapter', () => {
       expect(mockedMkdir).toHaveBeenCalledWith('.evlog/logs', { recursive: true })
       expect(mockedAppendFile).toHaveBeenCalledTimes(1)
 
-      const [filePath, content] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
+      const content = getAppendFileContent()
       expect(filePath).toBe(join('.evlog/logs', '2026-03-14.jsonl'))
       expect(content).toBe(`${JSON.stringify(event) }\n`)
     })
@@ -105,7 +117,7 @@ describe('fs adapter', () => {
 
       await writeToFs(event, { dir: '.evlog/logs', pretty: true })
 
-      const [, content] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const content = getAppendFileContent()
       expect(content).toBe(`${JSON.stringify(event, null, 2) }\n`)
     })
 
@@ -114,7 +126,7 @@ describe('fs adapter', () => {
 
       await writeToFs(createTestEvent(), { dir: 'logs', pretty: false })
 
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('logs', '2025-12-25.jsonl'))
     })
   })
@@ -130,7 +142,7 @@ describe('fs adapter', () => {
       await writeBatchToFs(events, { dir: '.evlog/logs', pretty: false })
 
       expect(mockedAppendFile).toHaveBeenCalledTimes(1)
-      const [, content] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const content = getAppendFileContent()
       const lines = content.trimEnd().split('\n')
       expect(lines).toHaveLength(3)
 
@@ -151,14 +163,14 @@ describe('fs adapter', () => {
       await writeBatchToFs([createTestEvent()], { dir: '/var/log/app', pretty: false })
 
       expect(mockedMkdir).toHaveBeenCalledWith('/var/log/app', { recursive: true })
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('/var/log/app', '2026-03-14.jsonl'))
     })
   })
 
   describe('file rotation (maxSizePerFile)', () => {
     it('uses base file when under size limit', async () => {
-      mockedStat.mockResolvedValueOnce({ size: 500 } as any)
+      mockedStat.mockResolvedValueOnce({ size: 500 } as Stats)
 
       await writeToFs(createTestEvent(), {
         dir: '.evlog/logs',
@@ -166,13 +178,13 @@ describe('fs adapter', () => {
         maxSizePerFile: 1024,
       })
 
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('.evlog/logs', '2026-03-14.jsonl'))
     })
 
     it('rotates to suffixed file when base file exceeds size limit', async () => {
       mockedStat
-        .mockResolvedValueOnce({ size: 2048 } as any)
+        .mockResolvedValueOnce({ size: 2048 } as Stats)
         .mockRejectedValueOnce(new Error('ENOENT'))
 
       await writeToFs(createTestEvent(), {
@@ -181,15 +193,15 @@ describe('fs adapter', () => {
         maxSizePerFile: 1024,
       })
 
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('.evlog/logs', '2026-03-14.1.jsonl'))
     })
 
     it('skips full rotated files and finds next available', async () => {
       mockedStat
-        .mockResolvedValueOnce({ size: 2048 } as any)
-        .mockResolvedValueOnce({ size: 2048 } as any)
-        .mockResolvedValueOnce({ size: 2048 } as any)
+        .mockResolvedValueOnce({ size: 2048 } as Stats)
+        .mockResolvedValueOnce({ size: 2048 } as Stats)
+        .mockResolvedValueOnce({ size: 2048 } as Stats)
         .mockRejectedValueOnce(new Error('ENOENT'))
 
       await writeToFs(createTestEvent(), {
@@ -198,7 +210,7 @@ describe('fs adapter', () => {
         maxSizePerFile: 1024,
       })
 
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('.evlog/logs', '2026-03-14.3.jsonl'))
     })
 
@@ -209,20 +221,20 @@ describe('fs adapter', () => {
         maxSizePerFile: 1024,
       })
 
-      const [filePath] = mockedAppendFile.mock.calls[0] as [string, string, string]
+      const [filePath] = defined(mockedAppendFile.mock.calls[0], 'appendFile call')
       expect(filePath).toBe(join('.evlog/logs', '2026-03-14.jsonl'))
     })
   })
 
   describe('cleanup (maxFiles)', () => {
     it('deletes oldest files when exceeding maxFiles', async () => {
-      mockedReaddir.mockResolvedValueOnce([
+      mockReaddirNames([
         '2026-03-10.jsonl',
         '2026-03-11.jsonl',
         '2026-03-12.jsonl',
         '2026-03-13.jsonl',
         '2026-03-14.jsonl',
-      ] as any)
+      ])
 
       await writeToFs(createTestEvent(), {
         dir: '.evlog/logs',
@@ -236,10 +248,10 @@ describe('fs adapter', () => {
     })
 
     it('does not delete files when under maxFiles limit', async () => {
-      mockedReaddir.mockResolvedValueOnce([
+      mockReaddirNames([
         '2026-03-13.jsonl',
         '2026-03-14.jsonl',
-      ] as any)
+      ])
 
       await writeToFs(createTestEvent(), {
         dir: '.evlog/logs',
@@ -251,13 +263,13 @@ describe('fs adapter', () => {
     })
 
     it('ignores non-jsonl files during cleanup', async () => {
-      mockedReaddir.mockResolvedValueOnce([
+      mockReaddirNames([
         '2026-03-10.jsonl',
         '2026-03-11.jsonl',
         '2026-03-12.jsonl',
         'README.md',
         '.gitkeep',
-      ] as any)
+      ])
 
       await writeToFs(createTestEvent(), {
         dir: '.evlog/logs',

--- a/packages/evlog/test/ai/ai.test.ts
+++ b/packages/evlog/test/ai/ai.test.ts
@@ -3,36 +3,8 @@ import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3Finish
 import type { OnFinishEvent, OnStartEvent, OnToolCallFinishEvent, TelemetryIntegration } from 'ai'
 import type { RequestLogger } from '../../src/types'
 import { createAILogger, createAIMiddleware, createEvlogIntegration } from '../../src/ai'
-import { createLogger } from '../../src/logger'
+import { createLogger, mergeWideEventFields } from '../../src/logger'
 import { defined } from '../helpers/defined'
-
-/**
- * Mirrors evlog's `mergeInto` so the mock reflects what the wide event
- * actually accumulates: arrays are concatenated, plain objects are merged
- * recursively, scalars are replaced. Without this, a `log.set()` mock that
- * just records each call would hide bugs whose impact only shows up on
- * the assembled wide event (e.g. quadratic array growth).
- */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
-  const proto = Object.getPrototypeOf(value)
-  return proto === Object.prototype || proto === null
-}
-
-function mergeInto(target: Record<string, unknown>, source: Record<string, unknown>): void {
-  for (const key in source) {
-    const sourceVal = source[key]
-    if (sourceVal === undefined || sourceVal === null) continue
-    const targetVal = target[key]
-    if (isPlainObject(sourceVal) && isPlainObject(targetVal)) {
-      mergeInto(targetVal, sourceVal)
-    } else if (Array.isArray(targetVal) && Array.isArray(sourceVal)) {
-      target[key] = [...targetVal, ...sourceVal]
-    } else {
-      target[key] = sourceVal
-    }
-  }
-}
 
 interface MockLogger extends RequestLogger {
   setCalls: Array<Record<string, unknown>>
@@ -53,7 +25,7 @@ function createMockLogger(): MockLogger {
     set: vi.fn((data: Record<string, unknown>) => {
       const cloned = structuredClone(data)
       setCalls.push(cloned)
-      mergeInto(merged, structuredClone(data))
+      mergeWideEventFields(merged, structuredClone(data))
     }),
     error: vi.fn(),
     info: vi.fn(),

--- a/packages/evlog/test/ai/ai.test.ts
+++ b/packages/evlog/test/ai/ai.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { LanguageModelV3, LanguageModelV3FinishReason, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3FinishReason, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type { OnFinishEvent, OnStartEvent, OnToolCallFinishEvent, TelemetryIntegration } from 'ai'
 import type { RequestLogger } from '../../src/types'
 import { createAILogger, createAIMiddleware, createEvlogIntegration } from '../../src/ai'
 import { createLogger } from '../../src/logger'
+import { defined } from '../helpers/defined'
 
 /**
  * Mirrors evlog's `mergeInto` so the mock reflects what the wide event
@@ -84,15 +86,81 @@ function createMockUsage(overrides?: Partial<{
   }
 }
 
-function createMockModel(overrides?: Partial<{ provider: string, modelId: string }>): LanguageModelV3 {
+type GenerateResult = Awaited<ReturnType<LanguageModelV3['doGenerate']>>
+type StreamResult = Awaited<ReturnType<LanguageModelV3['doStream']>>
+
+/** AI SDK generate results require many fields — partial mocks cast once here. */
+function asGenerateResult(value: Record<string, unknown>): GenerateResult {
+  return value as GenerateResult
+}
+
+function asStreamResult(value: Record<string, unknown>): StreamResult {
+  return value as StreamResult
+}
+
+type MockLanguageModel = Pick<LanguageModelV3, 'specificationVersion' | 'provider' | 'modelId'> & {
+  doGenerate: ReturnType<typeof vi.fn<LanguageModelV3['doGenerate']>>
+  doStream: ReturnType<typeof vi.fn<LanguageModelV3['doStream']>>
+}
+
+function createMockCallOptions(): LanguageModelV3CallOptions {
+  return { prompt: [] }
+}
+
+function getLastAiData(log: MockLogger): Record<string, unknown> {
+  return defined(log.setCalls.at(-1)?.ai, 'last ai payload') as Record<string, unknown>
+}
+
+function callIntegrationOnStart(integration: TelemetryIntegration, event?: Partial<OnStartEvent>) {
+  defined(integration.onStart, 'onStart')({
+    model: { provider: 'anthropic', modelId: 'claude-sonnet-4.6' },
+    maxRetries: 0,
+    ...event,
+  } as OnStartEvent)
+}
+
+/** createEvlogIntegration ignores the onFinish payload — cast kept in one place. */
+function callIntegrationOnFinish(integration: TelemetryIntegration) {
+  defined(integration.onFinish, 'onFinish')({} as OnFinishEvent)
+}
+
+function callIntegrationOnToolCallFinish(
+  integration: TelemetryIntegration,
+  input: {
+    toolName: string
+    durationMs: number
+    success: boolean
+    output?: unknown
+    error?: unknown
+  },
+) {
+  const base = {
+    toolCall: { toolName: input.toolName, toolCallId: 'tc1', input: {} },
+    durationMs: input.durationMs,
+    messages: [],
+    stepNumber: undefined,
+    model: undefined,
+    abortSignal: undefined,
+    functionId: undefined,
+    metadata: undefined,
+    experimental_context: undefined,
+  }
+
+  const event: OnToolCallFinishEvent = input.success
+    ? { ...base, success: true, output: input.output ?? {} }
+    : { ...base, success: false, error: input.error ?? new Error('failed') }
+
+  defined(integration.onToolCallFinish, 'onToolCallFinish')(event as OnToolCallFinishEvent)
+}
+
+function createMockModel(overrides?: Partial<{ provider: string, modelId: string }>): MockLanguageModel {
   return {
     specificationVersion: 'v3',
     provider: overrides?.provider ?? 'anthropic',
     modelId: overrides?.modelId ?? 'claude-sonnet-4.6',
-    defaultObjectGenerationMode: 'json',
     doGenerate: vi.fn(),
     doStream: vi.fn(),
-  } as unknown as LanguageModelV3
+  }
 }
 
 function createFinishReason(unified: LanguageModelV3FinishReason['unified'] = 'stop'): LanguageModelV3FinishReason {
@@ -141,8 +209,8 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       expect(log.set).toHaveBeenCalled()
       const lastSetCall = log.setCalls[log.setCalls.length - 1]
@@ -170,8 +238,8 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.cacheReadTokens).toBe(150)
@@ -192,8 +260,8 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.cacheReadTokens).toBeUndefined()
@@ -218,8 +286,8 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.toolCalls).toEqual(['searchWeb', 'calculatePrice'])
@@ -239,8 +307,8 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6-20250514' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.model).toBe('claude-sonnet-4.6-20250514')
@@ -258,8 +326,8 @@ describe('createAILogger', () => {
         usage: createMockUsage(),
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.model).toBe('claude-sonnet-4.6')
@@ -285,11 +353,11 @@ describe('createAILogger', () => {
         },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -312,11 +380,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -339,11 +407,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason('tool-calls'), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -364,11 +432,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -388,11 +456,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(inputChunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       const outputChunks = await consumeStream(result.stream)
 
       expect(outputChunks).toHaveLength(inputChunks.length)
@@ -407,7 +475,7 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>)
+      vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
           content: [],
           finishReason: createFinishReason(),
@@ -421,8 +489,8 @@ describe('createAILogger', () => {
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-      await wrappedModel.doGenerate({} as any)
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.calls).toBe(2)
@@ -444,14 +512,14 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
       let aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.steps).toBeUndefined()
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
-      await wrappedModel.doGenerate({} as any)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
+      await wrappedModel.doGenerate(createMockCallOptions())
       aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.steps).toBe(2)
     })
@@ -466,22 +534,22 @@ describe('createAILogger', () => {
       const wrappedGemini = ai.wrap(gemini)
       const wrappedClaude = ai.wrap(claude)
 
-      ;(gemini.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(gemini.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
         response: { modelId: 'gemini-3-flash' },
       })
 
-      ;(claude.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(claude.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 200, outputTotal: 100 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedGemini.doGenerate({} as any)
-      await wrappedClaude.doGenerate({} as any)
+      await wrappedGemini.doGenerate(createMockCallOptions())
+      await wrappedClaude.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.model).toBe('claude-sonnet-4.6')
@@ -503,10 +571,10 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       }
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult)
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult(mockResult))
 
-      await wrappedModel.doGenerate({} as any)
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.model).toBe('claude-sonnet-4.6')
@@ -519,7 +587,7 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>)
+      vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', args: '{}' }],
           finishReason: createFinishReason('tool-calls'),
@@ -533,8 +601,8 @@ describe('createAILogger', () => {
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-      await wrappedModel.doGenerate({} as any)
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.merged.ai as Record<string, unknown>
       expect(aiData.toolCalls).toEqual(['search', 'calculate'])
@@ -548,7 +616,7 @@ describe('createAILogger', () => {
 
       const tools = ['list-pages', 'get-page', 'get-page', 'get-page', 'get-page', 'get-page']
 
-      const doGenerate = model.doGenerate as ReturnType<typeof vi.fn>
+      const doGenerate = vi.mocked(model.doGenerate)
       for (const toolName of tools) {
         doGenerate.mockResolvedValueOnce({
           content: [{ type: 'tool-call', toolCallId: `tc-${toolName}`, toolName, args: '{}' }],
@@ -556,7 +624,7 @@ describe('createAILogger', () => {
           usage: createMockUsage({ inputTotal: 100, outputTotal: 20 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
       }
 
       const merged = log.merged.ai as Record<string, unknown>
@@ -581,13 +649,13 @@ describe('createAILogger', () => {
       const model = createMockModel({ provider: 'gateway', modelId: 'google/gemini-3-flash' })
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage(),
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.provider).toBe('google')
@@ -600,14 +668,14 @@ describe('createAILogger', () => {
       const model = createMockModel({ provider: 'gateway', modelId: 'anthropic/claude-sonnet-4.6' })
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage(),
         response: { modelId: 'anthropic/claude-sonnet-4.6-20250514' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.provider).toBe('anthropic')
@@ -620,14 +688,14 @@ describe('createAILogger', () => {
       const model = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.provider).toBe('anthropic')
@@ -647,11 +715,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -685,12 +753,12 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage({ outputTotal: 500 }) },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      vi.mocked(model.doStream).mockImplementation(async () => {
         await new Promise(r => setTimeout(r, 20))
         return { stream: makeReadableStream(chunks) }
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -712,11 +780,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage({ outputTotal: 500 }) },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -733,9 +801,9 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('API rate limit exceeded'))
+      vi.mocked(model.doGenerate).mockRejectedValue(new Error('API rate limit exceeded'))
 
-      await expect(wrappedModel.doGenerate({} as any)).rejects.toThrow('API rate limit exceeded')
+      await expect(wrappedModel.doGenerate(createMockCallOptions())).rejects.toThrow('API rate limit exceeded')
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.error).toBe('API rate limit exceeded')
@@ -749,9 +817,9 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Connection timeout'))
+      vi.mocked(model.doStream).mockRejectedValue(new Error('Connection timeout'))
 
-      await expect(wrappedModel.doStream({} as any)).rejects.toThrow('Connection timeout')
+      await expect(wrappedModel.doStream(createMockCallOptions())).rejects.toThrow('Connection timeout')
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.error).toBe('Connection timeout')
@@ -771,11 +839,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason('content-filter'), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -805,14 +873,14 @@ describe('createAILogger', () => {
 
       ai.captureEmbed({ usage: { tokens: 30 } })
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 200, outputTotal: 100 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.calls).toBe(2)
@@ -829,14 +897,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'searchWeb', input: '{"query":"weather"}' }],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.toolCalls).toEqual(['searchWeb'])
@@ -848,7 +916,7 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [
           { type: 'tool-call', toolCallId: 'tc1', toolName: 'searchWeb', input: '{"query":"weather in SF"}' },
           { type: 'tool-call', toolCallId: 'tc2', toolName: 'calculate', input: '{"expression":"2+2"}' },
@@ -858,7 +926,7 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.toolCalls).toEqual([
@@ -873,14 +941,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'run', input: 'not-json' }],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const toolCalls = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -901,11 +969,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason('tool-calls'), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -925,11 +993,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason('tool-calls'), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -942,14 +1010,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'run', input: { already: 'parsed' } }],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const toolCalls = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -962,14 +1030,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'queryDB', input: '{"sql":"SELECT * FROM events WHERE status = 200 ORDER BY created_at DESC LIMIT 50"}' },],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const inputs = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -984,14 +1052,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"q":"hello"}' },],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const inputs = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -1013,7 +1081,7 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [
           { type: 'tool-call', toolCallId: 'tc1', toolName: 'queryDB', input: '{"sql":"SELECT * FROM users"}' },
           { type: 'tool-call', toolCallId: 'tc2', toolName: 'search', input: '{"q":"hello"}' },
@@ -1023,7 +1091,7 @@ describe('createAILogger', () => {
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const inputs = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -1042,14 +1110,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"query":"a very long search query that exceeds the limit"}' },],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const inputs = aiData.toolCalls as Array<{ name: string, input: unknown }>
@@ -1071,11 +1139,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason('tool-calls'), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -1092,14 +1160,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6', id: 'msg_01XFDUDYJgAACzvnptvVoYEL' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.responseId).toBe('msg_01XFDUDYJgAACzvnptvVoYEL')
@@ -1119,11 +1187,11 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage() },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doStream).mockResolvedValue({
         stream: makeReadableStream(chunks),
       })
 
-      const result = await wrappedModel.doStream({} as any)
+      const result = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -1136,14 +1204,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage(),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.responseId).toBeUndefined()
@@ -1157,14 +1225,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.stepsUsage).toBeUndefined()
@@ -1177,7 +1245,7 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>)
+      vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{}' }],
           finishReason: createFinishReason('tool-calls'),
@@ -1191,8 +1259,8 @@ describe('createAILogger', () => {
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-      await wrappedModel.doGenerate({} as any)
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.steps).toBe(2)
@@ -1231,13 +1299,13 @@ describe('createAILogger', () => {
         { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage({ inputTotal: 400, outputTotal: 100 }) },
       ]
 
-      ;(model.doStream as ReturnType<typeof vi.fn>)
+      vi.mocked(model.doStream)
         .mockResolvedValueOnce({ stream: makeReadableStream(chunks1) })
         .mockResolvedValueOnce({ stream: makeReadableStream(chunks2) })
 
-      const result1 = await wrappedModel.doStream({} as any)
+      const result1 = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result1.stream)
-      const result2 = await wrappedModel.doStream({} as any)
+      const result2 = await wrappedModel.doStream(createMockCallOptions())
       await consumeStream(result2.stream)
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
@@ -1266,22 +1334,22 @@ describe('createAILogger', () => {
       const wrappedFast = ai.wrap(fast)
       const wrappedSmart = ai.wrap(smart)
 
-      ;(fast.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(fast.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 50, outputTotal: 20 }),
         response: { modelId: 'claude-haiku-4.5' },
       })
 
-      ;(smart.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(smart.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 200, outputTotal: 100 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedFast.doGenerate({} as any)
-      await wrappedSmart.doGenerate({} as any)
+      await wrappedFast.doGenerate(createMockCallOptions())
+      await wrappedSmart.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       const stepsUsage = aiData.stepsUsage as Array<Record<string, unknown>>
@@ -1308,14 +1376,14 @@ describe('createAILogger', () => {
 
       const wrappedModel = wrapLanguageModel({ model, middleware })
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"q":"test"}' }],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
         response: { modelId: 'claude-sonnet-4.6', id: 'msg_abc' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.calls).toBe(1)
@@ -1393,14 +1461,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 1_000_000, outputTotal: 500_000 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       // 1M input * $3/1M = $3 + 500K output * $15/1M = $7.5 => $10.5
@@ -1417,14 +1485,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.estimatedCost).toBeUndefined()
@@ -1436,14 +1504,14 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
         finishReason: createFinishReason(),
         usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      await wrappedModel.doGenerate({} as any)
+      await wrappedModel.doGenerate(createMockCallOptions())
 
       const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
       expect(aiData.estimatedCost).toBeUndefined()
@@ -1465,20 +1533,16 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({
-        model: { provider: 'anthropic', modelId: 'claude-sonnet-4.6' },
-      } as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'getWeather', toolCallId: 'tc1', input: {} },
+      callIntegrationOnStart(integration)
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'getWeather',
         durationMs: 150,
         success: true,
         output: { temperature: 22 },
-      } as any)
+      })
+      callIntegrationOnFinish(integration)
 
-      integration.onFinish!({} as any)
-
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       const tools = aiData.tools as Array<Record<string, unknown>>
       expect(tools).toHaveLength(1)
       expect(tools[0]).toEqual({
@@ -1494,18 +1558,16 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({} as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'searchDB', toolCallId: 'tc2', input: {} },
+      callIntegrationOnStart(integration)
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'searchDB',
         durationMs: 50,
         success: false,
         error: new Error('Connection refused'),
-      } as any)
+      })
+      callIntegrationOnFinish(integration)
 
-      integration.onFinish!({} as any)
-
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       const tools = aiData.tools as Array<Record<string, unknown>>
       expect(tools).toHaveLength(1)
       expect(tools[0]).toEqual({
@@ -1520,25 +1582,22 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({} as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'getWeather', toolCallId: 'tc1', input: {} },
+      callIntegrationOnStart(integration)
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'getWeather',
         durationMs: 100,
         success: true,
         output: {},
-      } as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'searchDB', toolCallId: 'tc2', input: {} },
+      })
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'searchDB',
         durationMs: 250,
         success: true,
         output: {},
-      } as any)
+      })
+      callIntegrationOnFinish(integration)
 
-      integration.onFinish!({} as any)
-
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       const tools = aiData.tools as Array<Record<string, unknown>>
       expect(tools).toHaveLength(2)
       expect(tools[0].name).toBe('getWeather')
@@ -1552,26 +1611,24 @@ describe('createAILogger', () => {
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
-      ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'getWeather', input: '{}' }],
         finishReason: createFinishReason('tool-calls'),
         usage: createMockUsage({ inputTotal: 200, outputTotal: 100 }),
         response: { modelId: 'claude-sonnet-4.6' },
       })
 
-      integration.onStart!({} as any)
-      await wrappedModel.doGenerate({} as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'getWeather', toolCallId: 'tc1', input: {} },
+      callIntegrationOnStart(integration)
+      await wrappedModel.doGenerate(createMockCallOptions())
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'getWeather',
         durationMs: 75,
         success: true,
         output: { temp: 20 },
-      } as any)
+      })
+      callIntegrationOnFinish(integration)
 
-      integration.onFinish!({} as any)
-
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       expect(aiData.calls).toBe(1)
       expect(aiData.model).toBe('claude-sonnet-4.6')
       expect(aiData.inputTokens).toBe(200)
@@ -1587,11 +1644,11 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({} as any)
+      callIntegrationOnStart(integration)
       await new Promise(resolve => setTimeout(resolve, 20))
-      integration.onFinish!({} as any)
+      callIntegrationOnFinish(integration)
 
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       expect(aiData.totalDurationMs).toBeTypeOf('number')
       expect(aiData.totalDurationMs as number).toBeGreaterThanOrEqual(15)
     })
@@ -1600,18 +1657,16 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({} as any)
-
-      integration.onToolCallFinish!({
-        toolCall: { toolName: 'myTool', toolCallId: 'tc1', input: {} },
+      callIntegrationOnStart(integration)
+      callIntegrationOnToolCallFinish(integration, {
+        toolName: 'myTool',
         durationMs: 10,
         success: false,
         error: 'Something went wrong',
-      } as any)
+      })
+      callIntegrationOnFinish(integration)
 
-      integration.onFinish!({} as any)
-
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       const tools = aiData.tools as Array<Record<string, unknown>>
       expect(tools[0].error).toBe('Something went wrong')
     })
@@ -1620,10 +1675,10 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const integration = createEvlogIntegration(log)
 
-      integration.onStart!({} as any)
-      integration.onFinish!({} as any)
+      callIntegrationOnStart(integration)
+      callIntegrationOnFinish(integration)
 
-      const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
+      const aiData = getLastAiData(log)
       expect(aiData.tools).toBeUndefined()
     })
   })
@@ -1653,14 +1708,14 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{}' }],
           finishReason: createFinishReason('tool-calls'),
           usage: createMockUsage({ inputTotal: 1_000_000, outputTotal: 500_000 }),
           response: { modelId: 'claude-sonnet-4.6', id: 'msg_abc' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
 
         const aiData = log.setCalls[log.setCalls.length - 1].ai as Record<string, unknown>
         const metadata = ai.getMetadata()
@@ -1684,14 +1739,14 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{}' }],
           finishReason: createFinishReason('tool-calls'),
           usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
 
         const first = ai.getMetadata()
         ;(first.toolCalls as string[]).push('mutated')
@@ -1708,7 +1763,7 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>)
+        vi.mocked(model.doGenerate)
           .mockResolvedValueOnce({
             content: [],
             finishReason: createFinishReason(),
@@ -1722,12 +1777,12 @@ describe('createAILogger', () => {
             response: { modelId: 'claude-sonnet-4.6' },
           })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         const afterStep1 = ai.getMetadata()
         expect(afterStep1.calls).toBe(1)
         expect(afterStep1.totalTokens).toBe(150)
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         const afterStep2 = ai.getMetadata()
         expect(afterStep2.calls).toBe(2)
         expect(afterStep2.totalTokens).toBe(450)
@@ -1755,9 +1810,9 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('quota exceeded'))
+        vi.mocked(model.doGenerate).mockRejectedValue(new Error('quota exceeded'))
 
-        await expect(wrappedModel.doGenerate({} as any)).rejects.toThrow('quota exceeded')
+        await expect(wrappedModel.doGenerate(createMockCallOptions())).rejects.toThrow('quota exceeded')
 
         const metadata = ai.getMetadata()
         expect(metadata.error).toBe('quota exceeded')
@@ -1772,14 +1827,14 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
           finishReason: createFinishReason(),
           usage: createMockUsage({ inputTotal: 100, outputTotal: 50 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         expect(ai.getEstimatedCost()).toBeUndefined()
       })
 
@@ -1791,14 +1846,14 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
           finishReason: createFinishReason(),
           usage: createMockUsage({ inputTotal: 1_000_000, outputTotal: 500_000 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
 
         expect(ai.getEstimatedCost()).toBe(10.5)
         expect(ai.getEstimatedCost()).toBe(ai.getMetadata().estimatedCost)
@@ -1810,14 +1865,14 @@ describe('createAILogger', () => {
         const model = createMockModel()
         const wrappedModel = ai.wrap(model)
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
           finishReason: createFinishReason(),
           usage: createMockUsage(),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         expect(ai.getEstimatedCost()).toBeUndefined()
       })
     })
@@ -1834,7 +1889,7 @@ describe('createAILogger', () => {
           updates.push(metadata)
         })
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>)
+        vi.mocked(model.doGenerate)
           .mockResolvedValueOnce({
             content: [],
             finishReason: createFinishReason(),
@@ -1848,8 +1903,8 @@ describe('createAILogger', () => {
             response: { modelId: 'claude-sonnet-4.6' },
           })
 
-        await wrappedModel.doGenerate({} as any)
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
+        await wrappedModel.doGenerate(createMockCallOptions())
 
         expect(updates).toHaveLength(2)
         expect(updates[0].calls).toBe(1)
@@ -1880,8 +1935,8 @@ describe('createAILogger', () => {
         const updates: Array<ReturnType<typeof ai.getMetadata>> = []
         ai.onUpdate(metadata => updates.push(metadata))
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'))
-        await expect(wrappedModel.doGenerate({} as any)).rejects.toThrow('boom')
+        vi.mocked(model.doGenerate).mockRejectedValue(new Error('boom'))
+        await expect(wrappedModel.doGenerate(createMockCallOptions())).rejects.toThrow('boom')
 
         expect(updates).toHaveLength(1)
         expect(updates[0].error).toBe('boom')
@@ -1898,22 +1953,22 @@ describe('createAILogger', () => {
         const updates: Array<ReturnType<typeof ai.getMetadata>> = []
         ai.onUpdate(metadata => updates.push(metadata))
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'getWeather', input: '{}' }],
           finishReason: createFinishReason('tool-calls'),
           usage: createMockUsage({ inputTotal: 200, outputTotal: 100 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        integration.onStart!({} as any)
-        await wrappedModel.doGenerate({} as any)
-        integration.onToolCallFinish!({
-          toolCall: { toolName: 'getWeather', toolCallId: 'tc1', input: {} },
+        callIntegrationOnStart(integration)
+        await wrappedModel.doGenerate(createMockCallOptions())
+        callIntegrationOnToolCallFinish(integration, {
+          toolName: 'getWeather',
           durationMs: 50,
           success: true,
           output: {},
-        } as any)
-        integration.onFinish!({} as any)
+        })
+        callIntegrationOnFinish(integration)
 
         expect(updates.length).toBeGreaterThanOrEqual(2)
         const last = updates[updates.length - 1]
@@ -1932,19 +1987,19 @@ describe('createAILogger', () => {
           count++ 
         })
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
           finishReason: createFinishReason(),
           usage: createMockUsage(),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         expect(count).toBe(1)
 
         off()
 
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
         expect(count).toBe(1)
       })
 
@@ -1982,14 +2037,14 @@ describe('createAILogger', () => {
           calls++ 
         })
 
-        ;(model.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
           finishReason: createFinishReason(),
           usage: createMockUsage(),
           response: { modelId: 'claude-sonnet-4.6' },
         })
 
-        await expect(wrappedModel.doGenerate({} as any)).resolves.toBeDefined()
+        await expect(wrappedModel.doGenerate(createMockCallOptions())).resolves.toBeDefined()
         expect(calls).toBe(1)
       })
 
@@ -2014,12 +2069,12 @@ describe('createAILogger', () => {
   describe('end-to-end with the real logger', () => {
     it('produces a wide event with linear array growth across a multi-step run', async () => {
       const log = createLogger()
-      const ai = createAILogger(log as unknown as RequestLogger)
+      const ai = createAILogger(log)
       const model = createMockModel()
       const wrappedModel = ai.wrap(model)
 
       const tools = ['list-pages', 'get-page', 'get-page', 'get-page', 'get-page', 'get-page']
-      const doGenerate = model.doGenerate as ReturnType<typeof vi.fn>
+      const doGenerate = vi.mocked(model.doGenerate)
       for (const toolName of tools) {
         doGenerate.mockResolvedValueOnce({
           content: [{ type: 'tool-call', toolCallId: `tc-${toolName}`, toolName, args: '{}' }],
@@ -2027,12 +2082,12 @@ describe('createAILogger', () => {
           usage: createMockUsage({ inputTotal: 100, outputTotal: 20 }),
           response: { modelId: 'claude-sonnet-4.6' },
         })
-        await wrappedModel.doGenerate({} as any)
+        await wrappedModel.doGenerate(createMockCallOptions())
       }
 
-      const wide = log.emit({ _forceKeep: true } as any)
+      const wide = defined(log.emit({ _forceKeep: true }), 'wide event')
       expect(wide).not.toBeNull()
-      const aiData = (wide as Record<string, unknown>).ai as Record<string, unknown>
+      const aiData = defined(wide.ai, 'wide event ai') as Record<string, unknown>
 
       expect((aiData.toolCalls as string[])).toEqual(tools)
       expect((aiData.stepsUsage as unknown[])).toHaveLength(tools.length)
@@ -2044,7 +2099,7 @@ describe('createAILogger', () => {
 
     it('keeps `models` deduplicated across many flushes on the real wide event', async () => {
       const log = createLogger()
-      const ai = createAILogger(log as unknown as RequestLogger)
+      const ai = createAILogger(log)
 
       const gemini = createMockModel({ provider: 'google', modelId: 'gemini-3-flash' })
       const claude = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
@@ -2057,17 +2112,17 @@ describe('createAILogger', () => {
         usage: createMockUsage({ inputTotal: 50, outputTotal: 10 }),
         response: { modelId },
       })
-      ;(gemini.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(baseResult('gemini-3-flash'))
-      ;(claude.doGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(baseResult('claude-sonnet-4.6'))
+      vi.mocked(gemini.doGenerate).mockResolvedValue(baseResult('gemini-3-flash'))
+      vi.mocked(claude.doGenerate).mockResolvedValue(baseResult('claude-sonnet-4.6'))
 
       // Alternate models so each `flushState` re-evaluates the unique set.
-      await wrappedGemini.doGenerate({} as any)
-      await wrappedClaude.doGenerate({} as any)
-      await wrappedGemini.doGenerate({} as any)
-      await wrappedClaude.doGenerate({} as any)
+      await wrappedGemini.doGenerate(createMockCallOptions())
+      await wrappedClaude.doGenerate(createMockCallOptions())
+      await wrappedGemini.doGenerate(createMockCallOptions())
+      await wrappedClaude.doGenerate(createMockCallOptions())
 
-      const wide = log.emit({ _forceKeep: true } as any)
-      const aiData = (wide as Record<string, unknown>).ai as Record<string, unknown>
+      const wide = defined(log.emit({ _forceKeep: true }), 'wide event')
+      const aiData = defined(wide.ai, 'wide event ai') as Record<string, unknown>
       expect(aiData.models).toEqual(['gemini-3-flash', 'claude-sonnet-4.6'])
     })
   })

--- a/packages/evlog/test/core/audit.test.ts
+++ b/packages/evlog/test/core/audit.test.ts
@@ -396,6 +396,38 @@ describe('idempotency key', () => {
   })
 })
 
+describe('stableStringify plain-object guard', () => {
+  it('serializes Date in audit changes via JSON.stringify, not key enumeration', async () => {
+    const calls: WideEvent[] = []
+    const when = new Date('2026-01-01T00:00:00.000Z')
+    const drain = signed((ctx: DrainContext) => {
+      calls.push(ctx.event)
+    }, { strategy: 'hmac', secret: 'test-secret' })
+
+    await drain(createDrainCtx({
+      audit: {
+        action: 'update',
+        actor: { type: 'user', id: 'u1' },
+        outcome: 'success',
+        changes: { when },
+      },
+    }))
+    await drain(createDrainCtx({
+      audit: {
+        action: 'update',
+        actor: { type: 'user', id: 'u1' },
+        outcome: 'success',
+        changes: { when: new Date('2026-01-01T00:00:00.000Z') },
+      },
+    }))
+
+    const sig1 = defined(defined(calls[0], 'first event').audit as AuditFields).signature
+    const sig2 = defined(defined(calls[1], 'second event').audit as AuditFields).signature
+    expect(sig1).toBeDefined()
+    expect(sig1).toBe(sig2)
+  })
+})
+
 describe('end-to-end: audit + auditOnly + global drain', () => {
   it('routes audit-only drain alongside the main drain', () => {
     const main = vi.fn<(ctx: DrainContext) => void>()

--- a/packages/evlog/test/core/audit.test.ts
+++ b/packages/evlog/test/core/audit.test.ts
@@ -17,6 +17,7 @@ import {
 import type { AuditFields, DrainContext, EnrichContext, WideEvent } from '../../src/types'
 import { createLogger, createRequestLogger, initLogger } from '../../src/logger'
 import { resolveRedactConfig } from '../../src/redact'
+import { defined } from '../helpers/defined'
 
 function createDrainCtx(event: Partial<WideEvent> = {}): DrainContext {
   const wide: WideEvent = {
@@ -87,9 +88,8 @@ describe('log.audit() on createLogger', () => {
       actor: { type: 'user', id: 'u1' },
       target: { type: 'invoice', id: 'inv_1' },
     })
-    const event = log.emit()
-    expect(event).not.toBeNull()
-    const audit = event!.audit as AuditFields
+    const event = defined(log.emit(), 'emitted event')
+    const audit = event.audit as AuditFields
     expect(audit.action).toBe('invoice.refund')
     expect(audit.outcome).toBe('success')
     expect(audit.idempotencyKey).toMatch(/^[\da-f]{32}$/)
@@ -102,8 +102,8 @@ describe('log.audit() on createLogger', () => {
       actor: { type: 'user', id: 'u1' },
       target: { type: 'invoice', id: 'inv_1' },
     })
-    const event = log.emit()
-    const audit = event!.audit as AuditFields
+    const event = defined(log.emit(), 'emitted event')
+    const audit = event.audit as AuditFields
     expect(audit.outcome).toBe('denied')
     expect(audit.reason).toBe('Insufficient permissions')
   })
@@ -112,9 +112,8 @@ describe('log.audit() on createLogger', () => {
     initLogger({ pretty: false, redact: false, sampling: { rates: { info: 0 } } })
     const log = createLogger()
     log.set({ audit: buildAuditFields({ action: 'manual', actor: { type: 'system', id: 's' } }) })
-    const event = log.emit()
-    expect(event).not.toBeNull()
-    expect((event!.audit as AuditFields).action).toBe('manual')
+    const event = defined(log.emit(), 'emitted event')
+    expect((event.audit as AuditFields).action).toBe('manual')
   })
 
   it('createRequestLogger exposes the same audit method', () => {
@@ -125,12 +124,11 @@ describe('log.audit() on createLogger', () => {
 
 describe('standalone audit()', () => {
   it('emits an event tagged as audit and returns it', () => {
-    const event = audit({
+    const event = defined(audit({
       action: 'cron.cleanup',
       actor: { type: 'system', id: 'cron' },
-    })
-    expect(event).not.toBeNull()
-    expect((event!.audit as AuditFields).action).toBe('cron.cleanup')
+    }), 'audit event')
+    expect((event.audit as AuditFields).action).toBe('cron.cleanup')
   })
 
   it('is force-kept even when info sampling is at 0%', () => {
@@ -152,8 +150,9 @@ describe('withAudit()', () => {
     )
     await refund({ id: 'inv_1' }, { actor: { type: 'user', id: 'u1' } })
     expect(collector.events).toHaveLength(1)
-    expect(collector.events[0]!.outcome).toBe('success')
-    expect(collector.events[0]!.target).toEqual({ type: 'invoice', id: 'inv_1' })
+    const recorded = defined(collector.events[0], 'audit event')
+    expect(recorded.outcome).toBe('success')
+    expect(recorded.target).toEqual({ type: 'invoice', id: 'inv_1' })
     collector.restore()
   })
 
@@ -163,8 +162,9 @@ describe('withAudit()', () => {
       throw new AuditDeniedError('not allowed')
     })
     await expect(fn(null, { actor: { type: 'user', id: 'u1' } })).rejects.toThrow('not allowed')
-    expect(collector.events[0]!.outcome).toBe('denied')
-    expect(collector.events[0]!.reason).toBe('not allowed')
+    const denied = defined(collector.events[0], 'audit event')
+    expect(denied.outcome).toBe('denied')
+    expect(denied.reason).toBe('not allowed')
     collector.restore()
   })
 
@@ -176,7 +176,7 @@ describe('withAudit()', () => {
       throw err
     })
     await expect(fn(null, { actor: { type: 'user', id: 'u1' } })).rejects.toThrow('forbidden')
-    expect(collector.events[0]!.outcome).toBe('denied')
+    expect(defined(collector.events[0], 'audit event').outcome).toBe('denied')
     collector.restore()
   })
 
@@ -186,8 +186,9 @@ describe('withAudit()', () => {
       throw new Error('boom')
     })
     await expect(fn(null, { actor: { type: 'user', id: 'u1' } })).rejects.toThrow('boom')
-    expect(collector.events[0]!.outcome).toBe('failure')
-    expect(collector.events[0]!.reason).toBe('boom')
+    const recorded = defined(collector.events[0], 'audit event')
+    expect(recorded.outcome).toBe('failure')
+    expect(recorded.reason).toBe('boom')
     collector.restore()
   })
 })
@@ -319,8 +320,10 @@ describe('signed() — hmac', () => {
     const ctx2 = createDrainCtx({ audit: { action: 'a', actor: { type: 'user', id: 'u1' }, outcome: 'success' } })
     await drain(ctx1)
     await drain(ctx2)
-    expect((calls[0]!.audit as AuditFields).signature).toBeDefined()
-    expect((calls[0]!.audit as AuditFields).signature).toBe((calls[1]!.audit as AuditFields).signature)
+    const firstAudit = defined(defined(calls[0], 'first event').audit, 'first audit') as AuditFields
+    const secondAudit = defined(defined(calls[1], 'second event').audit, 'second audit') as AuditFields
+    expect(firstAudit.signature).toBeDefined()
+    expect(firstAudit.signature).toBe(secondAudit.signature)
   })
 
   it('passes through events without audit', async () => {
@@ -340,9 +343,9 @@ describe('signed() — hash-chain', () => {
     await drain(make())
     await drain(make())
 
-    const a1 = calls[0]!.audit as AuditFields
-    const a2 = calls[1]!.audit as AuditFields
-    const a3 = calls[2]!.audit as AuditFields
+    const a1 = defined(defined(calls[0], 'audit event 1').audit, 'audit 1') as AuditFields
+    const a2 = defined(defined(calls[1], 'audit event 2').audit, 'audit 2') as AuditFields
+    const a3 = defined(defined(calls[2], 'audit event 3').audit, 'audit 3') as AuditFields
     expect(a1.prevHash).toBeUndefined()
     expect(a2.prevHash).toBe(a1.hash)
     expect(a3.prevHash).toBe(a2.hash)
@@ -377,14 +380,14 @@ describe('signed() — hash-chain', () => {
       state: { load: () => 'previous-hash-from-disk', save: () => {} },
     })
     await drain(createDrainCtx({ audit: { action: 'a', actor: { type: 'user', id: 'u1' }, outcome: 'success' } }))
-    expect((calls[0]!.audit as AuditFields).prevHash).toBe('previous-hash-from-disk')
+    expect((defined(defined(calls[0], 'audit event').audit, 'audit') as AuditFields).prevHash).toBe('previous-hash-from-disk')
   })
 })
 
 describe('idempotency key', () => {
   it('is stable across identical events in the same second', () => {
-    const e1 = audit({ action: 'a', actor: { type: 'user', id: 'u1' }, target: { type: 't', id: 'r1' } })!
-    const e2 = audit({ action: 'a', actor: { type: 'user', id: 'u1' }, target: { type: 't', id: 'r1' } })!
+    const e1 = defined(audit({ action: 'a', actor: { type: 'user', id: 'u1' }, target: { type: 't', id: 'r1' } }), 'audit event 1')
+    const e2 = defined(audit({ action: 'a', actor: { type: 'user', id: 'u1' }, target: { type: 't', id: 'r1' } }), 'audit event 2')
     const t1 = (e1.timestamp as string).slice(0, 19)
     const t2 = (e2.timestamp as string).slice(0, 19)
     if (t1 === t2) {
@@ -418,12 +421,12 @@ describe('end-to-end: audit + auditOnly + global drain', () => {
 
 describe('auditRedactPreset', () => {
   it('drops authorization headers', () => {
-    const config = resolveRedactConfig(auditRedactPreset)!
+    const config = defined(resolveRedactConfig(auditRedactPreset), 'audit redact preset')
     expect(config.paths).toContain('headers.authorization')
   })
 
   it('drops password fields under audit.changes', () => {
-    const config = resolveRedactConfig(auditRedactPreset)!
+    const config = defined(resolveRedactConfig(auditRedactPreset), 'audit redact preset')
     expect(config.paths).toContain('audit.changes.before.password')
     expect(config.paths).toContain('audit.changes.after.password')
   })

--- a/packages/evlog/test/core/logger-request-logger.test.ts
+++ b/packages/evlog/test/core/logger-request-logger.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createError } from '../../src/error'
 import { createRequestLogger, initLogger } from '../../src/logger'
+import type { FieldContext } from '../../src/types'
 import { withFakeTimers } from '../helpers/timers'
+import { defined } from '../helpers/defined'
 
 describe('createRequestLogger', () => {
   let infoSpy: ReturnType<typeof vi.spyOn>
@@ -217,14 +219,12 @@ describe('createRequestLogger', () => {
     const logger = createRequestLogger({})
 
     logger.info('First entry')
-    logger.info('Second entry', { requestLogs: 'should be ignored' } as any)
-    logger.warn('Third entry', { requestLogs: [{ fake: true }] } as any)
+    logger.info('Second entry', { requestLogs: 'should be ignored' } as FieldContext)
+    logger.warn('Third entry', { requestLogs: [{ fake: true }] } as FieldContext)
 
     const context = logger.getContext()
-    expect(context.requestLogs).toHaveLength(3)
-    expect((context.requestLogs as Array<{ message: string }>)[0]!.message).toBe('First entry')
-    expect((context.requestLogs as Array<{ message: string }>)[1]!.message).toBe('Second entry')
-    expect((context.requestLogs as Array<{ message: string }>)[2]!.message).toBe('Third entry')
+    const logs = defined(context.requestLogs, 'requestLogs') as Array<{ message: string }>
+    expect(logs.map(entry => entry.message)).toEqual(['First entry', 'Second entry', 'Third entry'])
   })
 
   it('captures custom error properties (statusCode, data, cause)', () => {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createError } from '../../src/error'
 import { createLogger, createRequestLogger, getEnvironment, initLogger, isEnabled, log } from '../../src/logger'
 import { withFakeTimers } from '../helpers/timers'
+import { defined } from '../helpers/defined'
 
 describe('initLogger', () => {
   beforeEach(() => {
@@ -238,9 +239,8 @@ describe('createLogger', () => {
     logger.warn('Slow downstream query')
 
     const context = logger.getContext()
-    expect(context.requestLogs).toHaveLength(2)
-    expect((context.requestLogs as Array<{ message: string }>)[0]!.message).toBe('Extracting data')
-    expect((context.requestLogs as Array<{ message: string }>)[1]!.message).toBe('Slow downstream query')
+    const logs = defined(context.requestLogs, 'requestLogs') as Array<{ message: string }>
+    expect(logs.map(entry => entry.message)).toEqual(['Extracting data', 'Slow downstream query'])
   })
 
   it('returns WideEvent on emit', () => {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -1150,3 +1150,29 @@ describe('silent option', () => {
     expect(ctx.event.message).toBe('User logged in')
   })
 })
+
+describe('pretty-print tool input serialization', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    initLogger({ pretty: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not throw on BigInt or circular tool inputs', () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    const logger = createRequestLogger({ method: 'GET', path: '/ai', requestId: 'r1' })
+    logger.set({
+      ai: {
+        toolCalls: [
+          { name: 'big', input: { n: 1n } },
+          { name: 'circ', input: circular },
+        ],
+      },
+    })
+    expect(() => logger.emit()).not.toThrow()
+  })
+})

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initLogger } from '../../src/logger'
 import { createMiddlewareLogger } from '../../src/shared/middleware'
+import { defined } from '../helpers/defined'
 
 describe('createMiddlewareLogger', () => {
   beforeEach(() => {
@@ -95,14 +96,13 @@ describe('createMiddlewareLogger', () => {
     })
 
     logger.set({ cart: { items: 3 } })
-    const event = await finish({ status: 200 })
+    const event = defined(await finish({ status: 200 }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect(event!.status).toBe(200)
-    expect(event!.method).toBe('POST')
-    expect(event!.path).toBe('/api/checkout')
-    expect(event!.duration).toBeDefined()
-    expect(event!.level).toBe('info')
+    expect(event.status).toBe(200)
+    expect(event.method).toBe('POST')
+    expect(event.path).toBe('/api/checkout')
+    expect(event.duration).toBeDefined()
+    expect(event.level).toBe('info')
   })
 
   it('finish() with error captures error and sets error status', async () => {
@@ -113,13 +113,12 @@ describe('createMiddlewareLogger', () => {
     })
 
     const error = Object.assign(new Error('Payment failed'), { status: 402 })
-    const event = await finish({ error })
+    const event = defined(await finish({ error }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect(event!.status).toBe(402)
-    expect(event!.level).toBe('error')
-    expect(event!.error).toBeDefined()
-    expect((event!.error as Record<string, unknown>).message).toBe('Payment failed')
+    expect(event.status).toBe(402)
+    expect(event.level).toBe('error')
+    expect(event.error).toBeDefined()
+    expect((event.error as Record<string, unknown>).message).toBe('Payment failed')
   })
 
   it('finish() with error defaults to status 500', async () => {
@@ -128,10 +127,9 @@ describe('createMiddlewareLogger', () => {
       path: '/api/fail',
     })
 
-    const event = await finish({ error: new Error('crash') })
+    const event = defined(await finish({ error: new Error('crash') }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect(event!.status).toBe(500)
+    expect(event.status).toBe(500)
   })
 
   it('finish() calls keep callback for tail sampling', async () => {
@@ -189,11 +187,10 @@ describe('createMiddlewareLogger', () => {
     logger.set({ user: { id: 'u-1' } })
     logger.set({ db: { queries: 3 } })
 
-    const event = await finish({ status: 200 })
+    const event = defined(await finish({ status: 200 }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect((event!.user as Record<string, unknown>).id).toBe('u-1')
-    expect((event!.db as Record<string, unknown>).queries).toBe(3)
+    expect((event.user as Record<string, unknown>).id).toBe('u-1')
+    expect((event.db as Record<string, unknown>).queries).toBe(3)
   })
 
   it('finish() includes duration', async () => {
@@ -202,11 +199,10 @@ describe('createMiddlewareLogger', () => {
       path: '/api/slow',
     })
 
-    const event = await finish({ status: 200 })
+    const event = defined(await finish({ status: 200 }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect(event!.duration).toBeDefined()
-    expect(typeof event!.duration).toBe('string')
+    expect(event.duration).toBeDefined()
+    expect(typeof event.duration).toBe('string')
   })
 
   it('finish() with warn level when logger has warnings', async () => {
@@ -216,10 +212,9 @@ describe('createMiddlewareLogger', () => {
     })
 
     logger.warn('Deprecated endpoint')
-    const event = await finish({ status: 200 })
+    const event = defined(await finish({ status: 200 }), 'finish event')
 
-    expect(event).not.toBeNull()
-    expect(event!.level).toBe('warn')
+    expect(event.level).toBe('warn')
   })
 
   describe('built-in drain/enrich pipeline', () => {

--- a/packages/evlog/test/core/pipeline.test.ts
+++ b/packages/evlog/test/core/pipeline.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DrainContext } from '../../src/types'
 import { createDrainPipeline } from '../../src/pipeline'
+import { defined } from '../helpers/defined'
+
+function getBatchArg(call: unknown[]): DrainContext[] {
+  return defined(call[0], 'batch arg') as DrainContext[]
+}
 
 function createTestContext(id: number): DrainContext {
   return {
@@ -48,11 +53,11 @@ describe('createDrainPipeline', () => {
       await vi.runAllTimersAsync()
 
       expect(drain).toHaveBeenCalledTimes(1)
-      const batch = drain.mock.calls[0]![0] as DrainContext[]
+      const batch = getBatchArg(defined(drain.mock.calls[0], 'drain call'))
       expect(batch).toHaveLength(3)
-      expect(batch[0]!.event.id).toBe(1)
-      expect(batch[1]!.event.id).toBe(2)
-      expect(batch[2]!.event.id).toBe(3)
+      expect(defined(batch[0], 'batch[0]').event.id).toBe(1)
+      expect(defined(batch[1], 'batch[1]').event.id).toBe(2)
+      expect(defined(batch[2], 'batch[2]').event.id).toBe(3)
     })
 
     it('splits into multiple batches', async () => {
@@ -64,9 +69,9 @@ describe('createDrainPipeline', () => {
       await hook.flush()
 
       expect(drain).toHaveBeenCalledTimes(3)
-      expect((drain.mock.calls[0]![0] as DrainContext[])).toHaveLength(3)
-      expect((drain.mock.calls[1]![0] as DrainContext[])).toHaveLength(3)
-      expect((drain.mock.calls[2]![0] as DrainContext[])).toHaveLength(1)
+      expect(getBatchArg(defined(drain.mock.calls[0], 'drain call 0'))).toHaveLength(3)
+      expect(getBatchArg(defined(drain.mock.calls[1], 'drain call 1'))).toHaveLength(3)
+      expect(getBatchArg(defined(drain.mock.calls[2], 'drain call 2'))).toHaveLength(1)
     })
   })
 
@@ -83,7 +88,7 @@ describe('createDrainPipeline', () => {
 
       await vi.advanceTimersByTimeAsync(1)
       expect(drain).toHaveBeenCalledTimes(1)
-      expect((drain.mock.calls[0]![0] as DrainContext[])).toHaveLength(2)
+      expect(getBatchArg(defined(drain.mock.calls[0], 'drain call'))).toHaveLength(2)
     })
 
     it('resets interval when batch size is reached', async () => {
@@ -216,9 +221,10 @@ describe('createDrainPipeline', () => {
 
       expect(drain).toHaveBeenCalledTimes(2)
       expect(onDropped).toHaveBeenCalledTimes(1)
-      expect((onDropped.mock.calls[0]![0] as DrainContext[])).toHaveLength(1)
-      expect(onDropped.mock.calls[0]![1]).toBeInstanceOf(Error)
-      expect((onDropped.mock.calls[0]![1] as Error).message).toBe('permanent failure')
+      const droppedCall = defined(onDropped.mock.calls[0], 'onDropped call')
+      expect(getBatchArg(droppedCall)).toHaveLength(1)
+      expect(droppedCall[1]).toBeInstanceOf(Error)
+      expect((defined(droppedCall[1], 'dropped error') as Error).message).toBe('permanent failure')
     })
   })
 
@@ -241,14 +247,15 @@ describe('createDrainPipeline', () => {
       // Buffer full - should drop oldest
       hook(createTestContext(4))
       expect(onDropped).toHaveBeenCalledTimes(1)
-      expect((onDropped.mock.calls[0]![0] as DrainContext[])).toHaveLength(1)
-      expect((onDropped.mock.calls[0]![0] as DrainContext[])[0]!.event.id).toBe(1)
+      const droppedBatch = getBatchArg(defined(onDropped.mock.calls[0], 'onDropped call'))
+      expect(droppedBatch).toHaveLength(1)
+      expect(defined(droppedBatch[0], 'dropped batch[0]').event.id).toBe(1)
 
       expect(hook.pending).toBe(3)
 
       // Flush and verify the remaining events are 2, 3, 4
       await hook.flush()
-      const batch = drain.mock.calls[0]![0] as DrainContext[]
+      const batch = getBatchArg(defined(drain.mock.calls[0], 'drain call'))
       expect(batch.map(c => c.event.id)).toEqual([2, 3, 4])
     })
   })
@@ -265,7 +272,7 @@ describe('createDrainPipeline', () => {
       await hook.flush()
 
       expect(drain).toHaveBeenCalledTimes(1)
-      expect((drain.mock.calls[0]![0] as DrainContext[])).toHaveLength(3)
+      expect(getBatchArg(defined(drain.mock.calls[0], 'drain call'))).toHaveLength(3)
       expect(hook.pending).toBe(0)
     })
 

--- a/packages/evlog/test/core/redact-integration.test.ts
+++ b/packages/evlog/test/core/redact-integration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { redactEvent, resolveRedactConfig } from '../../src/redact'
 import { createLogger, initLogger } from '../../src/logger'
 import { createPipelineSpies, waitForDrainCalls } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 
 describe('initLogger + redact integration', () => {
@@ -24,10 +25,8 @@ describe('initLogger + redact integration', () => {
     })
 
     const logger = createLogger({ user: { email: 'alice@example.com', id: '123' } })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    const user = event!.user as Record<string, unknown>
+    const event = defined(logger.emit(), 'emitted event')
+    const user = event.user as Record<string, unknown>
     expect(user.email).toBe('[REDACTED]')
     expect(user.id).toBe('123')
   })
@@ -42,10 +41,8 @@ describe('initLogger + redact integration', () => {
     })
 
     const logger = createLogger({ message: 'Contact alice@example.com' })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.message).toBe('Contact [REDACTED]')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.message).toBe('Contact [REDACTED]')
   })
 
   it('redacts before console output', () => {
@@ -85,7 +82,7 @@ describe('initLogger + redact integration', () => {
     logger.emit()
 
     await waitForDrainCalls(drain)
-    const drained = drain.mock.calls[0]![0].event
+    const drained = getDrainCallArg(defined(drain.mock.calls[0], 'drain call')).event
     expect((drained.user as Record<string, unknown>).email).toBe('[REDACTED]')
     expect(drained.note).toBe('Card ****1111')
   })
@@ -96,12 +93,10 @@ describe('initLogger + redact integration', () => {
     const logger = createLogger({
       message: 'User alice@example.com paid with 4111-1111-1111-1111 from 192.168.1.100',
     })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.message).not.toContain('alice@example.com')
-    expect(event!.message).not.toContain('4111-1111-1111-1111')
-    expect(event!.message).not.toContain('192.168.1.100')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.message).not.toContain('alice@example.com')
+    expect(event.message).not.toContain('4111-1111-1111-1111')
+    expect(event.message).not.toContain('192.168.1.100')
   })
 
   it('redact: true with custom paths on top', () => {
@@ -115,10 +110,8 @@ describe('initLogger + redact integration', () => {
     const logger = createLogger({
       user: { password: 'secret123', email: 'alice@example.com' },
     })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    const user = event!.user as Record<string, unknown>
+    const event = defined(logger.emit(), 'emitted event')
+    const user = event.user as Record<string, unknown>
     expect(user.password).toBe('[REDACTED]')
     expect(user.email).toBe('a***@***.com')
   })
@@ -136,11 +129,9 @@ describe('initLogger + redact integration', () => {
       secret: 'hidden',
       email: 'alice@example.com',
     })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.secret).toBe('[REDACTED]')
-    expect(event!.email).toBe('alice@example.com')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.secret).toBe('[REDACTED]')
+    expect(event.email).toBe('alice@example.com')
   })
 
   it('redact with selected builtins', () => {
@@ -155,11 +146,9 @@ describe('initLogger + redact integration', () => {
       contact: 'alice@example.com',
       card: '4111-1111-1111-1111',
     })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.contact).not.toContain('alice@example.com')
-    expect(event!.card).toBe('4111-1111-1111-1111')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.contact).not.toContain('alice@example.com')
+    expect(event.card).toBe('4111-1111-1111-1111')
   })
 })
 
@@ -183,10 +172,8 @@ describe('default redaction behavior', () => {
     initLogger({ pretty: false })
 
     const logger = createLogger({ email: 'alice@example.com' })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.email).toBe('a***@***.com')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.email).toBe('a***@***.com')
   })
 
   it('disables redaction by default in development', () => {
@@ -194,10 +181,8 @@ describe('default redaction behavior', () => {
     initLogger({ pretty: false })
 
     const logger = createLogger({ email: 'alice@example.com' })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.email).toBe('alice@example.com')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.email).toBe('alice@example.com')
   })
 
   it('respects explicit redact: false in production', () => {
@@ -205,10 +190,8 @@ describe('default redaction behavior', () => {
     initLogger({ pretty: false, redact: false })
 
     const logger = createLogger({ email: 'alice@example.com' })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.email).toBe('alice@example.com')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.email).toBe('alice@example.com')
   })
 
   it('respects explicit redact: true in development', () => {
@@ -216,10 +199,8 @@ describe('default redaction behavior', () => {
     initLogger({ pretty: false, redact: true })
 
     const logger = createLogger({ email: 'alice@example.com' })
-    const event = logger.emit()
-
-    expect(event).not.toBeNull()
-    expect(event!.email).toBe('a***@***.com')
+    const event = defined(logger.emit(), 'emitted event')
+    expect(event.email).toBe('a***@***.com')
   })
 })
 
@@ -231,7 +212,7 @@ describe('built-in smart masking', () => {
       c: '4111 1111 1111 1111',
       safe: 'no card here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['creditCard'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['creditCard'] }), 'redact config'))
     expect(event.a).toBe('****1111')
     expect(event.b).toBe('****1111')
     expect(event.c).toBe('****1111')
@@ -244,7 +225,7 @@ describe('built-in smart masking', () => {
       b: 'Contact bob.smith+tag@company.co.uk',
       safe: 'no email here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['email'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['email'] }), 'redact config'))
     expect(event.a).toBe('a***@***.com')
     expect(event.b).toBe('Contact b***@***.uk')
     expect(event.safe).toBe('no email here')
@@ -257,7 +238,7 @@ describe('built-in smart masking', () => {
       localhost: '127.0.0.1',
       zero: '0.0.0.0',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['ipv4'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['ipv4'] }), 'redact config'))
     expect(event.a).toBe('***.***.***.1')
     expect(event.b).toBe('Client ***.***.***.5 connected')
     expect(event.localhost).toBe('127.0.0.1')
@@ -273,7 +254,7 @@ describe('built-in smart masking', () => {
       parens: '(555) 123-4567',
       safe: 'no phone here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['phone'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
     expect(event.us).toContain('****')
     expect(event.us).not.toContain('555')
     expect(event.fr).not.toContain('12 34')
@@ -291,7 +272,7 @@ describe('built-in smart masking', () => {
       bareDigits: '0612345678',
       localPhone: '06 12 34 56 78',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['phone'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
     expect(event.uuid).toBe('12345642-f647-42bb-9fda-742d2b4f41fa')
     expect(event.requestId).toBe('00000000-1111-2222-3333-444444444444')
     expect(event.idempotencyKey).toBe('961da3f34097bb096902b5457ae02687')
@@ -310,7 +291,7 @@ describe('built-in smart masking', () => {
       auth: `Token: ${token}`,
       safe: 'no jwt here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['jwt'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['jwt'] }), 'redact config'))
     expect(event.auth).toContain('eyJ***')
     expect(event.auth).not.toContain(tokenTail)
     expect(event.safe).toBe('no jwt here')
@@ -323,7 +304,7 @@ describe('built-in smart masking', () => {
       header: `Bearer ${fakeStripeKey}`,
       safe: 'no bearer here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['bearer'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['bearer'] }), 'redact config'))
     expect(event.header).toContain('Bearer')
     expect(event.header).not.toContain(fakeStripeKey)
     expect(event.safe).toBe('no bearer here')
@@ -335,7 +316,7 @@ describe('built-in smart masking', () => {
       de: 'DE89 3704 0044 0532 0130 00',
       safe: 'no iban here',
     }
-    redactEvent(event, resolveRedactConfig({ builtins: ['iban'] })!)
+    redactEvent(event, defined(resolveRedactConfig({ builtins: ['iban'] }), 'redact config'))
     expect(event.fr).toContain('FR76')
     expect(event.fr).not.toContain('3000')
     expect(event.de).toContain('DE89')

--- a/packages/evlog/test/core/redact.test.ts
+++ b/packages/evlog/test/core/redact.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { redactEvent, normalizeRedactConfig, resolveRedactConfig, builtinPatterns } from '../../src/redact'
 import type { RedactConfig } from '../../src/types'
 import { createLogger, initLogger } from '../../src/logger'
+import { defined } from '../helpers/defined'
 
 describe('redactEvent - path-based', () => {
   it('redacts a top-level field', () => {
@@ -132,9 +133,9 @@ describe('redactEvent - pattern-based', () => {
     }
     redactEvent(event, { patterns: [emailPattern] })
     const users = event.users as Record<string, unknown>[]
-    expect(users[0]!.email).toBe('[REDACTED]')
-    expect(users[1]!.email).toBe('[REDACTED]')
-    expect(users[0]!.name).toBe('Alice')
+    expect(defined(users[0], 'users[0]').email).toBe('[REDACTED]')
+    expect(defined(users[1], 'users[1]').email).toBe('[REDACTED]')
+    expect(defined(users[0], 'users[0]').name).toBe('Alice')
   })
 
   it('uses custom replacement string', () => {
@@ -226,37 +227,36 @@ describe('resolveRedactConfig', () => {
   })
 
   it('returns all built-in maskers for true', () => {
-    const config = resolveRedactConfig(true)
-    expect(config).toBeDefined()
-    expect(config!._maskers).toHaveLength(Object.keys(builtinPatterns).length)
+    const config = defined(resolveRedactConfig(true), 'redact config')
+    expect(config._maskers).toHaveLength(Object.keys(builtinPatterns).length)
   })
 
   it('includes built-in maskers by default when object is passed', () => {
-    const config = resolveRedactConfig({ paths: ['user.password'] })
-    expect(config!.paths).toEqual(['user.password'])
-    expect(config!._maskers).toHaveLength(Object.keys(builtinPatterns).length)
+    const config = defined(resolveRedactConfig({ paths: ['user.password'] }), 'redact config')
+    expect(config.paths).toEqual(['user.password'])
+    expect(config._maskers).toHaveLength(Object.keys(builtinPatterns).length)
   })
 
   it('disables built-ins with builtins: false', () => {
-    const config = resolveRedactConfig({ builtins: false, paths: ['user.email'] })
-    expect(config!.paths).toEqual(['user.email'])
-    expect(config!._maskers).toBeUndefined()
-    expect(config!.patterns).toBeUndefined()
+    const config = defined(resolveRedactConfig({ builtins: false, paths: ['user.email'] }), 'redact config')
+    expect(config.paths).toEqual(['user.email'])
+    expect(config._maskers).toBeUndefined()
+    expect(config.patterns).toBeUndefined()
   })
 
   it('selects specific built-in maskers', () => {
-    const config = resolveRedactConfig({ builtins: ['email', 'creditCard'] })
-    expect(config!._maskers).toHaveLength(2)
+    const config = defined(resolveRedactConfig({ builtins: ['email', 'creditCard'] }), 'redact config')
+    expect(config._maskers).toHaveLength(2)
   })
 
   it('keeps custom patterns separate from built-in maskers', () => {
     const custom = /SECRET_\w+/g
-    const config = resolveRedactConfig({
+    const config = defined(resolveRedactConfig({
       builtins: ['email'],
       patterns: [custom],
-    })
-    expect(config!._maskers).toHaveLength(1)
-    expect(config!.patterns).toHaveLength(1)
+    }), 'redact config')
+    expect(config._maskers).toHaveLength(1)
+    expect(config.patterns).toHaveLength(1)
   })
 })
 
@@ -270,9 +270,8 @@ describe('normalizeRedactConfig', () => {
   })
 
   it('resolves true to all built-in maskers', () => {
-    const config = normalizeRedactConfig(true)
-    expect(config).toBeDefined()
-    expect(config!._maskers!.length).toBe(Object.keys(builtinPatterns).length)
+    const config = defined(normalizeRedactConfig(true), 'redact config')
+    expect(defined(config._maskers, 'maskers').length).toBe(Object.keys(builtinPatterns).length)
   })
 
   it('preserves paths and replacement', () => {
@@ -285,32 +284,32 @@ describe('normalizeRedactConfig', () => {
   })
 
   it('converts string patterns to RegExp separately from built-in maskers', () => {
-    const config = normalizeRedactConfig({
+    const config = defined(normalizeRedactConfig({
       patterns: ['\\b\\d{4}\\b'],
-    })
-    expect(config?._maskers).toHaveLength(Object.keys(builtinPatterns).length)
-    expect(config?.patterns).toHaveLength(1)
-    expect(config?.patterns![0]!.source).toBe('\\b\\d{4}\\b')
+    }), 'redact config')
+    expect(config._maskers).toHaveLength(Object.keys(builtinPatterns).length)
+    expect(config.patterns).toHaveLength(1)
+    expect(defined(config.patterns?.[0], 'patterns[0]').source).toBe('\\b\\d{4}\\b')
   })
 
   it('converts source/flags objects to RegExp', () => {
-    const config = normalizeRedactConfig({
+    const config = defined(normalizeRedactConfig({
       builtins: false,
       patterns: [{ source: '\\d+', flags: 'gi' }],
-    })
-    expect(config?.patterns).toHaveLength(1)
-    expect(config?.patterns![0]).toBeInstanceOf(RegExp)
-    expect(config?.patterns![0]!.source).toBe('\\d+')
-    expect(config?.patterns![0]!.flags).toBe('gi')
+    }), 'redact config')
+    const pattern = defined(config.patterns?.[0], 'patterns[0]')
+    expect(pattern).toBeInstanceOf(RegExp)
+    expect(pattern.source).toBe('\\d+')
+    expect(pattern.flags).toBe('gi')
   })
 
   it('preserves existing RegExp instances', () => {
     const re = /test/g
-    const config = normalizeRedactConfig({
+    const config = defined(normalizeRedactConfig({
       builtins: false,
       patterns: [re],
-    })
-    expect(config?.patterns![0]).toBe(re)
+    }), 'redact config')
+    expect(defined(config.patterns?.[0], 'patterns[0]')).toBe(re)
   })
 
   it('filters out invalid pattern entries', () => {

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -5,9 +5,13 @@ import { evlog, useLogger } from '../../src/elysia/index'
 import {
   assertDrainCalledWith,
   assertEnrichBeforeDrain,
+  assertHttpEventEmitted,
   assertSensitiveHeadersFiltered,
   createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 function delay(ms = 1) {
   return new Promise((resolve) => {
@@ -56,86 +60,76 @@ describe('evlog/elysia', () => {
   })
 
   it('emits event with correct method, path, and status', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
+      .use(evlog({ drain }))
       .get('/api/users', () => ({ users: [] }))
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/users')
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.method).toBe('GET')
-    expect(event.path).toBe('/api/users')
-    expect(event.status).toBe(200)
-    expect(event.level).toBe('info')
+    const event = assertHttpEventEmitted(drain, {
+      path: '/api/users',
+      method: 'GET',
+      status: 200,
+      level: 'info',
+    })
     expect(event.duration).toBeDefined()
   })
 
   it('emits event with correct status when using Elysia.status', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
+      .use(evlog({ drain }))
       .get('/api/users', ({ status }) => status(422, ({ users: [] })))
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/users')
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.method).toBe('GET')
-    expect(event.path).toBe('/api/users')
-    expect(event.status).toBe(422)
-    expect(event.level).toBe('info')
+    const event = assertHttpEventEmitted(drain, {
+      path: '/api/users',
+      method: 'GET',
+      status: 422,
+      level: 'info',
+    })
     expect(event.duration).toBeDefined()
   })
 
   it('accumulates context set by route handler', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
-      .get('/api/users', ({ log }) => {
-        log.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+      .use(evlog({ drain }))
+      .get('/api/users', () => {
+        useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
         return { users: [] }
       })
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/users')
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"user"'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
     )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.user.id).toBe('u-1')
-    expect(event.db.queries).toBe(3)
+    expect(event.user).toEqual({ id: 'u-1' })
+    expect(event.db).toEqual({ queries: 3 })
   })
 
   it('logs error context when handler throws', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
+      .use(evlog({ drain }))
       .get('/api/fail', () => {
         throw new Error('Something broke')
       })
 
-    const errorSpy = vi.mocked(console.error)
     await request(app, '/api/fail')
+    await waitForDrainCalls(drain)
 
-    const lastCall = errorSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/fail"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.path).toBe('/api/fail')
-    expect(event.level).toBe('error')
+    assertHttpEventEmitted(drain, {
+      path: '/api/fail',
+      level: 'error',
+    })
   })
 
   it('skips routes not matching include patterns', async () => {
@@ -150,53 +144,48 @@ describe('evlog/elysia', () => {
   })
 
   it('logs routes matching include patterns', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog({ include: ['/api/**'] }))
-      .get('/api/data', ({ log }) => {
-        log.set({ data: true })
+      .use(evlog({ include: ['/api/**'], drain }))
+      .get('/api/data', () => {
+        useLogger().set({ data: true })
         return { ok: true }
       })
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/data')
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/data"'),
-    )
-    expect(lastCall).toBeDefined()
+    expect(findEventViaDrain(drain, e => e.path === '/api/data')).toBeDefined()
   })
 
   it('uses x-request-id header when present', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
+      .use(evlog({ drain }))
       .get('/api/test', () => ({ ok: true }))
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/test', {
       headers: { 'x-request-id': 'custom-req-id' },
     })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('custom-req-id'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
     )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
     expect(event.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
-      .use(evlog())
+      .use(evlog({ drain }))
       .post('/api/checkout', () => ({ ok: true }))
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/checkout', { method: 'POST' })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"method":"POST"'),
-    )
-    expect(lastCall).toBeDefined()
+    assertHttpEventEmitted(drain, { path: '/api/checkout', method: 'POST' })
   })
 
   it('excludes routes matching exclude patterns', async () => {
@@ -211,19 +200,22 @@ describe('evlog/elysia', () => {
   })
 
   it('applies route-based service override', async () => {
+    const { drain } = createPipelineSpies()
     const app = new Elysia()
       .use(evlog({
         routes: { '/api/auth/**': { service: 'auth-service' } },
+        drain,
       }))
       .get('/api/auth/login', () => ({ ok: true }))
 
-    const consoleSpy = vi.mocked(console.info)
     await request(app, '/api/auth/login')
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"service":"auth-service"'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
     )
-    expect(lastCall).toBeDefined()
+    expect(event.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -232,8 +224,8 @@ describe('evlog/elysia', () => {
 
       const app = new Elysia()
         .use(evlog({ drain }))
-        .get('/api/test', ({ log }) => {
-          log.set({ user: { id: 'u-1' } })
+        .get('/api/test', () => {
+          useLogger().set({ user: { id: 'u-1' } })
           return { ok: true }
         })
 
@@ -272,10 +264,10 @@ describe('evlog/elysia', () => {
       })
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -293,8 +285,9 @@ describe('evlog/elysia', () => {
         },
       })
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -305,8 +298,8 @@ describe('evlog/elysia', () => {
 
       const app = new Elysia()
         .use(evlog({ keep, drain }))
-        .get('/api/test', ({ log }) => {
-          log.set({ important: true })
+        .get('/api/test', () => {
+          useLogger().set({ important: true })
           return { ok: true }
         })
 
@@ -396,29 +389,23 @@ describe('evlog/elysia', () => {
     })
 
     it('works across async boundaries', async () => {
-      let captured = false
+      const { drain } = createPipelineSpies()
 
       function serviceFunction() {
-        const log = useLogger()
-        log.set({ fromService: true })
-        captured = true
+        useLogger().set({ fromService: true })
       }
 
       const app = new Elysia()
-        .use(evlog())
+        .use(evlog({ drain }))
         .get('/api/test', async () => {
           await serviceFunction()
           return { ok: true }
         })
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app, '/api/test')
+      await waitForDrainCalls(drain)
 
-      expect(captured).toBe(true)
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"fromService":true'),
-      )
-      expect(lastCall).toBeDefined()
+      expect(findEventViaDrain(drain, e => e.fromService === true)).toBeDefined()
     })
   })
 })

--- a/packages/evlog/test/frameworks/express.test.ts
+++ b/packages/evlog/test/frameworks/express.test.ts
@@ -1,9 +1,9 @@
 import http from 'node:http'
-import type { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { initLogger } from '../../src/logger'
+import type { RequestLogger } from '../../src/types'
 import { evlog, useLogger } from '../../src/express/index'
 import {
   assertDrainCalledWith,
@@ -14,6 +14,7 @@ import {
   findEventViaDrain,
   waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 import { describeStandardHttpMatrix } from '../helpers/frameworkMatrix'
 
 describeStandardHttpMatrix({
@@ -88,26 +89,28 @@ describe('evlog/express', () => {
     const { drain } = createPipelineSpies()
     const app = express()
     app.use(evlog({ drain }))
-    app.get('/api/users', (req, res) => {
-      req.log.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+    app.get('/api/users', (_req, res) => {
+      useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
       res.json({ users: [] })
     })
 
     await request(app).get('/api/users')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/users')
-    expect(event).toBeDefined()
-    expect((event!.user as { id: string }).id).toBe('u-1')
-    expect((event!.db as { queries: number }).queries).toBe(3)
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
+    )
+    expect(event.user).toEqual({ id: 'u-1' })
+    expect(event.db).toEqual({ queries: 3 })
   })
 
   it('logs error status when handler sends error response', async () => {
     const { drain } = createPipelineSpies()
     const app = express()
     app.use(evlog({ drain }))
-    app.get('/api/fail', (req, res) => {
-      req.log.error(new Error('Something broke'))
+    app.get('/api/fail', (_req, res) => {
+      useLogger().error(new Error('Something broke'))
       res.status(500).json({ error: 'fail' })
     })
 
@@ -139,8 +142,8 @@ describe('evlog/express', () => {
     const { drain } = createPipelineSpies()
     const app = express()
     app.use(evlog({ include: ['/api/**'], drain }))
-    app.get('/api/data', (req, res) => {
-      req.log.set({ data: true })
+    app.get('/api/data', (_req, res) => {
+      useLogger().set({ data: true })
       res.json({ ok: true })
     })
 
@@ -159,9 +162,11 @@ describe('evlog/express', () => {
     await request(app).get('/api/test').set('x-request-id', 'custom-req-id')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/test')
-    expect(event).toBeDefined()
-    expect(event!.requestId).toBe('custom-req-id')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
+    )
+    expect(event.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
@@ -202,9 +207,11 @@ describe('evlog/express', () => {
     await request(app).get('/api/auth/login')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/auth/login')
-    expect(event).toBeDefined()
-    expect(event!.service).toBe('auth-service')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
+    )
+    expect(event.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -213,8 +220,8 @@ describe('evlog/express', () => {
 
       const app = express()
       app.use(evlog({ drain }))
-      app.get('/api/test', (req, res) => {
-        req.log.set({ user: { id: 'u-1' } })
+      app.get('/api/test', (_req, res) => {
+        useLogger().set({ user: { id: 'u-1' } })
         res.json({ ok: true })
       })
 
@@ -254,10 +261,10 @@ describe('evlog/express', () => {
         .set('x-custom', 'value')
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -273,8 +280,9 @@ describe('evlog/express', () => {
         .set('cookie', 'session=abc')
         .set('x-safe', 'visible')
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -285,8 +293,8 @@ describe('evlog/express', () => {
 
       const app = express()
       app.use(evlog({ keep, drain }))
-      app.get('/api/test', (req, res) => {
-        req.log.set({ important: true })
+      app.get('/api/test', (_req, res) => {
+        useLogger().set({ important: true })
         res.json({ ok: true })
       })
 
@@ -302,8 +310,8 @@ describe('evlog/express', () => {
 
       const app = express()
       app.use(evlog({ drain }))
-      app.get('/api/fail', (req, res) => {
-        req.log.error(new Error('something broke'))
+      app.get('/api/fail', (_req, res) => {
+        useLogger().error(new Error('something broke'))
         res.status(500).json({ error: 'fail' })
       })
 
@@ -363,7 +371,7 @@ describe('evlog/express', () => {
       const app = express()
       app.use(evlog({ drain }))
 
-      let loggerFromService: unknown
+      let loggerFromService: RequestLogger | undefined
       function serviceFunction() {
         loggerFromService = useLogger()
         useLogger().set({ fromService: true })
@@ -378,7 +386,7 @@ describe('evlog/express', () => {
       await waitForDrainCalls(drain)
 
       expect(loggerFromService).toBeDefined()
-      expect(typeof (loggerFromService as Record<string, unknown>).set).toBe('function')
+      expect(typeof defined(loggerFromService).set).toBe('function')
 
       const event = findEventViaDrain(drain, e => e.fromService === true)
       expect(event).toBeDefined()
@@ -390,7 +398,7 @@ describe('evlog/express', () => {
 
       let isSame = false
       app.get('/api/test', (req, res) => {
-        isSame = useLogger() === req.log
+        isSame = useLogger() === defined(req.log, 'req.log in middleware')
         res.json({ ok: true })
       })
 
@@ -439,7 +447,7 @@ describe('evlog/express', () => {
         if (!address || typeof address === 'string') {
           throw new Error('Failed to bind test server to an ephemeral port')
         }
-        const { port } = address as AddressInfo
+        const { port } = address
         const req = http.request({ host: '127.0.0.1', port, path, method: 'GET' })
         req.on('error', () => {})
         req.end()
@@ -455,21 +463,23 @@ describe('evlog/express', () => {
       const { drain } = createPipelineSpies()
       const app = express()
       app.use(evlog({ drain }))
-      app.get('/api/slow', async (req, res) => {
-        req.log.set({ step: 'before-sleep' })
+      app.get('/api/slow', async (_req, res) => {
+        useLogger().set({ step: 'before-sleep' })
         await new Promise(resolve => setTimeout(resolve, 100))
-        req.log.set({ step: 'after-sleep' })
+        useLogger().set({ step: 'after-sleep' })
         res.json({ ok: true })
       })
 
       await abortMidRequest(app, '/api/slow', 20)
       await waitForDrainCalls(drain)
 
-      const event = findEventViaDrain(drain, e => e.path === '/api/slow')
-      expect(event).toBeDefined()
-      expect(event!.connectionClosed).toBe(true)
-      expect(event!.method).toBe('GET')
-      expect(event!.step).toBe('before-sleep')
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/slow'),
+        'connectionClosed event',
+      )
+      expect(event.connectionClosed).toBe(true)
+      expect(event.method).toBe('GET')
+      expect(event.step).toBe('before-sleep')
     })
 
     it('does not flag connectionClosed when the response completes normally', async () => {
@@ -481,10 +491,12 @@ describe('evlog/express', () => {
       await request(app).get('/api/fast')
       await waitForDrainCalls(drain)
 
-      const event = findEventViaDrain(drain, e => e.path === '/api/fast')
-      expect(event).toBeDefined()
-      expect(event!.connectionClosed).toBeUndefined()
-      expect(event!.status).toBe(200)
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/fast'),
+        'normal completion event',
+      )
+      expect(event.connectionClosed).toBeUndefined()
+      expect(event.status).toBe(200)
     })
 
     it('runs drain exactly once when the client aborts mid-handler', async () => {

--- a/packages/evlog/test/frameworks/fastify.test.ts
+++ b/packages/evlog/test/frameworks/fastify.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Fastify from 'fastify'
-import type { RequestLogger } from '../../src/types'
 import { initLogger } from '../../src/logger'
+import type { RequestLogger } from '../../src/types'
 import { evlog, useLogger } from '../../src/fastify/index'
 import {
   assertDrainCalledWith,
@@ -12,6 +12,7 @@ import {
   findEventViaDrain,
   waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 describe('evlog/fastify', () => {
   beforeEach(() => {
@@ -35,7 +36,7 @@ describe('evlog/fastify', () => {
 
     let hasLogger = false
     app.get('/api/test', (request) => {
-      hasLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
+      hasLogger = request.log !== undefined && typeof request.log.set === 'function'
       return { ok: true }
     })
 
@@ -65,26 +66,28 @@ describe('evlog/fastify', () => {
     const { drain } = createPipelineSpies()
     const app = Fastify({ logger: false })
     await app.register(evlog, { drain })
-    app.get('/api/users', (request) => {
-      ((request.log) as unknown as RequestLogger).set({ user: { id: 'u-1' }, db: { queries: 3 } })
+    app.get('/api/users', () => {
+      useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
       return { users: [] }
     })
 
     await app.inject({ method: 'GET', url: '/api/users' })
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/users')
-    expect(event).toBeDefined()
-    expect((event!.user as { id: string }).id).toBe('u-1')
-    expect((event!.db as { queries: number }).queries).toBe(3)
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
+    )
+    expect(event.user).toEqual({ id: 'u-1' })
+    expect(event.db).toEqual({ queries: 3 })
   })
 
   it('logs error status when handler throws', async () => {
     const { drain } = createPipelineSpies()
     const app = Fastify({ logger: false })
     await app.register(evlog, { drain })
-    app.get('/api/fail', (request) => {
-      ((request.log) as unknown as RequestLogger).error(new Error('Something broke'))
+    app.get('/api/fail', () => {
+      useLogger().error(new Error('Something broke'))
       const error = new Error('Something broke') as Error & { statusCode?: number }
       error.statusCode = 500
       throw error
@@ -102,7 +105,7 @@ describe('evlog/fastify', () => {
 
     let isEvlogLogger = false
     app.get('/health', (request) => {
-      isEvlogLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
+      isEvlogLogger = typeof request.log?.set === 'function'
       return { ok: true }
     })
 
@@ -114,8 +117,8 @@ describe('evlog/fastify', () => {
     const { drain } = createPipelineSpies()
     const app = Fastify({ logger: false })
     await app.register(evlog, { include: ['/api/**'], drain })
-    app.get('/api/data', (request) => {
-      ((request.log) as unknown as RequestLogger).set({ data: true })
+    app.get('/api/data', () => {
+      useLogger().set({ data: true })
       return { ok: true }
     })
 
@@ -138,9 +141,11 @@ describe('evlog/fastify', () => {
     })
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/test')
-    expect(event).toBeDefined()
-    expect(event!.requestId).toBe('custom-req-id')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
+    )
+    expect(event.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
@@ -161,7 +166,7 @@ describe('evlog/fastify', () => {
 
     let isEvlogLogger = false
     app.get('/_internal/probe', (request) => {
-      isEvlogLogger = typeof (request.log as unknown as RequestLogger)?.set === 'function'
+      isEvlogLogger = typeof request.log?.set === 'function'
       return { ok: true }
     })
 
@@ -181,9 +186,11 @@ describe('evlog/fastify', () => {
     await app.inject({ method: 'GET', url: '/api/auth/login' })
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/auth/login')
-    expect(event).toBeDefined()
-    expect(event!.service).toBe('auth-service')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
+    )
+    expect(event.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -192,8 +199,8 @@ describe('evlog/fastify', () => {
 
       const app = Fastify({ logger: false })
       await app.register(evlog, { drain })
-      app.get('/api/test', (request) => {
-        ((request.log) as unknown as RequestLogger).set({ user: { id: 'u-1' } })
+      app.get('/api/test', () => {
+        useLogger().set({ user: { id: 'u-1' } })
         return { ok: true }
       })
 
@@ -237,10 +244,10 @@ describe('evlog/fastify', () => {
       })
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -260,8 +267,9 @@ describe('evlog/fastify', () => {
         },
       })
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -272,8 +280,8 @@ describe('evlog/fastify', () => {
 
       const app = Fastify({ logger: false })
       await app.register(evlog, { keep, drain })
-      app.get('/api/test', (request) => {
-        ((request.log) as unknown as RequestLogger).set({ important: true })
+      app.get('/api/test', () => {
+        useLogger().set({ important: true })
         return { ok: true }
       })
 
@@ -330,30 +338,29 @@ describe('evlog/fastify', () => {
 
   describe('useLogger()', () => {
     it('returns the request-scoped logger from anywhere in the call stack', async () => {
+      const { drain } = createPipelineSpies()
       const app = Fastify({ logger: false })
-      await app.register(evlog)
+      await app.register(evlog, { drain })
 
-      let loggerFromService: unknown
+      let loggerFromService: RequestLogger | undefined
       function serviceFunction() {
         loggerFromService = useLogger()
         useLogger().set({ fromService: true })
       }
 
-      app.get('/api/test', (_request) => {
+      app.get('/api/test', () => {
         serviceFunction()
         return { ok: true }
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await app.inject({ method: 'GET', url: '/api/test' })
+      await waitForDrainCalls(drain)
 
       expect(loggerFromService).toBeDefined()
-      expect(typeof (loggerFromService as Record<string, unknown>).set).toBe('function')
+      expect(typeof defined(loggerFromService).set).toBe('function')
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"fromService":true'),
-      )
-      expect(lastCall).toBeDefined()
+      const event = findEventViaDrain(drain, e => e.fromService === true)
+      expect(event).toBeDefined()
     })
 
     it('returns the same logger as request.log', async () => {
@@ -362,7 +369,7 @@ describe('evlog/fastify', () => {
 
       let isSame = false
       app.get('/api/test', (request) => {
-        isSame = useLogger() === (request.log as unknown as RequestLogger)
+        isSame = useLogger() === defined(request.log, 'request.log in handler')
         return { ok: true }
       })
 
@@ -375,26 +382,25 @@ describe('evlog/fastify', () => {
     })
 
     it('works across async boundaries', async () => {
+      const { drain } = createPipelineSpies()
       const app = Fastify({ logger: false })
-      await app.register(evlog)
+      await app.register(evlog, { drain })
 
       async function asyncService() {
         await new Promise(resolve => setTimeout(resolve, 5))
         useLogger().set({ asyncWork: 'done' })
       }
 
-      app.get('/api/test', async (_request) => {
+      app.get('/api/test', async () => {
         await asyncService()
         return { ok: true }
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await app.inject({ method: 'GET', url: '/api/test' })
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"asyncWork":"done"'),
-      )
-      expect(lastCall).toBeDefined()
+      const event = findEventViaDrain(drain, e => e.asyncWork === 'done')
+      expect(event).toBeDefined()
     })
   })
 })

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -11,6 +11,7 @@ import {
   findEventViaDrain,
   waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 describe('evlog/hono', () => {
   beforeEach(() => {
@@ -73,10 +74,12 @@ describe('evlog/hono', () => {
     await app.request('/api/users')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/users')
-    expect(event).toBeDefined()
-    expect((event!.user as { id: string }).id).toBe('u-1')
-    expect((event!.db as { queries: number }).queries).toBe(3)
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
+    )
+    expect(event.user).toEqual({ id: 'u-1' })
+    expect(event.db).toEqual({ queries: 3 })
   })
 
   it('logs status 500 when handler throws and Hono handles the error', async () => {
@@ -153,9 +156,11 @@ describe('evlog/hono', () => {
     })
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/test')
-    expect(event).toBeDefined()
-    expect(event!.requestId).toBe('custom-req-id')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
+    )
+    expect(event.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
@@ -200,9 +205,11 @@ describe('evlog/hono', () => {
     await app.request('/api/auth/login')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/auth/login')
-    expect(event).toBeDefined()
-    expect(event!.service).toBe('auth-service')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
+    )
+    expect(event.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -251,10 +258,10 @@ describe('evlog/hono', () => {
       })
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -272,8 +279,9 @@ describe('evlog/hono', () => {
         },
       })
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {

--- a/packages/evlog/test/frameworks/nestjs-real-runtime.test.ts
+++ b/packages/evlog/test/frameworks/nestjs-real-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   findEventViaDrain,
   waitForDrainCalls,
 } from '../helpers/framework'
+import { defined } from '../helpers/defined'
 
 /**
  * Stress test: boot a real NestJS app with NestFactory's Express adapter,
@@ -96,9 +97,11 @@ describe('evlog/nestjs (real NestJS runtime)', () => {
     expect(res.status).toBe(200)
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/me')
-    expect(event).toBeDefined()
-    expect((event!.user as { id: string }).id).toBe('u-1')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/me'),
+      'wide event for /api/me',
+    )
+    expect((event.user as { id: string }).id).toBe('u-1')
   })
 
   it('drains the wide event with status 500 when a controller throws', async () => {
@@ -126,8 +129,10 @@ describe('evlog/nestjs (real NestJS runtime)', () => {
       .set('x-request-id', 'real-nest-req')
     await waitForDrainCalls(drain)
 
-    const event = findEventViaDrain(drain, e => e.path === '/api/users')
-    expect(event).toBeDefined()
-    expect(event!.requestId).toBe('real-nest-req')
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'wide event for /api/users',
+    )
+    expect(event.requestId).toBe('real-nest-req')
   })
 })

--- a/packages/evlog/test/frameworks/nestjs.test.ts
+++ b/packages/evlog/test/frameworks/nestjs.test.ts
@@ -1,36 +1,59 @@
 import http from 'node:http'
-import type { AddressInfo } from 'node:net'
+import type { MiddlewareConsumer } from '@nestjs/common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import express from 'express'
+import express, { type RequestHandler } from 'express'
 import request from 'supertest'
 import { initLogger } from '../../src/logger'
 import { EvlogModule, useLogger } from '../../src/nestjs/index'
 import type { EvlogNestJSOptions } from '../../src/nestjs/index'
+import type { RequestLogger } from '../../src/types'
 import {
   assertDrainCalledWith,
   assertEnrichBeforeDrain,
+  assertHttpEventEmitted,
   assertSensitiveHeadersFiltered,
   createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
+
+type MiddlewareProxyStub = {
+  forRoutes: (...routes: unknown[]) => MiddlewareConsumer
+  exclude: (...routes: unknown[]) => MiddlewareProxyStub
+}
+
+/** Minimal {@link MiddlewareConsumer} stub that captures the applied middleware. */
+function createMiddlewareConsumerCapture(onApply: (mw: RequestHandler) => void): MiddlewareConsumer {
+  const proxy: MiddlewareProxyStub = {
+    forRoutes: () => consumer,
+    exclude: () => proxy,
+  }
+
+  const consumer = {
+    apply: ((mw: unknown) => {
+      onApply(mw as RequestHandler)
+      return proxy
+    }) as MiddlewareConsumer['apply'],
+  } satisfies Pick<MiddlewareConsumer, 'apply'>
+
+  return consumer as MiddlewareConsumer
+}
 
 /**
  * Extract the middleware function from EvlogModule.configure() for testing.
  * This lets us test the actual middleware pipeline through the NestJS module API
  * without needing the full NestJS runtime.
  */
-function getMiddleware(options: EvlogNestJSOptions = {}): any {
-  let middleware: any
-  const consumer = {
-    apply: (mw: any) => {
-      middleware = mw
-      return { forRoutes: () => {} }
-    },
-  }
+function getMiddleware(options: EvlogNestJSOptions = {}): RequestHandler {
+  let middleware: RequestHandler | undefined
 
   EvlogModule.forRoot(options)
   const module = new EvlogModule()
-  module.configure(consumer as any)
-  return middleware
+  module.configure(createMiddlewareConsumerCapture((mw) => {
+    middleware = mw
+  }))
+  return defined(middleware, 'evlog middleware from configure()')
 }
 
 describe('evlog/nestjs', () => {
@@ -63,7 +86,7 @@ describe('evlog/nestjs', () => {
       expect(result).toHaveProperty('module', EvlogModule)
       expect(result).toHaveProperty('global', true)
       expect(result.providers).toBeDefined()
-      expect(result.providers!.length).toBe(1)
+      expect(defined(result.providers).length).toBe(1)
     })
 
     it('forRootAsync() includes imports when provided', () => {
@@ -78,15 +101,19 @@ describe('evlog/nestjs', () => {
 
     it('configure() applies middleware via consumer', () => {
       const forRoutes = vi.fn()
-      const apply = vi.fn(() => ({ forRoutes }))
-      const consumer = { apply } as any
+      const proxy: MiddlewareProxyStub = {
+        forRoutes,
+        exclude: vi.fn(() => proxy),
+      }
+      const apply = vi.fn<(mw: unknown) => MiddlewareProxyStub>(() => proxy)
+      const consumer = { apply: apply as MiddlewareConsumer['apply'] } satisfies Pick<MiddlewareConsumer, 'apply'>
 
       EvlogModule.forRoot()
       const module = new EvlogModule()
-      module.configure(consumer)
+      module.configure(consumer as MiddlewareConsumer)
 
       expect(apply).toHaveBeenCalledOnce()
-      expect((apply.mock.calls[0] as unknown as [unknown])[0]).toBeTypeOf('function')
+      expect(defined(apply.mock.calls[0], 'apply call')[0]).toBeTypeOf('function')
       expect(forRoutes).toHaveBeenCalledWith('*')
     })
   })
@@ -98,7 +125,7 @@ describe('evlog/nestjs', () => {
 
       let hasLogger = false
       app.get('/api/test', (req, res) => {
-        hasLogger = req.log !== undefined && typeof req.log.set === 'function'
+        hasLogger = req.log !== undefined && typeof defined(req.log).set === 'function'
         res.json({ ok: true })
       })
 
@@ -107,66 +134,60 @@ describe('evlog/nestjs', () => {
     })
 
     it('emits event with correct method, path, and status', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
+      app.use(getMiddleware({ drain }))
       app.get('/api/users', (_req, res) => res.json({ users: [] }))
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/users')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
-      )
-      expect(lastCall).toBeDefined()
-
-      const event = JSON.parse(lastCall![0] as string)
-      expect(event.method).toBe('GET')
-      expect(event.path).toBe('/api/users')
-      expect(event.status).toBe(200)
-      expect(event.level).toBe('info')
+      const event = assertHttpEventEmitted(drain, {
+        path: '/api/users',
+        method: 'GET',
+        status: 200,
+        level: 'info',
+      })
       expect(event.duration).toBeDefined()
     })
 
     it('accumulates context set by route handler', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
-      app.get('/api/users', (req, res) => {
-        req.log!.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+      app.use(getMiddleware({ drain }))
+      app.get('/api/users', (_req, res) => {
+        useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
         res.json({ users: [] })
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/users')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"user"'),
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/users'),
+        'accumulated context event',
       )
-      expect(lastCall).toBeDefined()
-
-      const event = JSON.parse(lastCall![0] as string)
-      expect(event.user.id).toBe('u-1')
-      expect(event.db.queries).toBe(3)
+      expect(event.user).toEqual({ id: 'u-1' })
+      expect(event.db).toEqual({ queries: 3 })
     })
 
     it('logs error status when handler sends error response', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
-      app.get('/api/fail', (req, res) => {
-        req.log!.error(new Error('Something broke'))
+      app.use(getMiddleware({ drain }))
+      app.get('/api/fail', (_req, res) => {
+        useLogger().error(new Error('Something broke'))
         res.status(500).json({ error: 'fail' })
       })
 
-      const errorSpy = vi.mocked(console.error)
       await request(app).get('/api/fail')
+      await waitForDrainCalls(drain)
 
-      const lastCall = errorSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"level":"error"'),
-      )
-      expect(lastCall).toBeDefined()
-
-      const event = JSON.parse(lastCall![0] as string)
-      expect(event.level).toBe('error')
-      expect(event.status).toBe(500)
+      assertHttpEventEmitted(drain, {
+        path: '/api/fail',
+        level: 'error',
+        status: 500,
+      })
     })
 
     it('skips routes not matching include patterns', async () => {
@@ -184,51 +205,46 @@ describe('evlog/nestjs', () => {
     })
 
     it('logs routes matching include patterns', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware({ include: ['/api/**'] }))
-      app.get('/api/data', (req, res) => {
-        req.log!.set({ data: true })
+      app.use(getMiddleware({ include: ['/api/**'], drain }))
+      app.get('/api/data', (_req, res) => {
+        useLogger().set({ data: true })
         res.json({ ok: true })
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/data')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"path":"/api/data"'),
-      )
-      expect(lastCall).toBeDefined()
+      expect(findEventViaDrain(drain, e => e.path === '/api/data')).toBeDefined()
     })
 
     it('uses x-request-id header when present', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
+      app.use(getMiddleware({ drain }))
       app.get('/api/test', (_req, res) => res.json({ ok: true }))
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/test').set('x-request-id', 'custom-req-id')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('custom-req-id'),
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/test'),
+        'event with x-request-id',
       )
-      expect(lastCall).toBeDefined()
-
-      const event = JSON.parse(lastCall![0] as string)
       expect(event.requestId).toBe('custom-req-id')
     })
 
     it('handles POST requests with correct method', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
+      app.use(getMiddleware({ drain }))
       app.post('/api/checkout', (_req, res) => res.json({ ok: true }))
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).post('/api/checkout')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"method":"POST"'),
-      )
-      expect(lastCall).toBeDefined()
+      assertHttpEventEmitted(drain, { path: '/api/checkout', method: 'POST' })
     })
 
     it('excludes routes matching exclude patterns', async () => {
@@ -246,19 +262,22 @@ describe('evlog/nestjs', () => {
     })
 
     it('applies route-based service override', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
       app.use(getMiddleware({
         routes: { '/api/auth/**': { service: 'auth-service' } },
+        drain,
       }))
       app.get('/api/auth/login', (_req, res) => res.json({ ok: true }))
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/auth/login')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"service":"auth-service"'),
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+        'route service override event',
       )
-      expect(lastCall).toBeDefined()
+      expect(event.service).toBe('auth-service')
     })
   })
 
@@ -268,8 +287,8 @@ describe('evlog/nestjs', () => {
 
       const app = express()
       app.use(getMiddleware({ drain }))
-      app.get('/api/test', (req, res) => {
-        req.log!.set({ user: { id: 'u-1' } })
+      app.get('/api/test', (_req, res) => {
+        useLogger().set({ user: { id: 'u-1' } })
         res.json({ ok: true })
       })
 
@@ -309,10 +328,10 @@ describe('evlog/nestjs', () => {
         .set('x-custom', 'value')
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -328,8 +347,9 @@ describe('evlog/nestjs', () => {
         .set('cookie', 'session=abc')
         .set('x-safe', 'visible')
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -340,8 +360,8 @@ describe('evlog/nestjs', () => {
 
       const app = express()
       app.use(getMiddleware({ keep, drain }))
-      app.get('/api/test', (req, res) => {
-        req.log!.set({ important: true })
+      app.get('/api/test', (_req, res) => {
+        useLogger().set({ important: true })
         res.json({ ok: true })
       })
 
@@ -379,6 +399,7 @@ describe('evlog/nestjs', () => {
       const res = await request(app).get('/api/test')
       expect(res.status).toBe(200)
       expect(enrich).toHaveBeenCalledOnce()
+      await waitForDrainCalls(drain)
       expect(drain).toHaveBeenCalledOnce()
     })
 
@@ -398,10 +419,11 @@ describe('evlog/nestjs', () => {
 
   describe('useLogger()', () => {
     it('returns the request-scoped logger from anywhere in the call stack', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
+      app.use(getMiddleware({ drain }))
 
-      let loggerFromService: unknown
+      let loggerFromService: RequestLogger | undefined
       function serviceFunction() {
         loggerFromService = useLogger()
         useLogger().set({ fromService: true })
@@ -412,16 +434,14 @@ describe('evlog/nestjs', () => {
         res.json({ ok: true })
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/test')
+      await waitForDrainCalls(drain)
 
       expect(loggerFromService).toBeDefined()
-      expect(typeof (loggerFromService as Record<string, unknown>).set).toBe('function')
+      expect(typeof defined(loggerFromService).set).toBe('function')
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"fromService":true'),
-      )
-      expect(lastCall).toBeDefined()
+      const event = findEventViaDrain(drain, e => e.fromService === true)
+      expect(event).toBeDefined()
     })
 
     it('returns the same logger as req.log', async () => {
@@ -430,7 +450,7 @@ describe('evlog/nestjs', () => {
 
       let isSame = false
       app.get('/api/test', (req, res) => {
-        isSame = useLogger() === req.log
+        isSame = useLogger() === defined(req.log, 'req.log in middleware')
         res.json({ ok: true })
       })
 
@@ -443,8 +463,9 @@ describe('evlog/nestjs', () => {
     })
 
     it('works across async boundaries', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
+      app.use(getMiddleware({ drain }))
 
       async function asyncService() {
         await new Promise(resolve => setTimeout(resolve, 5))
@@ -456,13 +477,11 @@ describe('evlog/nestjs', () => {
         res.json({ ok: true })
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await request(app).get('/api/test')
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"asyncWork":"done"'),
-      )
-      expect(lastCall).toBeDefined()
+      const event = findEventViaDrain(drain, e => e.asyncWork === 'done')
+      expect(event).toBeDefined()
     })
   })
 
@@ -488,24 +507,23 @@ describe('evlog/nestjs', () => {
     }
 
     it('emits the wide event with connectionClosed=true when the client aborts mid-handler', async () => {
+      const { drain } = createPipelineSpies()
       const app = express()
-      app.use(getMiddleware())
-      app.get('/api/slow', async (req, res) => {
-        req.log!.set({ step: 'before-sleep' })
+      app.use(getMiddleware({ drain }))
+      app.get('/api/slow', async (_req, res) => {
+        useLogger().set({ step: 'before-sleep' })
         await new Promise(resolve => setTimeout(resolve, 100))
-        req.log!.set({ step: 'after-sleep' })
+        useLogger().set({ step: 'after-sleep' })
         res.json({ ok: true })
       })
 
-      const consoleSpy = vi.mocked(console.info)
       await abortMidRequest(app, '/api/slow', 20)
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"path":"/api/slow"'),
+      const event = defined(
+        findEventViaDrain(drain, e => e.path === '/api/slow'),
+        'connectionClosed event',
       )
-      expect(lastCall).toBeDefined()
-
-      const event = JSON.parse(lastCall![0] as string)
       expect(event.connectionClosed).toBe(true)
       expect(event.method).toBe('GET')
       expect(event.path).toBe('/api/slow')
@@ -513,7 +531,7 @@ describe('evlog/nestjs', () => {
     })
 
     it('runs drain exactly once when the client aborts mid-handler', async () => {
-      const drain = vi.fn()
+      const { drain } = createPipelineSpies()
 
       const app = express()
       app.use(getMiddleware({ drain }))

--- a/packages/evlog/test/frameworks/react-router.test.ts
+++ b/packages/evlog/test/frameworks/react-router.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RouterContextProvider } from 'react-router'
 import { initLogger } from '../../src/logger'
+import type { RequestLogger } from '../../src/types'
 import { evlog, loggerContext, useLogger } from '../../src/react-router/index'
 import {
   assertDrainCalledWith,
   assertEnrichBeforeDrain,
+  assertHttpEventEmitted,
   assertSensitiveHeadersFiltered,
   createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 // Use the actual react-router context provider. `RouterContextProvider` is
 // the same class react-router instantiates per request server-side; passing
@@ -54,66 +59,58 @@ describe('evlog/react-router', () => {
   })
 
   it('emits event with correct method, path, and status', async () => {
-    const middleware = evlog()
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ drain })
     const context = createMockContext()
     const next = vi.fn(() => okResponse())
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({ request: createRequest('/api/users'), context }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.method).toBe('GET')
-    expect(event.path).toBe('/api/users')
-    expect(event.status).toBe(200)
-    expect(event.level).toBe('info')
+    const event = assertHttpEventEmitted(drain, {
+      path: '/api/users',
+      method: 'GET',
+      status: 200,
+      level: 'info',
+    })
     expect(event.duration).toBeDefined()
   })
 
   it('accumulates context set by loader', async () => {
-    const middleware = evlog()
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ drain })
     const context = createMockContext()
     const next = vi.fn(() => {
-      const logger = context.get(loggerContext) as any
-      logger.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+      useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
       return okResponse()
     })
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({ request: createRequest('/api/users'), context }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"user"'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
     )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.user.id).toBe('u-1')
-    expect(event.db.queries).toBe(3)
+    expect(event.user).toEqual({ id: 'u-1' })
+    expect(event.db).toEqual({ queries: 3 })
   })
 
   it('logs status 500 when handler throws', async () => {
-    const middleware = evlog()
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ drain })
     const context = createMockContext()
     const next = vi.fn(() => Promise.reject(new Error('Something broke')))
 
-    const errorSpy = vi.mocked(console.error)
     await expect(
       middleware({ request: createRequest('/api/fail'), context }, next),
     ).rejects.toThrow('Something broke')
+    await waitForDrainCalls(drain)
 
-    const lastCall = errorSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/fail"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
-    expect(event.status).toBe(500)
-    expect(event.path).toBe('/api/fail')
+    assertHttpEventEmitted(drain, {
+      path: '/api/fail',
+      status: 500,
+    })
   })
 
   it('re-throws all errors from handler', async () => {
@@ -142,56 +139,51 @@ describe('evlog/react-router', () => {
   })
 
   it('logs routes matching include patterns', async () => {
-    const middleware = evlog({ include: ['/api/**'] })
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ include: ['/api/**'], drain })
     const context = createMockContext()
     const next = vi.fn(() => okResponse())
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({ request: createRequest('/api/data'), context }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/data"'),
-    )
-    expect(lastCall).toBeDefined()
+    expect(findEventViaDrain(drain, e => e.path === '/api/data')).toBeDefined()
   })
 
   it('uses x-request-id header when present', async () => {
-    const middleware = evlog()
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ drain })
     const context = createMockContext()
     const next = vi.fn(() => okResponse())
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({
       request: createRequest('/api/test', {
         headers: { 'x-request-id': 'custom-req-id' },
       }),
       context,
     }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('custom-req-id'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
     )
-    expect(lastCall).toBeDefined()
-
-    const event = JSON.parse(lastCall![0] as string)
     expect(event.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
-    const middleware = evlog()
+    const { drain } = createPipelineSpies()
+    const middleware = evlog({ drain })
     const context = createMockContext()
     const next = vi.fn(() => okResponse())
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({
       request: createRequest('/api/checkout', { method: 'POST' }),
       context,
     }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"method":"POST"'),
-    )
-    expect(lastCall).toBeDefined()
+    assertHttpEventEmitted(drain, { path: '/api/checkout', method: 'POST' })
   })
 
   it('excludes routes matching exclude patterns', async () => {
@@ -208,19 +200,22 @@ describe('evlog/react-router', () => {
   })
 
   it('applies route-based service override', async () => {
+    const { drain } = createPipelineSpies()
     const middleware = evlog({
       routes: { '/api/auth/**': { service: 'auth-service' } },
+      drain,
     })
     const context = createMockContext()
     const next = vi.fn(() => okResponse())
 
-    const consoleSpy = vi.mocked(console.info)
     await middleware({ request: createRequest('/api/auth/login'), context }, next)
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"service":"auth-service"'),
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
     )
-    expect(lastCall).toBeDefined()
+    expect(event.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -230,8 +225,7 @@ describe('evlog/react-router', () => {
       const middleware = evlog({ drain })
       const context = createMockContext()
       const next = vi.fn(() => {
-        const logger = context.get(loggerContext) as any
-        logger.set({ user: { id: 'u-1' } })
+        useLogger().set({ user: { id: 'u-1' } })
         return okResponse()
       })
 
@@ -273,10 +267,10 @@ describe('evlog/react-router', () => {
       }, next)
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -297,8 +291,9 @@ describe('evlog/react-router', () => {
         context,
       }, next)
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -310,8 +305,7 @@ describe('evlog/react-router', () => {
       const middleware = evlog({ keep, drain })
       const context = createMockContext()
       const next = vi.fn(() => {
-        const logger = context.get(loggerContext) as any
-        logger.set({ important: true })
+        useLogger().set({ important: true })
         return okResponse()
       })
 
@@ -328,8 +322,7 @@ describe('evlog/react-router', () => {
       const middleware = evlog({ drain })
       const context = createMockContext()
       const next = vi.fn(() => {
-        const logger = context.get(loggerContext) as any
-        logger.error(new Error('something broke'))
+        useLogger().error(new Error('something broke'))
         return Promise.resolve(new Response('error', { status: 500 }))
       })
 
@@ -384,7 +377,7 @@ describe('evlog/react-router', () => {
 
   describe('useLogger', () => {
     it('returns same logger in middleware context', async () => {
-      let loggerFromUseLogger: any
+      let loggerFromUseLogger: RequestLogger | undefined
 
       const middleware = evlog()
       const context = createMockContext()
@@ -404,7 +397,7 @@ describe('evlog/react-router', () => {
     })
 
     it('works across async boundaries', async () => {
-      let loggerFromAsync: any
+      let loggerFromAsync: RequestLogger | undefined
 
       const middleware = evlog()
       const context = createMockContext()
@@ -416,8 +409,7 @@ describe('evlog/react-router', () => {
 
       await middleware({ request: createRequest('/api/test'), context }, next)
 
-      expect(loggerFromAsync).toBeDefined()
-      expect(typeof loggerFromAsync.set).toBe('function')
+      expect(typeof defined(loggerFromAsync).set).toBe('function')
     })
   })
 })

--- a/packages/evlog/test/frameworks/sveltekit.test.ts
+++ b/packages/evlog/test/frameworks/sveltekit.test.ts
@@ -1,25 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initLogger } from '../../src/logger'
+import type { RequestLogger } from '../../src/types'
 import { evlog, evlogHandleError, createEvlogHooks, useLogger } from '../../src/sveltekit/index'
 import { EvlogError } from '../../src/error'
 import {
   assertDrainCalledWith,
   assertEnrichBeforeDrain,
+  assertHttpEventEmitted,
   assertSensitiveHeadersFiltered,
   createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
 } from '../helpers/framework'
+import { defined, getDrainCallArg } from '../helpers/defined'
 
 function createMockEvent(method = 'GET', path = '/api/test', headers: Record<string, string> = {}) {
   const reqHeaders = new Headers(headers)
   return {
     request: new Request(`http://localhost${path}`, { method, headers: reqHeaders }),
     url: new URL(`http://localhost${path}`),
-    locals: {} as Record<string, any>,
+    locals: {} as Record<string, unknown>,
   }
 }
 
-function createMockResolve(status = 200): (event: any) => Promise<Response> {
-  return vi.fn((_ev: any) => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status })))
+function createMockResolve(status = 200): (event: ReturnType<typeof createMockEvent>) => Promise<Response> {
+  return vi.fn((_ev) => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status })))
 }
 
 describe('evlog/sveltekit', () => {
@@ -53,64 +58,58 @@ describe('evlog/sveltekit', () => {
   })
 
   it('emits event with correct method, path, and status', async () => {
-    const handle = evlog()
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ drain })
     const event = createMockEvent('GET', '/api/users')
     const resolve = createMockResolve()
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/users"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const emitted = JSON.parse(lastCall![0] as string)
-    expect(emitted.method).toBe('GET')
-    expect(emitted.path).toBe('/api/users')
-    expect(emitted.status).toBe(200)
-    expect(emitted.level).toBe('info')
+    const emitted = assertHttpEventEmitted(drain, {
+      path: '/api/users',
+      method: 'GET',
+      status: 200,
+      level: 'info',
+    })
     expect(emitted.duration).toBeDefined()
   })
 
   it('accumulates context set by route handler', async () => {
-    const handle = evlog()
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ drain })
     const event = createMockEvent('GET', '/api/users')
-    const resolve = vi.fn((ev: any) => {
-      ev.locals.log.set({ user: { id: 'u-1' }, db: { queries: 3 } })
+    const resolve = vi.fn(() => {
+      useLogger().set({ user: { id: 'u-1' }, db: { queries: 3 } })
       return new Response(JSON.stringify({ users: [] }), { status: 200 })
     })
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"user"'),
+    const emitted = defined(
+      findEventViaDrain(drain, e => e.path === '/api/users'),
+      'accumulated context event',
     )
-    expect(lastCall).toBeDefined()
-
-    const emitted = JSON.parse(lastCall![0] as string)
-    expect(emitted.user.id).toBe('u-1')
-    expect(emitted.db.queries).toBe(3)
+    expect(emitted.user).toEqual({ id: 'u-1' })
+    expect(emitted.db).toEqual({ queries: 3 })
   })
 
   it('logs error status when handler throws', async () => {
-    const handle = evlog()
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ drain })
     const event = createMockEvent('GET', '/api/fail')
     const resolve = vi.fn(() => {
       throw new Error('Something broke')
     })
 
-    const errorSpy = vi.mocked(console.error)
     await expect(handle({ event, resolve })).rejects.toThrow('Something broke')
+    await waitForDrainCalls(drain)
 
-    const lastCall = errorSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"level":"error"'),
-    )
-    expect(lastCall).toBeDefined()
-
-    const emitted = JSON.parse(lastCall![0] as string)
-    expect(emitted.level).toBe('error')
+    assertHttpEventEmitted(drain, {
+      path: '/api/fail',
+      level: 'error',
+    })
   })
 
   it('returns structured JSON response for thrown EvlogError', async () => {
@@ -149,7 +148,7 @@ describe('evlog/sveltekit', () => {
     await handle({ event, resolve })
 
     expect(drain).toHaveBeenCalledOnce()
-    const [[drainCtx]] = drain.mock.calls
+    const drainCtx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
     expect(drainCtx.event.level).toBe('error')
     expect(drainCtx.event.status).toBe(402)
   })
@@ -210,48 +209,43 @@ describe('evlog/sveltekit', () => {
   })
 
   it('logs routes matching include patterns', async () => {
-    const handle = evlog({ include: ['/api/**'] })
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ include: ['/api/**'], drain })
     const event = createMockEvent('GET', '/api/data')
     const resolve = createMockResolve()
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"path":"/api/data"'),
-    )
-    expect(lastCall).toBeDefined()
+    expect(findEventViaDrain(drain, e => e.path === '/api/data')).toBeDefined()
   })
 
   it('uses x-request-id header when present', async () => {
-    const handle = evlog()
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ drain })
     const event = createMockEvent('GET', '/api/test', { 'x-request-id': 'custom-req-id' })
     const resolve = createMockResolve()
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('custom-req-id'),
+    const emitted = defined(
+      findEventViaDrain(drain, e => e.path === '/api/test'),
+      'event with x-request-id',
     )
-    expect(lastCall).toBeDefined()
-
-    const emitted = JSON.parse(lastCall![0] as string)
     expect(emitted.requestId).toBe('custom-req-id')
   })
 
   it('handles POST requests with correct method', async () => {
-    const handle = evlog()
+    const { drain } = createPipelineSpies()
+    const handle = evlog({ drain })
     const event = createMockEvent('POST', '/api/checkout')
     const resolve = createMockResolve()
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"method":"POST"'),
-    )
-    expect(lastCall).toBeDefined()
+    assertHttpEventEmitted(drain, { path: '/api/checkout', method: 'POST' })
   })
 
   it('excludes routes matching exclude patterns', async () => {
@@ -265,19 +259,22 @@ describe('evlog/sveltekit', () => {
   })
 
   it('applies route-based service override', async () => {
+    const { drain } = createPipelineSpies()
     const handle = evlog({
       routes: { '/api/auth/**': { service: 'auth-service' } },
+      drain,
     })
     const event = createMockEvent('GET', '/api/auth/login')
     const resolve = createMockResolve()
 
-    const consoleSpy = vi.mocked(console.info)
     await handle({ event, resolve })
+    await waitForDrainCalls(drain)
 
-    const lastCall = consoleSpy.mock.calls.find(call =>
-      typeof call[0] === 'string' && call[0].includes('"service":"auth-service"'),
+    const emitted = defined(
+      findEventViaDrain(drain, e => e.path === '/api/auth/login'),
+      'route service override event',
     )
-    expect(lastCall).toBeDefined()
+    expect(emitted.service).toBe('auth-service')
   })
 
   describe('drain / enrich / keep', () => {
@@ -286,8 +283,8 @@ describe('evlog/sveltekit', () => {
 
       const handle = evlog({ drain })
       const event = createMockEvent('GET', '/api/test')
-      const resolve = vi.fn((ev: any) => {
-        ev.locals.log.set({ user: { id: 'u-1' } })
+      const resolve = vi.fn(() => {
+        useLogger().set({ user: { id: 'u-1' } })
         return new Response(JSON.stringify({ ok: true }), { status: 200 })
       })
 
@@ -327,10 +324,10 @@ describe('evlog/sveltekit', () => {
       await handle({ event, resolve })
 
       expect(enrich).toHaveBeenCalledOnce()
-      const [[ctx]] = enrich.mock.calls
-      expect(ctx.response!.status).toBe(200)
-      expect(ctx.headers!['user-agent']).toBe('test-bot/1.0')
-      expect(ctx.headers!['x-custom']).toBe('value')
+      const ctx = defined(enrich.mock.calls[0]?.[0], 'enrich context')
+      expect(ctx.response?.status).toBe(200)
+      expect(ctx.headers?.['user-agent']).toBe('test-bot/1.0')
+      expect(ctx.headers?.['x-custom']).toBe('value')
     })
 
     it('filters sensitive headers (shared helpers)', async () => {
@@ -346,8 +343,9 @@ describe('evlog/sveltekit', () => {
 
       await handle({ event, resolve })
 
-      assertSensitiveHeadersFiltered(drain.mock.calls[0][0])
-      expect(drain.mock.calls[0][0].headers!['x-safe']).toBe('visible')
+      const ctx = getDrainCallArg(defined(drain.mock.calls[0], 'drain call'))
+      assertSensitiveHeadersFiltered(ctx)
+      expect(ctx.headers?.['x-safe']).toBe('visible')
     })
 
     it('calls keep callback for tail sampling', async () => {
@@ -358,8 +356,8 @@ describe('evlog/sveltekit', () => {
 
       const handle = evlog({ keep, drain })
       const event = createMockEvent('GET', '/api/test')
-      const resolve = vi.fn((ev: any) => {
-        ev.locals.log.set({ important: true })
+      const resolve = vi.fn(() => {
+        useLogger().set({ important: true })
         return new Response(JSON.stringify({ ok: true }), { status: 200 })
       })
 
@@ -416,9 +414,10 @@ describe('evlog/sveltekit', () => {
 
   describe('useLogger()', () => {
     it('returns the request-scoped logger from anywhere in the call stack', async () => {
-      const handle = evlog()
+      const { drain } = createPipelineSpies()
+      const handle = evlog({ drain })
 
-      let loggerFromService: unknown
+      let loggerFromService: RequestLogger | undefined
       const resolve = vi.fn(() => {
         loggerFromService = useLogger()
         useLogger().set({ fromService: true })
@@ -426,16 +425,11 @@ describe('evlog/sveltekit', () => {
       })
 
       const event = createMockEvent('GET', '/api/test')
-      const consoleSpy = vi.mocked(console.info)
       await handle({ event, resolve })
+      await waitForDrainCalls(drain)
 
-      expect(loggerFromService).toBeDefined()
-      expect(typeof (loggerFromService as Record<string, unknown>).set).toBe('function')
-
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"fromService":true'),
-      )
-      expect(lastCall).toBeDefined()
+      expect(typeof defined(loggerFromService).set).toBe('function')
+      expect(findEventViaDrain(drain, e => e.fromService === true)).toBeDefined()
     })
 
     it('returns the same logger as event.locals.log', async () => {
@@ -444,7 +438,7 @@ describe('evlog/sveltekit', () => {
       let isSame = false
       const event = createMockEvent('GET', '/api/test')
       const resolve = vi.fn(() => {
-        isSame = useLogger() === event.locals.log
+        isSame = useLogger() === defined(event.locals.log, 'event.locals.log in resolve')
         return new Response(JSON.stringify({ ok: true }), { status: 200 })
       })
 
@@ -457,7 +451,8 @@ describe('evlog/sveltekit', () => {
     })
 
     it('works across async boundaries', async () => {
-      const handle = evlog()
+      const { drain } = createPipelineSpies()
+      const handle = evlog({ drain })
 
       async function asyncService() {
         await new Promise(resolve => setTimeout(resolve, 5))
@@ -470,13 +465,10 @@ describe('evlog/sveltekit', () => {
       })
 
       const event = createMockEvent('GET', '/api/test')
-      const consoleSpy = vi.mocked(console.info)
       await handle({ event, resolve })
+      await waitForDrainCalls(drain)
 
-      const lastCall = consoleSpy.mock.calls.find(call =>
-        typeof call[0] === 'string' && call[0].includes('"asyncWork":"done"'),
-      )
-      expect(lastCall).toBeDefined()
+      expect(findEventViaDrain(drain, e => e.asyncWork === 'done')).toBeDefined()
     })
   })
 
@@ -524,14 +516,16 @@ describe('evlog/sveltekit', () => {
         link: 'https://docs.example.com/payments',
       })
 
-      const result = handleError({ error, event, status: 402, message: 'Payment failed' })
+      const result = defined(
+        handleError({ error, event, status: 402, message: 'Payment failed' }),
+        'EvlogError handleError result',
+      )
 
-      expect(result).toBeDefined()
-      expect((result as any).message).toBe('Payment failed')
-      expect((result as any).status).toBe(402)
-      expect((result as any).why).toBe('Card declined')
-      expect((result as any).fix).toBe('Try another card')
-      expect((result as any).link).toBe('https://docs.example.com/payments')
+      expect(result.message).toBe('Payment failed')
+      expect(result.status).toBe(402)
+      expect(result.why).toBe('Card declined')
+      expect(result.fix).toBe('Try another card')
+      expect(result.link).toBe('https://docs.example.com/payments')
     })
 
     it('returns generic response for non-EvlogError', () => {
@@ -550,17 +544,19 @@ describe('evlog/sveltekit', () => {
         },
       }
 
-      const result = handleError({
-        error: new Error('Something broke'),
-        event,
-        status: 500,
-        message: 'Internal Error',
-      })
+      const result = defined(
+        handleError({
+          error: new Error('Something broke'),
+          event,
+          status: 500,
+          message: 'Internal Error',
+        }),
+        'generic handleError result',
+      )
 
-      expect(result).toBeDefined()
-      expect((result as any).message).toBe('Internal Error')
-      expect((result as any).status).toBe(500)
-      expect((result as any).why).toBeUndefined()
+      expect(result.message).toBe('Internal Error')
+      expect(result.status).toBe(500)
+      expect(result.why).toBeUndefined()
     })
 
     it('handles missing logger gracefully', () => {
@@ -568,15 +564,17 @@ describe('evlog/sveltekit', () => {
       const event = createMockEvent('GET', '/api/fail')
       // No locals.log set
 
-      const result = handleError({
-        error: new Error('crash'),
-        event,
-        status: 500,
-        message: 'Internal Error',
-      })
+      const result = defined(
+        handleError({
+          error: new Error('crash'),
+          event,
+          status: 500,
+          message: 'Internal Error',
+        }),
+        'handleError result without logger',
+      )
 
-      expect(result).toBeDefined()
-      expect((result as any).message).toBe('Internal Error')
+      expect(result.message).toBe('Internal Error')
     })
   })
 
@@ -621,8 +619,11 @@ describe('evlog/sveltekit', () => {
         why: 'Card declined',
       })
 
-      const result = handleError({ error, event, status: 402, message: 'Payment failed' })
-      expect((result as any).why).toBe('Card declined')
+      const result = defined(
+        handleError({ error, event, status: 402, message: 'Payment failed' }),
+        'createEvlogHooks handleError result',
+      )
+      expect(result.why).toBe('Card declined')
     })
   })
 })

--- a/packages/evlog/test/helpers/defined.ts
+++ b/packages/evlog/test/helpers/defined.ts
@@ -1,0 +1,20 @@
+import { expect } from 'vitest'
+import type { DrainContext } from '../../src/types'
+
+/**
+ * Vitest assertion + type narrowing — replaces `value!` after
+ * `expect(value).toBeDefined()`.
+ */
+export function defined<T>(value: T | null | undefined, label?: string): T {
+  expect(value, label).toBeDefined()
+  if (value === null || value === undefined) throw new Error(label ?? 'expected defined value')
+  return value
+}
+
+/**
+ * Extract the first argument from a Vitest mock call as {@link DrainContext}.
+ * Encapsulates the single cast needed for untyped `mock.calls` entries.
+ */
+export function getDrainCallArg(call: unknown[]): DrainContext {
+  return defined(call[0], 'drain mock call arg') as DrainContext
+}

--- a/packages/evlog/test/helpers/framework.ts
+++ b/packages/evlog/test/helpers/framework.ts
@@ -1,5 +1,6 @@
 import { vi, expect } from 'vitest'
 import type { DrainContext, EnrichContext, TailSamplingContext, WideEvent } from '../../src/types'
+import { defined, getDrainCallArg } from './defined'
 
 /**
  * Wait for a drain spy to be called at least `count` times. Wraps `vi.waitFor`
@@ -46,8 +47,8 @@ export function findEventViaDrain(
   predicate: (event: WideEvent) => boolean,
 ): WideEvent | undefined {
   for (const call of drainFn.mock.calls) {
-    const ctx = call[0] as DrainContext | undefined
-    if (ctx?.event && predicate(ctx.event)) return ctx.event
+    const ctx = getDrainCallArg(call)
+    if (ctx.event && predicate(ctx.event)) return ctx.event
   }
   return undefined
 }
@@ -62,8 +63,8 @@ export function findContextViaDrain(
   predicate: (event: WideEvent) => boolean,
 ): DrainContext | undefined {
   for (const call of drainFn.mock.calls) {
-    const ctx = call[0] as DrainContext | undefined
-    if (ctx?.event && predicate(ctx.event)) return ctx
+    const ctx = getDrainCallArg(call)
+    if (ctx.event && predicate(ctx.event)) return ctx
   }
   return undefined
 }
@@ -81,19 +82,20 @@ export function assertDrainCalledWith(
   },
 ) {
   expect(drainFn).toHaveBeenCalled()
-  const ctx = drainFn.mock.calls[0][0] as DrainContext
-  expect(ctx.event).toBeDefined()
-  expect(ctx.event.path).toBe(expected.path)
-  expect(ctx.request).toBeDefined()
-  expect(ctx.request!.path).toBe(expected.path)
+  const call = defined(drainFn.mock.calls[0], 'first drain call')
+  const ctx = getDrainCallArg(call)
+  const event = defined(ctx.event, 'drained event')
+  expect(event.path).toBe(expected.path)
+  const request = defined(ctx.request, 'drain request context')
+  expect(request.path).toBe(expected.path)
 
   if (expected.method) {
-    expect(ctx.event.method).toBe(expected.method)
-    expect(ctx.request!.method).toBe(expected.method)
+    expect(event.method).toBe(expected.method)
+    expect(request.method).toBe(expected.method)
   }
-  if (expected.level) expect(ctx.event.level).toBe(expected.level)
-  if (expected.status) expect(ctx.event.status).toBe(expected.status)
-  expect(ctx.request!.requestId).toBeDefined()
+  if (expected.level) expect(event.level).toBe(expected.level)
+  if (expected.status) expect(event.status).toBe(expected.status)
+  expect(request.requestId).toBeDefined()
 }
 
 /**
@@ -106,12 +108,14 @@ export function assertHttpEventEmitted(
   expected: { path: string, method?: string, status?: number, level?: string },
 ): WideEvent {
   expect(drainFn).toHaveBeenCalled()
-  const event = findEventViaDrain(drainFn, e => e.path === expected.path)
-  expect(event, `no drained event matched path=${expected.path}`).toBeDefined()
-  if (expected.method) expect(event!.method).toBe(expected.method)
-  if (expected.status) expect(event!.status).toBe(expected.status)
-  if (expected.level) expect(event!.level).toBe(expected.level)
-  return event!
+  const event = defined(
+    findEventViaDrain(drainFn, e => e.path === expected.path),
+    `no drained event matched path=${expected.path}`,
+  )
+  if (expected.method) expect(event.method).toBe(expected.method)
+  if (expected.status) expect(event.status).toBe(expected.status)
+  if (expected.level) expect(event.level).toBe(expected.level)
+  return event
 }
 
 /**

--- a/packages/evlog/test/helpers/frameworkMatrix.ts
+++ b/packages/evlog/test/helpers/frameworkMatrix.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { BaseEvlogOptions } from '../../src/shared/middleware'
 import { assertHttpEventEmitted, createPipelineSpies, findEventViaDrain, waitForDrainCalls } from './framework'
+import { defined } from './defined'
 
 /**
  * Minimal viable surface every framework adapter must expose for the shared
@@ -78,9 +79,11 @@ export function describeStandardHttpMatrix(adapter: FrameworkAdapter): void {
       try {
         await fire({ method: 'GET', path: '/api/users', headers: { 'x-request-id': 'shared-matrix-id' } })
         await waitForDrainCalls(drain)
-        const event = findEventViaDrain(drain, e => e.path === '/api/users')
-        expect(event).toBeDefined()
-        expect(event!.requestId).toBe('shared-matrix-id')
+        const event = defined(
+          findEventViaDrain(drain, e => e.path === '/api/users'),
+          'event with x-request-id',
+        )
+        expect(event.requestId).toBe('shared-matrix-id')
       } finally {
         await cleanup?.()
       }
@@ -95,9 +98,11 @@ export function describeStandardHttpMatrix(adapter: FrameworkAdapter): void {
       try {
         await fire({ method: 'GET', path: '/api/users' })
         await waitForDrainCalls(drain)
-        const event = findEventViaDrain(drain, e => e.path === '/api/users')
-        expect(event).toBeDefined()
-        expect(event!.service).toBe('matrix-service')
+        const event = defined(
+          findEventViaDrain(drain, e => e.path === '/api/users'),
+          'event with service override',
+        )
+        expect(event.service).toBe('matrix-service')
       } finally {
         await cleanup?.()
       }

--- a/packages/evlog/test/helpers/vite.ts
+++ b/packages/evlog/test/helpers/vite.ts
@@ -1,0 +1,68 @@
+import { parse } from 'acorn'
+import type { Plugin, ResolvedConfig } from 'vite'
+import type { TransformPluginContext } from 'rollup'
+
+type PluginHook<T> = T | { handler: T, filter?: unknown }
+
+/**
+ * Unwrap a Vite plugin hook whether it is a bare function or `{ handler }`.
+ */
+export function getPluginHook<T extends(...args: never[]) => unknown>(
+  plugin: Plugin,
+  hookName: keyof Plugin,
+): T {
+  const hook = plugin[hookName] as PluginHook<T> | undefined
+  if (!hook) {
+    throw new Error(`Plugin hook ${String(hookName)} is undefined`)
+  }
+  if (typeof hook === 'function') {
+    return hook
+  }
+  if (typeof hook === 'object' && hook !== null && 'handler' in hook) {
+    return hook.handler
+  }
+  throw new Error(`Plugin hook ${String(hookName)} is not callable`)
+}
+
+/** Minimal `configResolved` input for plugin tests. */
+export function callConfigResolved(plugin: Plugin, config: Pick<ResolvedConfig, 'command'> & Partial<ResolvedConfig>): void {
+  const hook = plugin.configResolved
+  if (!hook) return
+  if (typeof hook === 'function') {
+    hook(config as ResolvedConfig)
+    return
+  }
+  hook.handler(config as ResolvedConfig)
+}
+
+/** Rollup transform context stub with acorn `parse` — matches Vite's transform hook. */
+export function createParseTransformContext(): Pick<TransformPluginContext, 'parse'> {
+  return {
+    parse(code: string) {
+      return parse(code, { ecmaVersion: 'latest', sourceType: 'module' })
+    },
+  }
+}
+
+type TransformResult = { code: string, map?: object } | undefined | null
+
+type PluginTransformHandler = (
+  this: TransformPluginContext,
+  code: string,
+  id: string,
+) => TransformResult | Promise<TransformResult>
+
+/** Run a plugin `transform` hook after optional `configResolved`. */
+export function runPluginTransform(
+  plugin: Plugin,
+  code: string,
+  id: string,
+  options?: { config?: Pick<ResolvedConfig, 'command'> & Partial<ResolvedConfig> },
+): TransformResult | Promise<TransformResult> {
+  if (options?.config) {
+    callConfigResolved(plugin, options.config)
+  }
+  const handler = getPluginHook<PluginTransformHandler>(plugin, 'transform')
+  const ctx = createParseTransformContext() as TransformPluginContext
+  return handler.call(ctx, code, id)
+}

--- a/packages/evlog/test/helpers/vite.ts
+++ b/packages/evlog/test/helpers/vite.ts
@@ -25,14 +25,17 @@ export function getPluginHook<T extends(...args: never[]) => unknown>(
 }
 
 /** Minimal `configResolved` input for plugin tests. */
-export function callConfigResolved(plugin: Plugin, config: Pick<ResolvedConfig, 'command'> & Partial<ResolvedConfig>): void {
+export async function callConfigResolved(
+  plugin: Plugin,
+  config: Pick<ResolvedConfig, 'command'> & Partial<ResolvedConfig>,
+): Promise<void> {
   const hook = plugin.configResolved
   if (!hook) return
   if (typeof hook === 'function') {
-    hook(config as ResolvedConfig)
+    await hook(config as ResolvedConfig)
     return
   }
-  hook.handler(config as ResolvedConfig)
+  await hook.handler(config as ResolvedConfig)
 }
 
 /** Rollup transform context stub with acorn `parse` — matches Vite's transform hook. */
@@ -53,14 +56,14 @@ type PluginTransformHandler = (
 ) => TransformResult | Promise<TransformResult>
 
 /** Run a plugin `transform` hook after optional `configResolved`. */
-export function runPluginTransform(
+export async function runPluginTransform(
   plugin: Plugin,
   code: string,
   id: string,
   options?: { config?: Pick<ResolvedConfig, 'command'> & Partial<ResolvedConfig> },
-): TransformResult | Promise<TransformResult> {
+): Promise<TransformResult> {
   if (options?.config) {
-    callConfigResolved(plugin, options.config)
+    await callConfigResolved(plugin, options.config)
   }
   const handler = getPluginHook<PluginTransformHandler>(plugin, 'transform')
   const ctx = createParseTransformContext() as TransformPluginContext

--- a/packages/evlog/test/http/stream-server.test.ts
+++ b/packages/evlog/test/http/stream-server.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetStreamServerForTests, setDefaultStream, startStreamServer, type StreamServer } from '../../src/stream'
 import type { WideEvent } from '../../src/types'
 import { makeEvent } from '../helpers/events'
+import { defined } from '../helpers/defined'
 
 async function readSSE(url: string, durationMs: number, headers: Record<string, string> = {}): Promise<string[]> {
   const session = await openSSE(url, headers)
@@ -22,7 +23,7 @@ async function openSSE(url: string, headers: Record<string, string> = {}): Promi
 }> {
   const res = await fetch(url, { headers })
   expect(res.ok).toBe(true)
-  const reader = res.body!.getReader()
+  const reader = defined(res.body, 'response body').getReader()
   const decoder = new TextDecoder()
   const frames: string[] = []
   let buffer = ''
@@ -156,7 +157,7 @@ describe('startStreamServer', () => {
     const parsed = parseDataFrames(frames)
 
     expect(parsed[0]).toMatchObject({ type: 'hello' })
-    expect(parsed[0]!.data).toMatchObject({ bufferSize: 50, heartbeatMs: 60_000 })
+    expect(defined(parsed[0], 'hello frame').data).toMatchObject({ bufferSize: 50, heartbeatMs: 60_000 })
   })
 
   it('forwards drained events as event frames', async () => {
@@ -171,8 +172,8 @@ describe('startStreamServer', () => {
     const events = parsed.filter(p => p.type === 'event')
 
     expect(events).toHaveLength(2)
-    expect((events[0]!.data as WideEvent).id).toBe(1)
-    expect((events[1]!.data as WideEvent).id).toBe(2)
+    expect((defined(events[0], 'event 0').data as WideEvent).id).toBe(1)
+    expect((defined(events[1], 'event 1').data as WideEvent).id).toBe(2)
   })
 
   it('replays buffered events when ?since is set', async () => {
@@ -187,7 +188,7 @@ describe('startStreamServer', () => {
     const replays = parsed.filter(p => p.type === 'replay')
 
     expect(replays).toHaveLength(1)
-    expect((replays[0]!.data as WideEvent).id).toBe(11)
+    expect((defined(replays[0], 'replay 0').data as WideEvent).id).toBe(11)
   })
 
   it('exposes /info with version and config', async () => {

--- a/packages/evlog/test/next/middleware.test.ts
+++ b/packages/evlog/test/next/middleware.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defined } from '../helpers/defined'
 import { evlogMiddleware } from '../../src/next/middleware'
 
-// Mock next/server
+type MockNextRequest = {
+  nextUrl: { pathname: string }
+  headers: { get(name: string): string | null }
+}
+
 const mockNextResponse = {
   next: vi.fn((options?: { request?: { headers: Headers } }) => {
     const headers = new Map<string, string>()
@@ -18,7 +23,7 @@ vi.mock('next/server', () => ({
   NextResponse: mockNextResponse,
 }))
 
-function createMockRequest(pathname: string, headers: Record<string, string> = {}) {
+function createMockRequest(pathname: string, headers: Record<string, string> = {}): MockNextRequest {
   return {
     nextUrl: { pathname },
     headers: {
@@ -44,7 +49,7 @@ describe('evlogMiddleware', () => {
   it('sets x-request-id header on response', async () => {
     const middleware = evlogMiddleware()
     const request = createMockRequest('/api/test')
-    const response = await middleware(request as any)
+    const response = await middleware(request)
 
     expect(response.headers.get('x-request-id')).toBeDefined()
     expect(typeof response.headers.get('x-request-id')).toBe('string')
@@ -53,7 +58,7 @@ describe('evlogMiddleware', () => {
   it('reuses existing x-request-id from request', async () => {
     const middleware = evlogMiddleware()
     const request = createMockRequest('/api/test', { 'x-request-id': 'existing-id' })
-    const response = await middleware(request as any)
+    const response = await middleware(request)
 
     expect(response.headers.get('x-request-id')).toBe('existing-id')
   })
@@ -61,24 +66,23 @@ describe('evlogMiddleware', () => {
   it('passes request headers via NextResponse.next()', async () => {
     const middleware = evlogMiddleware()
     const request = createMockRequest('/api/test')
-    await middleware(request as any)
+    await middleware(request)
 
     expect(mockNextResponse.next).toHaveBeenCalled()
-    const [[callArgs]] = mockNextResponse.next.mock.calls
-    expect(callArgs!.request!.headers).toBeInstanceOf(Headers)
-
-    const { headers } = callArgs!.request!
-    expect(headers.get('x-request-id')).toBeDefined()
-    expect(headers.get('x-evlog-start')).toBeDefined()
+    const callArgs = defined(mockNextResponse.next.mock.calls[0]?.[0], 'NextResponse.next args')
+    const requestHeaders = defined(callArgs.request, 'next request').headers
+    expect(requestHeaders).toBeInstanceOf(Headers)
+    expect(requestHeaders.get('x-request-id')).toBeDefined()
+    expect(requestHeaders.get('x-evlog-start')).toBeDefined()
   })
 
   it('sets x-evlog-start header with timestamp', async () => {
     const middleware = evlogMiddleware()
     const request = createMockRequest('/api/test')
-    await middleware(request as any)
+    await middleware(request)
 
-    const [[callArgs2]] = mockNextResponse.next.mock.calls
-    const startTime = Number(callArgs2!.request!.headers.get('x-evlog-start'))
+    const callArgs = defined(mockNextResponse.next.mock.calls[0]?.[0], 'NextResponse.next args')
+    const startTime = Number(defined(callArgs.request, 'next request').headers.get('x-evlog-start'))
     expect(startTime).toBeGreaterThan(0)
     expect(startTime).toBeLessThanOrEqual(Date.now())
   })
@@ -86,30 +90,26 @@ describe('evlogMiddleware', () => {
   it('skips excluded routes', async () => {
     const middleware = evlogMiddleware({ exclude: ['/_next/**'] })
     const request = createMockRequest('/_next/static/chunk.js')
-    await middleware(request as any)
+    await middleware(request)
 
-    // Should call NextResponse.next() without custom headers
     expect(mockNextResponse.next).toHaveBeenCalled()
     const [excludedCallArgs] = mockNextResponse.next.mock.calls
-    // For excluded routes, no request headers are passed
     expect(excludedCallArgs[0]).toBeUndefined()
   })
 
   it('respects include patterns', async () => {
     const middleware = evlogMiddleware({ include: ['/api/**'] })
 
-    // Matching route - should add headers
     const apiRequest = createMockRequest('/api/test')
-    await middleware(apiRequest as any)
+    await middleware(apiRequest)
     expect(mockNextResponse.next).toHaveBeenCalledTimes(1)
-    const [[apiCallArgs]] = mockNextResponse.next.mock.calls
-    expect(apiCallArgs!.request!.headers.get('x-request-id')).toBeDefined()
+    const apiCallArgs = defined(mockNextResponse.next.mock.calls[0]?.[0], 'api NextResponse.next args')
+    expect(defined(apiCallArgs.request, 'api next request').headers.get('x-request-id')).toBeDefined()
 
     vi.clearAllMocks()
 
-    // Non-matching route - should skip
     const pageRequest = createMockRequest('/about')
-    await middleware(pageRequest as any)
+    await middleware(pageRequest)
     expect(mockNextResponse.next).toHaveBeenCalledTimes(1)
     const [pageCallArgs] = mockNextResponse.next.mock.calls
     expect(pageCallArgs[0]).toBeUndefined()

--- a/packages/evlog/test/next/storage.test.ts
+++ b/packages/evlog/test/next/storage.test.ts
@@ -1,6 +1,21 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { describe, expect, it } from 'vitest'
+import type { RequestLogger } from '../../src/types'
+import { defined } from '../helpers/defined'
 import { evlogStorage, useLogger } from '../../src/next/storage'
+
+function createMockLogger(overrides: Partial<RequestLogger & { id?: number }> = {}): RequestLogger {
+  return {
+    set: () => {},
+    setLevel: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+    emit: () => null,
+    getContext: () => ({}),
+    ...overrides,
+  }
+}
 
 describe('evlogStorage', () => {
   it('is an AsyncLocalStorage instance', () => {
@@ -12,15 +27,7 @@ describe('evlogStorage', () => {
   })
 
   it('stores and retrieves a logger inside a run context', () => {
-    const mockLogger = {
-      set: () => {},
-      setLevel: () => {},
-      error: () => {},
-      info: () => {},
-      warn: () => {},
-      emit: () => null,
-      getContext: () => ({}),
-    }
+    const mockLogger = createMockLogger()
 
     evlogStorage.run(mockLogger, () => {
       expect(evlogStorage.getStore()).toBe(mockLogger)
@@ -28,21 +35,23 @@ describe('evlogStorage', () => {
   })
 
   it('isolates stores across concurrent runs', async () => {
-    const logger1 = { id: 1, set: () => {}, setLevel: () => {}, error: () => {}, info: () => {}, warn: () => {}, emit: () => null, getContext: () => ({}) }
-    const logger2 = { id: 2, set: () => {}, setLevel: () => {}, error: () => {}, info: () => {}, warn: () => {}, emit: () => null, getContext: () => ({}) }
+    const logger1 = createMockLogger({ id: 1 })
+    const logger2 = createMockLogger({ id: 2 })
 
     const results: number[] = []
 
     await Promise.all([
       new Promise<void>((resolve) => {
-        evlogStorage.run(logger1 as any, () => {
-          results.push((evlogStorage.getStore() as any).id)
+        evlogStorage.run(logger1, () => {
+          const store = defined(evlogStorage.getStore(), 'logger1 store') as RequestLogger & { id?: number }
+          results.push(defined(store.id, 'logger1 id'))
           resolve()
         })
       }),
       new Promise<void>((resolve) => {
-        evlogStorage.run(logger2 as any, () => {
-          results.push((evlogStorage.getStore() as any).id)
+        evlogStorage.run(logger2, () => {
+          const store = defined(evlogStorage.getStore(), 'logger2 store') as RequestLogger & { id?: number }
+          results.push(defined(store.id, 'logger2 id'))
           resolve()
         })
       }),
@@ -59,15 +68,7 @@ describe('useLogger', () => {
   })
 
   it('returns the logger from the current AsyncLocalStorage context', () => {
-    const mockLogger = {
-      set: () => {},
-      setLevel: () => {},
-      error: () => {},
-      info: () => {},
-      warn: () => {},
-      emit: () => null,
-      getContext: () => ({}),
-    }
+    const mockLogger = createMockLogger()
 
     evlogStorage.run(mockLogger, () => {
       const logger = useLogger()

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { H3Event } from 'h3'
+import { defined } from '../helpers/defined'
 
-// Mock h3 functions
 const mockSetResponseStatus = vi.fn()
 const mockSetResponseHeader = vi.fn()
 const mockSend = vi.fn()
 const mockGetRequestURL = vi.fn(() => ({ pathname: '/api/test' }))
 
 vi.mock('h3', () => ({
-  setResponseStatus: (...args: any[]) => mockSetResponseStatus(...args),
-  setResponseHeader: (...args: any[]) => mockSetResponseHeader(...args),
-  send: (...args: any[]) => mockSend(...args),
-  getRequestURL: (...args: any[]) => (mockGetRequestURL as (...a: any[]) => unknown)(...args),
+  setResponseStatus: (event: H3Event, status: number) => mockSetResponseStatus(event, status),
+  setResponseHeader: (event: H3Event, name: string, value: string) => mockSetResponseHeader(event, name, value),
+  send: (event: H3Event, body: string) => mockSend(event, body),
+  getRequestURL: (event: H3Event, options?: { xForwardedHost?: boolean }) => mockGetRequestURL(event, options),
 }))
 
-// Mock nitropack/runtime
 vi.mock('nitropack/runtime', () => ({
   defineNitroErrorHandler: <T>(handler: T) => handler,
 }))
@@ -21,9 +21,13 @@ vi.mock('nitropack/runtime', () => ({
 import { createError } from '../../src/error'
 import errorHandler from '../../src/nitro/errorHandler'
 
-describe('errorHandler', () => {
-  const mockEvent = { node: { req: {}, res: {} } }
+const mockEvent = { node: { req: {}, res: {} } } as H3Event
 
+function invokeErrorHandler(error: Error) {
+  errorHandler(error, mockEvent, { defaultHandler: vi.fn() })
+}
+
+describe('errorHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubEnv('NODE_ENV', 'development')
@@ -31,9 +35,8 @@ describe('errorHandler', () => {
 
   describe('EvlogError handling', () => {
     it('serializes EvlogError with all data fields', () => {
-      const evlogError = {
+      const evlogError = Object.assign(new Error('Payment failed'), {
         name: 'EvlogError',
-        message: 'Payment failed',
         status: 402,
         statusText: 'Payment failed',
         statusCode: 402,
@@ -43,14 +46,14 @@ describe('errorHandler', () => {
           fix: 'Try another card',
           link: 'https://docs.example.com',
         },
-      }
+      })
 
-      errorHandler(evlogError as any, mockEvent as any, {} as any)
+      invokeErrorHandler(evlogError)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 402)
       expect(mockSetResponseHeader).toHaveBeenCalledWith(mockEvent, 'Content-Type', 'application/json')
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.statusCode).toBe(402)
       expect(sentBody.message).toBe('Payment failed')
       expect(sentBody.url).toBe('/api/test')
@@ -63,39 +66,30 @@ describe('errorHandler', () => {
     })
 
     it('derives HTTP status from evlogError when in error.cause', () => {
-      const evlogError = {
+      const evlogError = Object.assign(new Error('Not found'), {
         name: 'EvlogError',
-        message: 'Not found',
         status: 404,
         statusText: 'Not found',
         statusCode: 404,
         statusMessage: 'Not found',
         data: { why: 'Resource does not exist' },
-      }
+      })
 
-      const wrapperError = {
-        name: 'Error',
-        message: 'Wrapper error',
-        cause: evlogError,
-      }
+      const wrapperError = Object.assign(new Error('Wrapper error'), { cause: evlogError })
 
-      errorHandler(wrapperError as any, mockEvent as any, {} as any)
+      invokeErrorHandler(wrapperError)
 
-      // HTTP status should come from evlogError, not wrapper
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 404)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.statusCode).toBe(404)
       expect(sentBody.data).toEqual({ why: 'Resource does not exist' })
     })
 
     it('defaults to 500 when no status on evlogError', () => {
-      const evlogError = {
-        name: 'EvlogError',
-        message: 'Unknown error',
-      }
+      const evlogError = Object.assign(new Error('Unknown error'), { name: 'EvlogError' })
 
-      errorHandler(evlogError as any, mockEvent as any, {} as any)
+      invokeErrorHandler(evlogError)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 500)
     })
@@ -108,9 +102,9 @@ describe('errorHandler', () => {
         internal: { userId: 'u-internal', rawPolicy: 'deny:admin' },
       })
 
-      errorHandler(err as any, mockEvent as any, {} as any)
+      invokeErrorHandler(err)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.internal).toBeUndefined()
       expect(JSON.stringify(sentBody)).not.toContain('u-internal')
       expect(JSON.stringify(sentBody)).not.toContain('rawPolicy')
@@ -124,46 +118,37 @@ describe('errorHandler', () => {
 
   describe('non-EvlogError handling', () => {
     it('uses Nitro-compatible format for standard errors', () => {
-      const error = {
-        name: 'Error',
-        message: 'Something went wrong',
+      const error = Object.assign(new Error('Something went wrong'), {
         statusCode: 400,
-      }
+      })
 
-      errorHandler(error as any, mockEvent as any, {} as any)
+      invokeErrorHandler(error)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 400)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.statusCode).toBe(400)
       expect(sentBody.statusMessage).toBe('Something went wrong')
       expect(sentBody.message).toBe('Something went wrong')
       expect(sentBody.url).toBe('/api/test')
       expect(sentBody.error).toBe(true)
-      // Should NOT include extended fields
       expect(sentBody.data).toBeUndefined()
     })
 
     it('defaults to 500 for errors without status', () => {
-      const error = {
-        name: 'Error',
-        message: 'Generic error',
-      }
+      const error = new Error('Generic error')
 
-      errorHandler(error as any, mockEvent as any, {} as any)
+      invokeErrorHandler(error)
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 500)
     })
 
     it('uses "Internal Server Error" when no message', () => {
-      const error = {
-        name: 'Error',
-        message: '',
-      }
+      const error = new Error('')
 
-      errorHandler(error as any, mockEvent as any, {} as any)
+      invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.message).toBe('Internal Server Error')
       expect(sentBody.statusMessage).toBe('Internal Server Error')
     })
@@ -171,15 +156,13 @@ describe('errorHandler', () => {
     it('sanitizes 5xx error messages in production', () => {
       vi.stubEnv('NODE_ENV', 'production')
 
-      const error = {
-        name: 'Error',
-        message: 'Database connection failed: password invalid',
+      const error = Object.assign(new Error('Database connection failed: password invalid'), {
         statusCode: 500,
-      }
+      })
 
-      errorHandler(error as any, mockEvent as any, {} as any)
+      invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.message).toBe('Internal Server Error')
       expect(sentBody.statusMessage).toBe('Internal Server Error')
     })
@@ -187,15 +170,13 @@ describe('errorHandler', () => {
     it('preserves 4xx error messages in production', () => {
       vi.stubEnv('NODE_ENV', 'production')
 
-      const error = {
-        name: 'Error',
-        message: 'Invalid email format',
+      const error = Object.assign(new Error('Invalid email format'), {
         statusCode: 400,
-      }
+      })
 
-      errorHandler(error as any, mockEvent as any, {} as any)
+      invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(mockSend.mock.calls[0][1])
+      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
       expect(sentBody.message).toBe('Invalid email format')
       expect(sentBody.statusMessage).toBe('Invalid email format')
     })

--- a/packages/evlog/test/nitro/plugin-enrichment.test.ts
+++ b/packages/evlog/test/nitro/plugin-enrichment.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getHeaders } from 'h3'
-import type { DrainContext, EnrichContext, RequestLogger, ServerEvent, WideEvent } from '../../src/types'
+import type { DrainContext, EnrichContext, ServerEvent, WideEvent } from '../../src/types'
+import { defined } from '../helpers/defined'
 import { filterSafeHeaders } from '../../src/utils'
 import { createRequestLogger, initLogger } from '../../src/logger'
 
@@ -173,11 +174,11 @@ describe('nitro plugin - enrichment pipeline (T7)', () => {
     const mockHooks = {
       callHook: vi.fn().mockImplementation((hookName: string, ctx: EnrichContext | DrainContext) => {
         if (hookName === 'evlog:enrich') {
-          (ctx as EnrichContext).event.enriched = true
-          ;(ctx as EnrichContext).event.customField = 'added-by-enricher'
+          ctx.event.enriched = true
+          ctx.event.customField = 'added-by-enricher'
         }
         if (hookName === 'evlog:drain') {
-          drainEvent = (ctx as DrainContext).event
+          drainEvent = ctx.event
         }
         return Promise.resolve()
       }),
@@ -198,9 +199,9 @@ describe('nitro plugin - enrichment pipeline (T7)', () => {
 
     await callEnrichAndDrain({ hooks: mockHooks }, emittedEvent, mockEvent)
 
-    expect(drainEvent).not.toBeNull()
-    expect(drainEvent!.enriched).toBe(true)
-    expect(drainEvent!.customField).toBe('added-by-enricher')
+    const drained = defined(drainEvent, 'drainEvent')
+    expect(drained.enriched).toBe(true)
+    expect(drained.customField).toBe('added-by-enricher')
   })
 
   it('passes headers to both enrich and drain hooks', async () => {
@@ -215,10 +216,10 @@ describe('nitro plugin - enrichment pipeline (T7)', () => {
     const mockHooks = {
       callHook: vi.fn().mockImplementation((hookName: string, ctx: EnrichContext | DrainContext) => {
         if (hookName === 'evlog:enrich') {
-          enrichHeaders = (ctx as EnrichContext).headers
+          enrichHeaders = ctx.headers
         }
         if (hookName === 'evlog:drain') {
-          drainHeaders = (ctx as DrainContext).headers
+          drainHeaders = ctx.headers
         }
         return Promise.resolve()
       }),

--- a/packages/evlog/test/nitro/plugin.test.ts
+++ b/packages/evlog/test/nitro/plugin.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getHeaders } from 'h3'
-import type { DrainContext, EnrichContext, RequestLogger, RouteConfig, ServerEvent, WideEvent } from '../../src/types'
+import type { DrainContext, RouteConfig, ServerEvent, WideEvent } from '../../src/types'
+import { defined } from '../helpers/defined'
 import { filterSafeHeaders } from '../../src/utils'
 import { getServiceForPath, shouldLog } from '../../src/shared/routes'
 import { createRequestLogger, initLogger } from '../../src/logger'
@@ -48,7 +49,7 @@ describe('nitro plugin - drain hook headers', () => {
     }
 
     // Simulate what callDrainHook does
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: mockEmittedEvent,
       request: {
@@ -71,8 +72,8 @@ describe('nitro plugin - drain hook headers', () => {
     }))
 
     // Verify drainContext contains headers
-    expect(drainContext).not.toBeNull()
-    expect(drainContext!.headers).toMatchObject({
+    const ctx = defined(drainContext, 'drainContext')
+    expect(ctx.headers).toMatchObject({
       'content-type': 'application/json',
       'x-request-id': 'test-123',
       'x-posthog-session-id': 'session-456',
@@ -108,24 +109,26 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/api/users', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
       headers: getSafeHeaders(allHeaders),
     })
 
+    const ctx = defined(drainContext, 'drainContext')
+
     // Verify sensitive headers are NOT included
-    expect(drainContext!.headers).not.toHaveProperty('authorization')
-    expect(drainContext!.headers).not.toHaveProperty('cookie')
-    expect(drainContext!.headers).not.toHaveProperty('set-cookie')
-    expect(drainContext!.headers).not.toHaveProperty('x-api-key')
-    expect(drainContext!.headers).not.toHaveProperty('x-auth-token')
-    expect(drainContext!.headers).not.toHaveProperty('proxy-authorization')
+    expect(ctx.headers).not.toHaveProperty('authorization')
+    expect(ctx.headers).not.toHaveProperty('cookie')
+    expect(ctx.headers).not.toHaveProperty('set-cookie')
+    expect(ctx.headers).not.toHaveProperty('x-api-key')
+    expect(ctx.headers).not.toHaveProperty('x-auth-token')
+    expect(ctx.headers).not.toHaveProperty('proxy-authorization')
 
     // Verify safe headers ARE included
-    expect(drainContext!.headers).toHaveProperty('content-type', 'application/json')
-    expect(drainContext!.headers).toHaveProperty('x-request-id', 'test-123')
+    expect(ctx.headers).toHaveProperty('content-type', 'application/json')
+    expect(ctx.headers).toHaveProperty('x-request-id', 'test-123')
   })
 
   it('includes all standard non-sensitive HTTP headers', () => {
@@ -155,17 +158,19 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/api/users', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
       headers: getSafeHeaders(allHeaders),
     })
 
+    const ctx = defined(drainContext, 'drainContext')
+
     // Verify all safe headers are passed through
-    expect(drainContext!.headers).toEqual(mockHeaders)
-    expect(drainContext!.headers?.['user-agent']).toBe('Mozilla/5.0')
-    expect(drainContext!.headers?.['x-forwarded-for']).toBe('192.168.1.1')
+    expect(ctx.headers).toEqual(mockHeaders)
+    expect(ctx.headers?.['user-agent']).toBe('Mozilla/5.0')
+    expect(ctx.headers?.['x-forwarded-for']).toBe('192.168.1.1')
   })
 
   it('handles empty headers', () => {
@@ -184,14 +189,14 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
       headers: getSafeHeaders(allHeaders),
     })
 
-    expect(drainContext!.headers).toEqual({})
+    expect(defined(drainContext, 'drainContext').headers).toEqual({})
   })
 
   it('preserves custom correlation headers for external services', () => {
@@ -226,19 +231,21 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'POST', path: '/api/checkout', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
       headers: getSafeHeaders(allHeaders),
     })
 
+    const ctx = defined(drainContext, 'drainContext')
+
     // Verify all correlation headers are available
-    expect(drainContext!.headers?.['x-posthog-session-id']).toBe('ph-session-123')
-    expect(drainContext!.headers?.['x-posthog-distinct-id']).toBe('ph-user-456')
-    expect(drainContext!.headers?.['sentry-trace']).toBe('00-abc123-def456-01')
-    expect(drainContext!.headers?.['traceparent']).toBeDefined()
-    expect(drainContext!.headers?.['x-correlation-id']).toBe('corr-789')
+    expect(ctx.headers?.['x-posthog-session-id']).toBe('ph-session-123')
+    expect(ctx.headers?.['x-posthog-distinct-id']).toBe('ph-user-456')
+    expect(ctx.headers?.['sentry-trace']).toBe('00-abc123-def456-01')
+    expect(ctx.headers?.['traceparent']).toBeDefined()
+    expect(ctx.headers?.['x-correlation-id']).toBe('corr-789')
   })
 
   it('filters sensitive headers case-insensitively', () => {
@@ -264,20 +271,22 @@ describe('nitro plugin - drain hook headers', () => {
     const mockNitroApp = { hooks: mockHooks }
     const mockEvent = { method: 'GET', path: '/', context: {} }
 
-    const allHeaders = getHeaders(mockEvent as unknown as Parameters<typeof getHeaders>[0])
+    const allHeaders = getHeaders(mockEvent as Parameters<typeof getHeaders>[0])
     mockNitroApp.hooks.callHook('evlog:drain', {
       event: { timestamp: '', level: 'info', service: 'test', environment: 'test' },
       request: { method: mockEvent.method, path: mockEvent.path },
       headers: getSafeHeaders(allHeaders),
     })
 
+    const ctx = defined(drainContext, 'drainContext')
+
     // Verify sensitive headers are filtered regardless of case
-    expect(drainContext!.headers).not.toHaveProperty('Authorization')
-    expect(drainContext!.headers).not.toHaveProperty('COOKIE')
-    expect(drainContext!.headers).not.toHaveProperty('X-Api-Key')
+    expect(ctx.headers).not.toHaveProperty('Authorization')
+    expect(ctx.headers).not.toHaveProperty('COOKIE')
+    expect(ctx.headers).not.toHaveProperty('X-Api-Key')
 
     // Verify safe headers are kept
-    expect(drainContext!.headers).toHaveProperty('content-type', 'application/json')
+    expect(ctx.headers).toHaveProperty('content-type', 'application/json')
   })
 })
 
@@ -840,7 +849,7 @@ describe('nitro plugin - middleware compatibility (#210)', () => {
     if (event.context._evlogEmitted || !event.context._evlogShouldEmit) {
       return { emitted: false }
     }
-    const log = event.context.log as RequestLogger | undefined
+    const { log } = event.context
     if (!log) return { emitted: false }
     log.set({ status: 200 })
     const result = log.emit()
@@ -852,7 +861,7 @@ describe('nitro plugin - middleware compatibility (#210)', () => {
    */
   function simulateErrorHook(event: ServerEvent, error: Error): { emitted: boolean } {
     if (!event.context._evlogShouldEmit) return { emitted: false }
-    const log = event.context.log as RequestLogger | undefined
+    const { log } = event.context
     if (!log) return { emitted: false }
     log.error(error)
     log.set({ status: 500 })
@@ -894,9 +903,10 @@ describe('nitro plugin - middleware compatibility (#210)', () => {
     simulateRequestHook(event, { include: ['/api/**'] })
 
     expect(event.context._evlogShouldEmit).toBe(false)
-    event.context.log!.set({ user: { id: 'usr_123', plan: 'enterprise' } })
+    const log = defined(event.context.log, 'event.context.log')
+    log.set({ user: { id: 'usr_123', plan: 'enterprise' } })
 
-    const ctx = event.context.log!.getContext()
+    const ctx = log.getContext()
     expect(ctx.user).toEqual({ id: 'usr_123', plan: 'enterprise' })
   })
 
@@ -905,7 +915,7 @@ describe('nitro plugin - middleware compatibility (#210)', () => {
     const event: ServerEvent = { method: 'GET', path: '/dashboard', context: {} }
 
     simulateRequestHook(event, { include: ['/api/**'] })
-    event.context.log!.set({ user: { id: 'test' } })
+    defined(event.context.log, 'event.context.log').set({ user: { id: 'test' } })
 
     const { emitted } = simulateAfterResponseHook(event)
 

--- a/packages/evlog/test/vite/auto-imports.test.ts
+++ b/packages/evlog/test/vite/auto-imports.test.ts
@@ -1,49 +1,35 @@
-import { parse } from 'acorn'
 import { describe, expect, it } from 'vitest'
+import { defined } from '../helpers/defined'
+import { runPluginTransform } from '../helpers/vite'
 import { createAutoImportsPlugin } from '../../src/vite/auto-imports'
-
-function createTransformContext() {
-  return {
-    parse(code: string) {
-      return parse(code, { ecmaVersion: 'latest', sourceType: 'module' })
-    },
-  }
-}
 
 function autoImportTransform(code: string, id = 'src/app.ts', options = {}) {
   const plugin = createAutoImportsPlugin(options)
-  const ctx = createTransformContext()
-  const t = (plugin as any).transform
-  const handler = typeof t === 'function' ? t : t.handler
-  return handler.call(ctx, code, id)
+  return runPluginTransform(plugin, code, id)
 }
 
 describe('vite auto-imports plugin', () => {
   it('adds import for log when log.info() is used', () => {
     const code = `log.info('auth', 'User logged in')`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
   })
 
   it('adds import for log when log.error() is used', () => {
     const code = `log.error({ action: 'payment', error: 'declined' })`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
   })
 
   it('adds import for createEvlogError when called', () => {
     const code = `throw createEvlogError({ message: 'test', status: 400 })`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { createEvlogError } from \'evlog\'')
   })
 
   it('adds import for parseError when called', () => {
     const code = `const err = parseError(caught)`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { parseError } from \'evlog\'')
   })
 
@@ -73,8 +59,7 @@ describe('vite auto-imports plugin', () => {
 
   it('adds multiple imports when needed', () => {
     const code = `log.info('test', 'msg')\nthrow createEvlogError('error')`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('log')
     expect(result.code).toContain('createEvlogError')
   })
@@ -93,41 +78,36 @@ describe('vite auto-imports plugin', () => {
 
   it('respects custom imports list', () => {
     const code = `log.info('test', 'msg')\nthrow createEvlogError('error')`
-    const result = autoImportTransform(code, 'src/app.ts', { imports: ['log'] })
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code, 'src/app.ts', { imports: ['log'] }), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
     expect(result.code).not.toContain('import { createEvlogError')
   })
 
   it('generates sourcemap', () => {
     const code = `log.info('test', 'msg')`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.map).toBeTruthy()
   })
 
   it('adds import for setIdentity from evlog/client', () => {
     const code = `setIdentity({ userId: '123' })`
-    const result = autoImportTransform(code, 'src/app.ts', {
+    const result = defined(autoImportTransform(code, 'src/app.ts', {
       imports: ['setIdentity'],
-    })
-    expect(result).toBeTruthy()
+    }), 'auto-import result')
     expect(result.code).toContain('import { setIdentity } from \'evlog/client\'')
   })
 
   it('adds import for clearIdentity from evlog/client', () => {
     const code = `clearIdentity()`
-    const result = autoImportTransform(code, 'src/app.ts', {
+    const result = defined(autoImportTransform(code, 'src/app.ts', {
       imports: ['clearIdentity'],
-    })
-    expect(result).toBeTruthy()
+    }), 'auto-import result')
     expect(result.code).toContain('import { clearIdentity } from \'evlog/client\'')
   })
 
   it('groups log and parseError in same evlog import', () => {
     const code = `log.info('test', 'msg')\nconst e = parseError(err)`
-    const result = autoImportTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log, parseError } from \'evlog\'')
   })
 })

--- a/packages/evlog/test/vite/auto-imports.test.ts
+++ b/packages/evlog/test/vite/auto-imports.test.ts
@@ -3,111 +3,111 @@ import { defined } from '../helpers/defined'
 import { runPluginTransform } from '../helpers/vite'
 import { createAutoImportsPlugin } from '../../src/vite/auto-imports'
 
-function autoImportTransform(code: string, id = 'src/app.ts', options = {}) {
+async function autoImportTransform(code: string, id = 'src/app.ts', options = {}) {
   const plugin = createAutoImportsPlugin(options)
-  return runPluginTransform(plugin, code, id)
+  return await runPluginTransform(plugin, code, id)
 }
 
 describe('vite auto-imports plugin', () => {
-  it('adds import for log when log.info() is used', () => {
+  it('adds import for log when log.info() is used', async () => {
     const code = `log.info('auth', 'User logged in')`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
   })
 
-  it('adds import for log when log.error() is used', () => {
+  it('adds import for log when log.error() is used', async () => {
     const code = `log.error({ action: 'payment', error: 'declined' })`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
   })
 
-  it('adds import for createEvlogError when called', () => {
+  it('adds import for createEvlogError when called', async () => {
     const code = `throw createEvlogError({ message: 'test', status: 400 })`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { createEvlogError } from \'evlog\'')
   })
 
-  it('adds import for parseError when called', () => {
+  it('adds import for parseError when called', async () => {
     const code = `const err = parseError(caught)`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { parseError } from \'evlog\'')
   })
 
-  it('does not add import if already imported from evlog', () => {
+  it('does not add import if already imported from evlog', async () => {
     const code = `import { log } from 'evlog'\nlog.info('test', 'msg')`
-    const result = autoImportTransform(code)
+    const result = await autoImportTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('does not add import if already imported from #imports', () => {
+  it('does not add import if already imported from #imports', async () => {
     const code = `import { log } from '#imports'\nlog.info('test', 'msg')`
-    const result = autoImportTransform(code)
+    const result = await autoImportTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('does not add import for locally declared log variable', () => {
+  it('does not add import for locally declared log variable', async () => {
     const code = `const log = console\nlog.info('test')`
-    const result = autoImportTransform(code)
+    const result = await autoImportTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('does not add import for imported log from other library', () => {
+  it('does not add import for imported log from other library', async () => {
     const code = `import { log } from 'other-lib'\nlog.info('test')`
-    const result = autoImportTransform(code)
+    const result = await autoImportTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('adds multiple imports when needed', () => {
+  it('adds multiple imports when needed', async () => {
     const code = `log.info('test', 'msg')\nthrow createEvlogError('error')`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('log')
     expect(result.code).toContain('createEvlogError')
   })
 
-  it('skips node_modules files', () => {
+  it('skips node_modules files', async () => {
     const code = `log.info('test', 'msg')`
-    const result = autoImportTransform(code, 'node_modules/lib/index.js')
+    const result = await autoImportTransform(code, 'node_modules/lib/index.js')
     expect(result).toBeUndefined()
   })
 
-  it('returns undefined when no symbols are used', () => {
+  it('returns undefined when no symbols are used', async () => {
     const code = `const x = 1 + 2`
-    const result = autoImportTransform(code)
+    const result = await autoImportTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('respects custom imports list', () => {
+  it('respects custom imports list', async () => {
     const code = `log.info('test', 'msg')\nthrow createEvlogError('error')`
-    const result = defined(autoImportTransform(code, 'src/app.ts', { imports: ['log'] }), 'auto-import result')
+    const result = defined(await autoImportTransform(code, 'src/app.ts', { imports: ['log'] }), 'auto-import result')
     expect(result.code).toContain('import { log } from \'evlog\'')
     expect(result.code).not.toContain('import { createEvlogError')
   })
 
-  it('generates sourcemap', () => {
+  it('generates sourcemap', async () => {
     const code = `log.info('test', 'msg')`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.map).toBeTruthy()
   })
 
-  it('adds import for setIdentity from evlog/client', () => {
+  it('adds import for setIdentity from evlog/client', async () => {
     const code = `setIdentity({ userId: '123' })`
-    const result = defined(autoImportTransform(code, 'src/app.ts', {
+    const result = defined(await autoImportTransform(code, 'src/app.ts', {
       imports: ['setIdentity'],
     }), 'auto-import result')
     expect(result.code).toContain('import { setIdentity } from \'evlog/client\'')
   })
 
-  it('adds import for clearIdentity from evlog/client', () => {
+  it('adds import for clearIdentity from evlog/client', async () => {
     const code = `clearIdentity()`
-    const result = defined(autoImportTransform(code, 'src/app.ts', {
+    const result = defined(await autoImportTransform(code, 'src/app.ts', {
       imports: ['clearIdentity'],
     }), 'auto-import result')
     expect(result.code).toContain('import { clearIdentity } from \'evlog/client\'')
   })
 
-  it('groups log and parseError in same evlog import', () => {
+  it('groups log and parseError in same evlog import', async () => {
     const code = `log.info('test', 'msg')\nconst e = parseError(err)`
-    const result = defined(autoImportTransform(code), 'auto-import result')
+    const result = defined(await autoImportTransform(code), 'auto-import result')
     expect(result.code).toContain('import { log, parseError } from \'evlog\'')
   })
 })

--- a/packages/evlog/test/vite/client-inject.test.ts
+++ b/packages/evlog/test/vite/client-inject.test.ts
@@ -4,20 +4,20 @@ import { defined } from '../helpers/defined'
 import { callConfigResolved, getPluginHook } from '../helpers/vite'
 import { createClientInjectPlugin } from '../../src/vite/client-inject'
 
-function runTransformIndexHtml(
+async function runTransformIndexHtml(
   plugin: Plugin,
   command: 'serve' | 'build' = 'serve',
-): HtmlTagDescriptor[] {
-  callConfigResolved(plugin, { command })
+): Promise<HtmlTagDescriptor[]> {
+  await callConfigResolved(plugin, { command })
   type TransformIndexHtmlHook = () => HtmlTagDescriptor | HtmlTagDescriptor[] | null | undefined
   const tags = getPluginHook<TransformIndexHtmlHook>(plugin, 'transformIndexHtml')()
   return defined(Array.isArray(tags) ? tags : tags ? [tags] : undefined, 'transformIndexHtml tags')
 }
 
 describe('vite client-inject plugin', () => {
-  it('injects script tag with initLog call', () => {
+  it('injects script tag with initLog call', async () => {
     const plugin = createClientInjectPlugin({ service: 'my-app' })
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result).toHaveLength(1)
     expect(result[0].tag).toBe('script')
     expect(result[0].attrs?.type).toBe('module')
@@ -26,51 +26,51 @@ describe('vite client-inject plugin', () => {
     expect(result[0].injectTo).toBe('head-prepend')
   })
 
-  it('includes transport config', () => {
+  it('includes transport config', async () => {
     const plugin = createClientInjectPlugin({
       transport: { enabled: true, endpoint: '/api/logs' },
     })
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('/api/logs')
   })
 
-  it('defaults service to client', () => {
+  it('defaults service to client', async () => {
     const plugin = createClientInjectPlugin({})
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('client')
   })
 
-  it('sets pretty based on dev mode', () => {
+  it('sets pretty based on dev mode', async () => {
     const plugin = createClientInjectPlugin({})
 
-    const devResult = runTransformIndexHtml(plugin, 'serve')
+    const devResult = await runTransformIndexHtml(plugin, 'serve')
     expect(devResult[0].children).toContain('"pretty":true')
 
-    const buildResult = runTransformIndexHtml(plugin, 'build')
+    const buildResult = await runTransformIndexHtml(plugin, 'build')
     expect(buildResult[0].children).toContain('"pretty":false')
   })
 
-  it('imports from evlog/client', () => {
+  it('imports from evlog/client', async () => {
     const plugin = createClientInjectPlugin({ service: 'test' })
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('from\'evlog/client\'')
   })
 
-  it('includes console: false in config when set', () => {
+  it('includes console: false in config when set', async () => {
     const plugin = createClientInjectPlugin({ console: false })
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('"console":false')
   })
 
-  it('omits console from config when not set', () => {
+  it('omits console from config when not set', async () => {
     const plugin = createClientInjectPlugin({})
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).not.toContain('"console"')
   })
 
-  it('omits transport when not configured', () => {
+  it('omits transport when not configured', async () => {
     const plugin = createClientInjectPlugin({ service: 'app' })
-    const result = runTransformIndexHtml(plugin)
+    const result = await runTransformIndexHtml(plugin)
     expect(result[0].children).not.toContain('transport')
   })
 })

--- a/packages/evlog/test/vite/client-inject.test.ts
+++ b/packages/evlog/test/vite/client-inject.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from 'vitest'
+import type { HtmlTagDescriptor, Plugin } from 'vite'
+import { defined } from '../helpers/defined'
+import { callConfigResolved, getPluginHook } from '../helpers/vite'
 import { createClientInjectPlugin } from '../../src/vite/client-inject'
+
+function runTransformIndexHtml(
+  plugin: Plugin,
+  command: 'serve' | 'build' = 'serve',
+): HtmlTagDescriptor[] {
+  callConfigResolved(plugin, { command })
+  type TransformIndexHtmlHook = () => HtmlTagDescriptor | HtmlTagDescriptor[] | null | undefined
+  const tags = getPluginHook<TransformIndexHtmlHook>(plugin, 'transformIndexHtml')()
+  return defined(Array.isArray(tags) ? tags : tags ? [tags] : undefined, 'transformIndexHtml tags')
+}
 
 describe('vite client-inject plugin', () => {
   it('injects script tag with initLog call', () => {
     const plugin = createClientInjectPlugin({ service: 'my-app' })
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result).toHaveLength(1)
     expect(result[0].tag).toBe('script')
-    expect(result[0].attrs.type).toBe('module')
+    expect(result[0].attrs?.type).toBe('module')
     expect(result[0].children).toContain('initLog')
     expect(result[0].children).toContain('my-app')
     expect(result[0].injectTo).toBe('head-prepend')
@@ -20,68 +30,47 @@ describe('vite client-inject plugin', () => {
     const plugin = createClientInjectPlugin({
       transport: { enabled: true, endpoint: '/api/logs' },
     })
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('/api/logs')
   })
 
   it('defaults service to client', () => {
     const plugin = createClientInjectPlugin({})
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('client')
   })
 
   it('sets pretty based on dev mode', () => {
     const plugin = createClientInjectPlugin({})
 
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-    const devResult = (plugin as any).transformIndexHtml()
+    const devResult = runTransformIndexHtml(plugin, 'serve')
     expect(devResult[0].children).toContain('"pretty":true')
 
-    configResolved({ command: 'build' })
-    const buildResult = (plugin as any).transformIndexHtml()
+    const buildResult = runTransformIndexHtml(plugin, 'build')
     expect(buildResult[0].children).toContain('"pretty":false')
   })
 
   it('imports from evlog/client', () => {
     const plugin = createClientInjectPlugin({ service: 'test' })
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('from\'evlog/client\'')
   })
 
   it('includes console: false in config when set', () => {
     const plugin = createClientInjectPlugin({ console: false })
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).toContain('"console":false')
   })
 
   it('omits console from config when not set', () => {
     const plugin = createClientInjectPlugin({})
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).not.toContain('"console"')
   })
 
   it('omits transport when not configured', () => {
     const plugin = createClientInjectPlugin({ service: 'app' })
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-
-    const result = (plugin as any).transformIndexHtml()
+    const result = runTransformIndexHtml(plugin)
     expect(result[0].children).not.toContain('transport')
   })
 })

--- a/packages/evlog/test/vite/source-location.test.ts
+++ b/packages/evlog/test/vite/source-location.test.ts
@@ -1,39 +1,24 @@
-import { parse } from 'acorn'
 import { describe, expect, it } from 'vitest'
+import { defined } from '../helpers/defined'
+import { callConfigResolved, runPluginTransform } from '../helpers/vite'
 import { createSourceLocationPlugin } from '../../src/vite/source-location'
-
-function createTransformContext() {
-  return {
-    parse(code: string) {
-      return parse(code, { ecmaVersion: 'latest', sourceType: 'module' })
-    },
-  }
-}
 
 function sourceLocationTransform(code: string, id = '/project/src/app.ts', root = '/project') {
   const plugin = createSourceLocationPlugin(true)
-  const { configResolved } = (plugin as any)
-  configResolved({ command: 'serve', root })
-
-  const ctx = createTransformContext()
-  const t = (plugin as any).transform
-  const handler = typeof t === 'function' ? t : t.handler
-  return handler.call(ctx, code, id)
+  return runPluginTransform(plugin, code, id, { config: { command: 'serve', root } })
 }
 
 describe('vite source-location plugin', () => {
   it('injects __source into object-form log calls', () => {
     const code = `log.info({ action: 'login' })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('src/app.ts:1')
   })
 
   it('handles objects with multiple properties', () => {
     const code = `log.error({ action: 'payment', error: 'declined' })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('action')
     expect(result.code).toContain('error')
@@ -47,8 +32,7 @@ describe('vite source-location plugin', () => {
 
   it('tracks correct line numbers', () => {
     const code = `const x = 1\nconst y = 2\nlog.info({ action: 'test' })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('src/app.ts:3')
   })
 
@@ -56,8 +40,7 @@ describe('vite source-location plugin', () => {
     const levels = ['info', 'error', 'warn', 'debug']
     for (const level of levels) {
       const code = `log.${level}({ action: 'test' })`
-      const result = sourceLocationTransform(code)
-      expect(result).toBeTruthy()
+      const result = defined(sourceLocationTransform(code), 'source-location result')
       expect(result.code).toContain('__source')
     }
   })
@@ -70,56 +53,52 @@ describe('vite source-location plugin', () => {
 
   it('generates sourcemap', () => {
     const code = `log.info({ action: 'test' })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.map).toBeTruthy()
   })
 
   it('does not activate when disabled', () => {
     const plugin = createSourceLocationPlugin(false)
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve', root: '/project' })
-
-    const ctx = createTransformContext()
-    const code = `log.info({ action: 'test' })`
-    const { handler } = (plugin as any).transform
-    const result = handler.call(ctx, code, '/project/src/app.ts')
+    const result = runPluginTransform(
+      plugin,
+      `log.info({ action: 'test' })`,
+      '/project/src/app.ts',
+      { config: { command: 'serve', root: '/project' } },
+    )
     expect(result).toBeUndefined()
   })
 
   it('uses relative path from root', () => {
     const code = `log.info({ action: 'test' })`
-    const result = sourceLocationTransform(code, '/my/project/src/routes/checkout.ts', '/my/project')
-    expect(result).toBeTruthy()
+    const result = defined(
+      sourceLocationTransform(code, '/my/project/src/routes/checkout.ts', '/my/project'),
+      'source-location result',
+    )
     expect(result.code).toContain('src/routes/checkout.ts:1')
   })
 
   it('injects into empty object', () => {
     const code = `log.info({})`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('src/app.ts:1')
   })
 
   it('injects into multiline object', () => {
     const code = `log.info({\n  action: 'login',\n  user: 'alice'\n})`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
   })
 
   it('injects into object with trailing comma', () => {
     const code = `log.info({ action: 'login', })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
   })
 
   it('injects into object with nested objects', () => {
     const code = `log.info({ user: { id: 1, name: 'alice' } })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('user')
   })
@@ -132,24 +111,20 @@ describe('vite source-location plugin', () => {
 
   it('uses JSON.stringify for path escaping', () => {
     const code = `log.info({ action: 'test' })`
-    const result = sourceLocationTransform(code)
-    expect(result).toBeTruthy()
+    const result = defined(sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source: "src/app.ts:1"')
   })
 
   it('defaults to dev-only when enabled is undefined', () => {
     const plugin = createSourceLocationPlugin()
-
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve', root: '/project' })
-    const ctx = createTransformContext()
     const code = `log.info({ action: 'test' })`
-    const { handler } = (plugin as any).transform
-    const devResult = handler.call(ctx, code, '/project/src/app.ts')
+    const id = '/project/src/app.ts'
+
+    const devResult = runPluginTransform(plugin, code, id, { config: { command: 'serve', root: '/project' } })
     expect(devResult).toBeTruthy()
 
-    configResolved({ command: 'build', root: '/project' })
-    const buildResult = handler.call(ctx, code, '/project/src/app.ts')
+    callConfigResolved(plugin, { command: 'build', root: '/project' })
+    const buildResult = runPluginTransform(plugin, code, id)
     expect(buildResult).toBeUndefined()
   })
 })

--- a/packages/evlog/test/vite/source-location.test.ts
+++ b/packages/evlog/test/vite/source-location.test.ts
@@ -3,63 +3,63 @@ import { defined } from '../helpers/defined'
 import { callConfigResolved, runPluginTransform } from '../helpers/vite'
 import { createSourceLocationPlugin } from '../../src/vite/source-location'
 
-function sourceLocationTransform(code: string, id = '/project/src/app.ts', root = '/project') {
+async function sourceLocationTransform(code: string, id = '/project/src/app.ts', root = '/project') {
   const plugin = createSourceLocationPlugin(true)
-  return runPluginTransform(plugin, code, id, { config: { command: 'serve', root } })
+  return await runPluginTransform(plugin, code, id, { config: { command: 'serve', root } })
 }
 
 describe('vite source-location plugin', () => {
-  it('injects __source into object-form log calls', () => {
+  it('injects __source into object-form log calls', async () => {
     const code = `log.info({ action: 'login' })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('src/app.ts:1')
   })
 
-  it('handles objects with multiple properties', () => {
+  it('handles objects with multiple properties', async () => {
     const code = `log.error({ action: 'payment', error: 'declined' })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('action')
     expect(result.code).toContain('error')
   })
 
-  it('does not transform tag-form log calls', () => {
+  it('does not transform tag-form log calls', async () => {
     const code = `log.info('auth', 'User logged in')`
-    const result = sourceLocationTransform(code)
+    const result = await sourceLocationTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('tracks correct line numbers', () => {
+  it('tracks correct line numbers', async () => {
     const code = `const x = 1\nconst y = 2\nlog.info({ action: 'test' })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('src/app.ts:3')
   })
 
-  it('handles all log levels', () => {
+  it('handles all log levels', async () => {
     const levels = ['info', 'error', 'warn', 'debug']
     for (const level of levels) {
       const code = `log.${level}({ action: 'test' })`
-      const result = defined(sourceLocationTransform(code), 'source-location result')
+      const result = defined(await sourceLocationTransform(code), 'source-location result')
       expect(result.code).toContain('__source')
     }
   })
 
-  it('skips node_modules', () => {
+  it('skips node_modules', async () => {
     const code = `log.info({ action: 'test' })`
-    const result = sourceLocationTransform(code, '/project/node_modules/lib/index.js')
+    const result = await sourceLocationTransform(code, '/project/node_modules/lib/index.js')
     expect(result).toBeUndefined()
   })
 
-  it('generates sourcemap', () => {
+  it('generates sourcemap', async () => {
     const code = `log.info({ action: 'test' })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.map).toBeTruthy()
   })
 
-  it('does not activate when disabled', () => {
+  it('does not activate when disabled', async () => {
     const plugin = createSourceLocationPlugin(false)
-    const result = runPluginTransform(
+    const result = await runPluginTransform(
       plugin,
       `log.info({ action: 'test' })`,
       '/project/src/app.ts',
@@ -68,63 +68,63 @@ describe('vite source-location plugin', () => {
     expect(result).toBeUndefined()
   })
 
-  it('uses relative path from root', () => {
+  it('uses relative path from root', async () => {
     const code = `log.info({ action: 'test' })`
     const result = defined(
-      sourceLocationTransform(code, '/my/project/src/routes/checkout.ts', '/my/project'),
+      await sourceLocationTransform(code, '/my/project/src/routes/checkout.ts', '/my/project'),
       'source-location result',
     )
     expect(result.code).toContain('src/routes/checkout.ts:1')
   })
 
-  it('injects into empty object', () => {
+  it('injects into empty object', async () => {
     const code = `log.info({})`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('src/app.ts:1')
   })
 
-  it('injects into multiline object', () => {
+  it('injects into multiline object', async () => {
     const code = `log.info({\n  action: 'login',\n  user: 'alice'\n})`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
   })
 
-  it('injects into object with trailing comma', () => {
+  it('injects into object with trailing comma', async () => {
     const code = `log.info({ action: 'login', })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
   })
 
-  it('injects into object with nested objects', () => {
+  it('injects into object with nested objects', async () => {
     const code = `log.info({ user: { id: 1, name: 'alice' } })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source')
     expect(result.code).toContain('user')
   })
 
-  it('skips object that already has __source', () => {
+  it('skips object that already has __source', async () => {
     const code = `log.info({ __source: 'custom', action: 'test' })`
-    const result = sourceLocationTransform(code)
+    const result = await sourceLocationTransform(code)
     expect(result).toBeUndefined()
   })
 
-  it('uses JSON.stringify for path escaping', () => {
+  it('uses JSON.stringify for path escaping', async () => {
     const code = `log.info({ action: 'test' })`
-    const result = defined(sourceLocationTransform(code), 'source-location result')
+    const result = defined(await sourceLocationTransform(code), 'source-location result')
     expect(result.code).toContain('__source: "src/app.ts:1"')
   })
 
-  it('defaults to dev-only when enabled is undefined', () => {
+  it('defaults to dev-only when enabled is undefined', async () => {
     const plugin = createSourceLocationPlugin()
     const code = `log.info({ action: 'test' })`
     const id = '/project/src/app.ts'
 
-    const devResult = runPluginTransform(plugin, code, id, { config: { command: 'serve', root: '/project' } })
+    const devResult = await runPluginTransform(plugin, code, id, { config: { command: 'serve', root: '/project' } })
     expect(devResult).toBeTruthy()
 
-    callConfigResolved(plugin, { command: 'build', root: '/project' })
-    const buildResult = runPluginTransform(plugin, code, id)
+    await callConfigResolved(plugin, { command: 'build', root: '/project' })
+    const buildResult = await runPluginTransform(plugin, code, id)
     expect(buildResult).toBeUndefined()
   })
 })

--- a/packages/evlog/test/vite/strip.test.ts
+++ b/packages/evlog/test/vite/strip.test.ts
@@ -1,62 +1,46 @@
-import { parse } from 'acorn'
 import { describe, expect, it } from 'vitest'
+import type { LogLevel } from '../../src/types'
+import { defined } from '../helpers/defined'
+import { callConfigResolved, createParseTransformContext, getPluginHook, runPluginTransform } from '../helpers/vite'
 import { createStripPlugin } from '../../src/vite/strip'
 
-function createTransformContext() {
-  return {
-    parse(code: string) {
-      return parse(code, { ecmaVersion: 'latest', sourceType: 'module' })
-    },
-  }
-}
-
-function stripTransform(code: string, levels: string[], id = 'src/app.ts') {
-  const plugin = createStripPlugin(levels as any)
-  const { configResolved } = (plugin as any)
-  if (configResolved) configResolved({ command: 'build' })
-  const ctx = createTransformContext()
-  const t = (plugin as any).transform
-  const handler = typeof t === 'function' ? t : t.handler
-  return handler.call(ctx, code, id)
+function stripTransform(code: string, levels: LogLevel[], id = 'src/app.ts') {
+  const plugin = createStripPlugin(levels)
+  return runPluginTransform(plugin, code, id, { config: { command: 'build' } })
 }
 
 describe('vite strip plugin', () => {
   it('removes log.debug() expression statements', () => {
     const code = `log.debug('cache', 'hit')\nconst x = 1`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('const x = 1')
   })
 
   it('removes log.debug() with object argument', () => {
     const code = `log.debug({ action: 'cache_hit', ratio: 0.95 })\nconst x = 1`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('const x = 1')
   })
 
   it('replaces log.debug() in assignment with void 0', () => {
     const code = `const x = log.debug('test', 'msg')`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
   it('does not strip levels not in the list', () => {
     const code = `log.info('app', 'started')\nlog.debug('cache', 'miss')`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('log.info')
     expect(result.code).not.toContain('log.debug')
   })
 
   it('strips multiple levels', () => {
     const code = `log.debug('a', 'b')\nlog.info('c', 'd')\nlog.warn('e', 'f')`
-    const result = stripTransform(code, ['debug', 'info'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug', 'info']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).not.toContain('log.info')
     expect(result.code).toContain('log.warn')
@@ -82,13 +66,12 @@ describe('vite strip plugin', () => {
 
   it('handles empty levels array', () => {
     const plugin = createStripPlugin([])
-    expect((plugin as any).transform).toBeUndefined()
+    expect(plugin.transform).toBeUndefined()
   })
 
   it('preserves surrounding code', () => {
     const code = `const a = 1\nlog.debug('x', 'y')\nconst b = 2`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('const a = 1')
     expect(result.code).toContain('const b = 2')
     expect(result.code).not.toContain('log.debug')
@@ -96,26 +79,22 @@ describe('vite strip plugin', () => {
 
   it('generates sourcemap', () => {
     const code = `log.debug('test', 'msg')\nconst x = 1`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.map).toBeTruthy()
   })
 
   it('does not strip in dev mode', () => {
-    const plugin = createStripPlugin(['debug'] as any)
-    const { configResolved } = (plugin as any)
-    configResolved({ command: 'serve' })
-    const ctx = createTransformContext()
+    const plugin = createStripPlugin(['debug'])
+    callConfigResolved(plugin, { command: 'serve' })
+    const handler = getPluginHook<(code: string, id: string) => unknown>(plugin, 'transform')
     const code = `log.debug('test', 'msg')\nconst x = 1`
-    const { handler } = (plugin as any).transform
-    const result = handler.call(ctx, code, 'src/app.ts')
+    const result = handler.call(createParseTransformContext() as never, code, 'src/app.ts')
     expect(result).toBeUndefined()
   })
 
   it('replaces log.debug() in ternary with void 0', () => {
     const code = `const x = cond ? log.debug('a') : 'fallback'`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('\'fallback\'')
@@ -123,8 +102,7 @@ describe('vite strip plugin', () => {
 
   it('replaces log.debug() in comma expression with void 0', () => {
     const code = `const x = (log.debug('a'), 42)`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).toContain('42')
     expect(result.code).not.toContain('log.debug')
@@ -132,32 +110,28 @@ describe('vite strip plugin', () => {
 
   it('replaces log.debug() in return statement with void 0', () => {
     const code = `function foo() { return log.debug('x') }`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('return void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
   it('replaces log.debug() in arrow function body with void 0', () => {
     const code = `const fn = () => log.debug('x')`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
   it('replaces log.debug() as function argument with void 0', () => {
     const code = `foo(log.debug('x'))`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('foo(void 0)')
     expect(result.code).not.toContain('log.debug')
   })
 
   it('replaces log.debug() in braceless if body with empty statement', () => {
     const code = `if (cond) log.debug('x')\nconst y = 1`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('if (cond) ;')
     expect(result.code).toContain('const y = 1')
     expect(result.code).not.toContain('log.debug')
@@ -165,8 +139,7 @@ describe('vite strip plugin', () => {
 
   it('replaces log.debug() in braceless while body with empty statement', () => {
     const code = `while (running) log.debug('tick')`
-    const result = stripTransform(code, ['debug'])
-    expect(result).toBeTruthy()
+    const result = defined(stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('while (running) ;')
     expect(result.code).not.toContain('log.debug')
   })

--- a/packages/evlog/test/vite/strip.test.ts
+++ b/packages/evlog/test/vite/strip.test.ts
@@ -4,63 +4,63 @@ import { defined } from '../helpers/defined'
 import { callConfigResolved, createParseTransformContext, getPluginHook, runPluginTransform } from '../helpers/vite'
 import { createStripPlugin } from '../../src/vite/strip'
 
-function stripTransform(code: string, levels: LogLevel[], id = 'src/app.ts') {
+async function stripTransform(code: string, levels: LogLevel[], id = 'src/app.ts') {
   const plugin = createStripPlugin(levels)
-  return runPluginTransform(plugin, code, id, { config: { command: 'build' } })
+  return await runPluginTransform(plugin, code, id, { config: { command: 'build' } })
 }
 
 describe('vite strip plugin', () => {
-  it('removes log.debug() expression statements', () => {
+  it('removes log.debug() expression statements', async () => {
     const code = `log.debug('cache', 'hit')\nconst x = 1`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('const x = 1')
   })
 
-  it('removes log.debug() with object argument', () => {
+  it('removes log.debug() with object argument', async () => {
     const code = `log.debug({ action: 'cache_hit', ratio: 0.95 })\nconst x = 1`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('const x = 1')
   })
 
-  it('replaces log.debug() in assignment with void 0', () => {
+  it('replaces log.debug() in assignment with void 0', async () => {
     const code = `const x = log.debug('test', 'msg')`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('does not strip levels not in the list', () => {
+  it('does not strip levels not in the list', async () => {
     const code = `log.info('app', 'started')\nlog.debug('cache', 'miss')`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('log.info')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('strips multiple levels', () => {
+  it('strips multiple levels', async () => {
     const code = `log.debug('a', 'b')\nlog.info('c', 'd')\nlog.warn('e', 'f')`
-    const result = defined(stripTransform(code, ['debug', 'info']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug', 'info']), 'strip result')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).not.toContain('log.info')
     expect(result.code).toContain('log.warn')
   })
 
-  it('returns undefined when no matching calls found', () => {
+  it('returns undefined when no matching calls found', async () => {
     const code = `log.info('app', 'started')\nconst x = 1`
-    const result = stripTransform(code, ['debug'])
+    const result = await stripTransform(code, ['debug'])
     expect(result).toBeUndefined()
   })
 
-  it('skips node_modules files', () => {
+  it('skips node_modules files', async () => {
     const code = `log.debug('test', 'msg')`
-    const result = stripTransform(code, ['debug'], 'node_modules/lib/index.js')
+    const result = await stripTransform(code, ['debug'], 'node_modules/lib/index.js')
     expect(result).toBeUndefined()
   })
 
-  it('skips virtual modules', () => {
+  it('skips virtual modules', async () => {
     const code = `log.debug('test', 'msg')`
-    const result = stripTransform(code, ['debug'], '\0virtual:something')
+    const result = await stripTransform(code, ['debug'], '\0virtual:something')
     expect(result).toBeUndefined()
   })
 
@@ -69,77 +69,77 @@ describe('vite strip plugin', () => {
     expect(plugin.transform).toBeUndefined()
   })
 
-  it('preserves surrounding code', () => {
+  it('preserves surrounding code', async () => {
     const code = `const a = 1\nlog.debug('x', 'y')\nconst b = 2`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('const a = 1')
     expect(result.code).toContain('const b = 2')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('generates sourcemap', () => {
+  it('generates sourcemap', async () => {
     const code = `log.debug('test', 'msg')\nconst x = 1`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.map).toBeTruthy()
   })
 
-  it('does not strip in dev mode', () => {
+  it('does not strip in dev mode', async () => {
     const plugin = createStripPlugin(['debug'])
-    callConfigResolved(plugin, { command: 'serve' })
+    await callConfigResolved(plugin, { command: 'serve' })
     const handler = getPluginHook<(code: string, id: string) => unknown>(plugin, 'transform')
     const code = `log.debug('test', 'msg')\nconst x = 1`
     const result = handler.call(createParseTransformContext() as never, code, 'src/app.ts')
     expect(result).toBeUndefined()
   })
 
-  it('replaces log.debug() in ternary with void 0', () => {
+  it('replaces log.debug() in ternary with void 0', async () => {
     const code = `const x = cond ? log.debug('a') : 'fallback'`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
     expect(result.code).toContain('\'fallback\'')
   })
 
-  it('replaces log.debug() in comma expression with void 0', () => {
+  it('replaces log.debug() in comma expression with void 0', async () => {
     const code = `const x = (log.debug('a'), 42)`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).toContain('42')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('replaces log.debug() in return statement with void 0', () => {
+  it('replaces log.debug() in return statement with void 0', async () => {
     const code = `function foo() { return log.debug('x') }`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('return void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('replaces log.debug() in arrow function body with void 0', () => {
+  it('replaces log.debug() in arrow function body with void 0', async () => {
     const code = `const fn = () => log.debug('x')`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('void 0')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('replaces log.debug() as function argument with void 0', () => {
+  it('replaces log.debug() as function argument with void 0', async () => {
     const code = `foo(log.debug('x'))`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('foo(void 0)')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('replaces log.debug() in braceless if body with empty statement', () => {
+  it('replaces log.debug() in braceless if body with empty statement', async () => {
     const code = `if (cond) log.debug('x')\nconst y = 1`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('if (cond) ;')
     expect(result.code).toContain('const y = 1')
     expect(result.code).not.toContain('log.debug')
   })
 
-  it('replaces log.debug() in braceless while body with empty statement', () => {
+  it('replaces log.debug() in braceless while body with empty statement', async () => {
     const code = `while (running) log.debug('tick')`
-    const result = defined(stripTransform(code, ['debug']), 'strip result')
+    const result = defined(await stripTransform(code, ['debug']), 'strip result')
     expect(result.code).toContain('while (running) ;')
     expect(result.code).not.toContain('log.debug')
   })

--- a/packages/nuxthub/src/config.ts
+++ b/packages/nuxthub/src/config.ts
@@ -1,0 +1,16 @@
+/** evlog module options read by @evlog/nuxthub (retention augments evlog/nuxt). */
+export interface EvlogHubConfig {
+  retention?: string
+}
+
+export interface NuxtOptionsWithEvlog {
+  evlog?: EvlogHubConfig
+}
+
+export interface RuntimeConfigWithEvlog {
+  evlog?: EvlogHubConfig
+}
+
+export function getNuxtEvlogConfig(nuxt: { options: NuxtOptionsWithEvlog }): EvlogHubConfig {
+  return nuxt.options.evlog ?? {}
+}

--- a/packages/nuxthub/src/module.ts
+++ b/packages/nuxthub/src/module.ts
@@ -5,6 +5,12 @@ import { consola } from 'consola'
 import type { NitroConfig } from 'nitropack'
 import { name, version } from '../package.json'
 import { retentionToCron } from './runtime/utils/retention'
+import { getNuxtEvlogConfig } from './config'
+
+interface VercelConfig {
+  crons?: Array<{ path: string, schedule: string }>
+  [key: string]: unknown
+}
 
 export default defineNuxtModule({
   meta: {
@@ -19,19 +25,20 @@ export default defineNuxtModule({
     if (typeof shouldSetup !== 'boolean' || !shouldSetup) return
 
     const vercelJsonPath = resolve(nuxt.options.rootDir, 'vercel.json')
-    let config: Record<string, any> = {}
+    let config: VercelConfig = {}
     if (existsSync(vercelJsonPath)) {
-      config = JSON.parse(await fsp.readFile(vercelJsonPath, 'utf-8'))
+      config = JSON.parse(await fsp.readFile(vercelJsonPath, 'utf-8')) as VercelConfig
     }
 
-    const evlogConfig = (nuxt.options as any).evlog || {}
+    const evlogConfig = getNuxtEvlogConfig(nuxt)
     const retention = evlogConfig.retention ?? '7d'
     const cron = retentionToCron(retention)
 
     const crons: Array<{ path: string, schedule: string }> = config.crons || []
     const existing = crons.findIndex(c => c.path === '/api/_cron/evlog-cleanup')
     if (existing >= 0) {
-      crons[existing]!.schedule = cron
+      const entry = crons[existing]
+      if (entry) entry.schedule = cron
     } else {
       crons.push({ path: '/api/_cron/evlog-cleanup', schedule: cron })
     }
@@ -65,7 +72,7 @@ export default defineNuxtModule({
     })
 
     // Read nuxthub options from evlog config key
-    const evlogConfig = (nuxt.options as any).evlog || {}
+    const evlogConfig = getNuxtEvlogConfig(nuxt)
     const retention: string = evlogConfig.retention ?? '7d'
 
     // Extend NuxtHub DB schema with dialect-specific evlog_events table

--- a/packages/nuxthub/src/module.ts
+++ b/packages/nuxthub/src/module.ts
@@ -34,7 +34,7 @@ export default defineNuxtModule({
     const retention = evlogConfig.retention ?? '7d'
     const cron = retentionToCron(retention)
 
-    const crons: Array<{ path: string, schedule: string }> = config.crons || []
+    const crons: Array<{ path: string, schedule: string }> = Array.isArray(config.crons) ? config.crons : []
     const existing = crons.findIndex(c => c.path === '/api/_cron/evlog-cleanup')
     if (existing >= 0) {
       const entry = crons[existing]

--- a/packages/nuxthub/src/runtime/drain.ts
+++ b/packages/nuxthub/src/runtime/drain.ts
@@ -5,11 +5,18 @@ import { db, schema } from '@nuxthub/db'
 
 type EventRow = typeof schema.evlogEvents.$inferInsert
 
+function coalesceString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
+
 function parseDurationMs(event: WideEvent): number | null {
   if (typeof event.durationMs === 'number') return event.durationMs
   if (typeof event.duration === 'number') return event.duration
   if (typeof event.duration === 'string') {
-    const str = event.duration as string
+    const str = event.duration
     const msMatch = str.match(/^([\d.]+)\s*ms$/)
     if (msMatch) return Math.round(Number.parseFloat(msMatch[1]))
     const sMatch = str.match(/^([\d.]+)\s*s$/)
@@ -64,12 +71,12 @@ function extractRow(ctx: DrainContext): EventRow {
     level: event.level,
     service: event.service,
     environment: event.environment,
-    method: (request?.method ?? event.method as string) || null,
-    path: (request?.path ?? event.path as string) || null,
+    method: coalesceString(request?.method, event.method),
+    path: coalesceString(request?.path, event.path),
     status: typeof event.status === 'number' ? event.status : null,
     durationMs: parseDurationMs(event),
-    requestId: (request?.requestId ?? event.requestId as string) || null,
-    source: (event.source as string) || null,
+    requestId: coalesceString(request?.requestId, event.requestId),
+    source: typeof event.source === 'string' && event.source.length > 0 ? event.source : null,
     error: errorJson,
     data: Object.keys(data).length > 0 ? JSON.stringify(data) : null,
     createdAt: new Date().toISOString(),
@@ -88,9 +95,9 @@ const RETRYABLE_CODES = new Set([
 ])
 
 function isRetryable(error: unknown): boolean {
-  if (error instanceof Error) {
-    const cause = (error as any).cause
-    if (cause && typeof cause.code === 'string') {
+  if (error instanceof Error && 'cause' in error) {
+    const { cause } = error
+    if (cause && typeof cause === 'object' && 'code' in cause && typeof cause.code === 'string') {
       return RETRYABLE_CODES.has(cause.code)
     }
   }

--- a/packages/nuxthub/src/runtime/tasks/evlog-cleanup.ts
+++ b/packages/nuxthub/src/runtime/tasks/evlog-cleanup.ts
@@ -3,6 +3,7 @@ import { lt } from 'drizzle-orm'
 // @ts-expect-error nuxthub/db is a virtual module provided by @nuxthub/core
 import { db, schema } from '@nuxthub/db'
 import { parseRetention } from '../utils/retention'
+import type { RuntimeConfigWithEvlog } from '../../config'
 
 export default defineTask({
   meta: {
@@ -10,8 +11,8 @@ export default defineTask({
     description: 'Clean up expired evlog events based on retention policy',
   },
   async run() {
-    const config = useRuntimeConfig()
-    const retention = (config as any).evlog?.retention ?? '7d'
+    const config = useRuntimeConfig() as RuntimeConfigWithEvlog
+    const retention = config.evlog?.retention ?? '7d'
     const { totalMs } = parseRetention(retention)
     const cutoff = new Date(Date.now() - totalMs).toISOString()
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety and error handling across apps and server routes; various UI null/undefined issues fixed.
* **Content & SEO**
  * More robust SEO metadata and Open Graph image generation; sitemap path/lastmod normalization.
* **UI / Docs**
  * Safer docs navigation rendering and improved demo/terminal behavior; stream/playground and chat UIs render more reliably.
* **Tests & Tooling**
  * Extensive test hardening and new helpers for more reliable assertions.
* **Performance**
  * Benchmark baselines updated to reflect measured size changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->