### PR TITLE
feat: improve audit mocks, types, and catalog metadata

### DIFF
--- a/.changeset/audit-catalog-metadata.md
+++ b/.changeset/audit-catalog-metadata.md
@@ -1,0 +1,5 @@
+---
+'evlog': minor
+---
+
+Add optional catalog metadata on `defineAuditCatalog` and `defineAuditAction` entries: `description`, `severity`, `requiresChanges`, `requiresReason`, and `redactPaths`. Metadata is exposed on each factory for introspection, docs, and review tooling.

--- a/.changeset/audit-quick-wins.md
+++ b/.changeset/audit-quick-wins.md
@@ -1,0 +1,5 @@
+---
+'evlog': patch
+---
+
+Fix `mockAudit()` to capture in-request `log.audit()` events on emit (with finalized `idempotencyKey`). Add `assertAudit()` matcher on the mock result. Type `AuditFields.changes.patch` via new `AuditChanges` export.

--- a/apps/docs/content/2.learn/8.catalogs.md
+++ b/apps/docs/content/2.learn/8.catalogs.md
@@ -89,8 +89,8 @@ export const errors = defineErrorCatalog('app', {
 import { defineAuditCatalog } from 'evlog'
 
 export const audit = defineAuditCatalog('app', {
-  USER_LOGIN: { target: 'user' },
-  USER_DELETE: { target: 'user' },
+  USER_LOGIN: { target: 'user', severity: 'medium' },
+  USER_DELETE: { target: 'user', severity: 'high', requiresChanges: true, requiresReason: true },
 })
 ```
 ::
@@ -420,7 +420,9 @@ expect(err.code).toBe('billing.PAYMENT_DECLINED')          // ✗ string literal
 | `defineError(code, options)` | factory | Standalone single-error factory. No prefix derivation. |
 | `defineErrorCatalog(prefix, map)` | factory | Bundle of typed errors sharing a prefix. |
 | `defineAuditAction(action, opts?)` | factory | Standalone single-action audit factory. |
-| `defineAuditCatalog(prefix, map)` | factory | Bundle of typed audit actions sharing a prefix. |
+| `defineAuditCatalog(prefix, map)` | factory | Bundle of typed audit actions sharing a prefix. Each entry accepts `target`, `description`, `severity`, `requiresChanges`, `requiresReason`, `redactPaths`. |
+| `AuditCatalogEntry` | type | Metadata shape for a single catalog entry (alias of `AuditActionDefinition`). |
+| `AuditSeverity` | type | `'low' \| 'medium' \| 'high' \| 'critical'`. |
 | `RegisteredErrorCatalogs` | interface | Augmentable registry of error catalogs. |
 | `RegisteredAuditCatalogs` | interface | Augmentable registry of audit catalogs. |
 | `ErrorCode` | type | Union of all registered error codes. |

--- a/apps/docs/content/4.use-cases/4.audit/02.schema.md
+++ b/apps/docs/content/4.use-cases/4.audit/02.schema.md
@@ -38,7 +38,7 @@ interface AuditFields {
   target?: { type: string, id: string, [k: string]: unknown }
   outcome: 'success' | 'failure' | 'denied'
   reason?: string
-  changes?: { before?: unknown, after?: unknown }
+  changes?: { before?: unknown, after?: unknown, patch?: AuditPatchOp[] }
   causationId?: string                    // ID of the action that caused this one
   correlationId?: string                  // Shared by every action in one operation
   version?: number                        // Defaults to 1

--- a/apps/docs/content/4.use-cases/4.audit/03.recording.md
+++ b/apps/docs/content/4.use-cases/4.audit/03.recording.md
@@ -146,10 +146,16 @@ For more than a handful of actions, group them in a typed **catalog** instead of
 import { defineAuditCatalog } from 'evlog'
 
 export const billingAudit = defineAuditCatalog('billing', {
-  INVOICE_REFUND:      { target: 'invoice' },
+  INVOICE_REFUND: {
+    target: 'invoice',
+    severity: 'high',
+    requiresChanges: true,
+    description: 'Refund an invoice to the customer',
+    redactPaths: ['cardNumber'],
+  },
   INVOICE_CREATE:      { target: 'invoice' },
-  INVOICE_VOID:        { target: 'invoice' },
-  SUBSCRIPTION_CANCEL: { target: 'subscription' },
+  INVOICE_VOID:        { target: 'invoice', severity: 'high', requiresReason: true },
+  SUBSCRIPTION_CANCEL: { target: 'subscription', severity: 'high' },
 })
 ```
 ```typescript [server/api/refund.post.ts]
@@ -163,13 +169,25 @@ log.audit(billingAudit.INVOICE_REFUND({
 ```
 ::
 
-Each entry produces a thin wrapper around `defineAuditAction` (target type is fixed at definition time, action name is auto-prefixed). Catalog metadata is exposed on `_actions` and `_prefix`:
+Each entry produces a thin wrapper around `defineAuditAction` (target type is fixed at definition time, action name is auto-prefixed). Catalog metadata is exposed on each factory and on `_actions` / `_prefix`:
 
 ```typescript
-billingAudit.INVOICE_REFUND.action // 'billing.INVOICE_REFUND' (literal type)
-billingAudit.INVOICE_REFUND.target // 'invoice'
-billingAudit._actions              // readonly ['billing.INVOICE_REFUND', ...]
+billingAudit.INVOICE_REFUND.action           // 'billing.INVOICE_REFUND' (literal type)
+billingAudit.INVOICE_REFUND.target           // 'invoice'
+billingAudit.INVOICE_REFUND.severity         // 'high'
+billingAudit.INVOICE_REFUND.requiresChanges // true
+billingAudit.INVOICE_REFUND.redactPaths      // ['cardNumber']
+billingAudit._actions                        // readonly ['billing.INVOICE_REFUND', ...]
 ```
+
+| Entry field | Purpose |
+|---|---|
+| `target` | Default `target.type` injected at call sites |
+| `description` | Human-readable label for docs, SIEM rules, review tooling |
+| `severity` | `'low' \| 'medium' \| 'high' \| 'critical'` — alerting and review priority |
+| `requiresChanges` | Document that callers should attach `changes` (e.g. via `auditDiff`) |
+| `requiresReason` | Document that callers should attach `reason` (especially denials) |
+| `redactPaths` | Default paths for `auditDiff({ redactPaths: [...] })` on this action |
 
 ### `defineAuditAction` vs `defineAuditCatalog` — when to choose
 

--- a/apps/docs/content/4.use-cases/4.audit/06.recipes.md
+++ b/apps/docs/content/4.use-cases/4.audit/06.recipes.md
@@ -109,7 +109,7 @@ The deterministic `idempotencyKey` makes retries safe — duplicate inserts coll
 
 ## Testing audits
 
-`mockAudit()` captures every audit event emitted during a test:
+`mockAudit()` captures every audit event on emit — from standalone `audit()`, `log.audit()`, and `log.set({ audit })`:
 
 ```typescript
 import { mockAudit } from 'evlog'
@@ -119,16 +119,17 @@ it('refunds the invoice and records an audit', async () => {
 
   await refundInvoice({ id: 'inv_889' }, { actor: { type: 'user', id: 'u1' } })
 
-  expect(captured.events).toHaveLength(1)
-  expect(captured.toIncludeAuditOf({
+  captured.assertAudit({
     action: 'invoice.refund',
     target: { type: 'invoice', id: 'inv_889' },
     outcome: 'success',
-  })).toBe(true)
+  })
 
   captured.restore()
 })
 ```
+
+Prefer `assertAudit()` when a missing audit should fail the test with a readable message. Use `toIncludeAuditOf()` when you need a boolean inside `expect(...)`.
 
 Always call `captured.restore()` in an `afterEach` (or wrap with a fixture) so a failing assertion never leaks into the next test.
 
@@ -144,7 +145,7 @@ Always call `captured.restore()` in an `afterEach` (or wrap with a fixture) so a
 | `audit(fields)` | function | Standalone for scripts / jobs |
 | `withAudit({ action, target })(fn)` | wrapper | Auto-emit success / failure / denied |
 | `auditDiff(before, after)` | helper | Redact-aware JSON Patch for `changes` |
-| `mockAudit()` | test util | Capture + assert audits in tests |
+| `mockAudit()` | test util | Capture audits on emit; `assertAudit()` or `toIncludeAuditOf()` |
 | `auditEnricher(opts?)` | enricher | Auto-fill request / runtime / tenant context |
 | `auditOnly(drain, { await? })` | wrapper | Routes only events with an `audit` field |
 | `signed(drain, opts)` | wrapper | Generic integrity wrapper (hmac / hash-chain) |

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -23,7 +23,7 @@ When you already know the system is wired and just need to remember the API:
 | Auto-record success / failure / denied for a function | `withAudit({ action, target }, fn)` |
 | Recording a state change | add `changes: auditDiff(before, after)` |
 | Centralised typed action vocabulary | `defineAuditAction('invoice.refund', { target: 'invoice' })` |
-| Asserting audits in tests | `mockAudit()` |
+| Asserting audits in tests | `mockAudit()` — `assertAudit()` or `toIncludeAuditOf()` |
 
 `AuditFields` schema (always provide `action`, `actor`, `outcome`; `target` strongly recommended; the rest is filled in for you):
 
@@ -34,7 +34,7 @@ interface AuditFields {
   outcome: 'success' | 'failure' | 'denied'
   target?: { type: string, id: string, [k: string]: unknown }
   reason?: string
-  changes?: { before?: unknown, after?: unknown } | AuditPatchOp[]
+  changes?: { before?: unknown, after?: unknown, patch?: AuditPatchOp[] }
   causationId?: string
   correlationId?: string
   version?: number                                // defaults to AUDIT_SCHEMA_VERSION
@@ -444,6 +444,6 @@ Then map each finding to the relevant step in the buildout above (e.g. P0 → St
 ## Reference
 
 - Per-framework wiring (Hono, Express, Next.js, standalone): [`references/framework-wiring.md`](references/framework-wiring.md)
-- Docs page: [`apps/docs/content/2.logging/7.audit.md`](../../../apps/docs/content/2.logging/7.audit.md)
+- Docs: [Audit logs overview](https://www.evlog.dev/use-cases/audit/overview) — source at [`apps/docs/content/4.use-cases/4.audit/`](../../../apps/docs/content/4.use-cases/4.audit/)
 - Source: [`packages/evlog/src/audit.ts`](../../../packages/evlog/src/audit.ts)
-- Tests: [`packages/evlog/test/audit.test.ts`](../../../packages/evlog/test/audit.test.ts)
+- Tests: [`packages/evlog/test/core/audit.test.ts`](../../../packages/evlog/test/core/audit.test.ts)

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -27,6 +27,22 @@ Review and improve logging patterns in TypeScript/JavaScript codebases. Transfor
 | Error handling          | [references/structured-errors.md](references/structured-errors.md) |
 | Code review checklist   | [references/code-review.md](references/code-review.md)             |
 | Drain pipeline          | [references/drain-pipeline.md](references/drain-pipeline.md)       |
+| Audit logs              | [build-audit-logs](../build-audit-logs/SKILL.md) skill + [docs](https://www.evlog.dev/use-cases/audit/overview) |
+
+## Audit logs
+
+For security-sensitive actions (auth, billing, admin, data export), use evlog's audit layer — a typed `audit` field on wide events, not a parallel logger. See the **`build-audit-logs`** skill for end-to-end setup (`log.audit`, `withAudit`, denials, `auditEnricher`, `auditOnly`, `signed`, `mockAudit`).
+
+```typescript
+log.audit({
+  action: 'invoice.refund',
+  actor: { type: 'user', id: user.id },
+  target: { type: 'invoice', id: invoice.id },
+  outcome: 'success',
+})
+```
+
+Docs: https://www.evlog.dev/use-cases/audit/overview
 
 ## Installation
 

--- a/apps/playground/server/utils/audit.ts
+++ b/apps/playground/server/utils/audit.ts
@@ -8,14 +8,20 @@ import { defineAuditCatalog } from 'evlog'
  * and the `target.type` is auto-injected when set on the catalog entry.
  */
 export const billingAudit = defineAuditCatalog('billing', {
-  INVOICE_REFUND: { target: 'invoice' },
-  INVOICE_CREATE: { target: 'invoice' },
-  INVOICE_VOID: { target: 'invoice' },
-  SUBSCRIPTION_CANCEL: { target: 'subscription' },
+  INVOICE_REFUND: {
+    target: 'invoice',
+    severity: 'high',
+    requiresChanges: true,
+    description: 'Refund an invoice to the customer',
+    redactPaths: ['cardNumber', 'cvv'],
+  },
+  INVOICE_CREATE: { target: 'invoice', severity: 'medium' },
+  INVOICE_VOID: { target: 'invoice', severity: 'high', requiresReason: true },
+  SUBSCRIPTION_CANCEL: { target: 'subscription', severity: 'high' },
   /**
    * No `target` set → call sites can pass any target shape (or none).
    */
-  PASSWORD_CHANGE: {},
+  PASSWORD_CHANGE: { severity: 'high', requiresChanges: true, redactPaths: ['password'] },
 })
 
 /**

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -1,4 +1,4 @@
-import type { AuditActor, AuditFields, AuditTarget, DrainContext, EnrichContext, FieldContext, RedactConfig, RequestLogger, WideEvent } from './types'
+import type { AuditActor, AuditActionDefinition, AuditFields, AuditPatchOp, AuditTarget, DrainContext, EnrichContext, FieldContext, RedactConfig, RequestLogger, WideEvent } from './types'
 import { createLogger } from './logger'
 import { getHeader as getSharedHeader } from './shared/headers'
 
@@ -206,9 +206,7 @@ export interface AuditMethod<T extends object = Record<string, unknown>> {
 export function audit(input: AuditInput): WideEvent | null {
   const fields = buildAuditFields(input)
   const logger = createLogger({ audit: fields })
-  const wide = logger.emit({ _forceKeep: true } as FieldContext<Record<string, unknown>> & { _forceKeep?: boolean })
-  _testCollector?.(fields, wide)
-  return wide
+  return logger.emit({ _forceKeep: true } as FieldContext<Record<string, unknown>> & { _forceKeep?: boolean })
 }
 
 /**
@@ -388,12 +386,7 @@ export function auditDiff(
   return result
 }
 
-/** Single JSON Patch operation produced by {@link auditDiff}. */
-export interface AuditPatchOp {
-  op: 'add' | 'remove' | 'replace'
-  path: string
-  value?: unknown
-}
+export type { AuditPatchOp } from './types'
 
 /** Options for {@link auditDiff}. */
 export interface AuditDiffOptions {
@@ -407,16 +400,25 @@ export interface AuditDiffOptions {
   includeAfter?: boolean
 }
 
+/** Options for {@link defineAuditAction}. Same shape as {@link AuditCatalogEntry}. */
+export type DefineAuditActionOptions = AuditActionDefinition
+
 /**
- * Define a typed audit action with an optional fixed target type.
+ * Define a typed audit action with optional fixed target type and catalog metadata.
  *
  * Returns a curried helper that fills in the action name (and target shape
  * if provided) so call sites stay terse and the action set is discoverable
- * in one place.
+ * in one place. Metadata (`description`, `severity`, `requiresChanges`, …)
+ * is exposed on the factory for introspection, docs, and review tooling.
  *
  * @example
  * ```ts
- * const refund = defineAuditAction('invoice.refund', { target: 'invoice' })
+ * const refund = defineAuditAction('invoice.refund', {
+ *   target: 'invoice',
+ *   severity: 'high',
+ *   requiresChanges: true,
+ *   redactPaths: ['cardNumber'],
+ * })
  *
  * log.audit(refund({
  *   actor: { type: 'user', id: user.id },
@@ -425,12 +427,12 @@ export interface AuditDiffOptions {
  * }))
  * ```
  */
-export function defineAuditAction<TTargetType extends string | undefined = undefined>(
-  action: string,
-  options?: { target?: TTargetType },
-): DefinedAuditAction<TTargetType> {
+export function defineAuditAction<
+  const TAction extends string,
+  const TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
+>(action: TAction, options?: TOptions): DefinedAuditAction<TAction, TOptions> {
   const targetType = options?.target
-  return (input) => {
+  const factory = ((input) => {
     const merged: AuditInput = {
       ...(input as AuditInput),
       action,
@@ -439,32 +441,55 @@ export function defineAuditAction<TTargetType extends string | undefined = undef
       merged.target = { ...input.target, type: targetType } as AuditTarget
     }
     return merged
-  }
+  }) as DefinedAuditAction<TAction, TOptions>
+
+  Object.defineProperties(factory, {
+    action: { value: action, enumerable: true },
+    target: { value: options?.target, enumerable: true },
+    description: { value: options?.description, enumerable: true },
+    severity: { value: options?.severity, enumerable: true },
+    requiresChanges: { value: options?.requiresChanges, enumerable: true },
+    requiresReason: { value: options?.requiresReason, enumerable: true },
+    redactPaths: { value: options?.redactPaths, enumerable: true },
+  })
+
+  return factory
 }
 
 /**
  * Return type of {@link defineAuditAction}. Accepts a partial input (no
  * `action`, target type pre-filled when provided).
  */
-export type DefinedAuditAction<TTargetType extends string | undefined> = (
-  input: TTargetType extends string
-    ? Omit<AuditInput, 'action' | 'target'> & { target?: Omit<AuditTarget, 'type'> & { type?: TTargetType } }
-    : Omit<AuditInput, 'action'>,
-) => AuditInput
+export type DefinedAuditAction<
+  TAction extends string = string,
+  TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
+> =
+  & ((
+    input: TOptions['target'] extends string
+      ? Omit<AuditInput, 'action' | 'target'> & { target?: Omit<AuditTarget, 'type'> & { type?: TOptions['target'] } }
+      : Omit<AuditInput, 'action'>,
+  ) => AuditInput)
+  & {
+    readonly action: TAction
+    readonly target: TOptions['target']
+    readonly description: TOptions['description']
+    readonly severity: TOptions['severity']
+    readonly requiresChanges: TOptions['requiresChanges']
+    readonly requiresReason: TOptions['requiresReason']
+    readonly redactPaths: TOptions['redactPaths']
+  }
 
 /**
  * Test helper that captures every audit event emitted while it is active.
  *
- * Returns `{ events, restore, expect }`:
+ * Returns `{ events, restore, toIncludeAuditOf, assertAudit }`:
  * - `events` — live array of captured `AuditFields`, populated as audits fire.
  * - `restore()` — uninstall the collector. Call from `afterEach()`.
- * - `expect.toIncludeAuditOf(matcher)` — assertion helper used inside `expect`
- *   blocks, returns `true` if at least one captured event matches.
+ * - `toIncludeAuditOf(matcher)` — returns `true` if at least one captured event matches.
+ * - `assertAudit(matcher)` — returns the matched event or throws with a readable summary.
  *
- * Only captures audits going through `log.audit()` and the standalone
- * `audit()` function. Events emitted via raw `log.set({ audit })` skip the
- * collector by design — wrap them with `log.audit()` to make them visible to
- * tests.
+ * Captures audits on emit from `log.audit()`, standalone `audit()`, and
+ * `log.set({ audit })` — including auto-filled `idempotencyKey`.
  *
  * @example
  * ```ts
@@ -490,6 +515,16 @@ export function mockAudit(): MockAudit {
     toIncludeAuditOf(matcher) {
       return events.some(event => matchesAudit(event, matcher))
     },
+    assertAudit(matcher) {
+      const match = events.find(event => matchesAudit(event, matcher))
+      if (!match) {
+        const summary = events.map(e => ({ action: e.action, outcome: e.outcome }))
+        throw new Error(
+          `No audit event matched ${JSON.stringify(matcher)}. Captured ${events.length} event(s): ${JSON.stringify(summary)}`,
+        )
+      }
+      return match
+    },
   }
 }
 
@@ -498,6 +533,8 @@ export interface MockAudit {
   events: AuditFields[]
   restore: () => void
   toIncludeAuditOf: (matcher: AuditMatcher) => boolean
+  /** Throws when no captured event matches; returns the matched event otherwise. */
+  assertAudit: (matcher: AuditMatcher) => AuditFields
 }
 
 /** Partial structural matcher for {@link MockAudit.toIncludeAuditOf}. */
@@ -555,6 +592,7 @@ export function finalizeAudit(event: WideEvent): void {
   if (!a) return
   const decorated = decorateAudit(a, String(event.timestamp))
   event.audit = decorated
+  _testCollector?.(decorated, event)
 }
 
 /** Shape of the optional better-auth bridge for the audit enricher. */

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -519,8 +519,9 @@ export function mockAudit(): MockAudit {
       const match = events.find(event => matchesAudit(event, matcher))
       if (!match) {
         const summary = events.map(e => ({ action: e.action, outcome: e.outcome }))
+        const matcherStr = JSON.stringify(matcher, (_k, v) => (v instanceof RegExp ? v.toString() : v))
         throw new Error(
-          `No audit event matched ${JSON.stringify(matcher)}. Captured ${events.length} event(s): ${JSON.stringify(summary)}`,
+          `No audit event matched ${matcherStr}. Captured ${events.length} event(s): ${JSON.stringify(summary)}`,
         )
       }
       return match

--- a/packages/evlog/src/catalog.ts
+++ b/packages/evlog/src/catalog.ts
@@ -1,5 +1,4 @@
-import type { AuditInput } from './audit'
-import type { AuditTarget } from './types'
+import type { AuditActionDefinition, AuditTarget } from './types'
 import { defineAuditAction } from './audit'
 import { EvlogError } from './error'
 
@@ -256,10 +255,7 @@ export function defineErrorCatalog<
 }
 
 /** Static metadata for a single entry in an audit catalog. */
-export interface AuditCatalogEntry {
-  /** Default `target.type` for every audit emitted from this action. */
-  target?: string
-}
+export type AuditCatalogEntry = AuditActionDefinition
 
 /** Map of audit catalog entries keyed by their (UPPER_SNAKE) name. */
 export interface AuditCatalogMap {
@@ -276,6 +272,11 @@ export type DefinedCatalogAudit<TAction extends string, TEntry extends AuditCata
   & {
     readonly action: TAction
     readonly target: TEntry['target']
+    readonly description: TEntry['description']
+    readonly severity: TEntry['severity']
+    readonly requiresChanges: TEntry['requiresChanges']
+    readonly requiresReason: TEntry['requiresReason']
+    readonly redactPaths: TEntry['redactPaths']
   }
 
 /**
@@ -302,7 +303,12 @@ export type AuditCatalog<TPrefix extends string, TMap extends AuditCatalogMap> =
  * import { defineAuditCatalog } from 'evlog'
  *
  * export const billingAudit = defineAuditCatalog('billing', {
- *   INVOICE_REFUND: { target: 'invoice' },
+ *   INVOICE_REFUND: {
+ *     target: 'invoice',
+ *     severity: 'high',
+ *     requiresChanges: true,
+ *     description: 'Refund an invoice to the customer',
+ *   },
  *   INVOICE_CREATE: { target: 'invoice' },
  * })
  *
@@ -328,12 +334,7 @@ export function defineAuditCatalog<
   for (const key of Object.keys(map)) {
     const action = `${prefix}.${key}`
     const entry = map[key]
-    const fn = defineAuditAction(action, entry.target ? { target: entry.target } : undefined) as ((input: unknown) => AuditInput) & { action: string, target?: string }
-    Object.defineProperties(fn, {
-      action: { value: action, enumerable: true },
-      target: { value: entry.target, enumerable: true },
-    })
-    out[key] = fn
+    out[key] = defineAuditAction(action, entry)
     actions.push(action)
   }
 

--- a/packages/evlog/src/index.ts
+++ b/packages/evlog/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './audit'
 export type {
   AuditDiffOptions,
+  DefineAuditActionOptions,
   AuditEnricherOptions,
   AuditInput,
   AuditMatcher,
@@ -69,9 +70,12 @@ export type { EvlogConfig } from './shared/define'
 
 export type {
   AuditAction,
+  AuditActionDefinition,
   AuditActor,
+  AuditChanges,
   AuditFields,
   AuditLoggerMethod,
+  AuditSeverity,
   AuditTarget,
   BaseWideEvent,
   DeepPartial,

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -415,6 +415,28 @@ export interface LoggerConfig {
  * `tools`, `reason`, and `promptId` are filled when `type === 'agent'` and
  * mirror the AI SDK fields already used by `evlog/ai`.
  */
+/** Relative importance of an audit action for alerting and review prioritisation. */
+export type AuditSeverity = 'low' | 'medium' | 'high' | 'critical'
+
+/**
+ * Static metadata for a single audit action — used by {@link defineAuditAction}
+ * and each entry of {@link defineAuditCatalog}.
+ */
+export interface AuditActionDefinition {
+  /** Default `target.type` for every audit emitted from this action. */
+  target?: string
+  /** Human-readable description for docs, SIEM rules, and review tooling. */
+  description?: string
+  /** Relative importance for alerting and review prioritisation. */
+  severity?: AuditSeverity
+  /** When true, callers should supply `changes` (e.g. via {@link auditDiff}). */
+  requiresChanges?: boolean
+  /** When true, callers should supply `reason` (especially for denials). */
+  requiresReason?: boolean
+  /** Default redact paths merged with {@link auditDiff} for this action. */
+  redactPaths?: readonly string[]
+}
+
 export interface AuditActor {
   type: 'user' | 'system' | 'api' | 'agent'
   id: string
@@ -459,6 +481,20 @@ export interface AuditTarget {
  * - `context` — request/runtime context auto-populated by {@link auditEnricher}
  *   (`requestId`, `traceId`, `ip`, `userAgent`, `tenantId`).
  */
+/** Single JSON Patch operation for audit change tracking (RFC 6902 subset). */
+export interface AuditPatchOp {
+  op: 'add' | 'remove' | 'replace'
+  path: string
+  value?: unknown
+}
+
+/** Before/after snapshots and optional patch produced by {@link auditDiff}. */
+export interface AuditChanges {
+  before?: unknown
+  after?: unknown
+  patch?: AuditPatchOp[]
+}
+
 export interface AuditFields {
   /** Action name. Convention: `'<resource>.<verb>'`, e.g. `'invoice.refund'`. */
   action: string
@@ -467,8 +503,8 @@ export interface AuditFields {
   outcome: 'success' | 'failure' | 'denied'
   /** Human-readable explanation, especially required for `outcome: 'denied'`. */
   reason?: string
-  /** Before/after snapshots for mutating actions. */
-  changes?: { before?: unknown, after?: unknown }
+  /** Before/after snapshots and optional patch from {@link auditDiff}. */
+  changes?: AuditChanges
   /** ID of the action that caused this one. */
   causationId?: string
   /** ID shared by every action in the same logical operation. */

--- a/packages/evlog/test/core/audit.test.ts
+++ b/packages/evlog/test/core/audit.test.ts
@@ -228,10 +228,25 @@ describe('defineAuditAction()', () => {
     expect(built.action).toBe('invoice.refund')
     expect(built.target).toEqual({ type: 'invoice', id: 'inv_1' })
   })
+
+  it('exposes catalog metadata on the factory', () => {
+    const refund = defineAuditAction('invoice.refund', {
+      target: 'invoice',
+      severity: 'high',
+      requiresChanges: true,
+      description: 'Refund an invoice',
+      redactPaths: ['cardNumber'],
+    })
+    expect(refund.action).toBe('invoice.refund')
+    expect(refund.severity).toBe('high')
+    expect(refund.requiresChanges).toBe(true)
+    expect(refund.description).toBe('Refund an invoice')
+    expect(refund.redactPaths).toEqual(['cardNumber'])
+  })
 })
 
 describe('mockAudit()', () => {
-  it('captures audit events from log.audit() and audit()', () => {
+  it('captures audit events from standalone audit()', () => {
     const captured = mockAudit()
     audit({ action: 'a', actor: { type: 'system', id: 's' } })
     expect(captured.events).toHaveLength(1)
@@ -240,10 +255,51 @@ describe('mockAudit()', () => {
     captured.restore()
   })
 
+  it('captures audit events from log.audit() on emit', () => {
+    const captured = mockAudit()
+    const log = createRequestLogger()
+    log.audit({
+      action: 'invoice.refund',
+      actor: { type: 'user', id: 'u1' },
+      target: { type: 'invoice', id: 'inv_1' },
+      outcome: 'success',
+    })
+    log.emit()
+    expect(captured.events).toHaveLength(1)
+    const recorded = defined(captured.events[0], 'audit event')
+    expect(recorded.action).toBe('invoice.refund')
+    expect(recorded.idempotencyKey).toBeDefined()
+    captured.restore()
+  })
+
+  it('captures log.audit.deny() with outcome denied', () => {
+    const captured = mockAudit()
+    const log = createRequestLogger()
+    log.audit.deny('Insufficient permissions', {
+      action: 'invoice.refund',
+      actor: { type: 'user', id: 'u1' },
+      target: { type: 'invoice', id: 'inv_1' },
+    })
+    log.emit()
+    const recorded = defined(captured.events[0], 'audit event')
+    expect(recorded.outcome).toBe('denied')
+    expect(recorded.reason).toBe('Insufficient permissions')
+    captured.restore()
+  })
+
   it('matcher supports regex actions', () => {
     const captured = mockAudit()
     audit({ action: 'invoice.refund', actor: { type: 'system', id: 's' } })
     expect(captured.toIncludeAuditOf({ action: /^invoice\./ })).toBe(true)
+    captured.restore()
+  })
+
+  it('assertAudit returns the matched event or throws', () => {
+    const captured = mockAudit()
+    audit({ action: 'invoice.refund', actor: { type: 'user', id: 'u1' }, outcome: 'success' })
+    const match = captured.assertAudit({ action: 'invoice.refund', outcome: 'success' })
+    expect(match.action).toBe('invoice.refund')
+    expect(() => captured.assertAudit({ action: 'missing' })).toThrow(/No audit event matched/)
     captured.restore()
   })
 })

--- a/packages/evlog/test/core/catalog.test.ts
+++ b/packages/evlog/test/core/catalog.test.ts
@@ -192,7 +192,13 @@ describe('defineErrorCatalog', () => {
 
 describe('defineAuditCatalog', () => {
   const billingAudit = defineAuditCatalog('billing', {
-    INVOICE_REFUND: { target: 'invoice' },
+    INVOICE_REFUND: {
+      target: 'invoice',
+      severity: 'high',
+      requiresChanges: true,
+      description: 'Refund an invoice to the customer',
+      redactPaths: ['cardNumber'],
+    },
     INVOICE_CREATE: { target: 'invoice' },
     SUBSCRIPTION_CANCEL: { target: 'subscription' },
     PASSWORD_CHANGE: {},
@@ -212,6 +218,10 @@ describe('defineAuditCatalog', () => {
   it('exposes static action and target on the factory itself', () => {
     expect(billingAudit.INVOICE_REFUND.action).toBe('billing.INVOICE_REFUND')
     expect(billingAudit.INVOICE_REFUND.target).toBe('invoice')
+    expect(billingAudit.INVOICE_REFUND.severity).toBe('high')
+    expect(billingAudit.INVOICE_REFUND.requiresChanges).toBe(true)
+    expect(billingAudit.INVOICE_REFUND.description).toBe('Refund an invoice to the customer')
+    expect(billingAudit.INVOICE_REFUND.redactPaths).toEqual(['cardNumber'])
     expect(billingAudit.PASSWORD_CHANGE.action).toBe('billing.PASSWORD_CHANGE')
     expect(billingAudit.PASSWORD_CHANGE.target).toBeUndefined()
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich audit metadata (description, severity, requiresChanges, requiresReason, redactPaths).
  * Audit change tracking now supports patch operations in addition to before/after snapshots.
  * Added assertAudit() matcher for precise audit assertions.

* **Bug Fixes**
  * Improved test helper to capture in-request audit events emitted via the logger.

* **Documentation**
  * Updated guides and examples to document new metadata, change format, and testing patterns.

* **Tests**
  * Expanded tests to cover metadata exposure and new assertion/capture behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->