### PR TITLE
feat: add @evlog/cli observability package

### DIFF
--- a/.changeset/cli-package-v1.md
+++ b/.changeset/cli-package-v1.md
@@ -1,0 +1,17 @@
+---
+"@evlog/cli": minor
+---
+
+Add `@evlog/cli` — CLI observability for evlog.
+
+- `setupEvlog()` + `invoke()` + `createCommandLogger()` + `useLogger()`
+- `@evlog/cli/citty` — `runMain()` adapter with auto-injected `--log` (peer: citty)
+- `@evlog/cli/http` — `createOutboundHooks()` for ofetch (peer: ofetch)
+- `errorCatalog` / `auditCatalog` config (symmetric with HTTP integrations)
+- `cliRedactPreset`, `parseCliError`, `exitWithError`, flush-on-exit
+- Default: drain-only (silent evlog console); `--log` / `logToConsole` for debug output
+- Drain routing: wire `evlog/fs`, `evlog/axiom`, etc. in `src/drain.ts`; operator selects destination via env (see docs)
+- Demo CLI: `pnpm example:cli` — citty + Clack, `useLogger()` for telemetry (see `examples/cli/`)
+- Docs: `/integrate/frameworks/cli`
+
+Peer dependency: `evlog`. Optional peers: `citty`, `ofetch`.

--- a/.changeset/cli-package-v1.md
+++ b/.changeset/cli-package-v1.md
@@ -2,6 +2,8 @@
 "@evlog/cli": minor
 ---
 
+# Add `@evlog/cli`
+
 Add `@evlog/cli` — CLI observability for evlog.
 
 - `setupEvlog()` + `invoke()` + `createCommandLogger()` + `useLogger()`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ scope.
 - bench (benchmarks)
 - better-auth (Better Auth integration)
 - better-stack (Better Stack drain adapter)
+- cli (@evlog/cli — citty observability)
 - core (logger, pipeline, error, redact, catalog internals)
 - datadog (Datadog drain adapter)
 - deps (the dependencies)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,11 @@ jobs:
         run: pnpm run dev:prepare
       - name: Build package
         run: pnpm run build:package
+      - name: Verify publish tarballs
+        run: |
+          for dir in packages/evlog packages/nuxthub packages/cli; do
+            echo "==> $dir"
+            (cd "$dir" && npm publish --dry-run --access public)
+          done
       - name: Publish
-        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub'
+        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub' './packages/cli'

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -27,6 +27,7 @@ jobs:
             bench
             better-auth
             better-stack
+            cli
             core
             datadog
             deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ packages/evlog/            Main package
   src/enrichers/           Built-in enrichers (UserAgent, Geo, RequestSize, TraceContext)
   src/runtime/             Runtime code (client/, server/, utils/)
   test/                    Tests
