### PR TITLE
fix(core): preserve source values during redaction

### DIFF
--- a/.changeset/redact-preserve-source.md
+++ b/.changeset/redact-preserve-source.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix redaction mutating source objects and arrays passed by reference. Wide events are now deep-cloned before redaction, so `log.info({ user })` and `createLogger().emit()` only scrub the emitted copy sent to console and drains.

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ apps/chat/.data
 
 # Local-only working notes (intentions, follow-ups, brain dumps)
 .notes/
+
+# Local bug repro scripts (not versioned)
+examples/repro/
 packages/evlog/test/nitro-v3/fixture/.wrangler
 apps/nuxthub-playground/.data
 .next/

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -230,7 +230,7 @@ function emitWideEvent(
   finalizeAudit(formatted)
 
   if (globalRedact) {
-    redactEvent(formatted, globalRedact)
+    formatted = redactEvent(formatted, globalRedact) as WideEvent
   }
 
   if (!globalSilent) {

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -1,7 +1,7 @@
 import type { AuditableLogger, AuditInput, AuditMethod } from './audit'
 import type { DrainContext, EnvironmentContext, FieldContext, Log, LogLevel, LoggerConfig, RedactConfig, RequestLogger, RequestLoggerOptions, SamplingConfig, TailSamplingContext, WideEvent } from './types'
 import { buildAuditFields, consumeAuditForceKeep, finalizeAudit } from './audit'
-import { redactEvent, resolveRedactConfig } from './redact'
+import { markGloballyRedacted, redactEvent, resolveRedactConfig } from './redact'
 import type { PluginRunner } from './shared/plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './shared/plugin'
 import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, matchesPattern } from './utils'
@@ -231,6 +231,7 @@ function emitWideEvent(
 
   if (globalRedact) {
     formatted = redactEvent(formatted, globalRedact) as WideEvent
+    markGloballyRedacted(formatted)
   }
 
   if (!globalSilent) {

--- a/packages/evlog/src/redact.ts
+++ b/packages/evlog/src/redact.ts
@@ -116,32 +116,36 @@ function cloneRegex(re: RegExp): RegExp {
 }
 
 /**
- * Redact sensitive data from a wide event in-place.
+ * Redact sensitive data from a wide event without mutating the input.
  *
- * Three strategies applied in order:
+ * Returns a deep clone with redaction applied. Three strategies run in order:
  * 1. **Path-based**: dot-notation paths — the leaf value is replaced with `replacement`.
  * 2. **Masker-based**: built-in patterns with smart partial masking (e.g. `****1111`).
  * 3. **Pattern-based**: custom RegExp patterns replaced with `replacement`.
  *
- * @param event - The wide event object (mutated in-place).
+ * @param event - The wide event object (not mutated).
  * @param config - Redaction configuration.
+ * @returns A redacted deep clone of `event`.
  */
-export function redactEvent(event: Record<string, unknown>, config: RedactConfig): void {
+export function redactEvent(event: Record<string, unknown>, config: RedactConfig): Record<string, unknown> {
+  const clone = structuredClone(event)
   const replacement = config.replacement ?? DEFAULT_REPLACEMENT
 
   if (config.paths?.length) {
     for (const path of config.paths) {
-      redactPath(event, path.split('.'), replacement)
+      redactPath(clone, path.split('.'), replacement)
     }
   }
 
   if (config._maskers?.length) {
-    applyMaskersToTree(event, config._maskers)
+    applyMaskersToTree(clone, config._maskers)
   }
 
   if (config.patterns?.length) {
-    redactPatterns(event, config.patterns, replacement)
+    redactPatterns(clone, config.patterns, replacement)
   }
+
+  return clone
 }
 
 function redactPath(obj: Record<string, unknown>, segments: string[], replacement: string): void {

--- a/packages/evlog/src/redact.ts
+++ b/packages/evlog/src/redact.ts
@@ -139,6 +139,7 @@ function cloneForRedaction(event: Record<string, unknown>): Record<string, unkno
     try {
       return JSON.parse(JSON.stringify(event)) as Record<string, unknown>
     } catch {
+      console.warn('[cloneForRedaction] Shallow clone used — nested objects may be mutated by redactPath, redactPatterns, and applyMaskersToTree')
       return { ...event }
     }
   }

--- a/packages/evlog/src/redact.ts
+++ b/packages/evlog/src/redact.ts
@@ -115,6 +115,35 @@ function cloneRegex(re: RegExp): RegExp {
   return new RegExp(re.source, re.flags)
 }
 
+/** @internal Set on wide events after initLogger redaction so middleware skips a second pass. */
+export const globallyRedacted = Symbol.for('evlog.globallyRedacted')
+
+/** @internal Mark a wide event as already redacted by {@link initLogger}. */
+export function markGloballyRedacted(event: Record<string, unknown>): void {
+  Object.defineProperty(event, globallyRedacted, { value: true, enumerable: false, configurable: true })
+}
+
+/** @internal Whether global redaction already ran on this wide event. */
+export function isGloballyRedacted(event: Record<string, unknown>): boolean {
+  return Reflect.has(event, globallyRedacted)
+}
+
+/**
+ * Clone before redaction. Wide events are JSON-shaped; fall back when
+ * `structuredClone` rejects non-cloneable values (functions, symbols, etc.).
+ */
+function cloneForRedaction(event: Record<string, unknown>): Record<string, unknown> {
+  try {
+    return structuredClone(event)
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(event)) as Record<string, unknown>
+    } catch {
+      return { ...event }
+    }
+  }
+}
+
 /**
  * Redact sensitive data from a wide event without mutating the input.
  *
@@ -128,7 +157,7 @@ function cloneRegex(re: RegExp): RegExp {
  * @returns A redacted deep clone of `event`.
  */
 export function redactEvent(event: Record<string, unknown>, config: RedactConfig): Record<string, unknown> {
-  const clone = structuredClone(event)
+  const clone = cloneForRedaction(event)
   const replacement = config.replacement ?? DEFAULT_REPLACEMENT
 
   if (config.paths?.length) {

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -1,6 +1,6 @@
 import type { DrainContext, EnrichContext, RedactConfig, RequestLogger, RouteConfig, TailSamplingContext, WideEvent } from '../types'
 import { createRequestLogger, getGlobalDrain, getGlobalPluginRunner, isEnabled, shouldKeep } from '../logger'
-import { redactEvent, resolveRedactConfig } from '../redact'
+import { isGloballyRedacted, redactEvent, resolveRedactConfig } from '../redact'
 import { extractErrorStatus } from './errors'
 import type { EvlogPlugin, PluginRunner } from './plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './plugin'
@@ -93,10 +93,10 @@ export function resolveMiddlewarePluginRunner(options: { plugins?: EvlogPlugin[]
 }
 
 /** Copy redacted fields onto the emitted event without replacing its identity. */
-function assignRedactedEvent(target: WideEvent, redacted: Record<string, unknown>): void {
-  for (const key of Object.keys(target)) {
+function assignRedactedEvent(target: WideEvent, redacted: Partial<WideEvent>): void {
+  for (const key of Object.keys(target) as Array<keyof WideEvent>) {
     if (!(key in redacted)) {
-      delete target[key as keyof WideEvent]
+      delete target[key]
     }
   }
   Object.assign(target, redacted)
@@ -116,8 +116,8 @@ export async function runEnrichAndDrain(
 ): Promise<void> {
   const runner = plugins ?? resolveMiddlewarePluginRunner(options)
   const resolvedRedact = resolveRedactConfig(options.redact)
-  if (resolvedRedact) {
-    assignRedactedEvent(emittedEvent, redactEvent(emittedEvent, resolvedRedact))
+  if (resolvedRedact && !isGloballyRedacted(emittedEvent)) {
+    assignRedactedEvent(emittedEvent, redactEvent(emittedEvent, resolvedRedact) as Partial<WideEvent>)
   }
 
   if (options.enrich || runner.hasEnrich) {

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -92,6 +92,16 @@ export function resolveMiddlewarePluginRunner(options: { plugins?: EvlogPlugin[]
   return runner
 }
 
+/** Copy redacted fields onto the emitted event without replacing its identity. */
+function assignRedactedEvent(target: WideEvent, redacted: Record<string, unknown>): void {
+  for (const key of Object.keys(target)) {
+    if (!(key in redacted)) {
+      delete target[key as keyof WideEvent]
+    }
+  }
+  Object.assign(target, redacted)
+}
+
 /**
  * Apply redact, enrich, and drain to an emitted wide event — the same
  * pipeline used by {@link createMiddlewareLogger}'s `finish`.
@@ -107,7 +117,7 @@ export async function runEnrichAndDrain(
   const runner = plugins ?? resolveMiddlewarePluginRunner(options)
   const resolvedRedact = resolveRedactConfig(options.redact)
   if (resolvedRedact) {
-    redactEvent(emittedEvent, resolvedRedact)
+    assignRedactedEvent(emittedEvent, redactEvent(emittedEvent, resolvedRedact))
   }
 
   if (options.enrich || runner.hasEnrich) {

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initLogger } from '../../src/logger'
+import { globallyRedacted } from '../../src/redact'
 import { createMiddlewareLogger } from '../../src/shared/middleware'
 import { defined } from '../helpers/defined'
+import { createPipelineSpies, waitForDrainCalls } from '../helpers/framework'
 
 describe('createMiddlewareLogger', () => {
   beforeEach(() => {
@@ -428,6 +430,32 @@ describe('createMiddlewareLogger', () => {
       expect(drain).toHaveBeenCalledOnce()
       expect(event).not.toBeNull()
       expect(drain.mock.calls[0][0].event.region).toBe('eu')
+    })
+  })
+
+  describe('redact', () => {
+    it('skips middleware redaction when initLogger already redacted the event', async () => {
+      const { drain } = createPipelineSpies()
+      initLogger({
+        env: { service: 'test-app' },
+        pretty: false,
+        silent: true,
+        redact: { builtins: ['email'] },
+        drain,
+      })
+
+      const { logger, finish } = createMiddlewareLogger({
+        method: 'GET',
+        path: '/api/users',
+        redact: { builtins: ['email'] },
+      })
+      logger.set({ contact: 'alice@example.com' })
+      const event = defined(await finish({ status: 200 }), 'emitted event')
+
+      expect(event.contact).toBe('a***@***.com')
+      expect(Reflect.has(event, globallyRedacted)).toBe(true)
+      await waitForDrainCalls(drain)
+      expect(drain.mock.calls[0]![0].event.contact).toBe('a***@***.com')
     })
   })
 })

--- a/packages/evlog/test/core/redact-integration.test.ts
+++ b/packages/evlog/test/core/redact-integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { redactEvent, resolveRedactConfig } from '../../src/redact'
-import { createLogger, initLogger } from '../../src/logger'
+import { createLogger, initLogger, log } from '../../src/logger'
 import { createPipelineSpies, waitForDrainCalls } from '../helpers/framework'
 import { defined, getDrainCallArg } from '../helpers/defined'
 
@@ -150,6 +150,37 @@ describe('initLogger + redact integration', () => {
     expect(event.contact).not.toContain('alice@example.com')
     expect(event.card).toBe('4111-1111-1111-1111')
   })
+
+  it('does not mutate source arrays or objects passed to log.info', () => {
+    initLogger({ pretty: false, redact: true })
+
+    const array = ['1.2.3.4']
+    const object = { redactedValue: '1.2.3.4' }
+    const str = '1.2.3.4'
+
+    log.info({ array })
+    expect(array).toEqual(['1.2.3.4'])
+
+    log.info({ object })
+    expect(object).toEqual({ redactedValue: '1.2.3.4' })
+
+    log.info({ str })
+    expect(str).toBe('1.2.3.4')
+  })
+
+  it('does not mutate nested context when createLogger emits', () => {
+    initLogger({ pretty: false, redact: true })
+
+    const nested = { ip: '192.168.1.100' }
+    const array = ['10.0.0.1']
+    const logger = createLogger({ nested, array })
+    const event = defined(logger.emit(), 'emitted event')
+
+    expect(nested.ip).toBe('192.168.1.100')
+    expect(array).toEqual(['10.0.0.1'])
+    expect((event.nested as Record<string, unknown>).ip).toBe('***.***.***.100')
+    expect(event.array).toEqual(['***.***.***.1'])
+  })
 })
 
 describe('default redaction behavior', () => {
@@ -206,13 +237,13 @@ describe('default redaction behavior', () => {
 
 describe('built-in smart masking', () => {
   it('masks credit card numbers keeping last 4 digits', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       a: '4111111111111111',
       b: '4111-1111-1111-1111',
       c: '4111 1111 1111 1111',
       safe: 'no card here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['creditCard'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['creditCard'] }), 'redact config'))
     expect(event.a).toBe('****1111')
     expect(event.b).toBe('****1111')
     expect(event.c).toBe('****1111')
@@ -220,25 +251,25 @@ describe('built-in smart masking', () => {
   })
 
   it('masks email addresses keeping first char and TLD', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       a: 'alice@example.com',
       b: 'Contact bob.smith+tag@company.co.uk',
       safe: 'no email here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['email'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['email'] }), 'redact config'))
     expect(event.a).toBe('a***@***.com')
     expect(event.b).toBe('Contact b***@***.uk')
     expect(event.safe).toBe('no email here')
   })
 
   it('masks IPv4 addresses keeping last octet', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       a: '192.168.1.1',
       b: 'Client 10.0.0.5 connected',
       localhost: '127.0.0.1',
       zero: '0.0.0.0',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['ipv4'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['ipv4'] }), 'redact config'))
     expect(event.a).toBe('***.***.***.1')
     expect(event.b).toBe('Client ***.***.***.5 connected')
     expect(event.localhost).toBe('127.0.0.1')
@@ -246,7 +277,7 @@ describe('built-in smart masking', () => {
   })
 
   it('masks international phone numbers keeping last 2 digits', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       us: '+1 (555) 123-4567',
       fr: '+33 6 12 34 56 78',
       uk: '+44 7911 123456',
@@ -254,7 +285,7 @@ describe('built-in smart masking', () => {
       parens: '(555) 123-4567',
       safe: 'no phone here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
     expect(event.us).toContain('****')
     expect(event.us).not.toContain('555')
     expect(event.fr).not.toContain('12 34')
@@ -264,7 +295,7 @@ describe('built-in smart masking', () => {
   })
 
   it('does not mask digit-rich identifiers (UUIDs, hex hashes, ids)', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       uuid: '12345642-f647-42bb-9fda-742d2b4f41fa',
       requestId: '00000000-1111-2222-3333-444444444444',
       idempotencyKey: '961da3f34097bb096902b5457ae02687',
@@ -272,7 +303,7 @@ describe('built-in smart masking', () => {
       bareDigits: '0612345678',
       localPhone: '06 12 34 56 78',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['phone'] }), 'redact config'))
     expect(event.uuid).toBe('12345642-f647-42bb-9fda-742d2b4f41fa')
     expect(event.requestId).toBe('00000000-1111-2222-3333-444444444444')
     expect(event.idempotencyKey).toBe('961da3f34097bb096902b5457ae02687')
@@ -287,11 +318,11 @@ describe('built-in smart masking', () => {
     // no semantic value.
     const tokenTail = 'X'.repeat(86)
     const token = ['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'eyJzdWIiOiIxMjM0NTY3ODkwIn0', tokenTail].join('.')
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       auth: `Token: ${token}`,
       safe: 'no jwt here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['jwt'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['jwt'] }), 'redact config'))
     expect(event.auth).toContain('eyJ***')
     expect(event.auth).not.toContain(tokenTail)
     expect(event.safe).toBe('no jwt here')
@@ -300,23 +331,23 @@ describe('built-in smart masking', () => {
   it('masks Bearer tokens keeping prefix', () => {
     // Stripe-shaped key built from fragments to avoid secret-scanner alarms.
     const fakeStripeKey = ['sk', 'live', 'abc123def456ghi789'].join('_')
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       header: `Bearer ${fakeStripeKey}`,
       safe: 'no bearer here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['bearer'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['bearer'] }), 'redact config'))
     expect(event.header).toContain('Bearer')
     expect(event.header).not.toContain(fakeStripeKey)
     expect(event.safe).toBe('no bearer here')
   })
 
   it('masks IBAN numbers keeping country code and last 3 digits', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       fr: 'FR76 3000 6000 0112 3456 7890 189',
       de: 'DE89 3704 0044 0532 0130 00',
       safe: 'no iban here',
     }
-    redactEvent(event, defined(resolveRedactConfig({ builtins: ['iban'] }), 'redact config'))
+    event = redactEvent(event, defined(resolveRedactConfig({ builtins: ['iban'] }), 'redact config'))
     expect(event.fr).toContain('FR76')
     expect(event.fr).not.toContain('3000')
     expect(event.de).toContain('DE89')

--- a/packages/evlog/test/core/redact.test.ts
+++ b/packages/evlog/test/core/redact.test.ts
@@ -6,17 +6,18 @@ import { defined } from '../helpers/defined'
 
 describe('redactEvent - path-based', () => {
   it('redacts a top-level field', () => {
-    const event: Record<string, unknown> = { email: 'alice@example.com', name: 'Alice' }
-    redactEvent(event, { paths: ['email'] })
+    const source: Record<string, unknown> = { email: 'alice@example.com', name: 'Alice' }
+    const event = redactEvent(source, { paths: ['email'] })
     expect(event.email).toBe('[REDACTED]')
     expect(event.name).toBe('Alice')
+    expect(source.email).toBe('alice@example.com')
   })
 
   it('redacts a nested field', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: { id: '123', email: 'alice@example.com', plan: 'pro' },
     }
-    redactEvent(event, { paths: ['user.email'] })
+    event = redactEvent(event, { paths: ['user.email'] })
     const user = event.user as Record<string, unknown>
     expect(user.email).toBe('[REDACTED]')
     expect(user.id).toBe('123')
@@ -24,28 +25,28 @@ describe('redactEvent - path-based', () => {
   })
 
   it('redacts deeply nested fields', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       payment: { card: { number: '4111111111111111', expiry: '12/26' } },
     }
-    redactEvent(event, { paths: ['payment.card.number'] })
+    event = redactEvent(event, { paths: ['payment.card.number'] })
     const card = (event.payment as Record<string, unknown>).card as Record<string, unknown>
     expect(card.number).toBe('[REDACTED]')
     expect(card.expiry).toBe('12/26')
   })
 
   it('silently skips missing paths', () => {
-    const event: Record<string, unknown> = { name: 'Alice' }
-    redactEvent(event, { paths: ['user.email', 'nonexistent'] })
+    let event: Record<string, unknown> = { name: 'Alice' }
+    event = redactEvent(event, { paths: ['user.email', 'nonexistent'] })
     expect(event.name).toBe('Alice')
     expect(event).not.toHaveProperty('user')
   })
 
   it('redacts multiple paths', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: { email: 'alice@example.com', ip: '192.168.1.1' },
       token: 'secret-jwt-token',
     }
-    redactEvent(event, { paths: ['user.email', 'user.ip', 'token'] })
+    event = redactEvent(event, { paths: ['user.email', 'user.ip', 'token'] })
     const user = event.user as Record<string, unknown>
     expect(user.email).toBe('[REDACTED]')
     expect(user.ip).toBe('[REDACTED]')
@@ -53,16 +54,16 @@ describe('redactEvent - path-based', () => {
   })
 
   it('uses custom replacement string', () => {
-    const event: Record<string, unknown> = { user: { email: 'alice@example.com' } }
-    redactEvent(event, { paths: ['user.email'], replacement: '***' })
+    let event: Record<string, unknown> = { user: { email: 'alice@example.com' } }
+    event = redactEvent(event, { paths: ['user.email'], replacement: '***' })
     expect((event.user as Record<string, unknown>).email).toBe('***')
   })
 
   it('redacts non-string values at path', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: { age: 25, settings: { notifications: true } },
     }
-    redactEvent(event, { paths: ['user.age', 'user.settings'] })
+    event = redactEvent(event, { paths: ['user.age', 'user.settings'] })
     const user = event.user as Record<string, unknown>
     expect(user.age).toBe('[REDACTED]')
     expect(user.settings).toBe('[REDACTED]')
@@ -72,31 +73,31 @@ describe('redactEvent - path-based', () => {
 describe('redactEvent - pattern-based', () => {
   it('redacts credit card numbers', () => {
     const ccPattern = /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       message: 'Card 4111 1111 1111 1111 was declined',
       other: 'no card here',
     }
-    redactEvent(event, { patterns: [ccPattern] })
+    event = redactEvent(event, { patterns: [ccPattern] })
     expect(event.message).toBe('Card [REDACTED] was declined')
     expect(event.other).toBe('no card here')
   })
 
   it('redacts email addresses', () => {
     const emailPattern = /[\w.+-]+@[\w-]+\.[\w.]+/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: { note: 'Contact alice@example.com for details' },
     }
-    redactEvent(event, { patterns: [emailPattern] })
+    event = redactEvent(event, { patterns: [emailPattern] })
     expect((event.user as Record<string, unknown>).note).toBe('Contact [REDACTED] for details')
   })
 
   it('redacts IP addresses', () => {
     const ipPattern = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       client: { ip: '192.168.1.1' },
       log: 'Connection from 10.0.0.5 established',
     }
-    redactEvent(event, { patterns: [ipPattern] })
+    event = redactEvent(event, { patterns: [ipPattern] })
     expect((event.client as Record<string, unknown>).ip).toBe('[REDACTED]')
     expect(event.log).toBe('Connection from [REDACTED] established')
   })
@@ -104,19 +105,19 @@ describe('redactEvent - pattern-based', () => {
   it('applies multiple patterns', () => {
     const emailPattern = /[\w.+-]+@[\w-]+\.[\w.]+/g
     const ipPattern = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       message: 'User alice@example.com connected from 10.0.0.1',
     }
-    redactEvent(event, { patterns: [emailPattern, ipPattern] })
+    event = redactEvent(event, { patterns: [emailPattern, ipPattern] })
     expect(event.message).toBe('User [REDACTED] connected from [REDACTED]')
   })
 
   it('handles arrays with string values', () => {
     const emailPattern = /[\w.+-]+@[\w-]+\.[\w.]+/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       recipients: ['alice@example.com', 'bob@example.com', 'not-an-email'],
     }
-    redactEvent(event, { patterns: [emailPattern] })
+    event = redactEvent(event, { patterns: [emailPattern] })
     const recipients = event.recipients as string[]
     expect(recipients[0]).toBe('[REDACTED]')
     expect(recipients[1]).toBe('[REDACTED]')
@@ -125,13 +126,13 @@ describe('redactEvent - pattern-based', () => {
 
   it('handles arrays with nested objects', () => {
     const emailPattern = /[\w.+-]+@[\w-]+\.[\w.]+/g
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       users: [
         { name: 'Alice', email: 'alice@test.com' },
         { name: 'Bob', email: 'bob@test.com' },
       ],
     }
-    redactEvent(event, { patterns: [emailPattern] })
+    event = redactEvent(event, { patterns: [emailPattern] })
     const users = event.users as Record<string, unknown>[]
     expect(defined(users[0], 'users[0]').email).toBe('[REDACTED]')
     expect(defined(users[1], 'users[1]').email).toBe('[REDACTED]')
@@ -139,10 +140,10 @@ describe('redactEvent - pattern-based', () => {
   })
 
   it('uses custom replacement string', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       message: 'User alice@example.com logged in',
     }
-    redactEvent(event, {
+    event = redactEvent(event, {
       patterns: [/[\w.+-]+@[\w-]+\.[\w.]+/g],
       replacement: '***',
     })
@@ -150,12 +151,12 @@ describe('redactEvent - pattern-based', () => {
   })
 
   it('skips non-string non-object values', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       count: 42,
       active: true,
       name: null,
     }
-    redactEvent(event, { patterns: [/test/g] })
+    event = redactEvent(event, { patterns: [/test/g] })
     expect(event.count).toBe(42)
     expect(event.active).toBe(true)
     expect(event.name).toBeNull()
@@ -164,14 +165,14 @@ describe('redactEvent - pattern-based', () => {
 
 describe('redactEvent - combined paths + patterns', () => {
   it('applies both path and pattern redaction', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: {
         email: 'alice@example.com',
         ip: '192.168.1.1',
       },
       message: 'Payment with card 4111-1111-1111-1111 processed',
     }
-    redactEvent(event, {
+    event = redactEvent(event, {
       paths: ['user.email', 'user.ip'],
       patterns: [/\b\d{4}[-]?\d{4}[-]?\d{4}[-]?\d{4}\b/g],
     })
@@ -183,31 +184,43 @@ describe('redactEvent - combined paths + patterns', () => {
 })
 
 describe('redactEvent - edge cases', () => {
+  it('does not mutate nested references in the input', () => {
+    const nested = { ip: '192.168.1.1' }
+    const array = ['192.168.1.2']
+    const source: Record<string, unknown> = { nested, items: array }
+    const redacted = redactEvent(source, defined(resolveRedactConfig({ builtins: ['ipv4'] }), 'redact config'))
+
+    expect(nested.ip).toBe('192.168.1.1')
+    expect(array).toEqual(['192.168.1.2'])
+    expect((redacted.nested as Record<string, unknown>).ip).toBe('***.***.***.1')
+    expect(redacted.items).toEqual(['***.***.***.2'])
+  })
+
   it('handles empty config gracefully', () => {
-    const event: Record<string, unknown> = { user: { email: 'alice@example.com' } }
-    redactEvent(event, {})
+    let event: Record<string, unknown> = { user: { email: 'alice@example.com' } }
+    event = redactEvent(event, {})
     expect((event.user as Record<string, unknown>).email).toBe('alice@example.com')
   })
 
   it('handles empty paths array', () => {
-    const event: Record<string, unknown> = { secret: 'value' }
-    redactEvent(event, { paths: [] })
+    let event: Record<string, unknown> = { secret: 'value' }
+    event = redactEvent(event, { paths: [] })
     expect(event.secret).toBe('value')
   })
 
   it('handles empty patterns array', () => {
-    const event: Record<string, unknown> = { secret: 'value' }
-    redactEvent(event, { patterns: [] })
+    let event: Record<string, unknown> = { secret: 'value' }
+    event = redactEvent(event, { patterns: [] })
     expect(event.secret).toBe('value')
   })
 
   it('handles null/undefined values in the tree', () => {
-    const event: Record<string, unknown> = {
+    let event: Record<string, unknown> = {
       user: null,
       data: undefined,
       valid: 'test@example.com',
     }
-    redactEvent(event, {
+    event = redactEvent(event, {
       paths: ['user.email'],
       patterns: [/[\w.+-]+@[\w-]+\.[\w.]+/g],
     })

--- a/packages/evlog/test/core/redact.test.ts
+++ b/packages/evlog/test/core/redact.test.ts
@@ -196,6 +196,17 @@ describe('redactEvent - edge cases', () => {
     expect(redacted.items).toEqual(['***.***.***.2'])
   })
 
+  it('redacts events that contain non-cloneable values', () => {
+    const source: Record<string, unknown> = {
+      email: 'alice@example.com',
+      handler: () => {},
+    }
+    const redacted = redactEvent(source, { patterns: [/[\w.+-]+@[\w-]+\.[\w.]+/g] })
+    expect(typeof source.handler).toBe('function')
+    expect(redacted.email).toBe('[REDACTED]')
+    expect(redacted).not.toHaveProperty('handler')
+  })
+
   it('handles empty config gracefully', () => {
     let event: Record<string, unknown> = { user: { email: 'alice@example.com' } }
     event = redactEvent(event, {})


### PR DESCRIPTION
Resolves #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redaction no longer mutates source objects/arrays; emitted events are deep-cloned before redaction and marked so they aren't redacted twice.

* **Tests**
  * Added/updated tests to verify original data remains unchanged and middleware-level redaction behaves correctly.

* **Chores**
  * Updated .gitignore to ignore local repro scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->