### PR TITLE
fix(elysia): evlog plugin initialize onRequest (#358)

### DIFF
--- a/.changeset/quiet-elysia-routes.md
+++ b/.changeset/quiet-elysia-routes.md
@@ -1,0 +1,5 @@
+---
+'evlog': patch
+---
+
+Fix `evlog/elysia` to capture unmatched routes so Elysia 404 responses emit HTTP events with the correct path and error level.

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -105,12 +105,16 @@ export function evlog(options: EvlogElysiaOptions = {}) {
   const requestState = new WeakMap<Request, RequestState>()
 
   return new Elysia({ name: 'evlog' })
-    .derive({ as: 'global' }, ({ request, path, headers }) => {
-      const ctx: ElysiaContext = { request, path, headers: headers as Record<string, string> }
+    .onRequest(({ request }) => {
+      const url = new URL(request.url)
+      const headers = (request.headers).toJSON?.() ?? Object.fromEntries(request.headers.entries())
+      const ctx: ElysiaContext = { request, path: url.pathname, headers }
       const { logger, finish, skipped } = integration.start(ctx, options)
       storage.enterWith(logger)
       requestState.set(request, { finish, skipped, logger })
-      return { log: logger }
+    })
+    .derive({ as: 'global' }, ({ request }) => {
+      return { log: requestState.get(request)?.logger as RequestLogger }
     })
     .onAfterResponse({ as: 'global' }, async ({ request, set }) => {
       const state = requestState.get(request)

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -133,6 +133,22 @@ describe('evlog/elysia', () => {
     })
   })
 
+  it('captures 404s for unmatched routes', async () => {
+    const { drain } = createPipelineSpies()
+    const app = new Elysia()
+      .use(evlog({ drain }))
+      .get('/api/exists', () => ({ ok: true }))
+
+    await request(app, '/api/does-not-exist')
+    await waitForDrainCalls(drain)
+
+    assertHttpEventEmitted(drain, {
+      path: '/api/does-not-exist',
+      status: 404,
+      level: 'error',
+    })
+  })
+
   it('skips routes not matching include patterns', async () => {
     const { drain } = createPipelineSpies()
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #358

### 📚 Description

The elysia plugin does not record 404's or any request that doesn't hit derive in Elysia lifecycle. 404 requests don't match any defined Elysia route therefore don't hit derive so there will be no evlog emitted for it. This is because the integration is started at `.derive()` instead of `onRequest()`.

The fix is to initialize the context `onRequest`. 

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-scoped logging initialization and more reliable per-request logger storage.
  * Enhanced header normalization with a robust fallback for broader compatibility.
  * Fixed capture of unmatched routes so 404 responses emit HTTP error events with correct path and level.

* **Tests**
  * Added a test verifying 404 responses for unmatched routes are captured and emitted as error events.

* **Chores**
  * Added a patch release note entry for the Elysia integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->