+packages/cli/              @evlog/cli — CLI observability (setupEvlog, citty, http)
+examples/cli/              Demo citty + Clack CLI
 .agents/skills/            Internal skills for creating adapters, enrichers, and framework integrations
 ```
 

--- a/apps/docs/content/1.start/3.installation.md
+++ b/apps/docs/content/1.start/3.installation.md
@@ -26,7 +26,7 @@ actions:
 
 Install evlog in my TypeScript project.
 
-- Detect the framework I'm using (Nuxt, Next.js, SvelteKit, Nitro, NestJS, Express, Hono, Fastify, Elysia, TanStack Start, React Router, Cloudflare Workers, or standalone)
+- Detect the framework I'm using (Nuxt, Next.js, SvelteKit, Nitro, NestJS, Express, Hono, Fastify, Elysia, TanStack Start, React Router, Cloudflare Workers, CLI with @evlog/cli, or standalone)
 - Install evlog with my package manager: pnpm add evlog (or npm/yarn/bun)
 - Wire up the framework-specific integration (module, plugin, or middleware)
 - Set evlog.env.service to my app name
@@ -176,6 +176,15 @@ After installing the package, follow the setup guide for your framework:
   color: neutral
   ---
   `withEvlog()` handler wrapper + `evlog()` procedure middleware.
+  :::
+  :::card
+  ---
+  icon: i-lucide-terminal
+  title: CLI
+  to: /integrate/frameworks/cli
+  color: neutral
+  ---
+  `@evlog/cli` — wide events per command, citty adapter, drain routing (fs / Axiom / …), catalogs.
   :::
   :::card
   ---

--- a/apps/docs/content/3.integrate/frameworks/00.overview.md
+++ b/apps/docs/content/3.integrate/frameworks/00.overview.md
@@ -32,6 +32,7 @@ No HTTP framework? Use [Standalone TypeScript](/integrate/frameworks/standalone)
 | [Cloudflare Workers](/integrate/frameworks/cloudflare-workers) | `evlog/workers` | Factory | `createWorkersLogger()` | Stable |
 | [AWS Lambda](/integrate/frameworks/aws-lambda) | `evlog` | Manual | `createLogger()` / `createRequestLogger()` | Guide |
 | [Standalone](/integrate/frameworks/standalone) | `evlog` | Manual | `createLogger()` / `createRequestLogger()` | Stable |
+| [CLI](/integrate/frameworks/cli) | `@evlog/cli` | Bootstrap + invoke | `useLogger()` / `log.audit()` | Stable |
 | [Astro](/integrate/frameworks/astro) | `evlog` | Manual | `createRequestLogger()` | Guide |
 | [Custom](/extend/custom-framework) | `evlog/toolkit` | Build your own | `createMiddlewareLogger()` | Beta |
 
@@ -48,6 +49,7 @@ Two things differ per framework: how you **bootstrap** evlog, and how you **acce
 | `EvlogModule.forRoot()` | NestJS |
 | Module default export | Nuxt, Nitro v2/v3 |
 | Manual factory | Cloudflare Workers (`createWorkersLogger`), Standalone, AWS Lambda, Astro |
+| `setupEvlog()` + `src/drain.ts` | CLI (`@evlog/cli`) — you wire the drain; env selects fs vs Axiom/etc. |
 
 ### Logger access
 
@@ -208,6 +210,15 @@ Hono intentionally has no `useLogger()` — use `c.get('log')` inside handlers. 
   color: neutral
   ---
   For scripts, CLI tools, queues, and any TypeScript process.
+  :::
+  :::card
+  ---
+  icon: i-lucide-terminal
+  title: CLI
+  to: /integrate/frameworks/cli
+  color: neutral
+  ---
+  `@evlog/cli` + citty — `setupEvlog({ drain })`, `useLogger()` per command. Wire Axiom/Datadog via `src/drain.ts` + env.
   :::
   :::card
   ---

--- a/apps/docs/content/3.integrate/frameworks/17.cli.md
+++ b/apps/docs/content/3.integrate/frameworks/17.cli.md
@@ -1,0 +1,667 @@
+---
+title: CLI
+description: Observability for command-line tools — wide events per command, drain pipeline, error/audit catalogs, and a citty adapter. Your UI stack stays unchanged.
+navigation:
+  title: CLI
+  icon: i-lucide-terminal
+links:
+  - label: Example CLI
+    icon: i-simple-icons-github
+    to: https://github.com/hugorcd/evlog/tree/main/examples/cli
+    color: neutral
+    variant: subtle
+---
+
+`@evlog/cli` adds **command → exit** observability on top of evlog. It does **not** replace citty, Clack, or your stdout JSON contract — it owns telemetry (wide events + drain) while you keep your existing CLI stack.
+
+::callout{icon="i-lucide-terminal" color="neutral"}
+Runnable demo in the evlog repo: `pnpm example:cli doctor` — wide events land in `examples/cli/.evlog/logs/`. Source: [examples/cli](https://github.com/hugorcd/evlog/tree/main/examples/cli).
+::
+
+::prompt
+---
+description: Add evlog to my existing CLI
+icon: i-lucide-terminal
+actions:
+  - copy
+  - cursor
+  - windsurf
+---
+
+Add evlog observability to my existing TypeScript CLI (citty + optional Clack). Do not replace my UI or stdout JSON contract.
+
+- Install: pnpm add @evlog/cli evlog citty
+- Create src/drain.ts — createCliDrain() with createFsDrain() default; switch to createAxiomDrain() when EVLOG_DRAIN=axiom (credentials from env, never in source)
+- Create src/evlog.ts — export const setup = setupEvlog({ service, version, drain: createCliDrain(), errorCatalog, auditCatalog })
+- Entry src/index.ts — runMain(main, setup) from @evlog/cli/citty, then setup.flush(), exitWithError on catch
+- In command handlers: import { useLogger } from '@evlog/cli' — log.set(), log.audit(auditCatalog.ACTION({ actor, target, outcome }))
+- Keep Clack/consola/console for terminal output; evlog drains wide events only (silent unless --log)
+- Optional catalogs: defineErrorCatalog → errorCatalog, defineAuditCatalog → auditCatalog with target, severity, description
+
+Docs: https://www.evlog.dev/integrate/frameworks/cli
+
+::
+
+::prompt
+---
+description: Create a new CLI with evlog
+icon: i-lucide-terminal
+actions:
+  - copy
+  - cursor
+  - windsurf
+---
+
+Create a new TypeScript CLI with citty, optional @clack/prompts, and evlog observability from day one.
+
+- Install: pnpm add @evlog/cli evlog citty @clack/prompts
+- Layout: src/index.ts, src/drain.ts, src/evlog.ts, src/catalogs/{errors,audit,actor}.ts, src/commands/*
+- src/drain.ts — createCliDrain(): fs by default, Axiom/Datadog/OTLP via env (see drain section below)
+- src/evlog.ts — setupEvlog({ service, version, drain: createCliDrain(), errorCatalog, auditCatalog })
+- src/index.ts — runMain(main, setup).then(() => setup.flush()).catch(exitWithError)
+- Commands — citty defineCommand + Clack for UI + useLogger() for telemetry
+- Audits — auditCatalog.SECRET_PULL({ actor: resolveCliActor(), target: { id, resource, access }, outcome, changes })
+- Runnable reference: examples/cli in the evlog repo (pnpm example:cli doctor)
+
+Docs: https://www.evlog.dev/integrate/frameworks/cli
+
+::
+
+## Add evlog to an existing citty CLI
+
+Three changes — everything else stays the same.
+
+```diff [src/drain.ts]
++ import type { DrainContext } from 'evlog'
++ import { createFsDrain } from 'evlog/fs'
++ import { createDrainPipeline } from 'evlog/pipeline'
++
++ const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
++
++ export function createCliDrain() {
++   return pipeline(createFsDrain({ dir: '.evlog/logs' }))
++ }
+```
+
+```diff [src/evlog.ts]
++ import { setupEvlog } from '@evlog/cli'
++ import { createCliDrain } from './drain'
++
++ export const setup = setupEvlog({
++   service: 'my-cli',
++   version: '1.0.0',
++   drain: createCliDrain(),
++ })
+```
+
+```diff [src/index.ts]
++ import { runMain } from '@evlog/cli/citty'
++ import { setup } from './evlog'
+- runMain(main)
++ runMain(main, setup)
++   .then(() => setup.flush())
++   .catch(err => exitWithError(err))
+```
+
+```diff [src/commands/doctor.ts]
++ import { useLogger } from '@evlog/cli'
+
+  async run() {
++   const log = useLogger()
++   log.set({ checks: results })
+    p.intro('my-cli doctor')   // Clack unchanged
+    // …
+  }
+```
+
+## What evlog does / does not do
+
+| | evlog | Your app |
+|---|-------|----------|
+| Routing (`--help`, subcommands) | | citty |
+| Terminal UI (spinners, colors) | | Clack, consola, … |
+| `--json` stdout shape | | your flag, your format |
+| Wide events + drain | yes | |
+| `--log` debug on stderr | yes | |
+| Redact secrets in `cli.flags` | yes | |
+| Error catalog (`errorCatalog`, `throw errorCatalog.X()`) | yes | |
+| Audit catalog (`auditCatalog`, `log.audit()`) | yes | |
+
+```text
+citty runMain
+    │
+    ▼
+evlog.invoke()  ──────────────────────────►  drain (.evlog/logs, Axiom, …)
+    │
+    ▼
+command handler  ──►  useLogger().set() / log.audit()
+    │
+    ▼
+Clack / console / your --json  ──►  stdout/stderr (unchanged)
+```
+
+**Default:** evlog console is **silent** — wide events go to the drain only. Pass `--log` (auto-injected by `runMain`) to echo wide events on stderr while debugging.
+
+## Why evlog on a CLI
+
+You do not need audit catalogs on day one. evlog gives you **one structured wide event per command** — duration, exit status, flags (redacted), and whatever you `log.set()` — drained automatically to a file or your observability provider.
+
+| Level | What you add | Demo command |
+|-------|----------------|--------------|
+| **Simple** | `setupEvlog` + `useLogger().set()` | `doctor` |
+| **Medium** | Outbound HTTP hooks, error catalog | `sync` |
+| **Advanced** | Audit catalog, `log.audit()`, deny | `pull`, `deploy` |
+
+Catalogs are optional. Start with a drain + `log.set()` — that alone replaces ad-hoc `console.log` debugging with queryable NDJSON.
+
+## Send events to Axiom (or another provider)
+
+::callout{icon="i-lucide-plug" color="warning"}
+**evlog does not auto-send to Axiom, Datadog, or OTLP.** Wide events only leave your process when you pass a **drain** to `setupEvlog({ drain })`. Without it, telemetry is dropped. The default in most setups is `createFsDrain()` — local NDJSON under `.evlog/logs/`.
+::
+
+On HTTP apps, the framework wires the drain for you (Nuxt hook, Express middleware, …). On a CLI, **you** choose the adapter in one file — usually `src/drain.ts` — and pass it to `setupEvlog`.
+
+### 1. Add `src/drain.ts`
+
+Pick a backend at **runtime** from environment variables. Never hard-code API keys in source or the published bundle.
+
+```typescript [src/drain.ts]
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createDatadogDrain } from 'evlog/datadog'
+import { createFsDrain } from 'evlog/fs'
+import { createOtlpDrain } from 'evlog/otlp'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
+
+export function createCliDrain() {
+  switch (process.env.EVLOG_DRAIN ?? 'fs') {
+    case 'axiom':
+      // Reads AXIOM_API_KEY / AXIOM_DATASET (or AXIOM_TOKEN) from the environment
+      return pipeline(createAxiomDrain())
+    case 'datadog':
+      return pipeline(createDatadogDrain())
+    case 'otlp':
+      return pipeline(createOtlpDrain())
+    default:
+      return pipeline(createFsDrain({
+        dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
+      }))
+  }
+}
+```
+
+`EVLOG_DRAIN` is a **convention for your CLI** — evlog does not define it. Name it whatever you want; the demo uses `fs` | `axiom` | `datadog` | `otlp`.
+
+Each adapter reads its own env vars when you call `createXxxDrain()` with no arguments. See the [adapters overview](/integrate/adapters/overview) for full lists.
+
+### 2. Wire the drain in `src/evlog.ts`
+
+```typescript [src/evlog.ts]
+import { setupEvlog } from '@evlog/cli'
+import { createCliDrain } from './drain'
+
+export const setup = setupEvlog({
+  service: 'my-cli',
+  version: '1.0.0',
+  redact: true,
+  drain: createCliDrain(),
+})
+```
+
+### 3. Configure credentials where the CLI runs
+
+| Where | What to set | Result |
+|-------|-------------|--------|
+| **Local dev** | nothing (default) | `.evlog/logs/YYYY-MM-DD.jsonl` on disk |
+| **Local dev + cloud** | `EVLOG_DRAIN=axiom` + Axiom env | events in your Axiom dataset |
+| **CI / cron / server** | same env on the host | operator chooses destination per environment |
+| **Published npm binary** | env on the machine that runs `my-cli` | no token in the package |
+
+```bash
+# Local — inspect NDJSON
+my-cli doctor
+tail -f .evlog/logs/$(date +%Y-%m-%d).jsonl
+
+# Send to Axiom instead (credentials on the host, not in your repo)
+export EVLOG_DRAIN=axiom
+export AXIOM_API_KEY=xaat-…          # or AXIOM_TOKEN (deprecated alias)
+export AXIOM_DATASET=my-cli
+my-cli doctor
+
+# Datadog
+export EVLOG_DRAIN=datadog
+export DATADOG_API_KEY=…
+export DATADOG_SITE=datadoghq.com
+
+# Any OTLP collector (Grafana Cloud, Honeycomb, …)
+export EVLOG_DRAIN=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://…
+export OTEL_SERVICE_NAME=my-cli
+```
+
+Ship a `.env.example` with commented placeholders — document what operators must set, not real secrets.
+
+### Provider env vars (quick reference)
+
+| Adapter | Import | Required env (typical) | Docs |
+|---------|--------|------------------------|------|
+| File system | `evlog/fs` | `EVLOG_LOG_DIR` (optional) | [fs](/integrate/adapters/self-hosted/fs) |
+| Axiom | `evlog/axiom` | `AXIOM_API_KEY`, `AXIOM_DATASET` | [axiom](/integrate/adapters/cloud/axiom) |
+| Datadog | `evlog/datadog` | `DATADOG_API_KEY`, `DATADOG_SITE` | [datadog](/integrate/adapters/cloud/datadog) |
+| OTLP | `evlog/otlp` | `OTEL_EXPORTER_OTLP_ENDPOINT` | [otlp](/integrate/adapters/cloud/otlp) |
+| Better Stack | `evlog/better-stack` | `BETTER_STACK_SOURCE_TOKEN` | [better-stack](/integrate/adapters/cloud/better-stack) |
+| HyperDX | `evlog/hyperdx` | `HYPERDX_API_KEY` | [hyperdx](/integrate/adapters/cloud/hyperdx) |
+| PostHog | `evlog/posthog` | `POSTHOG_API_KEY` | [posthog](/integrate/adapters/cloud/posthog) |
+| Sentry | `evlog/sentry` | `SENTRY_DSN` | [sentry](/integrate/adapters/cloud/sentry) |
+
+Adapters also accept config objects if you prefer explicit wiring in code (fine for internal tools, not for published CLIs):
+
+```typescript
+pipeline(createAxiomDrain({ apiKey: process.env.AXIOM_API_KEY!, dataset: 'my-cli' }))
+```
+
+### Packaged CLI — credentials never in the bundle
+
+A published CLI (`npm install -g my-cli`) **must not embed** provider tokens. The pattern above keeps observability in the binary and the **destination** on the host:
+
+1. **Default: local drain** — works offline, zero credentials, good for `doctor` / support scripts.
+2. **Production: env on the host** — platform team sets `EVLOG_DRAIN` + provider keys in systemd, CI secrets, or a `.env` the operator loads.
+
+The CLI author ships `drain.ts` + `.env.example`; the operator decides where events go.
+
+## Recommended project layout
+
+Mirror of the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli):
+
+```text [my-cli/]
+my-cli/
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts              # runMain, flush, exitWithError
+    ├── drain.ts              # createCliDrain() — fs default, axiom via env
+    ├── evlog.ts              # setupEvlog()
+    ├── catalogs/             # optional — advanced commands only
+    │   ├── actor.ts          # resolveCliActor() for audit.actor
+    │   ├── errors.ts
+    │   └── audit.ts
+    └── commands/
+        ├── index.ts          # main + subCommands
+        ├── doctor.ts
+        └── pull.ts
+```
+
+## Install
+
+::code-group
+```bash [pnpm]
+pnpm add @evlog/cli evlog citty
+pnpm add @clack/prompts   # optional — UI only
+```
+```bash [bun]
+bun add @evlog/cli evlog citty
+bun add @clack/prompts
+```
+```bash [yarn]
+yarn add @evlog/cli evlog citty
+yarn add @clack/prompts
+```
+```bash [npm]
+npm install @evlog/cli evlog citty
+npm install @clack/prompts
+```
+::
+
+| Package | Import | Role |
+|---------|--------|------|
+| `citty` | `@evlog/cli/citty` | `runMain(main, setup)` wraps each `run()` in `invoke()` |
+| `ofetch` | `@evlog/cli/http` | Outbound HTTP fields on the wide event |
+
+---
+
+## Walkthrough
+
+### 1. Drain + setup (no catalogs required)
+
+Start with local files; add Axiom/Datadog/OTLP branches when you need cloud — see [Send events to Axiom (or another provider)](#send-events-to-axiom-or-another-provider) above.
+
+```typescript [src/drain.ts]
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createFsDrain } from 'evlog/fs'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
+
+export function createCliDrain() {
+  if (process.env.EVLOG_DRAIN === 'axiom') {
+    return pipeline(createAxiomDrain())
+  }
+  return pipeline(createFsDrain({
+    dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
+  }))
+}
+```
+
+```typescript [src/evlog.ts]
+import { setupEvlog } from '@evlog/cli'
+import { createCliDrain } from './drain'
+
+export const setup = setupEvlog({
+  service: 'my-cli',
+  version: '1.0.0',
+  redact: true,
+  drain: createCliDrain(),
+})
+```
+
+Every command now emits a wide event to the drain on exit. Add `errorCatalog` / `auditCatalog` later when you need typed errors or audit trails.
+
+### 2. Simple command — wide event only
+
+```typescript [src/commands/doctor.ts]
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+
+export const doctor = defineCommand({
+  meta: { name: 'doctor', description: 'Health checks' },
+  async run() {
+    const log = useLogger()
+    p.intro('my-cli doctor')
+    const checks = [{ name: 'config', ok: true }, { name: 'api', ok: true }]
+    log.set({ checks })
+    p.outro(`All ${checks.length} checks passed`)
+  },
+})
+```
+
+That is enough for observability — one NDJSON line per run with `checks`, `duration`, `status`, `cli.command`.
+
+### 3. Optional — error & audit catalogs
+
+Add when commands throw typed errors or record sensitive actions:
+
+```typescript [src/catalogs/errors.ts]
+import { defineErrorCatalog } from 'evlog'
+
+export const errorCatalog = defineErrorCatalog('myapp', {
+  CONFIG_MISSING: {
+    status: 1,
+    message: 'No config file found',
+    fix: 'Run myapp init or set MYAPP_CONFIG.',
+  },
+})
+
+declare module 'evlog' {
+  interface RegisteredErrorCatalogs {
+    myapp: typeof errorCatalog
+  }
+}
+```
+
+```typescript [src/catalogs/audit.ts]
+import { defineAuditCatalog } from 'evlog'
+
+export const auditCatalog = defineAuditCatalog('myapp', {
+  SECRET_PULL: {
+    target: 'secret_store',
+    severity: 'high',
+    description: 'Read secrets from a remote store',
+    redactPaths: ['token', 'password'],
+  },
+  DEPLOY: {
+    target: 'deployment',
+    severity: 'critical',
+    requiresChanges: true,
+    description: 'Promote a build to a region',
+  },
+})
+
+declare module 'evlog' {
+  interface RegisteredAuditCatalogs {
+    myapp: typeof auditCatalog
+  }
+}
+```
+
+```typescript [src/catalogs/actor.ts]
+import type { AuditActor } from 'evlog'
+
+export function resolveCliActor(): AuditActor {
+  const id = process.env.USER ?? 'unknown'
+  return { type: 'user', id, displayName: id }
+}
+```
+
+Pass them to `setupEvlog({ errorCatalog, auditCatalog })`. See the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli) `pull` and `deploy` commands for full audit usage.
+
+### 4. Entry — `src/index.ts`
+
+```typescript [src/index.ts]
+import { exitWithError } from '@evlog/cli'
+import { runMain } from '@evlog/cli/citty'
+import { setup } from './evlog'
+import { main } from './commands'
+
+runMain(main, setup)
+  .then(() => setup.flush())
+  .catch(error => exitWithError(error))
+```
+
+### What you see vs what gets drained
+
+::code-group
+```bash [Normal (TTY)]
+$ my-cli doctor
+◆  my-cli doctor
+│
+◇  Running checks
+│
+◆  All 2 checks passed
+```
+```bash [--log (debug telemetry on stderr)]
+$ my-cli doctor --log
+◆  my-cli doctor
+…
+19:04:12 INFO [my-cli] CLI /doctor in 98ms
+  └─ checks: …
+```
+```bash [--json (your app contract)]
+$ my-cli doctor --json
+{"checks":[{"name":"config","ok":true},{"name":"api","ok":true}]}
+```
+::
+
+The NDJSON wide event is always written to the drain — e.g. `.evlog/logs/2026-05-30.jsonl` with `createFsDrain`.
+
+---
+
+## API reference
+
+### `setupEvlog(config)` vs `useLogger()`
+
+Two roles — same split as HTTP middleware:
+
+| | `setupEvlog()` | `useLogger()` |
+|---|----------------|---------------|
+| When | once at startup (`src/evlog.ts`) | inside every command handler |
+| Does | configure drain, redact, catalogs | returns the **command-scoped** logger |
+| Analog | `EvlogModule.forRoot()` / Nitro plugin | `useLogger()` in Express, Nest, Hono |
+| You call | `runMain(main, setup)`, `setup.flush()` | `log.set()`, `log.audit()`, `throw errorCatalog.X()` |
+
+`setupEvlog` configures the global pipeline. Each citty command gets its own logger (path `/doctor`, flags, duration) via AsyncLocalStorage — `useLogger()` retrieves it anywhere in the call stack.
+
+```typescript
+const log = useLogger()
+log.set({ checks })   // not setup.set() — setup is config, log is telemetry
+```
+
+### `setupEvlog(config)`
+
+Boot once at startup. Options: `service`, `version`, `drain`, `errorCatalog`, `auditCatalog`, `redact` (default `true`), `flushOnExit` (default `true`), `logToConsole` (always print wide events, same as `--log`).
+
+Returns `{ invoke, log, errorCatalog, auditCatalog, audit, flush }`.
+
+- `errorCatalog` — from config (`defineErrorCatalog`); import in commands for `throw errorCatalog.X()`
+- `auditCatalog` — from config (`defineAuditCatalog`); types for `log.audit({ action: 'myapp.…' })`
+- `audit()` — shortcut that calls `useLogger().audit()` outside a handler (rare)
+
+### `useLogger()`
+
+Inside any `invoke()` / `runMain` handler (or any function called from there). Import from `@evlog/cli` — no need to pass `setup` around.
+
+### `runMain(main, setup)` — `@evlog/cli/citty`
+
+Wraps every citty `run()` in `invoke()`. Auto-injects global `--log`.
+
+### `exitWithError(err)` / `parseCliError(err)`
+
+Human-readable message on stderr + `process.exit`. Throw catalog errors in handlers: `throw errorCatalog.CONFIG_MISSING()`.
+
+### `--log`
+
+evlog-only flag. Pretty wide events on stderr. Injected by `runMain` — no manual spread.
+
+---
+
+## Wide event shape
+
+| Field | CLI value |
+|-------|-----------|
+| `method` | `'CLI'` |
+| `path` | `'/<command>'` or `'/<cmd>/<subcmd>'` |
+| `status` | exit code (0 success, catalog status on error) |
+| `cli.command` | command segment |
+| `cli.flags` | parsed flags (secrets redacted) |
+| `cli.version` | from `setupEvlog({ version })` |
+| `cli.tty` | `{ stdin, stdout, stderr }` booleans |
+| `cli.ci` | `true` when `CI` env is set |
+
+---
+
+## Adoption levels
+
+### Level 0 — `createCommandLogger`
+
+For **libraries** inside someone else's CLI — no global drain bootstrap:
+
+```typescript
+import { createCommandLogger } from '@evlog/cli'
+
+const log = createCommandLogger({ command: 'migrate', version: '2.0.0' })
+log.set({ records: 150 })
+log.emit({ status: 0 })
+```
+
+### Level 1 — manual `invoke()`
+
+When not using citty:
+
+```typescript
+await setup.invoke({ command: 'backup', flags: { target: 's3' } }, async (log) => {
+  log.set({ files: 42 })
+})
+```
+
+### Level 2 — citty `runMain`
+
+Recommended for multi-command CLIs — see walkthrough above.
+
+---
+
+## Audit
+
+Use the catalog wrapper — `target.type` comes from the catalog entry; add resource metadata on `target`:
+
+```typescript
+import { auditCatalog } from '../catalogs/audit'
+import { resolveCliActor } from '../catalogs/actor'
+
+const log = useLogger()
+const actor = resolveCliActor()
+
+log.audit(auditCatalog.SECRET_PULL({
+  actor,
+  target: {
+    id: args.env,
+    env: args.env,
+    resource: 'secrets',
+    access: 'read',
+  },
+  outcome: 'success',
+  changes: {
+    after: { keyCount: 3, keys: ['DATABASE_URL', 'API_KEY'] },
+  },
+}))
+
+// AuthZ denial — auditors care about these too
+log.audit.deny('Missing API token', auditCatalog.SECRET_PULL({
+  actor,
+  target: { id: args.env, access: 'read' },
+}))
+```
+
+Fields merge into the wide event. `cliRedactPreset` + `auditRedactPreset` apply when `redact: true`.
+
+---
+
+## Outbound HTTP (ofetch)
+
+```typescript
+import { ofetch } from 'ofetch'
+import { useLogger } from '@evlog/cli'
+import { createOutboundHooks } from '@evlog/cli/http'
+
+const log = useLogger()
+const api = ofetch.create(createOutboundHooks(log))
+await api('https://api.example.com/v1/records')
+```
+
+---
+
+## Drain & long-running commands
+
+Same adapters as HTTP — `evlog/fs`, `evlog/axiom`, `evlog/datadog`, `evlog/otlp`, `evlog/pipeline`. Wire them in `src/drain.ts` and pass `createCliDrain()` to `setupEvlog`. Pipeline drains flush on exit by default.
+
+```typescript
+await setup.flush()
+```
+
+Watch / REPL — disable auto-emit:
+
+```typescript
+await setup.invoke({ command: 'run', longRunning: true }, async (log) => {
+  log.set({ phase: 'boot' })
+  log.emit()
+})
+```
+
+---
+
+## Demo CLI
+
+From the evlog monorepo root:
+
+::code-group
+```bash [Human output]
+pnpm example:cli doctor
+pnpm example:cli pull --env staging
+```
+```bash [Debug telemetry]
+pnpm example:cli doctor --log
+```
+```bash [App JSON stdout]
+pnpm example:cli doctor --json
+```
+```bash [Inspect drain]
+tail -f examples/cli/.evlog/logs/$(date +%Y-%m-%d).jsonl
+```
+```bash [Axiom (env on host)]
+export EVLOG_DRAIN=axiom AXIOM_API_KEY=… AXIOM_DATASET=my-cli
+pnpm example:cli doctor
+```
+::

--- a/apps/docs/content/3.integrate/frameworks/17.cli.md
+++ b/apps/docs/content/3.integrate/frameworks/17.cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Observability for command-line tools — wide events per command, drain pipeline, error/audit catalogs, and a citty adapter. Your UI stack stays unchanged.
+description: Observability for command-line tools. One wide event per command, drain pipeline, optional error and audit catalogs. Your citty and Clack stack stays unchanged.
 navigation:
   title: CLI
   icon: i-lucide-terminal
@@ -12,10 +12,10 @@ links:
     variant: subtle
 ---
 
-`@evlog/cli` adds **command → exit** observability on top of evlog. It does **not** replace citty, Clack, or your stdout JSON contract — it owns telemetry (wide events + drain) while you keep your existing CLI stack.
+`@evlog/cli` adds observability from **command start to exit**. It does not replace citty, Clack, or your `--json` stdout contract. You keep routing and terminal UI; evlog owns wide events, the drain, redaction, and optional catalogs.
 
 ::callout{icon="i-lucide-terminal" color="neutral"}
-Runnable demo in the evlog repo: `pnpm example:cli doctor` — wide events land in `examples/cli/.evlog/logs/`. Source: [examples/cli](https://github.com/hugorcd/evlog/tree/main/examples/cli).
+Try it in the repo: `pnpm example:cli doctor` writes NDJSON to `examples/cli/.evlog/logs/`. Source: [examples/cli](https://github.com/hugorcd/evlog/tree/main/examples/cli).
 ::
 
 ::prompt
@@ -67,234 +67,6 @@ Docs: https://www.evlog.dev/integrate/frameworks/cli
 
 ::
 
-## Add evlog to an existing citty CLI
-
-Three changes — everything else stays the same.
-
-```diff [src/drain.ts]
-+ import type { DrainContext } from 'evlog'
-+ import { createFsDrain } from 'evlog/fs'
-+ import { createDrainPipeline } from 'evlog/pipeline'
-+
-+ const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
-+
-+ export function createCliDrain() {
-+   return pipeline(createFsDrain({ dir: '.evlog/logs' }))
-+ }
-```
-
-```diff [src/evlog.ts]
-+ import { setupEvlog } from '@evlog/cli'
-+ import { createCliDrain } from './drain'
-+
-+ export const setup = setupEvlog({
-+   service: 'my-cli',
-+   version: '1.0.0',
-+   drain: createCliDrain(),
-+ })
-```
-
-```diff [src/index.ts]
-+ import { exitWithError } from '@evlog/cli'
-+ import { runMain } from '@evlog/cli/citty'
-+ import { setup } from './evlog'
-- runMain(main)
-+ runMain(main, setup)
-+   .then(() => setup.flush())
-+   .catch(err => exitWithError(err))
-```
-
-```diff [src/commands/doctor.ts]
-+ import { useLogger } from '@evlog/cli'
-
-  async run() {
-+   const log = useLogger()
-+   log.set({ checks: results })
-    p.intro('my-cli doctor')   // Clack unchanged
-    // …
-  }
-```
-
-## What evlog does / does not do
-
-| | evlog | Your app |
-|---|-------|----------|
-| Routing (`--help`, subcommands) | | citty |
-| Terminal UI (spinners, colors) | | Clack, consola, … |
-| `--json` stdout shape | | your flag, your format |
-| Wide events + drain | yes | |
-| `--log` debug on stderr | yes | |
-| Redact secrets in `cli.flags` | yes | |
-| Error catalog (`errorCatalog`, `throw errorCatalog.X()`) | yes | |
-| Audit catalog (`auditCatalog`, `log.audit()`) | yes | |
-
-```text
-citty runMain
-    │
-    ▼
-evlog.invoke()  ──────────────────────────►  drain (.evlog/logs, Axiom, …)
-    │
-    ▼
-command handler  ──►  useLogger().set() / log.audit()
-    │
-    ▼
-Clack / console / your --json  ──►  stdout/stderr (unchanged)
-```
-
-**Default:** evlog console is **silent** — wide events go to the drain only. Pass `--log` (auto-injected by `runMain`) to echo wide events on stderr while debugging.
-
-## Why evlog on a CLI
-
-You do not need audit catalogs on day one. evlog gives you **one structured wide event per command** — duration, exit status, flags (redacted), and whatever you `log.set()` — drained automatically to a file or your observability provider.
-
-| Level | What you add | Demo command |
-|-------|----------------|--------------|
-| **Simple** | `setupEvlog` + `useLogger().set()` | `doctor` |
-| **Medium** | Outbound HTTP hooks, error catalog | `sync` |
-| **Advanced** | Audit catalog, `log.audit()`, deny | `pull`, `deploy` |
-
-Catalogs are optional. Start with a drain + `log.set()` — that alone replaces ad-hoc `console.log` debugging with queryable NDJSON.
-
-## Send events to Axiom (or another provider)
-
-::callout{icon="i-lucide-plug" color="warning"}
-**evlog does not auto-send to Axiom, Datadog, or OTLP.** Wide events only leave your process when you pass a **drain** to `setupEvlog({ drain })`. Without it, telemetry is dropped. The default in most setups is `createFsDrain()` — local NDJSON under `.evlog/logs/`.
-::
-
-On HTTP apps, the framework wires the drain for you (Nuxt hook, Express middleware, …). On a CLI, **you** choose the adapter in one file — usually `src/drain.ts` — and pass it to `setupEvlog`.
-
-### 1. Add `src/drain.ts`
-
-Pick a backend at **runtime** from environment variables. Never hard-code API keys in source or the published bundle.
-
-```typescript [src/drain.ts]
-import type { DrainContext } from 'evlog'
-import { createAxiomDrain } from 'evlog/axiom'
-import { createDatadogDrain } from 'evlog/datadog'
-import { createFsDrain } from 'evlog/fs'
-import { createOtlpDrain } from 'evlog/otlp'
-import { createDrainPipeline } from 'evlog/pipeline'
-
-const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
-
-export function createCliDrain() {
-  switch (process.env.EVLOG_DRAIN ?? 'fs') {
-    case 'axiom':
-      // Reads AXIOM_API_KEY / AXIOM_DATASET (or AXIOM_TOKEN) from the environment
-      return pipeline(createAxiomDrain())
-    case 'datadog':
-      return pipeline(createDatadogDrain())
-    case 'otlp':
-      return pipeline(createOtlpDrain())
-    default:
-      return pipeline(createFsDrain({
-        dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
-      }))
-  }
-}
-```
-
-`EVLOG_DRAIN` is a **convention for your CLI** — evlog does not define it. Name it whatever you want; the demo uses `fs` | `axiom` | `datadog` | `otlp`.
-
-Each adapter reads its own env vars when you call `createXxxDrain()` with no arguments. See the [adapters overview](/integrate/adapters/overview) for full lists.
-
-### 2. Wire the drain in `src/evlog.ts`
-
-```typescript [src/evlog.ts]
-import { setupEvlog } from '@evlog/cli'
-import { createCliDrain } from './drain'
-
-export const setup = setupEvlog({
-  service: 'my-cli',
-  version: '1.0.0',
-  redact: true,
-  drain: createCliDrain(),
-})
-```
-
-### 3. Configure credentials where the CLI runs
-
-| Where | What to set | Result |
-|-------|-------------|--------|
-| **Local dev** | nothing (default) | `.evlog/logs/YYYY-MM-DD.jsonl` on disk |
-| **Local dev + cloud** | `EVLOG_DRAIN=axiom` + Axiom env | events in your Axiom dataset |
-| **CI / cron / server** | same env on the host | operator chooses destination per environment |
-| **Published npm binary** | env on the machine that runs `my-cli` | no token in the package |
-
-```bash
-# Local — inspect NDJSON
-my-cli doctor
-tail -f .evlog/logs/$(date +%Y-%m-%d).jsonl
-
-# Send to Axiom instead (credentials on the host, not in your repo)
-export EVLOG_DRAIN=axiom
-export AXIOM_API_KEY=xaat-…          # or AXIOM_TOKEN (deprecated alias)
-export AXIOM_DATASET=my-cli
-my-cli doctor
-
-# Datadog
-export EVLOG_DRAIN=datadog
-export DATADOG_API_KEY=…
-export DATADOG_SITE=datadoghq.com
-
-# Any OTLP collector (Grafana Cloud, Honeycomb, …)
-export EVLOG_DRAIN=otlp
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://…
-export OTEL_SERVICE_NAME=my-cli
-```
-
-Ship a `.env.example` with commented placeholders — document what operators must set, not real secrets.
-
-### Provider env vars (quick reference)
-
-| Adapter | Import | Required env (typical) | Docs |
-|---------|--------|------------------------|------|
-| File system | `evlog/fs` | `EVLOG_LOG_DIR` (optional) | [fs](/integrate/adapters/self-hosted/fs) |
-| Axiom | `evlog/axiom` | `AXIOM_API_KEY`, `AXIOM_DATASET` | [axiom](/integrate/adapters/cloud/axiom) |
-| Datadog | `evlog/datadog` | `DATADOG_API_KEY`, `DATADOG_SITE` | [datadog](/integrate/adapters/cloud/datadog) |
-| OTLP | `evlog/otlp` | `OTEL_EXPORTER_OTLP_ENDPOINT` | [otlp](/integrate/adapters/cloud/otlp) |
-| Better Stack | `evlog/better-stack` | `BETTER_STACK_SOURCE_TOKEN` | [better-stack](/integrate/adapters/cloud/better-stack) |
-| HyperDX | `evlog/hyperdx` | `HYPERDX_API_KEY` | [hyperdx](/integrate/adapters/cloud/hyperdx) |
-| PostHog | `evlog/posthog` | `POSTHOG_API_KEY` | [posthog](/integrate/adapters/cloud/posthog) |
-| Sentry | `evlog/sentry` | `SENTRY_DSN` | [sentry](/integrate/adapters/cloud/sentry) |
-
-Adapters also accept config objects if you prefer explicit wiring in code (fine for internal tools, not for published CLIs):
-
-```typescript
-pipeline(createAxiomDrain({ apiKey: process.env.AXIOM_API_KEY!, dataset: 'my-cli' }))
-```
-
-### Packaged CLI — credentials never in the bundle
-
-A published CLI (`npm install -g my-cli`) **must not embed** provider tokens. The pattern above keeps observability in the binary and the **destination** on the host:
-
-1. **Default: local drain** — works offline, zero credentials, good for `doctor` / support scripts.
-2. **Production: env on the host** — platform team sets `EVLOG_DRAIN` + provider keys in systemd, CI secrets, or a `.env` the operator loads.
-
-The CLI author ships `drain.ts` + `.env.example`; the operator decides where events go.
-
-## Recommended project layout
-
-Mirror of the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli):
-
-```text [my-cli/]
-my-cli/
-├── package.json
-├── tsconfig.json
-└── src/
-    ├── index.ts              # runMain, flush, exitWithError
-    ├── drain.ts              # createCliDrain() — fs default, axiom via env
-    ├── evlog.ts              # setupEvlog()
-    ├── catalogs/             # optional — advanced commands only
-    │   ├── actor.ts          # resolveCliActor() for audit.actor
-    │   ├── errors.ts
-    │   └── audit.ts
-    └── commands/
-        ├── index.ts          # main + subCommands
-        ├── doctor.ts
-        └── pull.ts
-```
-
 ## Install
 
 ::code-group
@@ -321,33 +93,25 @@ npm install @clack/prompts
 | `citty` | `@evlog/cli/citty` | `runMain(main, setup)` wraps each `run()` in `invoke()` |
 | `ofetch` | `@evlog/cli/http` | Outbound HTTP fields on the wide event |
 
----
+## Integrate (four files)
 
-## Walkthrough
+Add evlog to an existing citty CLI in four steps. Your Clack spinners, `--json` flag, and subcommand tree stay as they are.
 
-### 1. Drain + setup (no catalogs required)
+::code-group
 
-Start with local files; add Axiom/Datadog/OTLP branches when you need cloud — see [Send events to Axiom (or another provider)](#send-events-to-axiom-or-another-provider) above.
-
-```typescript [src/drain.ts]
+```typescript [1 · drain.ts]
 import type { DrainContext } from 'evlog'
-import { createAxiomDrain } from 'evlog/axiom'
 import { createFsDrain } from 'evlog/fs'
 import { createDrainPipeline } from 'evlog/pipeline'
 
 const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
 
 export function createCliDrain() {
-  if (process.env.EVLOG_DRAIN === 'axiom') {
-    return pipeline(createAxiomDrain())
-  }
-  return pipeline(createFsDrain({
-    dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
-  }))
+  return pipeline(createFsDrain({ dir: '.evlog/logs' }))
 }
 ```
 
