### PR TITLE
fix(nuxt): bake evlog config into nitro replace for silent mode

### DIFF
--- a/.changeset/nuxt-silent-nitro-replace.md
+++ b/.changeset/nuxt-silent-nitro-replace.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix Nuxt `silent` option not suppressing built-in console output in production builds on evlog 2.11+. The Nuxt module now bakes evlog options into `nitro.options.replace.__EVLOG_CONFIG__` (matching standalone Nitro modules), so the Nitro plugin receives `silent: true` and no longer emits an unenriched log line before your `evlog:drain` hook runs.

--- a/packages/evlog/src/nuxt/module.ts
+++ b/packages/evlog/src/nuxt/module.ts
@@ -361,7 +361,10 @@ export default defineNuxtModule<ModuleOptions>({
 
       const evlogForNitro = nuxt.options.runtimeConfig.evlog ?? options
       if (evlogForNitro !== undefined && typeof evlogForNitro === 'object') {
-        process.env.__EVLOG_CONFIG = JSON.stringify(evlogForNitro)
+        const serialized = JSON.stringify(evlogForNitro)
+        nitroConfig.replace = nitroConfig.replace || {}
+        nitroConfig.replace.__EVLOG_CONFIG__ = serialized
+        process.env.__EVLOG_CONFIG = serialized
       }
     })
     nuxt.options.runtimeConfig.public.evlog = {

--- a/packages/evlog/test/nitro/module-paths.test.ts
+++ b/packages/evlog/test/nitro/module-paths.test.ts
@@ -23,7 +23,7 @@ describe('nitro modules avoid backslash paths', () => {
 
   it('nitro v2 module pushes POSIX-style plugin and errorHandler paths', () => {
     const nitro = makeNitroStub()
-    nitroV2Module({ env: { service: 'test' } }).setup(nitro as never)
+    nitroV2Module({ env: { service: 'test' }, silent: true }).setup(nitro as never)
 
     expect(nitro.options.plugins).toHaveLength(1)
     expect(nitro.options.plugins[0]).not.toMatch(/\\/)
@@ -32,6 +32,9 @@ describe('nitro modules avoid backslash paths', () => {
     expect(nitro.options.errorHandler).toBeTypeOf('string')
     expect(nitro.options.errorHandler).not.toMatch(/\\/)
     expect(nitro.options.errorHandler).toMatch(/\/nitro\/errorHandler$/)
+
+    const { replace } = nitro.options as { replace?: Record<string, string> }
+    expect(JSON.parse(replace!.__EVLOG_CONFIG__)).toEqual({ env: { service: 'test' }, silent: true })
   })
 
   it('nitro v3 module pushes POSIX-style plugin and errorHandler paths', () => {

--- a/packages/evlog/test/shared/nitroConfigBridge.test.ts
+++ b/packages/evlog/test/shared/nitroConfigBridge.test.ts
@@ -104,6 +104,17 @@ describe('nitroConfigBridge — active runtime', () => {
     expect(importSpy).not.toHaveBeenCalled()
   })
 
+  it('preserves silent from inlined __EVLOG_CONFIG__', async () => {
+    globalThis.__EVLOG_CONFIG__ = { silent: true, pretty: false }
+    const { bridge, importSpy } = await loadBridgeWithMocks()
+    bridge.setActiveNitroRuntime('v2')
+
+    const config = await bridge.resolveEvlogConfigForNitroPlugin()
+
+    expect(config?.silent).toBe(true)
+    expect(importSpy).not.toHaveBeenCalled()
+  })
+
   it('prefers __EVLOG_CONFIG__ over process.env.__EVLOG_CONFIG', async () => {
     globalThis.__EVLOG_CONFIG__ = { env: { service: 'svc-inline' } }
     process.env.__EVLOG_CONFIG = JSON.stringify({ env: { service: 'svc-env' } })


### PR DESCRIPTION
Resolves #368 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `silent` option in evlog to properly suppress console output in Nuxt production builds on evlog 2.11+. The evlog configuration is now correctly passed to the Nitro plugin, preventing unenriched log lines from being emitted before expected hooks execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->