-```typescript [src/evlog.ts]
+```typescript [2 · evlog.ts]
 import { setupEvlog } from '@evlog/cli'
 import { createCliDrain } from './drain'
 
@@ -359,11 +123,21 @@ export const setup = setupEvlog({
 })
 ```
 
-Every command now emits a wide event to the drain on exit. Add `errorCatalog` / `auditCatalog` later when you need typed errors or audit trails.
+```typescript [3 · index.ts]
+import { exitWithError } from '@evlog/cli'
+import { runMain } from '@evlog/cli/citty'
+import { setup } from './evlog'
+import { main } from './commands'
 
-### 2. Simple command — wide event only
+runMain(main, setup)
+  .then(() => setup.flush())
+  .catch(async (error) => {
+    await setup.flush().catch(() => {})
+    exitWithError(error)
+  })
+```
 
-```typescript [src/commands/doctor.ts]
+```typescript [4 · commands/doctor.ts]
 import { defineCommand } from 'citty'
 import * as p from '@clack/prompts'
 import { useLogger } from '@evlog/cli'
@@ -380,13 +154,130 @@ export const doctor = defineCommand({
 })
 ```
 
-That is enough for observability — one NDJSON line per run with `checks`, `duration`, `status`, `cli.command`.
+::
 
-### 3. Optional — error & audit catalogs
+Each command run emits one wide event to the drain: duration, exit status, redacted flags, and whatever you pass to `log.set()`.
+
+### What you see vs what gets drained
+
+::code-group
+```bash [Terminal]
+$ my-cli doctor
+◆  my-cli doctor
+◇  Running checks
+◆  All 2 checks passed
+```
+```bash [--log]
+$ my-cli doctor --log
+… wide event pretty-printed on stderr …
+```
+```bash [--json (yours)]
+$ my-cli doctor --json
+{"checks":[{"name":"config","ok":true}]}
+```
+::
+
+Stdout stays yours. NDJSON wide events always go to the drain (for example `.evlog/logs/2026-05-30.jsonl` with `createFsDrain`).
+
+## What evlog does / does not do
+
+| | evlog | Your app |
+|---|-------|----------|
+| Routing (`--help`, subcommands) | | citty |
+| Terminal UI (spinners, colors) | | Clack, consola, … |
+| `--json` stdout shape | | your flag, your format |
+| Wide events + drain | yes | |
+| `--log` debug on stderr | yes | |
+| Redact secrets in `cli.flags` | yes | |
+| Error catalog | yes | |
+| Audit catalog | yes | |
+
+```text
+citty runMain → evlog.invoke() → drain (.evlog/logs, Axiom, …)
+                      ↓
+              useLogger().set() / log.audit()
+                      ↓
+         Clack / console / your --json → stdout (unchanged)
+```
+
+By default the evlog console is **silent**. Pass `--log` (auto-injected by `runMain`) to echo wide events on stderr while debugging.
+
+## Why evlog on a CLI
+
+Every command is a small operation with a clear start and end. That maps cleanly to a **wide event**: duration, exit code, redacted flags, and the fields you attach with `log.set()`. The result lands as queryable NDJSON locally, or in Axiom, Datadog, or OTLP when you wire a cloud drain.
+
+Audit and error catalogs are optional. Add them when you need typed throws or security-sensitive actions, not on day one.
+
+| Level | What you add | Demo |
+|-------|----------------|------|
+| **Simple** | `setupEvlog` + `useLogger().set()` | `doctor` |
+| **Medium** | Outbound HTTP hooks, error catalog | `sync` |
+| **Advanced** | Audit catalog, `log.audit()`, deny | `pull`, `deploy` |
+
+See the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli) for all three levels in one repo.
+
+## Send events to Axiom (or another provider)
+
+::callout{icon="i-lucide-plug" color="warning"}
+**evlog does not auto-send to Axiom, Datadog, or OTLP.** Wide events leave the process only when you pass a **drain** to `setupEvlog({ drain })`. Without it, telemetry is dropped. Most setups start with `createFsDrain()` and local NDJSON under `.evlog/logs/`.
+::
+
+On HTTP apps the framework wires the drain for you. On a CLI, you pick the adapter in `src/drain.ts` and pass `createCliDrain()` to `setupEvlog`. Credentials live on the host that runs the binary, never in the published package.
+
+::code-group
+
+```typescript [drain.ts]
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createFsDrain } from 'evlog/fs'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
+
+export function createCliDrain() {
+  if (process.env.EVLOG_DRAIN === 'axiom') {
+    return pipeline(createAxiomDrain()) // AXIOM_API_KEY, AXIOM_DATASET from env
+  }
+  return pipeline(createFsDrain({
+    dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
+  }))
+}
+```
+
+```bash [Local]
+my-cli doctor
+tail -f .evlog/logs/$(date +%Y-%m-%d).jsonl
+```
+
+```bash [Axiom]
+export EVLOG_DRAIN=axiom
+export AXIOM_API_KEY=xaat-…
+export AXIOM_DATASET=my-cli
+my-cli doctor
+```
+
+::
+
+`EVLOG_DRAIN` is a **convention for your CLI**, not a built-in evlog flag. Swap in `evlog/datadog`, `evlog/otlp`, etc. the same way. Full env lists: [adapters overview](/integrate/adapters/overview).
+
+| Adapter | Import | Typical env |
+|---------|--------|-------------|
+| File system | `evlog/fs` | `EVLOG_LOG_DIR` |
+| Axiom | `evlog/axiom` | `AXIOM_API_KEY`, `AXIOM_DATASET` |
+| Datadog | `evlog/datadog` | `DATADOG_API_KEY`, `DATADOG_SITE` |
+| OTLP | `evlog/otlp` | `OTEL_EXPORTER_OTLP_ENDPOINT` |
+
+Ship a `.env.example` with commented placeholders for operators. Never commit real keys.
+
+## Go further (optional)
+
+### Error and audit catalogs
 
 Add when commands throw typed errors or record sensitive actions:
 
-```typescript [src/catalogs/errors.ts]
+::code-group
+
+```typescript [catalogs/errors.ts]
 import { defineErrorCatalog } from 'evlog'
 
 export const errorCatalog = defineErrorCatalog('myapp', {
@@ -404,7 +295,7 @@ declare module 'evlog' {
 }
 ```
 
-```typescript [src/catalogs/audit.ts]
+```typescript [catalogs/audit.ts]
 import { defineAuditCatalog } from 'evlog'
 
 export const auditCatalog = defineAuditCatalog('myapp', {
@@ -413,12 +304,6 @@ export const auditCatalog = defineAuditCatalog('myapp', {
     severity: 'high',
     description: 'Read secrets from a remote store',
     redactPaths: ['token', 'password'],
-  },
-  DEPLOY: {
-    target: 'deployment',
-    severity: 'critical',
-    requiresChanges: true,
-    description: 'Promote a build to a region',
   },
 })
 
@@ -429,7 +314,7 @@ declare module 'evlog' {
 }
 ```
 
-```typescript [src/catalogs/actor.ts]
+```typescript [catalogs/actor.ts]
 import type { AuditActor } from 'evlog'
 
 export function resolveCliActor(): AuditActor {
@@ -438,117 +323,81 @@ export function resolveCliActor(): AuditActor {
 }
 ```
 
-Pass them to `setupEvlog({ errorCatalog, auditCatalog })`. See the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli) `pull` and `deploy` commands for full audit usage.
-
-### 4. Entry — `src/index.ts`
-
-```typescript [src/index.ts]
-import { exitWithError } from '@evlog/cli'
-import { runMain } from '@evlog/cli/citty'
-import { setup } from './evlog'
-import { main } from './commands'
-
-runMain(main, setup)
-  .then(() => setup.flush())
-  .catch(error => exitWithError(error))
-```
-
-### What you see vs what gets drained
-
-::code-group
-```bash [Normal (TTY)]
-$ my-cli doctor
-◆  my-cli doctor
-│
-◇  Running checks
-│
-◆  All 2 checks passed
-```
-```bash [--log (debug telemetry on stderr)]
-$ my-cli doctor --log
-◆  my-cli doctor
-…
-19:04:12 INFO [my-cli] CLI /doctor in 98ms
-  └─ checks: …
-```
-```bash [--json (your app contract)]
-$ my-cli doctor --json
-{"checks":[{"name":"config","ok":true},{"name":"api","ok":true}]}
-```
 ::
 
-The NDJSON wide event is always written to the drain — e.g. `.evlog/logs/2026-05-30.jsonl` with `createFsDrain`.
+Pass `errorCatalog` and `auditCatalog` to `setupEvlog()`. Full audit usage: demo `pull` and `deploy` commands.
+
+```typescript
+log.audit(auditCatalog.SECRET_PULL({
+  actor: resolveCliActor(),
+  target: { id: args.env, resource: 'secrets', access: 'read' },
+  outcome: 'success',
+}))
+
+log.audit.deny('Missing API token', auditCatalog.SECRET_PULL({
+  actor: resolveCliActor(),
+  target: { id: args.env, access: 'read' },
+}))
+```
+
+### Outbound HTTP (ofetch)
+
+```typescript
+import { ofetch } from 'ofetch'
+import { useLogger } from '@evlog/cli'
+import { createOutboundHooks } from '@evlog/cli/http'
+
+const api = ofetch.create(createOutboundHooks(useLogger()))
+await api('https://api.example.com/v1/records')
+```
+
+### Project layout
+
+```text
+my-cli/src/
+├── index.ts       # runMain, flush, exitWithError
+├── drain.ts       # createCliDrain()
+├── evlog.ts       # setupEvlog()
+├── catalogs/      # optional
+└── commands/
+```
 
 ---
 
 ## API reference
 
-### `setupEvlog(config)` vs `useLogger()`
-
-Two roles — same split as HTTP middleware:
+### `setupEvlog()` vs `useLogger()`
 
 | | `setupEvlog()` | `useLogger()` |
 |---|----------------|---------------|
-| When | once at startup (`src/evlog.ts`) | inside every command handler |
-| Does | configure drain, redact, catalogs | returns the **command-scoped** logger |
-| Analog | `EvlogModule.forRoot()` / Nitro plugin | `useLogger()` in Express, Nest, Hono |
+| When | once in `src/evlog.ts` | inside every command handler |
+| Role | drain, redact, catalogs | command-scoped logger |
 | You call | `runMain(main, setup)`, `setup.flush()` | `log.set()`, `log.audit()`, `throw errorCatalog.X()` |
 
-`setupEvlog` configures the global pipeline. Each citty command gets its own logger (path `/doctor`, flags, duration) via AsyncLocalStorage — `useLogger()` retrieves it anywhere in the call stack.
+`setupEvlog` configures the pipeline once. Each citty command gets its own logger (`path: /doctor`, flags, duration) via async context.
 
-```typescript
-const log = useLogger()
-log.set({ checks })   // not setup.set() — setup is config, log is telemetry
-```
+**`setupEvlog(config)`** — `service`, `version`, `drain`, `errorCatalog`, `auditCatalog`, `redact` (default `true`), `flushOnExit`, `logToConsole`. Returns `{ invoke, log, errorCatalog, auditCatalog, audit, flush }`.
 
-### `setupEvlog(config)`
+**`useLogger()`** — inside any `invoke()` / `runMain` handler. Import from `@evlog/cli`; no need to pass `setup` around.
 
-Boot once at startup. Options: `service`, `version`, `drain`, `errorCatalog`, `auditCatalog`, `redact` (default `true`), `flushOnExit` (default `true`), `logToConsole` (always print wide events, same as `--log`).
+**`runMain(main, setup)`** — `@evlog/cli/citty`. Wraps every `run()` in `invoke()`. Auto-injects `--log`.
 
-Returns `{ invoke, log, errorCatalog, auditCatalog, audit, flush }`.
+**`exitWithError(err)`** — human-readable stderr + `process.exit`. Use after `setup.flush()` on the error path.
 
-- `errorCatalog` — from config (`defineErrorCatalog`); import in commands for `throw errorCatalog.X()`
-- `auditCatalog` — from config (`defineAuditCatalog`); types for `log.audit({ action: 'myapp.…' })`
-- `audit()` — shortcut that calls `useLogger().audit()` outside a handler (rare)
-
-### `useLogger()`
-
-Inside any `invoke()` / `runMain` handler (or any function called from there). Import from `@evlog/cli` — no need to pass `setup` around.
-
-### `runMain(main, setup)` — `@evlog/cli/citty`
-
-Wraps every citty `run()` in `invoke()`. Auto-injects global `--log`.
-
-### `exitWithError(err)` / `parseCliError(err)`
-
-Human-readable message on stderr + `process.exit`. Throw catalog errors in handlers: `throw errorCatalog.CONFIG_MISSING()`.
-
-### `--log`
-
-evlog-only flag. Pretty wide events on stderr. Injected by `runMain` — no manual spread.
-
----
-
-## Wide event shape
+### Wide event shape
 
 | Field | CLI value |
 |-------|-----------|
 | `method` | `'CLI'` |
-| `path` | `'/<command>'` or `'/<cmd>/<subcmd>'` |
-| `status` | exit code (0 success, catalog status on error) |
+| `path` | `'/<command>'` |
+| `status` | exit code |
 | `cli.command` | command segment |
-| `cli.flags` | parsed flags (secrets redacted) |
+| `cli.flags` | parsed flags (redacted) |
 | `cli.version` | from `setupEvlog({ version })` |
-| `cli.tty` | `{ stdin, stdout, stderr }` booleans |
-| `cli.ci` | `true` when `CI` env is set |
 
----
+### `createCommandLogger` (libraries)
 
-## Adoption levels
-
-### Level 0 — `createCommandLogger`
-
-For **libraries** inside someone else's CLI — no global drain bootstrap:
+For code inside someone else's CLI, without global bootstrap:
 
 ```typescript
 import { createCommandLogger } from '@evlog/cli'
@@ -558,84 +407,12 @@ log.set({ records: 150 })
 log.emit({ status: 0 })
 ```
 
-### Level 1 — manual `invoke()`
-
-When not using citty:
-
-```typescript
-await setup.invoke({ command: 'backup', flags: { target: 's3' } }, async (log) => {
-  log.set({ files: 42 })
-})
-```
-
-### Level 2 — citty `runMain`
-
-Recommended for multi-command CLIs — see walkthrough above.
-
----
-
-## Audit
-
-Use the catalog wrapper — `target.type` comes from the catalog entry; add resource metadata on `target`:
-
-```typescript
-import { auditCatalog } from '../catalogs/audit'
-import { resolveCliActor } from '../catalogs/actor'
-
-const log = useLogger()
-const actor = resolveCliActor()
-
-log.audit(auditCatalog.SECRET_PULL({
-  actor,
-  target: {
-    id: args.env,
-    env: args.env,
-    resource: 'secrets',
-    access: 'read',
-  },
-  outcome: 'success',
-  changes: {
-    after: { keyCount: 3, keys: ['DATABASE_URL', 'API_KEY'] },
-  },
-}))
-
-// AuthZ denial — auditors care about these too
-log.audit.deny('Missing API token', auditCatalog.SECRET_PULL({
-  actor,
-  target: { id: args.env, access: 'read' },
-}))
-```
-
-Fields merge into the wide event. `cliRedactPreset` + `auditRedactPreset` apply when `redact: true`.
-
----
-
-## Outbound HTTP (ofetch)
-
-```typescript
-import { ofetch } from 'ofetch'
-import { useLogger } from '@evlog/cli'
-import { createOutboundHooks } from '@evlog/cli/http'
-
-const log = useLogger()
-const api = ofetch.create(createOutboundHooks(log))
-await api('https://api.example.com/v1/records')
-```
-
----
-
-## Drain & long-running commands
-
-Same adapters as HTTP — `evlog/fs`, `evlog/axiom`, `evlog/datadog`, `evlog/otlp`, `evlog/pipeline`. Wire them in `src/drain.ts` and pass `createCliDrain()` to `setupEvlog`. Pipeline drains flush on exit by default.
+### Long-running commands
 
 ```typescript
 await setup.flush()
-```
 
-Watch / REPL — disable auto-emit:
-
-```typescript
-await setup.invoke({ command: 'run', longRunning: true }, async (log) => {
+await setup.invoke({ command: 'watch', longRunning: true }, async (log) => {
   log.set({ phase: 'boot' })
   log.emit()
 })
@@ -643,26 +420,23 @@ await setup.invoke({ command: 'run', longRunning: true }, async (log) => {
 
 ---
 
-## Demo CLI
+## Try it
 
 From the evlog monorepo root:
 
 ::code-group
-```bash [Human output]
+```bash [Run]
 pnpm example:cli doctor
-pnpm example:cli pull --env staging
+pnpm example:cli sync 3
 ```
-```bash [Debug telemetry]
+```bash [Debug]
 pnpm example:cli doctor --log
-```
-```bash [App JSON stdout]
-pnpm example:cli doctor --json
 ```
 ```bash [Inspect drain]
 tail -f examples/cli/.evlog/logs/$(date +%Y-%m-%d).jsonl
 ```
-```bash [Axiom (env on host)]
-export EVLOG_DRAIN=axiom AXIOM_API_KEY=… AXIOM_DATASET=my-cli
+```bash [Axiom]
+export EVLOG_DRAIN=axiom AXIOM_API_KEY=… AXIOM_DATASET=evlog-demo-cli
 pnpm example:cli doctor
 ```
 ::

--- a/apps/docs/content/3.integrate/frameworks/17.cli.md
+++ b/apps/docs/content/3.integrate/frameworks/17.cli.md
@@ -95,11 +95,11 @@ npm install @clack/prompts
 
 ## Integrate (four files)
 
-Add evlog to an existing citty CLI in four steps. Your Clack spinners, `--json` flag, and subcommand tree stay as they are.
+Add evlog to an existing citty CLI in four steps. Your Clack spinners, `--json` flag, and subcommand tree stay as they are. Pick a file in the tree to view its code.
 
-::code-group
+::code-tree{defaultValue="src/evlog.ts"}
 
-```typescript [1 · drain.ts]
+```ts [src/drain.ts]
 import type { DrainContext } from 'evlog'
 import { createFsDrain } from 'evlog/fs'
 import { createDrainPipeline } from 'evlog/pipeline'
@@ -111,7 +111,7 @@ export function createCliDrain() {
 }
 ```
 
-```typescript [2 · evlog.ts]
+```ts [src/evlog.ts]
 import { setupEvlog } from '@evlog/cli'
 import { createCliDrain } from './drain'
 
@@ -123,7 +123,7 @@ export const setup = setupEvlog({
 })
 ```
 
-```typescript [3 · index.ts]
+```ts [src/index.ts]
 import { exitWithError } from '@evlog/cli'
 import { runMain } from '@evlog/cli/citty'
 import { setup } from './evlog'
@@ -137,7 +137,7 @@ runMain(main, setup)
   })
 ```
 
-```typescript [4 · commands/doctor.ts]
+```ts [src/commands/doctor.ts]
 import { defineCommand } from 'citty'
 import * as p from '@clack/prompts'
 import { useLogger } from '@evlog/cli'
@@ -224,9 +224,9 @@ See the [demo CLI](https://github.com/hugorcd/evlog/tree/main/examples/cli) for 
 
 On HTTP apps the framework wires the drain for you. On a CLI, you pick the adapter in `src/drain.ts` and pass `createCliDrain()` to `setupEvlog`. Credentials live on the host that runs the binary, never in the published package.
 
-::code-group
+::code-tree{defaultValue="src/drain.ts"}
 
-```typescript [drain.ts]
+```ts [src/drain.ts]
 import type { DrainContext } from 'evlog'
 import { createAxiomDrain } from 'evlog/axiom'
 import { createFsDrain } from 'evlog/fs'
@@ -244,18 +244,25 @@ export function createCliDrain() {
 }
 ```
 
+```bash [.env.example]
+# EVLOG_DRAIN=axiom
+# AXIOM_API_KEY=
+# AXIOM_DATASET=my-cli
+```
+
+::
+
+::code-group
 ```bash [Local]
 my-cli doctor
 tail -f .evlog/logs/$(date +%Y-%m-%d).jsonl
 ```
-
 ```bash [Axiom]
 export EVLOG_DRAIN=axiom
 export AXIOM_API_KEY=xaat-…
 export AXIOM_DATASET=my-cli
 my-cli doctor
 ```
-
 ::
 
 `EVLOG_DRAIN` is a **convention for your CLI**, not a built-in evlog flag. Swap in `evlog/datadog`, `evlog/otlp`, etc. the same way. Full env lists: [adapters overview](/integrate/adapters/overview).
@@ -275,9 +282,9 @@ Ship a `.env.example` with commented placeholders for operators. Never commit re
 
 Add when commands throw typed errors or record sensitive actions:
 
-::code-group
+::code-tree{defaultValue="src/catalogs/errors.ts"}
 
-```typescript [catalogs/errors.ts]
+```ts [src/catalogs/errors.ts]
 import { defineErrorCatalog } from 'evlog'
 
 export const errorCatalog = defineErrorCatalog('myapp', {
@@ -295,7 +302,7 @@ declare module 'evlog' {
 }
 ```
 
-```typescript [catalogs/audit.ts]
+```ts [src/catalogs/audit.ts]
 import { defineAuditCatalog } from 'evlog'
 
 export const auditCatalog = defineAuditCatalog('myapp', {
@@ -314,7 +321,7 @@ declare module 'evlog' {
 }
 ```
 
-```typescript [catalogs/actor.ts]
+```ts [src/catalogs/actor.ts]
 import type { AuditActor } from 'evlog'
 
 export function resolveCliActor(): AuditActor {
@@ -342,7 +349,9 @@ log.audit.deny('Missing API token', auditCatalog.SECRET_PULL({
 
 ### Outbound HTTP (ofetch)
 
-```typescript
+::code-tree{defaultValue="src/commands/sync.ts"}
+
+```ts [src/commands/sync.ts]
 import { ofetch } from 'ofetch'
 import { useLogger } from '@evlog/cli'
 import { createOutboundHooks } from '@evlog/cli/http'
@@ -350,6 +359,10 @@ import { createOutboundHooks } from '@evlog/cli/http'
 const api = ofetch.create(createOutboundHooks(useLogger()))
 await api('https://api.example.com/v1/records')
 ```
+
+::
+
+Outbound HTTP fields merge into the same wide event as the command.
 
 ### Project layout
 

--- a/apps/docs/content/3.integrate/frameworks/17.cli.md
+++ b/apps/docs/content/3.integrate/frameworks/17.cli.md
@@ -95,6 +95,7 @@ Three changes — everything else stays the same.
 ```
 
 ```diff [src/index.ts]
++ import { exitWithError } from '@evlog/cli'
 + import { runMain } from '@evlog/cli/citty'
 + import { setup } from './evlog'
 - runMain(main)

--- a/examples/cli/.env.example
+++ b/examples/cli/.env.example
@@ -1,0 +1,18 @@
+# Drain backend — convention used by examples/cli/src/drain.ts (not an evlog built-in)
+# EVLOG_DRAIN=fs
+# EVLOG_LOG_DIR=.evlog/logs
+
+# Send wide events to Axiom (set on the host, never commit real keys)
+# EVLOG_DRAIN=axiom
+# AXIOM_API_KEY=
+# AXIOM_DATASET=evlog-demo-cli
+
+# Datadog
+# EVLOG_DRAIN=datadog
+# DATADOG_API_KEY=
+# DATADOG_SITE=datadoghq.com
+
+# OTLP (Grafana Cloud, Honeycomb, any collector)
+# EVLOG_DRAIN=otlp
+# OTEL_EXPORTER_OTLP_ENDPOINT=
+# OTEL_SERVICE_NAME=evlog-demo-cli

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -1,0 +1,71 @@
+# evlog CLI example
+
+Three levels in one demo — why evlog on a CLI:
+
+| Level | Command | What you get |
+|-------|---------|----------------|
+| **Simple** | `doctor` | One wide event per run — duration, checks, exit status → drain |
+| **Medium** | `sync` | Same + outbound HTTP fields on the wide event |
+| **Advanced** | `pull`, `deploy` | Error catalog, audit catalog, deny, before/after changes |
+
+No audit or catalog required for basic observability — `useLogger().set()` is enough.
+
+## Run
+
+```bash
+pnpm example:cli doctor              # simple — wide event only
+pnpm example:cli sync 3              # medium — http.outbound on the event
+pnpm example:cli pull --token shlv_demo --env production   # audit + redact
+pnpm example:cli pull --env staging                        # audit.deny (no token)
+pnpm example:cli deploy --region us-east-1
+pnpm example:cli doctor --log          # debug: pretty event on stderr
+```
+
+## Where events go
+
+**evlog does not send anywhere by itself.** Wide events only leave the process through the **drain** you pass to `setupEvlog({ drain })`. This demo resolves the drain in `src/drain.ts` from `EVLOG_DRAIN`.
+
+### Default — local files (no token)
+
+```bash
+pnpm example:cli doctor
+# → examples/cli/.evlog/logs/YYYY-MM-DD.jsonl
+
+tail -f examples/cli/.evlog/logs/$(date +%Y-%m-%d).jsonl
+```
+
+### Axiom — env on the machine that runs the binary
+
+Never bake tokens into the package. Set env where the CLI runs (your shell, CI, cron, server):
+
+```bash
+export EVLOG_DRAIN=axiom
+export AXIOM_API_KEY=xaat-…    # or AXIOM_TOKEN
+export AXIOM_DATASET=evlog-demo-cli
+pnpm example:cli doctor
+```
+
+Check the dataset in [Axiom](https://app.axiom.co). Same wide event shape as the local NDJSON file.
+
+### Other providers
+
+Add a `case` in `src/drain.ts` and set the adapter env vars documented on [evlog.dev/adapters](https://evlog.dev/integrate/adapters/overview):
+
+| `EVLOG_DRAIN` | Import | Typical env |
+|---------------|--------|-------------|
+| `datadog` | `evlog/datadog` | `DATADOG_API_KEY`, `DATADOG_SITE` |
+| `otlp` | `evlog/otlp` | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME` |
+
+Copy `.env.example` to `.env` for local experiments (gitignored).
+
+## Layout
+
+```text
+src/
+├── drain.ts          # createCliDrain() — fs default, cloud via EVLOG_DRAIN
+├── evlog.ts          # setupEvlog({ drain: createCliDrain() })
+├── catalogs/         # optional — pull & deploy only
+└── commands/
+```
+
+Full walkthrough: [CLI integration docs](https://evlog.dev/integrate/frameworks/cli#send-events-to-axiom-or-another-provider).

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "evlog-cli-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0",
+    "@evlog/cli": "workspace:*",
+    "citty": "^0.2.2",
+    "evlog": "workspace:*"
+  }
+}

--- a/examples/cli/src/catalogs/actor.ts
+++ b/examples/cli/src/catalogs/actor.ts
@@ -1,0 +1,12 @@
+import type { AuditActor } from 'evlog'
+
+/** Resolve the CLI operator for audit `actor` fields (demo — replace with your auth). */
+export function resolveCliActor(): AuditActor {
+  const id = process.env.USER ?? process.env.LOGNAME ?? 'demo-user'
+  return {
+    type: 'user',
+    id,
+    displayName: id,
+    email: process.env.DEMO_USER_EMAIL,
+  }
+}

--- a/examples/cli/src/catalogs/audit.ts
+++ b/examples/cli/src/catalogs/audit.ts
@@ -1,0 +1,27 @@
+import { defineAuditCatalog } from 'evlog'
+
+export const auditCatalog = defineAuditCatalog('demo', {
+  SECRET_PULL: {
+    target: 'secret_store',
+    severity: 'high',
+    description: 'Read secrets from a remote store and materialize them locally',
+    redactPaths: ['token', 'password', 'secret'],
+  },
+  DEPLOY: {
+    target: 'deployment',
+    severity: 'critical',
+    description: 'Promote a build to a target region',
+    requiresChanges: true,
+  },
+  SYNC_EXPORT: {
+    target: 'dataset',
+    severity: 'medium',
+    description: 'Export records from a remote API into the local workspace',
+  },
+})
+
+declare module 'evlog' {
+  interface RegisteredAuditCatalogs {
+    demo: typeof auditCatalog
+  }
+}

--- a/examples/cli/src/catalogs/errors.ts
+++ b/examples/cli/src/catalogs/errors.ts
@@ -1,0 +1,25 @@
+import { defineErrorCatalog } from 'evlog'
+
+export const errorCatalog = defineErrorCatalog('demo', {
+  CONFIG_MISSING: {
+    status: 1,
+    message: 'No demo.config.json found',
+    fix: 'Run demo init or set DEMO_ENV=local',
+  },
+  AUTH_TOKEN_REQUIRED: {
+    status: 1,
+    message: 'API token required',
+    fix: 'Pass --token or set DEMO_API_TOKEN',
+  },
+  CHECK_FAILED: {
+    status: 2,
+    message: 'One or more checks failed',
+    fix: 'Run demo doctor --verbose for details',
+  },
+})
+
+declare module 'evlog' {
+  interface RegisteredErrorCatalogs {
+    demo: typeof errorCatalog
+  }
+}

--- a/examples/cli/src/commands/deploy.ts
+++ b/examples/cli/src/commands/deploy.ts
@@ -1,0 +1,69 @@
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+import { resolveCliActor } from '../catalogs/actor'
+import { auditCatalog } from '../catalogs/audit'
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export const deploy = defineCommand({
+  meta: {
+    name: 'deploy',
+    description: 'Fake deploy with phased wide-event context',
+  },
+  args: {
+    region: {
+      type: 'string',
+      description: 'Deploy region',
+      default: 'eu-west-1',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Machine-readable stdout (app contract)',
+    },
+  },
+  async run({ args }) {
+    const log = useLogger()
+    const actor = resolveCliActor()
+
+    if (!args.json) {
+      p.intro(`Deploying to ${args.region}`)
+    }
+
+    const build = args.json ? null : p.spinner()
+    build?.start('Building')
+    log.set({ phase: 'build' })
+    await sleep(60)
+    build?.stop('Build complete')
+
+    const rollout = args.json ? null : p.spinner()
+    rollout?.start('Rolling out')
+    log.set({ phase: 'rollout', region: args.region })
+    await sleep(80)
+    rollout?.stop('Rollout complete')
+
+    const instances = 3
+    log.set({ phase: 'complete', region: args.region, instances })
+
+    log.audit(auditCatalog.DEPLOY({
+      actor,
+      target: {
+        id: `deploy-${args.region}`,
+        region: args.region,
+        resource: 'deployment',
+      },
+      outcome: 'success',
+      changes: {
+        before: { phase: 'pending', instances: 0 },
+        after: { phase: 'complete', region: args.region, instances },
+      },
+    }))
+
+    const payload = { region: args.region, instances }
+    if (args.json) {
+      console.log(JSON.stringify(payload))
+    } else {
+      p.outro(`Deployed to ${args.region}`)
+    }
+  },
+})

--- a/examples/cli/src/commands/doctor.ts
+++ b/examples/cli/src/commands/doctor.ts
@@ -1,0 +1,64 @@
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+import { errorCatalog } from '../catalogs/errors'
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export const doctor = defineCommand({
+  meta: {
+    name: 'doctor',
+    description: 'Run fake health checks and emit a wide event',
+  },
+  args: {
+    verbose: {
+      type: 'boolean',
+      description: 'Show per-check output',
+      alias: 'v',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Machine-readable stdout (app contract)',
+    },
+  },
+  async run({ args }) {
+    const log = useLogger()
+
+    if (!args.json) {
+      p.intro('evlog-demo doctor')
+    }
+
+    const s = args.json ? null : p.spinner()
+    s?.start('Running checks')
+
+    const checks = [
+      { name: 'config', ok: true, ms: 12 },
+      { name: 'network', ok: true, ms: 48 },
+      { name: 'cache', ok: true, ms: 31 },
+    ]
+
+    for (const check of checks) {
+      await sleep(40)
+      log.set({ checks: checks.map(({ name, ok, ms }) => ({ name, ok, ms })) })
+      if (args.verbose && !args.json) {
+        p.log.info(`${check.ok ? '✓' : '✗'} ${check.name} (${check.ms}ms)`)
+      }
+    }
+
+    const failed = checks.filter(c => !c.ok)
+    if (failed.length > 0) {
+      throw errorCatalog.CHECK_FAILED({ internal: { failed: failed.map(c => c.name) } })
+    }
+
+    s?.stop('Done')
+
+    const payload = { checks, passed: checks.length, failed: 0 }
+    log.set({ result: payload })
+
+    if (args.json) {
+      console.log(JSON.stringify(payload))
+    } else {
+      p.outro(`All ${checks.length} checks passed`)
+    }
+  },
+})

--- a/examples/cli/src/commands/index.ts
+++ b/examples/cli/src/commands/index.ts
@@ -1,0 +1,19 @@
+import { defineCommand } from 'citty'
+import { deploy } from './deploy'
+import { doctor } from './doctor'
+import { pull } from './pull'
+import { sync } from './sync'
+
+export const main = defineCommand({
+  meta: {
+    name: 'evlog-demo',
+    version: '0.1.0',
+    description: 'Fake CLI to explore @evlog/cli — doctor, pull, sync, deploy',
+  },
+  subCommands: {
+    doctor,
+    pull,
+    sync,
+    deploy,
+  },
+})

--- a/examples/cli/src/commands/pull.ts
+++ b/examples/cli/src/commands/pull.ts
@@ -1,0 +1,79 @@
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+import { resolveCliActor } from '../catalogs/actor'
+import { auditCatalog } from '../catalogs/audit'
+import { errorCatalog } from '../catalogs/errors'
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export const pull = defineCommand({
+  meta: {
+    name: 'pull',
+    description: 'Fake secret pull with audit + redacted token flag',
+  },
+  args: {
+    token: {
+      type: 'string',
+      description: 'API token (redacted in logs)',
+    },
+    env: {
+      type: 'string',
+      description: 'Target environment',
+      default: 'staging',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Machine-readable stdout (app contract)',
+    },
+  },
+  async run({ args }) {
+    const log = useLogger()
+    const actor = resolveCliActor()
+
+    if (!args.env) {
+      throw errorCatalog.CONFIG_MISSING()
+    }
+
+    if (!args.token) {
+      log.audit.deny('Missing API token', auditCatalog.SECRET_PULL({
+        actor,
+        target: { id: args.env, env: args.env, access: 'read' },
+      }))
+      throw errorCatalog.AUTH_TOKEN_REQUIRED()
+    }
+
+    const s = args.json ? null : p.spinner()
+    s?.start(`Pulling secrets for ${args.env}`)
+    await sleep(120)
+
+    const keys = ['DATABASE_URL', 'API_KEY', 'SIGNING_SECRET']
+    log.set({
+      secrets: { env: args.env, keyCount: keys.length, keys },
+      flags: { token: args.token },
+    })
+
+    log.audit(auditCatalog.SECRET_PULL({
+      actor,
+      target: {
+        id: args.env,
+        env: args.env,
+        resource: 'secrets',
+        access: 'read',
+      },
+      outcome: 'success',
+      changes: {
+        after: { env: args.env, keyCount: keys.length, keys },
+      },
+    }))
+
+    s?.stop('Secrets pulled')
+
+    const payload = { env: args.env, keyCount: keys.length }
+    if (args.json) {
+      console.log(JSON.stringify(payload))
+    } else {
+      p.log.success(`Pulled ${keys.length} secrets for ${args.env}`)
+    }
+  },
+})

--- a/examples/cli/src/commands/sync.ts
+++ b/examples/cli/src/commands/sync.ts
@@ -24,7 +24,10 @@ export const sync = defineCommand({
   },
   async run({ args }) {
     const log = useLogger()
-    const count = Number(args.records) || 5
+    const count = Number(args.records)
+    if (!Number.isInteger(count) || count < 0) {
+      throw new TypeError('records must be a non-negative integer')
+    }
     const hooks = createOutboundHooks(log)
     const source = 'https://api.example.com'
 

--- a/examples/cli/src/commands/sync.ts
+++ b/examples/cli/src/commands/sync.ts
@@ -1,0 +1,57 @@
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+import { createOutboundHooks } from '@evlog/cli/http'
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/** Medium — wide event + outbound HTTP hooks, no audit catalog. */
+export const sync = defineCommand({
+  meta: {
+    name: 'sync',
+    description: 'Fake sync with outbound HTTP hooks on the wide event',
+  },
+  args: {
+    records: {
+      type: 'positional',
+      description: 'Number of records to sync',
+      default: '5',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Machine-readable stdout (app contract)',
+    },
+  },
+  async run({ args }) {
+    const log = useLogger()
+    const count = Number(args.records) || 5
+    const hooks = createOutboundHooks(log)
+    const source = 'https://api.example.com'
+
+    if (!args.json) {
+      p.log.info(`Syncing ${count} records…`)
+    }
+
+    for (let i = 1; i <= count; i++) {
+      await hooks.onRequest?.({
+        request: `/records/${i}`,
+        options: { method: 'GET', baseURL: source },
+      })
+      await hooks.onResponse?.({
+        request: `/records/${i}`,
+        options: { method: 'GET', baseURL: source },
+        response: new Response(JSON.stringify({ id: i }), { status: 200 }),
+      })
+
+      await sleep(30)
+      log.set({ sync: { processed: i, total: count } })
+    }
+
+    const payload = { processed: count, source }
+    if (args.json) {
+      console.log(JSON.stringify(payload))
+    } else {
+      p.log.success(`Synced ${count} records`)
+    }
+  },
+})

--- a/examples/cli/src/drain.ts
+++ b/examples/cli/src/drain.ts
@@ -1,0 +1,35 @@
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createDatadogDrain } from 'evlog/datadog'
+import { createFsDrain } from 'evlog/fs'
+import { createOtlpDrain } from 'evlog/otlp'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+const pipeline = createDrainPipeline<DrainContext>({
+  batch: { size: 5, intervalMs: 1000 },
+})
+
+/**
+ * Resolve the drain at runtime.
+ *
+ * Packaged CLIs must not embed provider tokens — read env on the machine that
+ * runs the binary. Default `fs` works offline with zero credentials.
+ *
+ * @see examples/cli/.env.example
+ * @see https://evlog.dev/integrate/frameworks/cli#send-events-to-axiom-or-another-provider
+ */
+export function createCliDrain() {
+  switch (process.env.EVLOG_DRAIN ?? 'fs') {
+    case 'axiom':
+      // Reads AXIOM_API_KEY / AXIOM_DATASET (or AXIOM_TOKEN) from the environment
+      return pipeline(createAxiomDrain())
+    case 'datadog':
+      return pipeline(createDatadogDrain())
+    case 'otlp':
+      return pipeline(createOtlpDrain())
+    default:
+      return pipeline(createFsDrain({
+        dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs',
+      }))
+  }
+}

--- a/examples/cli/src/evlog.ts
+++ b/examples/cli/src/evlog.ts
@@ -1,0 +1,13 @@
+import { setupEvlog } from '@evlog/cli'
+import { auditCatalog } from './catalogs/audit'
+import { errorCatalog } from './catalogs/errors'
+import { createCliDrain } from './drain'
+
+export const setup = setupEvlog({
+  service: 'evlog-demo-cli',
+  version: '0.1.0',
+  redact: true,
+  drain: createCliDrain(),
+  errorCatalog,
+  auditCatalog,
+})

--- a/examples/cli/src/index.ts
+++ b/examples/cli/src/index.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+import { exitWithError, parseCliError } from '@evlog/cli'
+import { runMain } from '@evlog/cli/citty'
+import { setup } from './evlog'
+import { main } from './commands'
+
+runMain(main, setup)
+  .then(() => setup.flush())
+  .catch((error: unknown) => {
+    if (process.env.DEBUG) {
+      console.error(parseCliError(error))
+    }
+    exitWithError(error)
+  })

--- a/examples/cli/src/index.ts
+++ b/examples/cli/src/index.ts
@@ -6,9 +6,10 @@ import { main } from './commands'
 
 runMain(main, setup)
   .then(() => setup.flush())
-  .catch((error: unknown) => {
+  .catch(async (error: unknown) => {
     if (process.env.DEBUG) {
       console.error(parseCliError(error))
     }
+    await setup.flush().catch(() => {})
     exitWithError(error)
   })

--- a/examples/cli/tsconfig.json
+++ b/examples/cli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../packages/evlog/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "example:browser": "dotenv -- turbo run dev --filter=evlog-browser-example",
     "example:bun-script": "dotenv -- turbo run dev --filter=evlog-bun-script-example",
     "example:tanstack-start": "dotenv -- turbo run dev --filter=evlog-tanstack-start-example",
+    "example:cli": "pnpm --filter @evlog/cli run build && pnpm --filter evlog-cli-example start",
     "example:vite": "dotenv -- turbo run dev --filter=evlog-vite-example",
     "build": "turbo run build",
     "build:package": "turbo run build --filter='./packages/*'",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -165,6 +165,7 @@ bun src/index.ts doctor --json   # your JSON on stdout; drain unchanged
 + export const setup = setupEvlog({ service: 'my-cli', version: '1.0.0', drain: createCliDrain() })
 
   // src/index.ts
++ import { exitWithError } from '@evlog/cli'
 + import { runMain } from '@evlog/cli/citty'
 + import { setup } from './evlog'
 - runMain(main)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,238 @@
+# @evlog/cli
+
+Observability for command-line tools — one **wide event per command**, drain pipeline, redact, **error and audit catalogs**.
+
+**evlog does not replace your CLI.** You keep citty for routing, Clack/consola for the terminal, and your own `--json` stdout contract. `setupEvlog()` configures observability underneath — drain, wide events, redact, catalogs.
+
+```text
+Your CLI (unchanged)          evlog (configured once)
+────────────────────          ────────────────────────
+citty — argv, subcommands     wide event per command
+Clack — spinners, colors      drain (.evlog/logs/…)
+console.log / your --json     redact + audit on flags
+```
+
+Full docs: https://evlog.dev/integrate/frameworks/cli
+
+## Install
+
+```bash
+pnpm add @evlog/cli evlog citty
+pnpm add @clack/prompts   # optional — UI only, not required by evlog
+```
+
+## Project layout
+
+Same shape as the [demo CLI](https://github.com/HugoRCD/evlog/tree/main/examples/cli):
+
+```text
+my-cli/
+└── src/
+    ├── index.ts          # entry — runMain + flush + exitWithError
+    ├── drain.ts          # createCliDrain() — fs default, Axiom/etc. via env
+    ├── evlog.ts          # setupEvlog({ drain: createCliDrain() })
+    ├── catalogs/
+    │   ├── errors.ts     # defineErrorCatalog → export errorCatalog
+    │   └── audit.ts      # defineAuditCatalog → export auditCatalog
+    └── commands/
+        ├── index.ts      # main + subCommands map
+        └── doctor.ts     # your command — Clack + useLogger()
+```
+
+---
+
+## Walkthrough
+
+### Step 1 — Drain + setup (`src/drain.ts` + `src/evlog.ts`)
+
+Wide events only leave your process when you wire a **drain**. Default: local NDJSON. For Axiom/Datadog/OTLP, resolve the adapter at runtime from env — never embed tokens in a published CLI.
+
+```typescript
+// src/drain.ts
+import type { DrainContext } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createFsDrain } from 'evlog/fs'
+import { createDrainPipeline } from 'evlog/pipeline'
+
+const pipeline = createDrainPipeline<DrainContext>({ batch: { size: 20 } })
+
+export function createCliDrain() {
+  if (process.env.EVLOG_DRAIN === 'axiom') {
+    return pipeline(createAxiomDrain()) // reads AXIOM_API_KEY, AXIOM_DATASET from env
+  }
+  return pipeline(createFsDrain({ dir: process.env.EVLOG_LOG_DIR ?? '.evlog/logs' }))
+}
+```
+
+```typescript
+// src/evlog.ts
+import { setupEvlog } from '@evlog/cli'
+import { createCliDrain } from './drain'
+
+export const setup = setupEvlog({
+  service: 'my-cli',
+  version: '1.0.0',
+  redact: true,
+  drain: createCliDrain(),
+})
+```
+
+What this sets up:
+
+- **Drain** — local `.evlog/logs/YYYY-MM-DD.jsonl` by default; set `EVLOG_DRAIN=axiom` (+ Axiom env) to send to a cloud dataset
+- **Silent console** — evlog does not print to the terminal by default
+- **Flush on exit** — pending batches are written before the process exits
+- **Catalogs** (optional) — `errorCatalog` and `auditCatalog` from `defineErrorCatalog` / `defineAuditCatalog`
+
+→ Full provider table and operator env vars: [Send events to Axiom (or another provider)](https://evlog.dev/integrate/frameworks/cli#send-events-to-axiom-or-another-provider)
+
+### Step 2 — Wire citty entry (`src/index.ts`)
+
+Pass `setup` to `runMain` — evlog wraps each command, your citty tree stays the same.
+
+```typescript
+import { exitWithError } from '@evlog/cli'
+import { runMain } from '@evlog/cli/citty'
+import { setup } from './evlog'
+import { main } from './commands'
+
+runMain(main, setup)          // was: runMain(main)
+  .then(() => setup.flush())  // flush batched drain writes
+  .catch(error => exitWithError(error))
+```
+
+`runMain(main, setup)` wraps every subcommand `run()` in `setup.invoke()` — one wide event per invocation (`method: CLI`, `path: /doctor`, duration, status). Global `--log` is injected automatically.
+
+### Step 3 — Define commands (`src/commands/doctor.ts`)
+
+**UI stays yours.** Telemetry goes through `useLogger()` — the command-scoped logger (same idea as HTTP middleware).
+
+```typescript
+import { defineCommand } from 'citty'
+import * as p from '@clack/prompts'
+import { useLogger } from '@evlog/cli'
+
+export const doctor = defineCommand({
+  meta: { name: 'doctor', description: 'Run health checks' },
+  args: {
+    json: { type: 'boolean', description: 'Machine-readable stdout (your format)' },
+  },
+  async run({ args }) {
+    const log = useLogger()
+
+    if (!args.json) p.intro('my-cli doctor')
+
+    const s = args.json ? null : p.spinner()
+    s?.start('Running checks')
+
+    const checks = [
+      { name: 'config', ok: true },
+      { name: 'api', ok: true },
+    ]
+
+    log.set({ checks })
+
+    s?.stop('Done')
+
+    if (args.json) {
+      console.log(JSON.stringify({ checks }))
+    } else {
+      p.outro(`All ${checks.length} checks passed`)
+    }
+  },
+})
+```
+
+### Step 4 — Run it
+
+```bash
+bun src/index.ts doctor
+# terminal → Clack UI
+# .evlog/logs/2026-05-30.jsonl → wide event
+
+bun src/index.ts doctor --log    # + pretty wide event on stderr
+bun src/index.ts doctor --json   # your JSON on stdout; drain unchanged
+```
+
+### Step 5 — Add to an existing citty CLI
+
+```diff
++ // src/drain.ts — fs by default; EVLOG_DRAIN=axiom for cloud
++ export function createCliDrain() { … }
+
+  // src/evlog.ts
++ import { createCliDrain } from './drain'
++ export const setup = setupEvlog({ service: 'my-cli', version: '1.0.0', drain: createCliDrain() })
+
+  // src/index.ts
++ import { runMain } from '@evlog/cli/citty'
++ import { setup } from './evlog'
+- runMain(main)
++ runMain(main, setup).then(() => setup.flush()).catch(exitWithError)
+
+  // src/commands/doctor.ts
++ import { useLogger } from '@evlog/cli'
+  async run() {
++   useLogger().set({ checks: results })
+    p.intro('…')    // unchanged
+  }
+```
+
+---
+
+## `setupEvlog()` vs `useLogger()`
+
+| | `setupEvlog()` | `useLogger()` |
+|---|----------------|---------------|
+| When | once in `src/evlog.ts` | inside every command handler |
+| Role | configure drain, redact, catalogs | command-scoped logger |
+| You call | `runMain(main, setup)`, `setup.flush()` | `log.set()`, `log.audit()` |
+
+---
+
+## What evlog does / does not do
+
+| | evlog | Your app |
+|---|-------|----------|
+| `--help`, subcommands | | citty |
+| Spinners, colors, intros | | Clack, consola, … |
+| `--json` stdout format | | your flag, your JSON shape |
+| Wide events + drain | yes | |
+| `--log` debug on stderr | yes | |
+| Error catalog | yes | |
+| Audit catalog | yes | |
+
+---
+
+## Optional — error catalog, audit catalog, HTTP
+
+Catalogs are optional — see walkthrough step 3 and `pull` / `deploy` in the demo CLI.
+
+---
+
+## Exports
+
+| Import | Description |
+|--------|-------------|
+| `@evlog/cli` | `setupEvlog`, `useLogger`, `createCommandLogger`, `parseCliError`, `exitWithError` |
+| `@evlog/cli/citty` | `runMain`, `wrapCommandTree` (peer: `citty`) |
+| `@evlog/cli/http` | `createOutboundHooks` (peer: `ofetch`) |
+
+---
+
+## Demo
+
+```bash
+# Local drain (default)
+pnpm example:cli doctor
+tail -f examples/cli/.evlog/logs/$(date +%Y-%m-%d).jsonl
+
+# Debug wide events on stderr
+pnpm example:cli doctor --log
+
+# Axiom — env on the host (see src/drain.ts)
+export EVLOG_DRAIN=axiom AXIOM_API_KEY=… AXIOM_DATASET=evlog-demo-cli
+pnpm example:cli doctor
+```
+
+Full drain walkthrough: [CLI integration docs](https://evlog.dev/integrate/frameworks/cli#send-events-to-axiom-or-another-provider).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,13 @@
   },
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      ".": ["./dist/index.d.mts"],
+      "citty": ["./dist/citty.d.mts"],
+      "http": ["./dist/http.d.mts"]
+    }
+  },
   "files": [
     "dist",
     "README.md"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@evlog/cli",
+  "version": "0.0.0",
+  "description": "CLI observability primitive for evlog — wide events, drain, catalogs, and audit for command-line tools",
+  "author": "HugoRCD <contact@hrcd.fr>",
+  "homepage": "https://evlog.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/HugoRCD/evlog/issues"
+  },
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./citty": {
+      "types": "./dist/citty.d.mts",
+      "import": "./dist/citty.mjs",
+      "default": "./dist/citty.mjs"
+    },
+    "./http": {
+      "types": "./dist/http.d.mts",
+      "import": "./dist/http.mjs",
+      "default": "./dist/http.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "cli",
+    "evlog",
+    "logging",
+    "wide-events",
+    "structured-logging",
+    "audit"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev:prepare": "tsdown",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "citty": "^0.2.2",
+    "evlog": "workspace:*",
+    "ofetch": "^1.4.1",
+    "tsdown": "^0.15.11",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "evlog": "^2.14.0",
+    "citty": "^0.1.6 || ^0.2.0",
+    "ofetch": "^1.4.0"
+  },
+  "peerDependenciesMeta": {
+    "evlog": {
+      "optional": false
+    },
+    "citty": {
+      "optional": true
+    },
+    "ofetch": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/citty.ts
+++ b/packages/cli/src/citty.ts
@@ -1,0 +1,89 @@
+import type { CommandDef } from 'citty'
+import { runMain as cittyRunMain } from 'citty'
+import { evlogLogArg } from './presentation'
+import type { EvlogSetup } from './types'
+
+/** Options forwarded to citty's {@link runMain}. */
+export interface RunMainOptions {
+  rawArgs?: string[]
+}
+
+function argsToFlags(args: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!args) return {}
+  return { ...args }
+}
+
+function resolveCommandName(path: string[]): string {
+  return path.length > 0 ? path.join('/') : 'main'
+}
+
+function mergeEvlogArgs(command: CommandDef): CommandDef['args'] {
+  return { ...evlogLogArg, ...command.args }
+}
+
+/**
+ * Wrap a citty command tree so every `run()` executes inside
+ * {@link EvlogSetup.invoke} (auto-emit wide event, drain, audit).
+ *
+ * Injects global `--log` on every command. Use {@link useLogger} inside handlers.
+ *
+ * @example
+ * ```ts
+ * import { defineCommand } from 'citty'
+ * import { setupEvlog } from '@evlog/cli'
+ * import { runMain } from '@evlog/cli/citty'
+ *
+ * const setup = setupEvlog({ service: 'my-cli', version: '1.0.0' })
+ * runMain(mainCommand, setup)
+ * ```
+ */
+export function wrapCommandTree(
+  command: CommandDef,
+  path: string[],
+  setup: EvlogSetup,
+  rawArgs: string[],
+): CommandDef {
+  const wrapped: CommandDef = {
+    ...command,
+    args: mergeEvlogArgs(command),
+  }
+
+  if (command.subCommands) {
+    wrapped.subCommands = Object.fromEntries(
+      Object.entries(command.subCommands).map(([name, sub]) => [
+        name,
+        wrapCommandTree(sub as CommandDef, [...path, name], setup, rawArgs),
+      ]),
+    )
+  }
+
+  if (command.run) {
+    const originalRun = command.run
+    wrapped.run = (context) => {
+      const commandName = resolveCommandName(path)
+      return setup.invoke(
+        {
+          command: commandName,
+          argv: rawArgs,
+          flags: argsToFlags(context.args as Record<string, unknown> | undefined),
+        },
+        () => originalRun(context),
+      )
+    }
+  }
+
+  return wrapped
+}
+
+/**
+ * citty entry point with evlog lifecycle wired around each command `run()`.
+ */
+export function runMain(
+  command: CommandDef,
+  setup: EvlogSetup,
+  options?: RunMainOptions,
+): Promise<void> {
+  const rawArgs = options?.rawArgs ?? process.argv.slice(2)
+  const wrapped = wrapCommandTree(command, [], setup, rawArgs)
+  return cittyRunMain(wrapped, options)
+}

--- a/packages/cli/src/enrichers.ts
+++ b/packages/cli/src/enrichers.ts
@@ -1,4 +1,4 @@
-import type { RequestLogger } from 'evlog'
+import type { FieldContext, RequestLogger } from 'evlog'
 
 /** Fields merged into the wide event under `cli.*`. */
 export interface CliContextFields {
@@ -10,12 +10,14 @@ export interface CliContextFields {
 
 /**
  * Build CLI context fields for a command invocation.
+ *
+ * Raw `argv` is intentionally omitted — secrets in `--token=…` or positional args
+ * would bypass flag-level redaction. Use structured `flags` instead.
  */
-export function buildCliContext(options: CliContextFields): Record<string, unknown> {
+export function buildCliContext(options: CliContextFields): FieldContext {
   return {
     cli: {
       command: options.command,
-      argv: options.argv,
       flags: options.flags,
       version: options.version,
       tty: {
@@ -32,5 +34,5 @@ export function buildCliContext(options: CliContextFields): Record<string, unkno
 
 /** Attach CLI context to a request logger before the handler runs. */
 export function applyCliContext(logger: RequestLogger, options: CliContextFields): void {
-  logger.set(buildCliContext(options) as never)
+  logger.set(buildCliContext(options))
 }

--- a/packages/cli/src/enrichers.ts
+++ b/packages/cli/src/enrichers.ts
@@ -1,0 +1,36 @@
+import type { RequestLogger } from 'evlog'
+
+/** Fields merged into the wide event under `cli.*`. */
+export interface CliContextFields {
+  command: string
+  argv?: string[]
+  flags?: Record<string, unknown>
+  version?: string
+}
+
+/**
+ * Build CLI context fields for a command invocation.
+ */
+export function buildCliContext(options: CliContextFields): Record<string, unknown> {
+  return {
+    cli: {
+      command: options.command,
+      argv: options.argv,
+      flags: options.flags,
+      version: options.version,
+      tty: {
+        stdin: !!process.stdin.isTTY,
+        stdout: !!process.stdout.isTTY,
+        stderr: !!process.stderr.isTTY,
+      },
+      platform: process.platform,
+      node: process.version,
+      ci: process.env.CI === 'true' || process.env.CI === '1',
+    },
+  }
+}
+
+/** Attach CLI context to a request logger before the handler runs. */
+export function applyCliContext(logger: RequestLogger, options: CliContextFields): void {
+  logger.set(buildCliContext(options) as never)
+}

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,48 @@
+import { parseError } from 'evlog'
+import { extractErrorStatus } from 'evlog/toolkit'
+import type { ParsedCliError } from './types'
+
+function readInternal(err: unknown): Record<string, unknown> | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const { internal } = err as { internal?: unknown }
+  return internal && typeof internal === 'object' && !Array.isArray(internal)
+    ? internal as Record<string, unknown>
+    : undefined
+}
+
+function resolveExitCode(status: number | undefined): number {
+  if (status === undefined) return 1
+  if (status >= 0 && status < 256) return status
+  return 1
+}
+
+/**
+ * Parse an error for CLI output — extends evlog's {@link parseError} with
+ * `hint` (from `fix` or `internal.hint`) and a process `exitCode`.
+ */
+export function parseCliError(err: unknown): ParsedCliError {
+  const parsed = parseError(err)
+  const internal = readInternal(err)
+  const hint = parsed.fix
+    ?? (typeof internal?.hint === 'string' ? internal.hint : undefined)
+
+  return {
+    ...parsed,
+    code: parsed.code ?? 'UNKNOWN',
+    hint,
+    exitCode: resolveExitCode(parsed.status ?? extractErrorStatus(err)),
+    raw: parsed.raw,
+  }
+}
+
+/**
+ * Print a human-readable error on stderr, then `process.exit`.
+ */
+export function exitWithError(err: unknown): never {
+  const parsed = parseCliError(err)
+
+  console.error(parsed.message)
+  if (parsed.hint) console.error(parsed.hint)
+
+  process.exit(parsed.exitCode ?? 1)
+}

--- a/packages/cli/src/flush.ts
+++ b/packages/cli/src/flush.ts
@@ -1,0 +1,52 @@
+let flushHandler: (() => Promise<void>) | undefined
+let listenersInstalled = false
+
+/**
+ * Extract a flush function from a pipeline drain (objects with `.flush()`).
+ */
+export function resolveFlushFn(drain: unknown): (() => Promise<void>) | undefined {
+  if (typeof drain !== 'function') return undefined
+  const candidate = drain as { flush?: () => Promise<void> }
+  if (typeof candidate.flush !== 'function') return undefined
+  return () => candidate.flush!()
+}
+
+/**
+ * Register process hooks that flush buffered drain events before exit.
+ *
+ * SIGINT/SIGTERM: flush, then re-emit the signal so the shell keeps default behaviour.
+ */
+export function installFlushOnExit(flush: () => Promise<void>): void {
+  if (listenersInstalled) return
+  listenersInstalled = true
+  flushHandler = flush
+
+  const runFlush = () => {
+    if (!flushHandler) return
+    void flushHandler().catch(err => console.error('[evlog/cli] flush failed:', err))
+  }
+
+  process.on('beforeExit', runFlush)
+
+  const handleSignal = (signal: NodeJS.Signals) => {
+    process.on(signal, () => {
+      const handler = flushHandler
+      if (!handler) {
+        process.kill(process.pid, signal)
+        return
+      }
+      void handler()
+        .catch(err => console.error('[evlog/cli] flush failed:', err))
+        .finally(() => process.kill(process.pid, signal))
+    })
+  }
+
+  handleSignal('SIGINT')
+  handleSignal('SIGTERM')
+}
+
+/** @internal Reset flush hooks between tests. */
+export function resetFlushOnExitForTests(): void {
+  flushHandler = undefined
+  listenersInstalled = false
+}

--- a/packages/cli/src/flush.ts
+++ b/packages/cli/src/flush.ts
@@ -1,14 +1,32 @@
 let flushHandler: (() => Promise<void>) | undefined
 let listenersInstalled = false
+let beforeExitHandler: (() => void) | undefined
+type SignalHandler = () => void
+const signalHandlers = new Map<NodeJS.Signals, SignalHandler>()
 
 /**
- * Extract a flush function from a pipeline drain (objects with `.flush()`).
+ * Extract a flush function from a pipeline drain (functions or objects with `.flush()`).
  */
 export function resolveFlushFn(drain: unknown): (() => Promise<void>) | undefined {
-  if (typeof drain !== 'function') return undefined
+  if (drain === null || drain === undefined) return undefined
+
   const candidate = drain as { flush?: () => Promise<void> }
   if (typeof candidate.flush !== 'function') return undefined
+
   return () => candidate.flush!()
+}
+
+function createSignalHandler(signal: NodeJS.Signals): () => void {
+  return () => {
+    const handlerFn = flushHandler
+    if (!handlerFn) {
+      process.kill(process.pid, signal)
+      return
+    }
+    void handlerFn()
+      .catch(err => console.error('[evlog/cli] flush failed:', err))
+      .finally(() => process.kill(process.pid, signal))
+  }
 }
 
 /**
@@ -26,27 +44,26 @@ export function installFlushOnExit(flush: () => Promise<void>): void {
     void flushHandler().catch(err => console.error('[evlog/cli] flush failed:', err))
   }
 
-  process.on('beforeExit', runFlush)
+  beforeExitHandler = runFlush
+  process.on('beforeExit', beforeExitHandler)
 
-  const handleSignal = (signal: NodeJS.Signals) => {
-    process.on(signal, () => {
-      const handler = flushHandler
-      if (!handler) {
-        process.kill(process.pid, signal)
-        return
-      }
-      void handler()
-        .catch(err => console.error('[evlog/cli] flush failed:', err))
-        .finally(() => process.kill(process.pid, signal))
-    })
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    const handler = createSignalHandler(signal)
+    signalHandlers.set(signal, handler)
+    process.once(signal, handler)
   }
-
-  handleSignal('SIGINT')
-  handleSignal('SIGTERM')
 }
 
 /** @internal Reset flush hooks between tests. */
 export function resetFlushOnExitForTests(): void {
+  if (beforeExitHandler) {
+    process.removeListener('beforeExit', beforeExitHandler)
+    beforeExitHandler = undefined
+  }
+  for (const [signal, handler] of signalHandlers) {
+    process.removeListener(signal, handler)
+  }
+  signalHandlers.clear()
   flushHandler = undefined
   listenersInstalled = false
 }

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -1,0 +1,67 @@
+import type { RequestLogger } from 'evlog'
+
+/** Minimal fetch context accepted by {@link createOutboundHooks}. */
+export interface OutboundFetchContext {
+  request: Request | string | URL
+  options: {
+    method?: string
+    baseURL?: string
+  }
+  response?: Response
+}
+
+/** Hooks compatible with `ofetch` / `$fetch` interceptors. */
+export interface OutboundHooks {
+  onRequest?(context: OutboundFetchContext): void | Promise<void>
+  onResponse?(context: OutboundFetchContext): void | Promise<void>
+}
+
+function resolveUrl(request: Request | string | URL, baseURL?: string): string {
+  if (typeof request === 'string') {
+    return baseURL ? new URL(request, baseURL).href : request
+  }
+  if (request instanceof URL) return request.href
+  return request.url
+}
+
+/**
+ * Track outbound HTTP calls on the current command logger.
+ *
+ * Pass the returned hooks to `ofetch.create()` or global `$fetch` options.
+ *
+ * @example
+ * ```ts
+ * import { ofetch } from 'ofetch'
+ * import { useLogger } from '@evlog/cli'
+ * import { createOutboundHooks } from '@evlog/cli/http'
+ *
+ * const api = ofetch.create(createOutboundHooks(useLogger()))
+ * await api('/users')
+ * ```
+ */
+export function createOutboundHooks(log: RequestLogger): OutboundHooks {
+  return {
+    onRequest({ request, options }) {
+      log.set({
+        http: {
+          outbound: {
+            method: options.method ?? 'GET',
+            url: resolveUrl(request, options.baseURL),
+          },
+        },
+      })
+    },
+    onResponse({ request, options, response }) {
+      if (!response) return
+      log.set({
+        http: {
+          outbound: {
+            method: options.method ?? 'GET',
+            url: resolveUrl(request, options.baseURL),
+            status: response.status,
+          },
+        },
+      })
+    },
+  }
+}

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -17,11 +17,17 @@ export interface OutboundHooks {
 }
 
 function resolveUrl(request: Request | string | URL, baseURL?: string): string {
-  if (typeof request === 'string') {
-    return baseURL ? new URL(request, baseURL).href : request
+  try {
+    if (typeof request === 'string') {
+      return baseURL ? new URL(request, baseURL).href : request
+    }
+    if (request instanceof URL) return request.href
+    return request.url
+  } catch {
+    if (typeof request === 'string') return request
+    if (request instanceof URL) return request.href
+    return request.url
   }
-  if (request instanceof URL) return request.href
-  return request.url
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,10 +41,10 @@ function bootstrapLogger(config: EvlogSetupConfig, argv: string[]): void {
     ...toLoggerConfig({ ...config, redact }),
     ...logToConsoleFlags(logToConsole),
     env: {
+      ...config.env,
       service: config.service ?? config.env?.service ?? 'cli',
       environment: config.environment ?? config.env?.environment,
       version: config.version ?? config.env?.version,
-      ...config.env,
     },
     _suppressDrainWarning: !logToConsole,
   })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,126 @@
+import {
+  initLogger,
+  log,
+  toLoggerConfig,
+  toMiddlewareOptions,
+  withAuditMethods,
+} from 'evlog'
+import type { AuditInput, AuditableLogger } from 'evlog'
+import { applyCliContext } from './enrichers'
+import { parseCliError, exitWithError } from './errors'
+import { installFlushOnExit, resolveFlushFn } from './flush'
+import { startCliCommand, useLogger } from './integration'
+import { logToConsoleFlags, shouldLogToConsole } from './presentation'
+import { cliRedactPreset, resolveCliRedact } from './redact'
+import type {
+  EvlogSetup,
+  EvlogSetupConfig,
+  InvokeOptions,
+} from './types'
+
+export type {
+  CliContext,
+  CreateCommandLoggerOptions,
+  EvlogSetup,
+  EvlogSetupConfig,
+  InvokeOptions,
+  ParsedCliError,
+} from './types'
+
+export { cliRedactPreset, resolveCliRedact } from './redact'
+export { buildCliContext, applyCliContext } from './enrichers'
+export { parseCliError, exitWithError } from './errors'
+export { evlogLogArg } from './presentation'
+export { createCommandLogger, useLogger } from './integration'
+
+function bootstrapLogger(config: EvlogSetupConfig, argv: string[]): void {
+  const logToConsole = shouldLogToConsole(argv, config.logToConsole)
+  const redact = resolveCliRedact(config.redact ?? true)
+
+  initLogger({
+    ...toLoggerConfig({ ...config, redact }),
+    ...logToConsoleFlags(logToConsole),
+    env: {
+      service: config.service ?? config.env?.service ?? 'cli',
+      environment: config.environment ?? config.env?.environment,
+      version: config.version ?? config.env?.version,
+      ...config.env,
+    },
+    _suppressDrainWarning: !logToConsole,
+  })
+}
+
+/**
+ * Configure evlog for your CLI: drain, redact, flush-on-exit, errorCatalog, auditCatalog,
+ * and command lifecycle via {@link EvlogSetup.invoke}.
+ *
+ * Does not replace your CLI — pass the returned handle to {@link runMain}
+ * from `@evlog/cli/citty` and use {@link useLogger} inside command handlers.
+ */
+export function setupEvlog(config: EvlogSetupConfig): EvlogSetup {
+  const middlewareOptions = toMiddlewareOptions({ ...config, redact: resolveCliRedact(config.redact ?? true) })
+  const flushFn = resolveFlushFn(config.drain)
+
+  bootstrapLogger(config, process.argv.slice(2))
+
+  if (flushFn && config.flushOnExit !== false) {
+    installFlushOnExit(flushFn)
+  }
+
+  async function invoke<T>(
+    options: InvokeOptions,
+    fn: (commandLog: AuditableLogger) => T | Promise<T>,
+  ): Promise<T> {
+    bootstrapLogger(config, options.argv ?? process.argv.slice(2))
+
+    const ctx = {
+      command: options.command,
+      argv: options.argv,
+      flags: options.flags,
+    }
+
+    const { skipped, finish, runWith, logger } = startCliCommand(ctx, middlewareOptions)
+
+    if (skipped) {
+      return await fn(withAuditMethods(logger))
+    }
+
+    applyCliContext(logger, {
+      command: options.command,
+      argv: options.argv,
+      flags: options.flags,
+      version: config.version,
+    })
+
+    const auditable = withAuditMethods(logger)
+
+    try {
+      const result = await runWith(() => fn(auditable))
+      if (!options.longRunning) {
+        await finish({ status: 0 })
+      }
+      return result
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      await finish({ error: err })
+      throw error
+    }
+  }
+
+  function audit(input: AuditInput): void {
+    withAuditMethods(useLogger()).audit(input)
+  }
+
+  async function flush(): Promise<void> {
+    if (flushFn) await flushFn()
+  }
+
+  return {
+    invoke,
+    log,
+    errorCatalog: config.errorCatalog,
+    auditCatalog: config.auditCatalog,
+    audit,
+    flush,
+  }
+}

--- a/packages/cli/src/integration.ts
+++ b/packages/cli/src/integration.ts
@@ -1,0 +1,61 @@
+import type { AuditableLogger } from 'evlog'
+import {
+  createLoggerStorage,
+  defineFrameworkIntegration,
+  type BaseEvlogOptions,
+} from 'evlog/toolkit'
+import { applyCliContext } from './enrichers'
+import type { CliContext, CreateCommandLoggerOptions } from './types'
+
+const { storage, useLogger: getLogger } = createLoggerStorage(
+  'command context. Wrap handlers with setup.invoke() or runMain() from @evlog/cli/citty.',
+)
+
+/**
+ * Request logger for the current command. Always auditable inside `invoke()`.
+ */
+function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
+  const logger = getLogger<T>()
+  return logger as AuditableLogger<T>
+}
+
+export { useLogger }
+
+const integration = defineFrameworkIntegration<CliContext>({
+  name: 'cli',
+  extractRequest: (ctx) => ({
+    method: 'CLI',
+    path: `/${ctx.command}`,
+    requestId: crypto.randomUUID(),
+  }),
+  attachLogger: () => {},
+  storage,
+})
+
+/**
+ * Start a CLI command lifecycle (used internally by {@link setupEvlog}).
+ */
+export function startCliCommand(ctx: CliContext, options: BaseEvlogOptions = {}) {
+  return integration.start(ctx, options)
+}
+
+/**
+ * Level 0 — create a standalone command logger without global bootstrap.
+ *
+ * Use in published libraries so the host app owns `initLogger` / drain config.
+ */
+export function createCommandLogger(
+  options: CreateCommandLoggerOptions & BaseEvlogOptions,
+): AuditableLogger {
+  const { command, argv, flags, version, ...middlewareOptions } = options
+  const ctx: CliContext = { command, argv, flags }
+  const handle = integration.start(ctx, middlewareOptions)
+
+  if (!handle.skipped) {
+    applyCliContext(handle.logger, { command, argv, flags, version })
+  }
+
+  return handle.logger as AuditableLogger
+}
+
+export { integration }

--- a/packages/cli/src/presentation.ts
+++ b/packages/cli/src/presentation.ts
@@ -1,0 +1,29 @@
+/** citty arg for `--log` — auto-injected by {@link runMain} from `@evlog/cli/citty`. */
+export const evlogLogArg = {
+  log: {
+    type: 'boolean' as const,
+    description: 'Print emitted wide events to stderr (debug)',
+  },
+} as const
+
+/**
+ * Whether evlog should echo wide events on stderr.
+ * Enabled by `--log` on argv or `logToConsole: true` in config.
+ */
+export function shouldLogToConsole(
+  argv: string[] = process.argv.slice(2),
+  configLogToConsole?: boolean,
+): boolean {
+  if (configLogToConsole) return true
+  return argv.includes('--log')
+}
+
+/** Map log-to-console flag to evlog console settings. */
+export function logToConsoleFlags(enabled: boolean): {
+  pretty?: boolean
+  silent?: boolean
+} {
+  return enabled
+    ? { pretty: true, silent: false }
+    : { pretty: false, silent: true }
+}

--- a/packages/cli/src/redact.ts
+++ b/packages/cli/src/redact.ts
@@ -1,0 +1,57 @@
+import { auditRedactPreset } from 'evlog'
+import type { RedactConfig } from 'evlog'
+
+/**
+ * CLI-specific redact preset extending {@link auditRedactPreset}.
+ *
+ * Covers env files, flag secrets, and common API token shapes.
+ */
+export const cliRedactPreset: RedactConfig = {
+  paths: [
+    'env.*',
+    'variables.*.value',
+    'flags.token',
+    'flags.password',
+    'flags.secret',
+    'flags.apiKey',
+    'config.token',
+    'config.secret',
+    'cli.flags.token',
+    'cli.flags.password',
+    'cli.flags.secret',
+    'cli.flags.apiKey',
+  ],
+  patterns: [
+    /\b(?:shlv_[\w-]+|sk_[\w-]+)\b/g,
+    /\bBearer\s+[\w\-.~+/]{8,}=*/gi,
+  ],
+}
+
+/**
+ * Resolve the effective redact config for a CLI bootstrap.
+ *
+ * @param redact - `true` merges audit + CLI presets; `false` disables redaction.
+ */
+export function resolveCliRedact(redact?: boolean | RedactConfig): boolean | RedactConfig | undefined {
+  if (redact === false) return false
+  if (typeof redact === 'object') {
+    return {
+      paths: [
+        ...(auditRedactPreset.paths ?? []),
+        ...(cliRedactPreset.paths ?? []),
+        ...(redact.paths ?? []),
+      ],
+      patterns: [
+        ...(cliRedactPreset.patterns ?? []),
+        ...(redact.patterns ?? []),
+      ],
+    }
+  }
+  return {
+    paths: [
+      ...(auditRedactPreset.paths ?? []),
+      ...(cliRedactPreset.paths ?? []),
+    ],
+    patterns: cliRedactPreset.patterns,
+  }
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,73 @@
+import type { EvlogConfig } from 'evlog'
+
+/** Per-command context passed to the CLI integration. */
+export interface CliContext {
+  command: string
+  argv?: string[]
+  flags?: Record<string, unknown>
+}
+
+/** Options for {@link EvlogSetup.invoke}. */
+export interface InvokeOptions {
+  /** Command path segment, e.g. `run` or `doctor`. */
+  command: string
+  /** Parsed argv without the node binary. */
+  argv?: string[]
+  /** Parsed flags (redacted before they reach the wide event). */
+  flags?: Record<string, unknown>
+  /**
+   * When true, skip auto-emit on successful return — call `log.emit()` manually
+   * (long-running commands, REPLs, watch mode).
+   */
+  longRunning?: boolean
+}
+
+/** Config for {@link setupEvlog} — observability for your existing CLI. */
+export interface EvlogSetupConfig extends EvlogConfig {
+  /** Binary version injected into `cli.version`. */
+  version?: string
+  /** Registered error catalog exposed on the returned setup handle. */
+  errorCatalog?: unknown
+  /** Registered audit catalog exposed on the returned setup handle. */
+  auditCatalog?: unknown
+  /** Merge {@link cliRedactPreset} with {@link auditRedactPreset} when true. @default true */
+  redact?: boolean | import('evlog').RedactConfig
+  /** Flush pipeline drains on `beforeExit` / SIGINT / SIGTERM. @default true */
+  flushOnExit?: boolean
+  /**
+   * Print emitted wide events to stderr (same as passing `--log`).
+   * @default false — drain only; evlog console silent
+   */
+  logToConsole?: boolean
+}
+
+/** Options for {@link createCommandLogger} (level 0 — no global bootstrap). */
+export interface CreateCommandLoggerOptions {
+  command: string
+  argv?: string[]
+  flags?: Record<string, unknown>
+  version?: string
+}
+
+/** Parsed CLI error with stable code and optional exit code. */
+export interface ParsedCliError {
+  message: string
+  status: number
+  code: string
+  why?: string
+  fix?: string
+  hint?: string
+  link?: string
+  exitCode?: number
+  raw: unknown
+}
+
+/** Handle returned by {@link setupEvlog} — lifecycle + catalogs, not the command logger. */
+export interface EvlogSetup {
+  invoke<T>(options: InvokeOptions, fn: (log: import('evlog').AuditableLogger) => T | Promise<T>): Promise<T>
+  log: import('evlog').Log
+  errorCatalog?: unknown
+  auditCatalog?: unknown
+  audit: (input: import('evlog').AuditInput) => void
+  flush: () => Promise<void>
+}

--- a/packages/cli/test/citty.test.ts
+++ b/packages/cli/test/citty.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineCommand } from 'citty'
+import { setupEvlog, useLogger } from '../src/index'
+import { runMain } from '../src/citty'
+import { createDrainSpy, findEventViaDrain, waitForDrainCalls } from './helpers/drain'
+
+describe('@evlog/cli/citty', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('wraps subcommand run() with invoke lifecycle', async () => {
+    const drain = createDrainSpy()
+    let sawLogger = false
+
+    const setup = setupEvlog({
+      service: 'citty-test',
+      drain,
+      flushOnExit: false,
+      redact: false,
+      silent: true,
+    })
+
+    const main = defineCommand({
+      meta: { name: 'demo', version: '0.0.0' },
+      subCommands: {
+        doctor: defineCommand({
+          meta: { name: 'doctor', description: 'Run checks' },
+          run() {
+            const log = useLogger()
+            sawLogger = typeof log.set === 'function'
+            log.set({ checks: { passed: 1 } })
+          },
+        }),
+      },
+    })
+
+    await runMain(main, setup, { rawArgs: ['doctor'] })
+
+    expect(sawLogger).toBe(true)
+    await waitForDrainCalls(drain, 1)
+
+    const event = findEventViaDrain(drain, e => e.path === '/doctor')
+    expect(event).toMatchObject({
+      method: 'CLI',
+      path: '/doctor',
+      status: 0,
+      checks: { passed: 1 },
+    })
+  })
+
+  it('auto-injects --log arg on wrapped commands', async () => {
+    const drain = createDrainSpy()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const setup = setupEvlog({
+      service: 'citty-test',
+      drain,
+      flushOnExit: false,
+      redact: false,
+    })
+
+    const main = defineCommand({
+      meta: { name: 'demo', version: '0.0.0' },
+      subCommands: {
+        status: defineCommand({
+          meta: { name: 'status' },
+          run({ args }) {
+            const log = useLogger()
+            log.set({ ok: true })
+            expect(args.log).toBe(true)
+          },
+        }),
+      },
+    })
+
+    await runMain(main, setup, { rawArgs: ['status', '--log'] })
+
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineErrorCatalog, EvlogError, initLogger } from 'evlog'
+import { createDrainPipeline } from 'evlog/pipeline'
+import { setupEvlog, createCommandLogger, parseCliError } from '../src/index'
+import { resetFlushOnExitForTests } from '../src/flush'
+import { createDrainSpy, findEventViaDrain, waitForDrainCalls } from './helpers/drain'
+
+describe('@evlog/cli', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetFlushOnExitForTests()
+  })
+
+  describe('invoke', () => {
+    it('emits a wide event with CLI method, path, duration, and status', async () => {
+      const drainSpy = vi.fn()
+      const pipeline = createDrainPipeline({ batch: { size: 1, intervalMs: 50_000 } })
+      const drain = pipeline((batch) => {
+        for (const event of batch) drainSpy(event)
+      })
+
+      const setup = setupEvlog({
+        service: 'cli-test',
+        version: '1.2.3',
+        drain,
+        flushOnExit: false,
+        redact: false,
+        pretty: false,
+        silent: true,
+      })
+
+      await setup.invoke({ command: 'doctor', argv: ['doctor'] }, (log) => {
+        log.set({ checks: { passed: 2 } })
+      })
+
+      await drain.flush()
+      await waitForDrainCalls(drainSpy as never, 1)
+
+      const event = findEventViaDrain(drainSpy as never, e => e.path === '/doctor')
+      expect(event).toBeDefined()
+      expect(event!.method).toBe('CLI')
+      expect(event!.path).toBe('/doctor')
+      expect(event!.status).toBe(0)
+      expect(event!.duration).toBeDefined()
+      expect(event!.checks).toEqual({ passed: 2 })
+      expect((event as Record<string, unknown>).cli).toMatchObject({
+        command: 'doctor',
+        version: '1.2.3',
+      })
+    })
+
+    it('does not auto-emit when longRunning is true', async () => {
+      const drain = createDrainSpy()
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: false,
+        silent: true,
+      })
+
+      await setup.invoke({ command: 'run', longRunning: true }, () => {
+        // handler returns without emit
+      })
+
+      expect(drain.mock.calls.length).toBe(0)
+    })
+
+    it('records catalog errors on finish and re-throws', async () => {
+      const drain = createDrainSpy()
+      const errorCatalog = defineErrorCatalog('testcli', {
+        CONFIG_MISSING: {
+          status: 1,
+          message: 'Config missing',
+          fix: 'Create config.json',
+        },
+      })
+
+      const setup = setupEvlog({
+        service: 'cli-test',
+        errorCatalog,
+        drain,
+        flushOnExit: false,
+        redact: false,
+        silent: true,
+      })
+
+      await expect(
+        setup.invoke({ command: 'pull' }, () => {
+          throw errorCatalog.CONFIG_MISSING()
+        }),
+      ).rejects.toThrow('Config missing')
+
+      await waitForDrainCalls(drain, 1)
+      const event = findEventViaDrain(drain, e => e.path === '/pull')
+      expect(event?.error).toMatchObject({ message: 'Config missing' })
+    })
+  })
+
+  describe('createCommandLogger', () => {
+    it('creates a logger with CLI context without global bootstrap', () => {
+      initLogger({ env: { service: 'host' }, silent: true })
+
+      const log = createCommandLogger({
+        command: 'migrate',
+        version: '0.0.1',
+        argv: ['migrate', '--yes'],
+      })
+
+      log.set({ records: 10 })
+      const event = log.emit({ status: 0 })
+
+      expect(event).toBeDefined()
+      expect(event!.method).toBe('CLI')
+      expect(event!.path).toBe('/migrate')
+      expect((event as Record<string, unknown>).cli).toMatchObject({
+        command: 'migrate',
+        version: '0.0.1',
+      })
+    })
+  })
+
+  describe('parseCliError', () => {
+    it('maps fix and internal.hint to hint with exit code', () => {
+      const err = new EvlogError({
+        code: 'testcli.CONFIG_MISSING',
+        message: 'Missing config',
+        status: 1,
+        fix: 'Run init',
+        internal: { hint: 'ignored when fix is set' },
+      })
+
+      expect(parseCliError(err)).toMatchObject({
+        code: 'testcli.CONFIG_MISSING',
+        message: 'Missing config',
+        hint: 'Run init',
+        exitCode: 1,
+      })
+    })
+
+    it('falls back to internal.hint when fix is absent', () => {
+      const err = new EvlogError({
+        code: 'testcli.BROKEN',
+        message: 'Broken',
+        status: 2,
+        internal: { hint: 'Try again' },
+      })
+
+      expect(parseCliError(err).hint).toBe('Try again')
+      expect(parseCliError(err).exitCode).toBe(2)
+    })
+  })
+
+  describe('redact', () => {
+    it('strips token flags before drain', async () => {
+      const drain = createDrainSpy()
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: true,
+        silent: true,
+      })
+
+      await setup.invoke(
+        {
+          command: 'login',
+          flags: { token: 'shlv_secret_token_abc' },
+        },
+        () => {},
+      )
+
+      await waitForDrainCalls(drain, 1)
+      const event = findEventViaDrain(drain, e => e.path === '/login')
+      const cli = (event as Record<string, unknown>).cli as Record<string, unknown>
+      expect(cli.flags).toEqual({ token: '[REDACTED]' })
+    })
+  })
+
+  describe('logToConsole', () => {
+    it('keeps evlog console silent by default', async () => {
+      const consoleSpy = vi.spyOn(console, 'log')
+      const drain = createDrainSpy()
+
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: false,
+      })
+
+      await setup.invoke({ command: 'status', argv: ['status'] }, (log) => {
+        log.set({ ok: true })
+      })
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+
+    it('prints wide events when --log is passed', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const drain = createDrainSpy()
+
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: false,
+      })
+
+      await setup.invoke({ command: 'status', argv: ['status', '--log'] }, (log) => {
+        log.set({ ok: true })
+      })
+
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+
+    it('prints wide events when logToConsole is true in config', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const drain = createDrainSpy()
+
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: false,
+        logToConsole: true,
+      })
+
+      await setup.invoke({ command: 'status', argv: ['status'] }, (log) => {
+        log.set({ ok: true })
+      })
+
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('audit', () => {
+    it('includes audit fields on the emitted wide event', async () => {
+      const drain = createDrainSpy()
+      const setup = setupEvlog({
+        service: 'cli-test',
+        drain,
+        flushOnExit: false,
+        redact: false,
+        silent: true,
+      })
+
+      await setup.invoke({ command: 'pull' }, (log) => {
+        log.audit({
+          action: 'testcli.SECRET_PULL',
+          actor: { type: 'user', id: 'u-1' },
+          target: { type: 'env', id: 'prod' },
+        })
+      })
+
+      await waitForDrainCalls(drain, 1)
+      const event = findEventViaDrain(drain, e => e.path === '/pull')
+      expect(event?.audit).toMatchObject({
+        action: 'testcli.SECRET_PULL',
+        actor: { type: 'user', id: 'u-1' },
+      })
+    })
+  })
+})

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -172,6 +172,7 @@ describe('@evlog/cli', () => {
       await setup.invoke(
         {
           command: 'login',
+          argv: ['login', '--token=shlv_secret'],
           flags: { token: 'shlv_secret_token_abc' },
         },
         () => {},
@@ -181,6 +182,29 @@ describe('@evlog/cli', () => {
       const event = findEventViaDrain(drain, e => e.path === '/login')
       const cli = (event as Record<string, unknown>).cli as Record<string, unknown>
       expect(cli.flags).toEqual({ token: '[REDACTED]' })
+      expect(cli.argv).toBeUndefined()
+    })
+  })
+
+  describe('env precedence', () => {
+    it('prefers top-level service and version over config.env', async () => {
+      const drain = createDrainSpy()
+      const setup = setupEvlog({
+        service: 'top-level-service',
+        version: '9.9.9',
+        env: { service: 'env-service', version: '1.0.0' },
+        drain,
+        flushOnExit: false,
+        redact: false,
+        silent: true,
+      })
+
+      await setup.invoke({ command: 'status' }, () => {})
+      await waitForDrainCalls(drain, 1)
+
+      const event = findEventViaDrain(drain, e => e.path === '/status')
+      expect(event?.service).toBe('top-level-service')
+      expect((event as Record<string, unknown>).cli).toMatchObject({ version: '9.9.9' })
     })
   })
 

--- a/packages/cli/test/flush.test.ts
+++ b/packages/cli/test/flush.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installFlushOnExit, resetFlushOnExitForTests, resolveFlushFn } from '../src/flush'
+
+describe('flush', () => {
+  afterEach(() => {
+    resetFlushOnExitForTests()
+  })
+
+  describe('resolveFlushFn', () => {
+    it('returns flush from pipeline-style function drains', async () => {
+      const flush = vi.fn(async () => {})
+      const drain = Object.assign(() => {}, { flush })
+
+      const run = resolveFlushFn(drain)
+      expect(run).toBeTypeOf('function')
+      await run!()
+      expect(flush).toHaveBeenCalledOnce()
+    })
+
+    it('returns flush from object drains that expose flush()', async () => {
+      const flush = vi.fn(async () => {})
+      const drain = { flush }
+
+      const run = resolveFlushFn(drain)
+      await run!()
+      expect(flush).toHaveBeenCalledOnce()
+    })
+
+    it('returns undefined when no flush method exists', () => {
+      expect(resolveFlushFn(() => {})).toBeUndefined()
+      expect(resolveFlushFn({})).toBeUndefined()
+    })
+  })
+
+  describe('resetFlushOnExitForTests', () => {
+    it('removes beforeExit listeners installed by installFlushOnExit', () => {
+      const flush = vi.fn(async () => {})
+      const beforeCount = process.listenerCount('beforeExit')
+
+      installFlushOnExit(flush)
+      expect(process.listenerCount('beforeExit')).toBe(beforeCount + 1)
+
+      resetFlushOnExitForTests()
+      expect(process.listenerCount('beforeExit')).toBe(beforeCount)
+    })
+  })
+})

--- a/packages/cli/test/helpers/drain.ts
+++ b/packages/cli/test/helpers/drain.ts
@@ -1,0 +1,27 @@
+import { vi, expect } from 'vitest'
+import type { DrainContext, WideEvent } from 'evlog'
+
+export function createDrainSpy() {
+  return vi.fn<(ctx: DrainContext) => void | Promise<void>>()
+}
+
+export async function waitForDrainCalls(
+  drainFn: ReturnType<typeof createDrainSpy>,
+  count = 1,
+  timeout = 1000,
+): Promise<void> {
+  await vi.waitFor(
+    () => expect(drainFn.mock.calls.length).toBeGreaterThanOrEqual(count),
+    { timeout, interval: 5 },
+  )
+}
+
+export function findEventViaDrain(
+  drainFn: ReturnType<typeof createDrainSpy>,
+  predicate: (event: WideEvent) => boolean,
+): WideEvent | undefined {
+  for (const [ctx] of drainFn.mock.calls) {
+    if (ctx?.event && predicate(ctx.event)) return ctx.event
+  }
+  return undefined
+}

--- a/packages/cli/test/http.test.ts
+++ b/packages/cli/test/http.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { createRequestLogger } from 'evlog'
+import { createOutboundHooks } from '../src/http'
+
+describe('@evlog/cli/http', () => {
+  it('records outbound request and response on the logger', async () => {
+    const log = createRequestLogger({ method: 'CLI', path: '/sync' })
+    const hooks = createOutboundHooks(log)
+
+    await hooks.onRequest?.({
+      request: '/users',
+      options: { method: 'GET', baseURL: 'https://api.example.com' },
+    })
+
+    await hooks.onResponse?.({
+      request: '/users',
+      options: { method: 'GET', baseURL: 'https://api.example.com' },
+      response: new Response('ok', { status: 200 }),
+    })
+
+    const ctx = log.getContext() as Record<string, unknown>
+    expect(ctx.http).toEqual({
+      outbound: {
+        method: 'GET',
+        url: 'https://api.example.com/users',
+        status: 200,
+      },
+    })
+  })
+})

--- a/packages/cli/test/http.test.ts
+++ b/packages/cli/test/http.test.ts
@@ -27,4 +27,20 @@ describe('@evlog/cli/http', () => {
       },
     })
   })
+
+  it('does not throw when URL resolution fails', () => {
+    const log = createRequestLogger({ method: 'CLI', path: '/sync' })
+    const hooks = createOutboundHooks(log)
+
+    expect(() => hooks.onRequest?.({
+      request: 'not a valid url',
+      options: { method: 'GET', baseURL: ':::invalid:::' },
+    })).not.toThrow()
+
+    const ctx = log.getContext() as Record<string, unknown>
+    expect((ctx.http as Record<string, unknown>).outbound).toMatchObject({
+      method: 'GET',
+      url: 'not a valid url',
+    })
+  })
 })

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ESNext"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    citty: 'src/citty.ts',
+    http: 'src/http.ts',
+  },
+  format: 'esm',
+  dts: true,
+  clean: true,
+  fixedExtension: true,
+  external: ['evlog', 'citty', 'ofetch'],
+})

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1391,6 +1391,7 @@ try {
 | **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([example](./examples/elysia)) |
 | **oRPC** | `withEvlog(handler)` + `os.use(evlog())` with `import { evlog, withEvlog } from 'evlog/orpc'` ([example](./examples/orpc)) |
 | **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([example](./examples/workers)) |
+| **CLI** | `setupEvlog({ drain })` with `import { setupEvlog, useLogger } from '@evlog/cli'` ([example](./examples/cli)) |
 | **Custom** | Build your own with `import { createMiddlewareLogger } from 'evlog/toolkit'` ([guide](https://evlog.dev/extend/custom-framework)) |
 | **Analog** | Nitro v2 module setup |
 | **Vinxi** | Nitro v2 module setup |

--- a/packages/evlog/test/README.md
+++ b/packages/evlog/test/README.md
@@ -176,6 +176,6 @@ Set `EVLOG_SLOW_TEST_BUDGET_MS=300 CI=1 pnpm test` to surface tests above 300ms
 - `typecheck` — `pnpm run dev:prepare` + `pnpm run typecheck`
 - `test` — `pnpm run dev:prepare` + `pnpm run build:package`, then `vitest run --shard=N/4` across a 4-way matrix
 - `coverage` — `pnpm run dev:prepare` + `pnpm run build:package` + `pnpm --filter evlog run test:coverage` (enforces the thresholds in `vitest.config.ts`)
-- `publish` — needs all of the above; runs `pkg-pr-new publish` for evlog + nuxthub on PR / main / manual dispatch
+- `publish` — needs all of the above; runs `npm publish --dry-run` on evlog, nuxthub, and `@evlog/cli`, then `pkg-pr-new publish` for those packages on PR / main / manual dispatch
 
 Mutation testing is intentionally separate: `.github/workflows/mutation.yml` runs Stryker on a weekly Monday cron and on `workflow_dispatch` (Stryker is too slow to gate every PR).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
     dependencies:
       '@databuddy/nuxt':
         specifier: ^2.4.20
-        version: 2.4.20(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.20(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/fonts':
         specifier: 0.14.0
         version: 0.14.0(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -74,22 +74,22 @@ importers:
         version: 2.6.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       docus:
         specifier: ^5.10.1
-        version: 5.10.1(6f8da7f1805eae88a33d7eaaf6520657)
+        version: 5.10.1(9a27e85267f2ac5f23f78eed25c15ff9)
       motion-v:
         specifier: ^2.2.1
         version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+        version: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       nuxt-studio:
         specifier: ^1.6.1
         version: 1.7.0(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
@@ -108,7 +108,7 @@ importers:
     dependencies:
       '@comark/nuxt':
         specifier: ^0.3.1
-        version: 0.3.1(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
+        version: 0.3.1(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/content':
         specifier: ^3.13.0
         version: 3.13.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.3))
@@ -117,16 +117,16 @@ importers:
         version: 4.7.1(109150d128b872a97f6986298b4d3c90)
       '@nuxtjs/sitemap':
         specifier: ^8.0.14
-        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+        version: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       shiki:
         specifier: 4.0.2
         version: 4.0.2
@@ -180,7 +180,7 @@ importers:
         version: 3.0.260522-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       rolldown:
         specifier: latest
-        version: 1.0.2
+        version: 1.0.3
 
   apps/nitro-v2-playground:
     dependencies:
@@ -193,7 +193,7 @@ importers:
         version: 1.15.11
       nitropack:
         specifier: ^2.13.3
-        version: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.2)
+        version: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.3)
 
   apps/nuxthub-playground:
     dependencies:
@@ -247,7 +247,7 @@ importers:
         version: link:../../packages/evlog
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+        version: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -277,6 +277,21 @@ importers:
 
   examples/bun-script:
     dependencies:
+      evlog:
+        specifier: workspace:*
+        version: link:../../packages/evlog
+
+  examples/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@evlog/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -479,7 +494,7 @@ importers:
         version: 0.15.4(solid-js@1.9.12)
       '@solidjs/start':
         specifier: ^1.2.1
-        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -532,7 +547,7 @@ importers:
         version: 1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.169.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.167.61(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 1.167.61(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -544,7 +559,7 @@ importers:
         version: 0.545.0(react@19.2.5)
       nitro:
         specifier: npm:nitro-nightly@latest
-        version: nitro-nightly@3.0.260522-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -608,6 +623,24 @@ importers:
       wrangler:
         specifier: ^3.101.0
         version: 3.114.17(@cloudflare/workers-types@4.20260503.1)
+
+  packages/cli:
+    devDependencies:
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      evlog:
+        specifier: workspace:*
+        version: link:../evlog
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
+      tsdown:
+        specifier: ^0.15.11
+        version: 0.15.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3)(unrun@0.2.37)(vue-tsc@3.2.7(typescript@6.0.3))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/evlog:
     dependencies:
@@ -1209,12 +1242,18 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
 
   '@clack/core@1.3.0':
     resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
     engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
@@ -3831,6 +3870,12 @@ packages:
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.95.0':
+    resolution: {integrity: sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==}
+
   '@oxc-transform/binding-android-arm-eabi@0.112.0':
     resolution: {integrity: sha512-r4LuBaPnOAi0eUOBNi880Fm2tO2omH7N1FRrL6+nyz/AjQ+QPPLtoyZJva0O+sKi1buyN/7IzM5p9m+5ANSDbg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4348,6 +4393,12 @@ packages:
     resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
     engines: {node: '>= 10'}
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.45':
+    resolution: {integrity: sha512-bfgKYhFiXJALeA/riil908+2vlyWGdwa7Ju5S+JgWZYdR4jtiPOGdM6WLfso1dojCh+4ZWeiTwPeV9IKQEX+4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-GoOVDy8bjw9z1K30Oo803nSzXJS/vWhFijFsW3kzvZCO8IZwFnNa6pGctmbbJstKl3Fv6UBwyjJQN6msejW0IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4360,17 +4411,23 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.18':
-    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.45':
+    resolution: {integrity: sha512-xjCv4CRVsSnnIxTuyH1RDJl5OEQ1c9JYOwfDAHddjJDxCw46ZX9q80+xq7Eok7KC4bRSZudMJllkvOKv0T9SeA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-9c4FOhRGpl+PX7zBK5p17c5efpF9aSpTPgyigv57hXf5NjQUaJOOiejPLAtFiKNBIfm5Uu6yFkvLKzOafNvlTw==}
@@ -4384,16 +4441,22 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
-    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.2':
     resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.45':
+    resolution: {integrity: sha512-ddcO9TD3D/CLUa/l8GO8LHzBOaZqWg5ClMy3jICoxwCuoz47h9dtqPsIeTiB6yR501LQTeDsjA4lIFd7u3Ljfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.57':
@@ -4408,17 +4471,23 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
-    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-x64@1.0.2':
     resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.45':
+    resolution: {integrity: sha512-MBTWdrzW9w+UMYDUvnEuh0pQvLENkl2Sis15fHTfHVW7ClbGuez+RWopZudIDEGkpZXdeI4CkRXk+vdIIebrmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
     resolution: {integrity: sha512-uA9kG7+MYkHTbqwv67Tx+5GV5YcKd33HCJIi0311iYBd25yuwyIqvJfBdt1VVB8tdOlyTb9cPAgfCki8nhwTQg==}
@@ -4432,17 +4501,23 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
-    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.2':
     resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.45':
+    resolution: {integrity: sha512-4YgoCFiki1HR6oSg+GxxfzfnVCesQxLF1LEnw9uXS/MpBmuog0EOO2rYfy69rWP4tFZL9IWp6KEfGZLrZ7aUog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
     resolution: {integrity: sha512-3KkS0cHsllT2T+Te+VZMKHNw6FPQihYsQh+8J4jkzwgvAQpbsbXmrqhkw3YU/QGRrD8qgcOvBr6z5y6Jid+rmw==}
@@ -4456,17 +4531,24 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
-    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
+    resolution: {integrity: sha512-LE1gjAwQRrbCOorJJ7LFr10s5vqYf5a00V5Ea9wXcT2+56n5YosJkcp8eQ12FxRBv2YX8dsdQJb+ZTtYJwb6XQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
     resolution: {integrity: sha512-A3/wu1RgsHhqP3rVH2+sM81bpk+Qd2XaHTl8LtX5/1LNR7QVBFBCpAoiXwjTdGnI5cMdBVi7Z1pi52euW760Fw==}
@@ -4482,19 +4564,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
-    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
+    resolution: {integrity: sha512-tdy8ThO/fPp40B81v0YK3QC+KODOmzJzSUOO37DinQxzlTJ026gqUSOM8tzlVixRbQJltgVDCTYF8HNPRErQTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg==}
@@ -4510,15 +4599,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
-    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
-    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -4531,15 +4620,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
-    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
-    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -4552,17 +4641,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
-    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
+    resolution: {integrity: sha512-lS082ROBWdmOyVY/0YB3JmsiClaWoxvC+dA8/rbhyB9VLkvVEaihLEOr4CYmrMse151C4+S6hCw6oa1iewox7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -4580,19 +4676,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
-    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
+    resolution: {integrity: sha512-Hi73aYY0cBkr1/SvNQqH8Cd+rSV6S9RB5izCv0ySBcRnd/Wfn5plguUoGYwBnhHgFbh6cPw9m2dUVBR6BG1gxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ==}
@@ -4608,19 +4711,25 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
-    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.45':
+    resolution: {integrity: sha512-fljEqbO7RHHogNDxYtTzr+GNjlfOx21RUyGmF+NrkebZ8emYYiIqzPxsaMZuRx0rgZmVmliOzEp86/CQFDKhJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA==}
@@ -4634,17 +4743,22 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
-    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.45':
+    resolution: {integrity: sha512-ZJDB7lkuZE9XUnWQSYrBObZxczut+8FZ5pdanm8nNS1DAo8zsrPuvGwn+U3fwU98WaiFsNrA4XHngesCGr8tEQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.57':
     resolution: {integrity: sha512-bRhcF7NLlCnpkzLVlVhrDEd0KH22VbTPkPTbMjlYvqhSmarxNIq5vtlQS8qmV7LkPKHrNLWyJW/V/sOyFba26Q==}
@@ -4656,15 +4770,21 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
-    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.2':
     resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.45':
+    resolution: {integrity: sha512-zyzAjItHPUmxg6Z8SyRhLdXlJn3/D9KL5b9mObUrBHhWS/GwRH4665xCiFqeuktAhhWutqfc+rOV2LjK4VYQGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57':
     resolution: {integrity: sha512-rnDVGRks2FQ2hgJ2g15pHtfxqkGFGjJQUDWzYznEkE8Ra2+Vag9OffxdbJMZqBWXHVM0iS4dv8qSiEn7bO+n1Q==}
@@ -4678,16 +4798,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
-    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
     resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.45':
+    resolution: {integrity: sha512-wODcGzlfxqS6D7BR0srkJk3drPwXYLu7jPHN27ce2c4PUnVVmJnp9mJzUQGT4LpmHmmVdMZ+P6hKvyTGBzc1CA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.45':
+    resolution: {integrity: sha512-wiU40G1nQo9rtfvF9jLbl79lUgjfaD/LTyUEw2Wg/gdF5OhjzpKMVugZQngO+RNdwYaNj+Fs+kWBWfp4VXPMHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
@@ -4702,20 +4834,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
-    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.2':
     resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.40':
     resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
+
+  '@rolldown/pluginutils@1.0.0-beta.45':
+    resolution: {integrity: sha512-Le9ulGCrD8ggInzWw/k2J8QcbPz7eGIOWqfJ2L+1R0Opm7n6J37s2hiDWlh6LJN0Lk9L5sUzMvRHKW7UxBZsQA==}
 
   '@rolldown/pluginutils@1.0.0-beta.57':
     resolution: {integrity: sha512-aQNelgx14tGA+n2tNSa9x6/jeoCL9fkDeCei7nOKnHx0fEFRRMu5ReiITo+zZD5TzWDGGRjbSYCs93IfRIyTuQ==}
@@ -8721,6 +8856,15 @@ packages:
   h3@1.15.3:
     resolution: {integrity: sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==}
 
+  h3@2.0.1-rc.2:
+    resolution: {integrity: sha512-2vS7OETzPDzGQxmmcs6ttu7p0NW25zAdkPXYOr43dn4GZf81uUljJvupa158mcpUGpsQUqIy4O4THWUQT1yVeA==}
+    engines: {node: '>=20.11.1'}
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
     engines: {node: '>=20.11.1'}
@@ -9947,41 +10091,29 @@ packages:
       sass:
         optional: true
 
+  nf3@0.1.12:
+    resolution: {integrity: sha512-qbMXT7RTGh74MYWPeqTIED8nDW70NXOULVHpdWcdZ7IVHVnAsMV9fNugSNnvooipDc1FMOzpis7T9nXJEbJhvQ==}
+
   nf3@0.3.16:
     resolution: {integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==}
 
   nf3@0.3.17:
     resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
 
-  nitro-nightly@3.0.260522-beta:
-    resolution: {integrity: sha512-Pm0AiQ1nLcreUFZKJcmVI4l9K/ygXoFamIPhc44XJHj9vmt25Rlqjv55frw6sS0L1qHrySpo3xyVVBmR9aTBqA==}
+  nitro-nightly@4.0.0-20251010-091516-7cafddba:
+    resolution: {integrity: sha512-biADkmoR/Nb9OmUURTfDI2BpGo2IMEt2RbsiMhjqdwz2w3tEm+tx0Hd28LXjBCwid+l8jpqyfmpwc8jzwdng3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@vercel/queue': ^0.2.0
-      dotenv: '*'
-      giget: '*'
-      jiti: ^2.6.1
-      rollup: ^4.60.3
-      vite: ^7 || ^8
+      rolldown: '*'
+      vite: ^7
       xml2js: ^0.6.2
-      zephyr-agent: ^0.2.0
     peerDependenciesMeta:
-      '@vercel/queue':
-        optional: true
-      dotenv:
-        optional: true
-      giget:
-        optional: true
-      jiti:
-        optional: true
-      rollup:
+      rolldown:
         optional: true
       vite:
         optional: true
       xml2js:
-        optional: true
-      zephyr-agent:
         optional: true
 
   nitro@3.0.260311-beta:
@@ -11004,6 +11136,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  rendu@0.0.6:
+    resolution: {integrity: sha512-nZ512Dw0MxKiIYfCVv8DPe6ig4m0Qt3FOYBJEXrammjIYBBPuHaudc0AGfYx+iyOw2q0itAtPywiVZXtTFCsig==}
+    hasBin: true
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -11046,6 +11182,25 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown-plugin-dts@0.17.8:
+    resolution: {integrity: sha512-76EEBlhF00yeY6M7VpMkWKI4r9WjuoMiOGey7j4D6zf3m0BR+ZrrY9hvSXdueJ3ljxSLq4DJBKFpX/X9+L7EKw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.44
+      typescript: ^5.0.0
+      vue-tsc: ~3.1.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown-plugin-dts@0.20.0:
     resolution: {integrity: sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA==}
     engines: {node: '>=20.19.0'}
@@ -11084,6 +11239,11 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown@1.0.0-beta.45:
+    resolution: {integrity: sha512-iMmuD72XXLf26Tqrv1cryNYLX6NNPLhZ3AmNkSf8+xda0H+yijjGJ+wVT9UdBUHOpKzq9RjKtQKRCWoEKQQBZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.0-beta.57:
     resolution: {integrity: sha512-lMMxcNN71GMsSko8RyeTaFoATHkCh4IWU7pYF73ziMYjhHZWfVesC6GQ+iaJCvZmVjvgSks9Ks1aaqEkBd8udg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11094,13 +11254,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-rc.18:
-    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.2:
-    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -11480,6 +11640,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.8.16:
+    resolution: {integrity: sha512-hmcGW4CgroeSmzgF1Ihwgl+Ths0JqAJ7HwjP2X7e3JzY7u4IydLMcdnlqGQiQGUswz+PO9oh/KtCpOISIvs9QQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
@@ -11800,6 +11965,31 @@ packages:
       typescript:
         optional: true
 
+  tsdown@0.15.12:
+    resolution: {integrity: sha512-c8VLlQm8/lFrOAg5VMVeN4NAbejZyVQkzd+ErjuaQgJFI/9MhR9ivr0H/CM7UlOF1+ELlF6YaI7sU/4itgGQ8w==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+      unrun: ^0.2.1
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
   tsdown@0.18.4:
     resolution: {integrity: sha512-J/tRS6hsZTkvqmt4+xdELUCkQYDuUCXgBv0fw3ImV09WPGbEKfsPD65E+WUjSu3E7Z6tji9XZ1iWs8rbGqB/ZA==}
     engines: {node: '>=20.19.0'}
@@ -11953,6 +12143,9 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
+  unconfig@7.5.0:
+    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
+
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
@@ -11984,6 +12177,9 @@ packages:
 
   unenv@2.0.0-rc.14:
     resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
+
+  unenv@2.0.0-rc.21:
+    resolution: {integrity: sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -12167,6 +12363,80 @@ packages:
       idb-keyval:
         optional: true
       ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  unstorage@2.0.0-alpha.3:
+    resolution: {integrity: sha512-BeoqISVh8jxqnPseHH7/92twe2VkQztrudXg8RFZVbXb4ckkFdpLk1LnNvsUndDltyodBMVxgI6V7JcbJYt2VQ==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6.0.3 || ^7.0.0
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4.0.3
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      lru-cache: ^11.2.2
+      mongodb: ^6.20.0
+      ofetch: ^1.4.1
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
         optional: true
       uploadthing:
         optional: true
@@ -13531,6 +13801,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@1.2.0':
     dependencies:
       fast-wrap-ansi: 0.1.6
@@ -13539,6 +13814,12 @@ snapshots:
   '@clack/core@1.3.0':
     dependencies:
       fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@1.2.0':
@@ -13606,12 +13887,12 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@comark/nuxt@0.3.1(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))':
+  '@comark/nuxt@0.3.1(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@comark/vue': 0.3.1(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       comark: 0.3.2(shiki@4.0.2)
-      nuxt: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+      nuxt: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
     transitivePeerDependencies:
       - beautiful-mermaid
       - katex
@@ -13636,12 +13917,12 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@databuddy/nuxt@2.4.20(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))':
+  '@databuddy/nuxt@2.4.20(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@databuddy/sdk': 2.4.20(react@19.2.5)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@nuxt/schema': 4.4.6
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
     optionalDependencies:
       vue: 3.5.33(typescript@6.0.3)
     transitivePeerDependencies:
@@ -14807,7 +15088,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.7.4
+      semver: 7.8.1
       tar: 7.5.13
     transitivePeerDependencies:
       - encoding
@@ -15640,7 +15921,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(oxc-parser@0.128.0)(rolldown@1.0.2)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(oxc-parser@0.128.0)(rolldown@1.0.3)(typescript@6.0.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -15658,8 +15939,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.2)
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.3)
+      nuxt: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -15711,7 +15992,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(oxc-parser@0.128.0)(rolldown@1.0.2)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(oxc-parser@0.128.0)(rolldown@1.0.3)(typescript@6.0.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -15729,8 +16010,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.2)
-      nuxt: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.3)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -16379,7 +16660,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(optionator@0.9.4)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -16397,7 +16678,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -16414,8 +16695,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.0.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.2)(rollup@4.60.2)
+      rolldown: 1.0.3
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -16503,7 +16784,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(optionator@0.9.4)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -16521,7 +16802,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+      nuxt: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -16538,8 +16819,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.0.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.2)(rollup@4.60.2)
+      rolldown: 1.0.3
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -16899,15 +17180,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)':
+  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -16920,14 +17201,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
+  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.7.2
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -17286,6 +17567,10 @@ snapshots:
   '@oxc-project/types@0.128.0': {}
 
   '@oxc-project/types@0.132.0': {}
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.95.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.112.0':
     optional: true
@@ -17649,16 +17934,22 @@ snapshots:
       '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.45':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-beta.57':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+  '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.2':
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
@@ -17667,10 +17958,13 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+  '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.2':
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.57':
@@ -17679,10 +17973,13 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+  '@rolldown/binding-darwin-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.2':
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
@@ -17691,10 +17988,13 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+  '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.2':
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
@@ -17703,10 +18003,13 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
@@ -17715,10 +18018,13 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
@@ -17727,28 +18033,31 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
@@ -17757,10 +18066,13 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.2':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
@@ -17769,10 +18081,13 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+  '@rolldown/binding-linux-x64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.2':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
@@ -17781,10 +18096,18 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+  '@rolldown/binding-openharmony-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.2':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -17802,18 +18125,21 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+  '@rolldown/binding-wasm32-wasi@1.0.2':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.2':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57':
@@ -17822,10 +18148,16 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.45':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
@@ -17834,13 +18166,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
-    optional: true
-
   '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.40': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.45': {}
 
   '@rolldown/pluginutils@1.0.0-beta.57': {}
 
@@ -18193,11 +18527,11 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
@@ -18209,7 +18543,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.12)
       tinyglobby: 0.2.16
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -18773,28 +19107,6 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.169.1
-      '@tanstack/router-utils': 1.161.7
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.11.15))
-      '@tanstack/start-storage-context': 1.166.34
-      pathe: 2.0.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - crossws
-      - supports-color
-      - vite
-      - vite-plugin-solid
-      - webpack
-
   '@tanstack/react-start-rsc@0.0.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18818,6 +19130,28 @@ snapshots:
       - webpack
     optional: true
 
+  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.8.16))
+      '@tanstack/start-storage-context': 1.166.34
+      pathe: 2.0.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/react-start-server@1.166.50(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -18829,29 +19163,19 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
       - crossws
+    optional: true
 
-  '@tanstack/react-start@1.167.61(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/react-start-server@1.166.50(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
+      '@tanstack/history': 1.161.6
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-client': 1.166.47(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-utils': 1.161.7
+      '@tanstack/router-core': 1.169.1
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.11.15))
-      pathe: 2.0.3
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.8.16))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
-      - '@rspack/core'
       - crossws
-      - react-server-dom-rspack
-      - supports-color
-      - vite-plugin-solid
-      - webpack
 
   '@tanstack/react-start@1.167.61(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -18876,6 +19200,29 @@ snapshots:
       - vite-plugin-solid
       - webpack
     optional: true
+
+  '@tanstack/react-start@1.167.61(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-client': 1.166.47(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.5(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.8.16))
+      pathe: 2.0.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -19001,40 +19348,6 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.0
-      '@babel/types': 7.29.0
-      '@rolldown/pluginutils': 1.0.0-beta.40
-      '@tanstack/router-core': 1.169.1
-      '@tanstack/router-generator': 1.166.39
-      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/router-utils': 1.161.7
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.11.15))
-      cheerio: 1.2.0
-      exsolve: 1.0.8
-      lightningcss: 1.32.0
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.2
-      source-map: 0.7.6
-      srvx: 0.11.15
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      vitefu: 1.1.3(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      xmlbuilder2: 4.0.3
-      zod: 3.25.76
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-    transitivePeerDependencies:
-      - '@tanstack/react-router'
-      - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
-
   '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -19070,6 +19383,40 @@ snapshots:
       - webpack
     optional: true
 
+  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@rolldown/pluginutils': 1.0.0-beta.40
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-generator': 1.166.39
+      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.5(srvx@0.8.16))
+      cheerio: 1.2.0
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      seroval: 1.5.2
+      source-map: 0.7.6
+      srvx: 0.11.15
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      xmlbuilder2: 4.0.3
+      zod: 3.25.76
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/start-server-core@1.167.28(crossws@0.4.5(srvx@0.11.15))':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -19078,6 +19425,19 @@ snapshots:
       '@tanstack/start-storage-context': 1.166.34
       fetchdts: 0.1.7
       h3-v2: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
+      seroval: 1.5.2
+    transitivePeerDependencies:
+      - crossws
+    optional: true
+
+  '@tanstack/start-server-core@1.167.28(crossws@0.4.5(srvx@0.8.16))':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-storage-context': 1.166.34
+      fetchdts: 0.1.7
+      h3-v2: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.8.16))
       seroval: 1.5.2
     transitivePeerDependencies:
       - crossws
@@ -19604,7 +19964,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -19702,20 +20062,20 @@ snapshots:
 
   '@uploadthing/mime-types@0.3.6': {}
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       react: 19.2.5
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      nuxt: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+      nuxt: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       react: 19.2.5
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -19741,11 +20101,11 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(react@19.2.5)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       react: 19.2.5
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -19770,7 +20130,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.3
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/parser': 7.29.3
       acorn: 8.16.0
@@ -19781,18 +20141,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -20976,6 +21336,10 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.15
 
+  crossws@0.4.5(srvx@0.8.16):
+    optionalDependencies:
+      srvx: 0.8.16
+
   css-background-parser@0.1.0: {}
 
   css-box-shadow@1.0.0-3: {}
@@ -21187,7 +21551,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docus@5.10.1(6f8da7f1805eae88a33d7eaaf6520657):
+  docus@5.10.1(9a27e85267f2ac5f23f78eed25c15ff9):
     dependencies:
       '@ai-sdk/gateway': 3.0.109(zod@4.4.2)
       '@ai-sdk/mcp': 1.0.39(zod@4.4.2)
@@ -21202,7 +21566,7 @@ snapshots:
       '@nuxtjs/i18n': 10.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@vue/compiler-dom@3.5.33)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
       '@nuxtjs/mcp-toolkit': 0.16.1(@vue/compiler-sfc@3.5.33)(h3@1.15.11)(magicast@0.5.2)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.2)
-      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -21215,9 +21579,9 @@ snapshots:
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vue@3.5.33(typescript@6.0.3))
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.4.10(8c55729e91d73effbb78df7b30a09103)
+      nuxt-og-image: 6.4.10(eb765369a582ff0a51c65779baeba36b)
       pkg-types: 2.3.1
       scule: 1.3.0
       shiki-stream: 0.1.4(react@19.2.5)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))
@@ -22603,12 +22967,28 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  h3@2.0.1-rc.2(crossws@0.4.5(srvx@0.8.16)):
+    dependencies:
+      cookie-es: 2.0.1
+      fetchdts: 0.1.7
+      rou3: 0.7.12
+      srvx: 0.8.16
+    optionalDependencies:
+      crossws: 0.4.5(srvx@0.8.16)
+
   h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
+
+  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.8.16)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
+    optionalDependencies:
+      crossws: 0.4.5(srvx@0.8.16)
 
   h3@2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
@@ -23439,7 +23819,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.1
 
   markdown-exit@1.0.0-beta.9:
     dependencies:
@@ -24055,30 +24435,33 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nf3@0.1.12: {}
+
   nf3@0.3.16: {}
 
   nf3@0.3.17: {}
 
-  nitro-nightly@3.0.260522-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
+  nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
-      crossws: 0.4.5(srvx@0.11.15)
+      cookie-es: 2.0.1
+      crossws: 0.4.5(srvx@0.8.16)
       db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
-      env-runner: 0.1.9
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
-      hookable: 6.1.1
-      nf3: 0.3.17
-      ocache: 0.1.4
-      ofetch: 2.0.0-alpha.3
-      ohash: 2.0.11
-      rolldown: 1.0.2
-      srvx: 0.11.15
-      unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
-    optionalDependencies:
-      dotenv: 17.4.2
-      giget: 3.2.0
+      esbuild: 0.25.12
+      fetchdts: 0.1.7
+      h3: 2.0.1-rc.2(crossws@0.4.5(srvx@0.8.16))
       jiti: 2.7.0
+      nf3: 0.1.12
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      rendu: 0.0.6
+      rollup: 4.60.2
+      srvx: 0.8.16
+      undici: 7.25.0
+      unenv: 2.0.0-rc.21
+      unstorage: 2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
+    optionalDependencies:
+      rolldown: 1.0.3
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -24092,7 +24475,6 @@ snapshots:
       - '@electric-sql/pglite'
       - '@libsql/client'
       - '@netlify/blobs'
-      - '@netlify/runtime'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/blob'
@@ -24105,7 +24487,6 @@ snapshots:
       - idb-keyval
       - ioredis
       - lru-cache
-      - miniflare
       - mongodb
       - mysql2
       - sqlite3
@@ -24123,7 +24504,7 @@ snapshots:
       ocache: 0.1.4
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.0.0-rc.18
+      rolldown: 1.0.2
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
@@ -24424,7 +24805,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.2):
+  nitropack@2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.3):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -24477,7 +24858,7 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.2)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.60.2)
       scule: 1.3.0
       semver: 7.7.4
       serve-placeholder: 2.0.2
@@ -24595,7 +24976,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.4.10(8c55729e91d73effbb78df7b30a09103):
+  nuxt-og-image@6.4.10(eb765369a582ff0a51c65779baeba36b):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
@@ -24611,8 +24992,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -24655,12 +25036,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
@@ -24673,12 +25054,12 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
@@ -24864,16 +25245,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d):
+  nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(oxc-parser@0.128.0)(rolldown@1.0.2)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(oxc-parser@0.128.0)(rolldown@1.0.3)(typescript@6.0.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(optionator@0.9.4)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -24993,16 +25374,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce):
+  nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(oxc-parser@0.128.0)(rolldown@1.0.2)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(oxc-parser@0.128.0)(rolldown@1.0.3)(typescript@6.0.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(optionator@0.9.4)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -25251,32 +25632,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
-    dependencies:
-      '@clack/prompts': 1.3.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/schema': 4.4.6
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.4.4(409faa2d09cfb6a8edd3813c1134db1d)
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      vue: 3.5.33(typescript@6.0.3)
-    optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(409faa2d09cfb6a8edd3813c1134db1d))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      zod: 4.4.2
-    transitivePeerDependencies:
-      - magicast
-      - vite
-
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -25285,7 +25641,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(71801589c663398b7779b77c63f5f3ce)
+      nuxt: 4.4.4(3430c2ce08e9a3c57fde374f57218646)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -25295,8 +25651,33 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(71801589c663398b7779b77c63f5f3ce))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(3430c2ce08e9a3c57fde374f57218646))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       zod: 3.25.76
+    transitivePeerDependencies:
+      - magicast
+      - vite
+
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
+    dependencies:
+      '@clack/prompts': 1.3.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/schema': 4.4.6
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.4.4(8d289dac780bbb4fc844d2f6bfb949d1)
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      vue: 3.5.33(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(8d289dac780bbb4fc844d2f6bfb949d1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      zod: 4.4.2
     transitivePeerDependencies:
       - magicast
       - vite
@@ -26321,6 +26702,11 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  rendu@0.0.6:
+    dependencies:
+      cookie-es: 2.0.1
+      srvx: 0.8.16
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -26347,6 +26733,24 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rolldown-plugin-dts@0.17.8(rolldown@1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      ast-kit: 2.2.0
+      birpc: 2.9.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.14.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+      vue-tsc: 3.2.7(typescript@6.0.3)
+    transitivePeerDependencies:
+      - oxc-resolver
 
   rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
     dependencies:
@@ -26401,6 +26805,29 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown@1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@oxc-project/types': 0.95.0
+      '@rolldown/pluginutils': 1.0.0-beta.45
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.45
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.45
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.45
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.45
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.45
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.45
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.45
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.45
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.45
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.45
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.45
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.45
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.45
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.103.0
@@ -26444,27 +26871,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rolldown@1.0.0-rc.18:
-    dependencies:
-      '@oxc-project/types': 0.128.0
-      '@rolldown/pluginutils': 1.0.0-rc.18
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.18
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
-
   rolldown@1.0.2:
     dependencies:
       '@oxc-project/types': 0.132.0
@@ -26485,6 +26891,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.2
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   rollup-plugin-dts@6.4.1(rollup@4.60.2)(typescript@6.0.3):
     dependencies:
@@ -26527,14 +26954,14 @@ snapshots:
       rolldown: 1.0.0-rc.17
       rollup: 4.60.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.2):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.2):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.0.2
+      rolldown: 1.0.3
       rollup: 4.60.2
 
   rollup-pluginutils@2.8.2:
@@ -27021,6 +27448,8 @@ snapshots:
 
   srvx@0.11.15: {}
 
+  srvx@0.8.16: {}
+
   stable-hash-x@0.2.0: {}
 
   stack-trace@0.0.10: {}
@@ -27350,6 +27779,34 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  tsdown@0.15.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3)(unrun@0.2.37)(vue-tsc@3.2.7(typescript@6.0.3)):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 4.0.3
+      debug: 4.4.3
+      diff: 8.0.4
+      empathic: 2.0.0
+      hookable: 5.5.3
+      rolldown: 1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.17.8(rolldown@1.0.0-beta.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
+      semver: 7.8.1
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig: 7.5.0
+    optionalDependencies:
+      typescript: 6.0.3
+      unrun: 0.2.37
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - supports-color
+      - vue-tsc
+
   tsdown@0.18.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
     dependencies:
       ansis: 4.2.0
@@ -27557,6 +28014,14 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
+  unconfig@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      defu: 6.1.7
+      jiti: 2.7.0
+      quansync: 1.0.0
+      unconfig-core: 7.5.0
+
   uncrypto@0.1.3: {}
 
   unctx@2.5.0:
@@ -27589,6 +28054,14 @@ snapshots:
       pathe: 1.1.2
 
   unenv@2.0.0-rc.14:
+    dependencies:
+      defu: 6.1.7
+      exsolve: 1.0.8
+      ohash: 2.0.11
+      pathe: 2.0.3
+      ufo: 1.6.4
+
+  unenv@2.0.0-rc.21:
     dependencies:
       defu: 6.1.7
       exsolve: 1.0.8
@@ -27804,6 +28277,14 @@ snapshots:
       db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
       ioredis: 5.10.1
 
+  unstorage@2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1):
+    optionalDependencies:
+      chokidar: 4.0.3
+      db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
+      ioredis: 5.10.1
+      lru-cache: 11.3.5
+      ofetch: 1.5.1
+
   unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1):
     optionalDependencies:
       chokidar: 5.0.0
@@ -27899,7 +28380,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
+  vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -27920,7 +28401,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.2)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.3)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2


### PR DESCRIPTION
## Summary

- Add `@evlog/cli` — wide events per command, `setupEvlog()` + `useLogger()`, citty (`runMain`) and ofetch (`createOutboundHooks`) entrypoints
- Demo CLI (`examples/cli`, `pnpm example:cli`) with fs/Axiom/Datadog/OTLP drain routing via env
- Docs at `/integrate/frameworks/cli` (drain setup, catalogs, progressive adoption)
- CI: pkg-pr-new + `npm publish --dry-run` for `@evlog/cli`

## Test plan

- [x] `pnpm --filter @evlog/cli run test` (14 tests)
- [x] `pnpm --filter @evlog/cli run typecheck`
- [x] `pnpm --filter @evlog/cli run lint`
- [x] `npm publish --dry-run` on `packages/cli`
- [ ] `pnpm example:cli doctor` — wide event in `.evlog/logs/`
- [ ] pkg-pr-new comment installs `@evlog/cli` on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces `@evlog/cli` for CLI observability (per-command telemetry, optional console logging via --log, error/audit helpers).
  * Built-in drain routing with defaults for local NDJSON and adapters for Axiom, Datadog, and OTLP.

* **Documentation**
  * New comprehensive CLI integration guide, API reference, and installation docs.

* **Chores**
  * Example multi-command CLI demo added.
  * CI updated to include CLI package in publish dry-run and publish steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/evlog/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->