### PR TITLE
fix(nitro): flush v2 error responses

### DIFF
--- a/.changeset/nitro-v2-error-flush.md
+++ b/.changeset/nitro-v2-error-flush.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix Nitro v2 error responses hanging in Nuxt/Nitro apps after thrown API errors. The Nitro v2 error handler now ends the Node response directly instead of relying on h3 `send()`, so clients receive the expected JSON error response.

--- a/packages/evlog/src/nitro/errorHandler.ts
+++ b/packages/evlog/src/nitro/errorHandler.ts
@@ -1,8 +1,7 @@
 // Import from specific subpath — the barrel 'nitropack/runtime' re-exports from
 // internal/app.mjs which imports virtual modules that crash outside rollup builds.
-import type { ServerResponse } from 'node:http'
 import { defineNitroErrorHandler } from 'nitropack/runtime/internal/error/utils'
-import { getRequestURL, setResponseHeader, setResponseStatus, send } from 'h3'
+import { getRequestURL, setResponseHeader, setResponseStatus } from 'h3'
 import type { H3Event } from 'h3'
 import {
   resolveEvlogError,
@@ -14,20 +13,18 @@ import {
   suppressNitroDevOverlay,
 } from '../nitro'
 
-type WritableNodeResponse = Pick<ServerResponse, 'end' | 'writableEnded'> & { ended?: boolean }
-
-async function sendNitroV2Json(event: H3Event, body: string): Promise<void> {
-  const res = event.node?.res as WritableNodeResponse | undefined
-  if (res) {
-    if (res.writableEnded || res.ended) {
-      return
-    }
-
-    res.end(body)
-    return
+/**
+ * Flush the error response by ending the Node response directly.
+ *
+ * h3 v1's `send()` is a no-op once the event is marked handled, and the event
+ * must be marked handled *before* responding so Nitro's chained dev handler
+ * (Youch overlay) does not run after us. Ending the Node response directly
+ * resolves that tension: the flush is synchronous and unconditional (#374).
+ */
+function endNodeResponse(event: H3Event, body: string): void {
+  if (!event.node.res.writableEnded) {
+    event.node.res.end(body)
   }
-
-  await send(event, body)
 }
 
 /**
@@ -41,6 +38,8 @@ async function sendNitroV2Json(event: H3Event, body: string): Promise<void> {
 export default defineNitroErrorHandler(async (error, event, ctx) => {
   const suppressOverlay = shouldSuppressNitroDevOverlay()
 
+  // Nitro v2 always passes `ctx`, but a missing context (e.g. the handler
+  // invoked directly) must degrade to a flushed response, not a crash.
   if (!suppressOverlay && ctx?.defaultHandler) {
     await ctx.defaultHandler(error, event, { silent: false })
   }
@@ -59,7 +58,7 @@ export default defineNitroErrorHandler(async (error, event, ctx) => {
     const body = buildPlainNitroErrorBody(error, url, isDev)
     setResponseStatus(event, body.status as number)
     setResponseHeader(event, 'Content-Type', 'application/json')
-    return sendNitroV2Json(event, JSON.stringify(body))
+    return endNodeResponse(event, JSON.stringify(body))
   }
 
   const status = extractErrorStatus(evlogError)
@@ -67,5 +66,5 @@ export default defineNitroErrorHandler(async (error, event, ctx) => {
   setResponseStatus(event, status)
   setResponseHeader(event, 'Content-Type', 'application/json')
 
-  return sendNitroV2Json(event, JSON.stringify(serializeEvlogErrorResponse(evlogError, url)))
+  return endNodeResponse(event, JSON.stringify(serializeEvlogErrorResponse(evlogError, url)))
 })

--- a/packages/evlog/src/nitro/errorHandler.ts
+++ b/packages/evlog/src/nitro/errorHandler.ts
@@ -1,7 +1,9 @@
 // Import from specific subpath — the barrel 'nitropack/runtime' re-exports from
 // internal/app.mjs which imports virtual modules that crash outside rollup builds.
+import type { ServerResponse } from 'node:http'
 import { defineNitroErrorHandler } from 'nitropack/runtime/internal/error/utils'
 import { getRequestURL, setResponseHeader, setResponseStatus, send } from 'h3'
+import type { H3Event } from 'h3'
 import {
   resolveEvlogError,
   extractErrorStatus,
@@ -11,7 +13,22 @@ import {
   shouldSuppressNitroDevOverlay,
   suppressNitroDevOverlay,
 } from '../nitro'
-import type { NitroErrorHandlerContext } from '../shared/nitro-types'
+
+type WritableNodeResponse = Pick<ServerResponse, 'end' | 'writableEnded'> & { ended?: boolean }
+
+async function sendNitroV2Json(event: H3Event, body: string): Promise<void> {
+  const res = event.node?.res as WritableNodeResponse | undefined
+  if (res) {
+    if (res.writableEnded || res.ended) {
+      return
+    }
+
+    res.end(body)
+    return
+  }
+
+  await send(event, body)
+}
 
 /**
  * Custom Nitro error handler that properly serializes EvlogError.
@@ -21,10 +38,10 @@ import type { NitroErrorHandlerContext } from '../shared/nitro-types'
  * For non-EvlogError, it preserves Nitro's default response shape while
  * sanitizing internal error details in production for 5xx errors.
  */
-export default defineNitroErrorHandler(async (error, event, ctx: NitroErrorHandlerContext) => {
+export default defineNitroErrorHandler(async (error, event, ctx) => {
   const suppressOverlay = shouldSuppressNitroDevOverlay()
 
-  if (!suppressOverlay) {
+  if (!suppressOverlay && ctx?.defaultHandler) {
     await ctx.defaultHandler(error, event, { silent: false })
   }
 
@@ -42,7 +59,7 @@ export default defineNitroErrorHandler(async (error, event, ctx: NitroErrorHandl
     const body = buildPlainNitroErrorBody(error, url, isDev)
     setResponseStatus(event, body.status as number)
     setResponseHeader(event, 'Content-Type', 'application/json')
-    return send(event, JSON.stringify(body))
+    return sendNitroV2Json(event, JSON.stringify(body))
   }
 
   const status = extractErrorStatus(evlogError)
@@ -50,5 +67,5 @@ export default defineNitroErrorHandler(async (error, event, ctx: NitroErrorHandl
   setResponseStatus(event, status)
   setResponseHeader(event, 'Content-Type', 'application/json')
 
-  return send(event, JSON.stringify(serializeEvlogErrorResponse(evlogError, url)))
+  return sendNitroV2Json(event, JSON.stringify(serializeEvlogErrorResponse(evlogError, url)))
 })

--- a/packages/evlog/test/nitro-v2/fixture/nitro.config.ts
+++ b/packages/evlog/test/nitro-v2/fixture/nitro.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'pathe'
+import { defineNitroConfig } from 'nitropack/config'
+
+const evlogRoot = resolve(__dirname, '../../../src')
+
+export default defineNitroConfig({
+  compatibilityDate: '2026-06-11',
+  errorHandler: resolve(evlogRoot, 'nitro/errorHandler.ts'),
+  alias: {
+    'evlog': resolve(evlogRoot, 'index.ts'),
+  },
+})

--- a/packages/evlog/test/nitro-v2/fixture/routes/throws-plain.ts
+++ b/packages/evlog/test/nitro-v2/fixture/routes/throws-plain.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  throw new Error('Database connection failed: password invalid')
+})

--- a/packages/evlog/test/nitro-v2/fixture/routes/throws.ts
+++ b/packages/evlog/test/nitro-v2/fixture/routes/throws.ts
@@ -1,0 +1,12 @@
+import { defineEventHandler } from 'h3'
+import { createError } from 'evlog'
+
+export default defineEventHandler(() => {
+  throw createError({
+    message: 'Payment failed',
+    status: 402,
+    why: 'Card declined by issuer (insufficient funds)',
+    fix: 'Try a different payment method or contact your bank',
+    link: 'https://docs.example.com/payments/declined',
+  })
+})

--- a/packages/evlog/test/nitro-v2/fixture/routes/works.ts
+++ b/packages/evlog/test/nitro-v2/fixture/routes/works.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => ({ success: true }))

--- a/packages/evlog/test/nitro-v2/nitro-v2.test.ts
+++ b/packages/evlog/test/nitro-v2/nitro-v2.test.ts
@@ -1,0 +1,108 @@
+import { createServer } from 'node:http'
+import type { Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import {
+  build,
+  createDevServer,
+  createNitro,
+  prepare,
+} from 'nitropack'
+import { toNodeListener } from 'h3'
+import { resolve } from 'pathe'
+
+const rootDir = resolve(__dirname, './fixture')
+
+/**
+ * Regression suite for #374: the v2 error handler used h3 v1's `send()`, which
+ * is a no-op once the event is marked handled, so thrown errors never flushed
+ * the response and clients hung forever. Unlike the unit tests in
+ * `test/nitro/errorHandler.test.ts` (which mock h3), this boots a real Nitro v2
+ * dev server so the real h3 v1 / Node response semantics are exercised.
+ */
+describe.sequential('Nitro v2 server with evlog error handler', () => {
+  let nitro: Awaited<ReturnType<typeof createNitro>>
+  let devServer: ReturnType<typeof createDevServer>
+  let server: Server
+  let baseURL: string
+
+  beforeAll(async () => {
+    nitro = await createNitro({
+      dev: true,
+      rootDir,
+    })
+    devServer = createDevServer(nitro)
+    // Bind our own ephemeral port instead of `devServer.listen()` so parallel
+    // CI shards never race for listhen's default port.
+    server = createServer(toNodeListener(devServer.app))
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    await prepare(nitro)
+    const ready = new Promise<void>((resolve) => {
+      nitro.hooks.hook('dev:reload', () => resolve())
+    })
+    await build(nitro)
+    await ready
+  }, 120_000)
+
+  afterAll(async () => {
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+    }
+    await devServer?.close()
+    await nitro?.close()
+  })
+
+  // A regression of #374 never flushes the response: the request would hang
+  // until the test times out, so abort early with an explicit failure instead.
+  async function fetchJson(path: string): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await fetch(new URL(path, baseURL), {
+      signal: AbortSignal.timeout(8_000),
+    }).catch((cause) => {
+      throw new Error(`response for ${path} was never flushed (regression of #374)`, { cause })
+    })
+    return { status: res.status, body: await res.json() }
+  }
+
+  it('serves non-error routes', async () => {
+    const { status, body } = await fetchJson('/works')
+
+    expect(status).toBe(200)
+    expect(body).toEqual({ success: true })
+  }, 15_000)
+
+  it('flushes thrown EvlogError as a serialized JSON response', async () => {
+    const { status, body } = await fetchJson('/throws')
+
+    expect(status).toBe(402)
+    expect(body).toMatchObject({
+      statusCode: 402,
+      message: 'Payment failed',
+      url: '/throws',
+      error: true,
+      data: {
+        why: 'Card declined by issuer (insufficient funds)',
+        fix: 'Try a different payment method or contact your bank',
+        link: 'https://docs.example.com/payments/declined',
+      },
+    })
+  }, 15_000)
+
+  it('flushes plain thrown errors with Nitro-compatible JSON', async () => {
+    const { status, body } = await fetchJson('/throws-plain')
+
+    expect(status).toBe(500)
+    expect(body).toMatchObject({
+      statusCode: 500,
+      url: '/throws-plain',
+      error: true,
+      message: expect.any(String),
+    })
+  }, 15_000)
+})

--- a/packages/evlog/test/nitro-v3/nitro-v3.test.ts
+++ b/packages/evlog/test/nitro-v3/nitro-v3.test.ts
@@ -17,7 +17,6 @@ import { consola } from 'consola'
 import { parseError } from '../../src/runtime/utils/parseError'
 
 const rootDir = resolve(__dirname, './fixture')
-const serverURL = 'http://localhost'
 
 describe.sequential('Nitro v3 Server with evlog', () => {
   let nitro: Awaited<ReturnType<typeof createNitro>>
@@ -33,7 +32,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
       rootDir,
     })
     devServer = createDevServer(nitro)
-    server = await devServer.listen({})
+    server = devServer.listen({})
     await prepare(nitro)
     const ready = new Promise<void>((resolve) => {
       nitro.hooks.hook('dev:reload', () => resolve())
@@ -50,7 +49,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
   })
 
   it('should be able to get the correct result', async () => {
-    const res = await server.fetch(new Request(new URL('/works', serverURL)))
+    const res = await server.fetch(new Request(new URL('/works', server.url)))
     const json = await res.json()
 
     expect(json).toEqual({ success: true })
@@ -66,7 +65,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', serverURL)))
+      await server.fetch(new Request(new URL('/works', server.url)))
 
       // Wait for async logs to be written
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -101,7 +100,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      const res = await server.fetch(new Request(new URL('/throws', serverURL)))
+      const res = await server.fetch(new Request(new URL('/throws', server.url)))
       
       expect(res.status).toBe(402)
       
@@ -149,7 +148,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', serverURL), {
+      await server.fetch(new Request(new URL('/works', server.url), {
         headers: {
           'Authorization': 'Bearer secret-token',
           'Cookie': 'session=abc123',
@@ -202,7 +201,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', serverURL)))
+      await server.fetch(new Request(new URL('/works', server.url)))
 
       // Wait for async logs and hooks to be called
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -249,7 +248,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', serverURL)))
+      await server.fetch(new Request(new URL('/works', server.url)))
 
       // Wait for async logs and hooks to be called
       await new Promise(resolve => setTimeout(resolve, 100))

--- a/packages/evlog/test/nitro-v3/nitro-v3.test.ts
+++ b/packages/evlog/test/nitro-v3/nitro-v3.test.ts
@@ -17,6 +17,7 @@ import { consola } from 'consola'
 import { parseError } from '../../src/runtime/utils/parseError'
 
 const rootDir = resolve(__dirname, './fixture')
+const serverURL = 'http://localhost'
 
 describe.sequential('Nitro v3 Server with evlog', () => {
   let nitro: Awaited<ReturnType<typeof createNitro>>
@@ -32,7 +33,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
       rootDir,
     })
     devServer = createDevServer(nitro)
-    server = devServer.listen({})
+    server = await devServer.listen({})
     await prepare(nitro)
     const ready = new Promise<void>((resolve) => {
       nitro.hooks.hook('dev:reload', () => resolve())
@@ -49,7 +50,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
   })
 
   it('should be able to get the correct result', async () => {
-    const res = await server.fetch(new Request(new URL('/works', server.url)))
+    const res = await server.fetch(new Request(new URL('/works', serverURL)))
     const json = await res.json()
 
     expect(json).toEqual({ success: true })
@@ -65,7 +66,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', server.url)))
+      await server.fetch(new Request(new URL('/works', serverURL)))
 
       // Wait for async logs to be written
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -100,7 +101,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      const res = await server.fetch(new Request(new URL('/throws', server.url)))
+      const res = await server.fetch(new Request(new URL('/throws', serverURL)))
       
       expect(res.status).toBe(402)
       
@@ -148,7 +149,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', server.url), {
+      await server.fetch(new Request(new URL('/works', serverURL), {
         headers: {
           'Authorization': 'Bearer secret-token',
           'Cookie': 'session=abc123',
@@ -201,7 +202,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', server.url)))
+      await server.fetch(new Request(new URL('/works', serverURL)))
 
       // Wait for async logs and hooks to be called
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -248,7 +249,7 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     consola.wrapAll()
 
     try {
-      await server.fetch(new Request(new URL('/works', server.url)))
+      await server.fetch(new Request(new URL('/works', serverURL)))
 
       // Wait for async logs and hooks to be called
       await new Promise(resolve => setTimeout(resolve, 100))

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -9,19 +9,13 @@ declare global {
 
 const mockSetResponseStatus = vi.fn<(event: H3Event, status: number) => void>()
 const mockSetResponseHeader = vi.fn<(event: H3Event, name: string, value: string) => void>()
-const mockSend = vi.fn<(event: H3Event, body: string) => void>()
 const mockGetRequestURL = vi.fn<(event: H3Event, options?: { xForwardedHost?: boolean }) => { pathname: string }>(() => ({ pathname: '/api/test' }))
 const mockResponseEnd = vi.fn<(body?: string) => void>()
 
 vi.mock('h3', () => ({
   setResponseStatus: (event: H3Event, status: number) => mockSetResponseStatus(event, status),
   setResponseHeader: (event: H3Event, name: string, value: string) => mockSetResponseHeader(event, name, value),
-  send: (event: H3Event, body: string) => mockSend(event, body),
   getRequestURL: (event: H3Event, options?: { xForwardedHost?: boolean }) => mockGetRequestURL(event, options),
-}))
-
-vi.mock('nitropack/runtime', () => ({
-  defineNitroErrorHandler: <T>(handler: T) => handler,
 }))
 
 import { createError } from '../../src/error'
@@ -35,6 +29,9 @@ const mockEvent = {
 
 const defaultHandlerMock = vi.fn().mockResolvedValue(undefined)
 
+// Relaxed signature: production code is typed against nitropack's
+// NitroErrorHandler (H3Error, full H3Event, required ctx); tests exercise the
+// runtime behavior with plain errors, a partial event and an optional ctx.
 type TestErrorHandler = (
   error: Error,
   event: typeof mockEvent,
@@ -48,8 +45,7 @@ function invokeErrorHandler(error: Error) {
 }
 
 function readResponseBody(): Record<string, unknown> {
-  const body = defined(mockResponseEnd.mock.calls[0]?.[0] ?? mockSend.mock.calls[0]?.[1], 'response body')
-  return JSON.parse(body)
+  return JSON.parse(defined(mockResponseEnd.mock.calls[0]?.[0], 'response body'))
 }
 
 describe('errorHandler', () => {
@@ -68,15 +64,20 @@ describe('errorHandler', () => {
     expect(mockEvent._handled).toBe(true)
   })
 
-  it('ends the Node response directly on Nitro v2', async () => {
+  it('ends the Node response directly so h3 v1 cannot skip the flush (#374)', async () => {
     await invokeErrorHandler(new Error('boom'))
     expect(mockResponseEnd).toHaveBeenCalledWith(expect.stringContaining('"statusCode":500'))
-    expect(mockSend).not.toHaveBeenCalled()
   })
 
-  it('does not require the Nitro v3 error handler context', async () => {
+  it('flushes the response even when invoked without a handler context', async () => {
     await testErrorHandler(new Error('boom'), mockEvent)
     expect(mockResponseEnd).toHaveBeenCalledWith(expect.stringContaining('"statusCode":500'))
+  })
+
+  it('does not end the response twice when already ended', async () => {
+    mockEvent.node.res.writableEnded = true
+    await invokeErrorHandler(new Error('boom'))
+    expect(mockResponseEnd).not.toHaveBeenCalled()
   })
 
   it('clears unhandled flag in dev pretty mode', async () => {

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -7,10 +7,11 @@ declare global {
   var __EVLOG_CONFIG__: unknown
 }
 
-const mockSetResponseStatus = vi.fn()
-const mockSetResponseHeader = vi.fn()
-const mockSend = vi.fn()
-const mockGetRequestURL = vi.fn(() => ({ pathname: '/api/test' }))
+const mockSetResponseStatus = vi.fn<(event: H3Event, status: number) => void>()
+const mockSetResponseHeader = vi.fn<(event: H3Event, name: string, value: string) => void>()
+const mockSend = vi.fn<(event: H3Event, body: string) => void>()
+const mockGetRequestURL = vi.fn<(event: H3Event, options?: { xForwardedHost?: boolean }) => { pathname: string }>(() => ({ pathname: '/api/test' }))
+const mockResponseEnd = vi.fn<(body?: string) => void>()
 
 vi.mock('h3', () => ({
   setResponseStatus: (event: H3Event, status: number) => mockSetResponseStatus(event, status),
@@ -27,12 +28,28 @@ import { createError } from '../../src/error'
 import errorHandler from '../../src/nitro/errorHandler'
 import { resetNitroDevOverlayCache, shouldSuppressNitroDevOverlay } from '../../src/nitro'
 
-const mockEvent = { node: { req: {}, res: {} }, _handled: false } as H3Event & { _handled: boolean }
+const mockEvent = {
+  node: { req: {}, res: { writableEnded: false, end: mockResponseEnd } },
+  _handled: false,
+} as unknown as H3Event & { _handled: boolean; node: { res: { writableEnded: boolean; end: typeof mockResponseEnd } } }
 
 const defaultHandlerMock = vi.fn().mockResolvedValue(undefined)
 
+type TestErrorHandler = (
+  error: Error,
+  event: typeof mockEvent,
+  ctx?: { defaultHandler: (error: Error, event: typeof mockEvent, opts?: { silent?: boolean; json?: boolean }) => unknown },
+) => Promise<void> | void
+
+const testErrorHandler = errorHandler as unknown as TestErrorHandler
+
 function invokeErrorHandler(error: Error) {
-  return errorHandler(error, mockEvent, { defaultHandler: defaultHandlerMock })
+  return testErrorHandler(error, mockEvent, { defaultHandler: defaultHandlerMock })
+}
+
+function readResponseBody(): Record<string, unknown> {
+  const body = defined(mockResponseEnd.mock.calls[0]?.[0] ?? mockSend.mock.calls[0]?.[1], 'response body')
+  return JSON.parse(body)
 }
 
 describe('errorHandler', () => {
@@ -43,11 +60,23 @@ describe('errorHandler', () => {
     delete globalThis.__EVLOG_CONFIG__
     resetNitroDevOverlayCache()
     mockEvent._handled = false
+    mockEvent.node.res.writableEnded = false
   })
 
   it('marks the h3 event handled so Nitro dev handler does not run', async () => {
     await invokeErrorHandler(new Error('boom'))
     expect(mockEvent._handled).toBe(true)
+  })
+
+  it('ends the Node response directly on Nitro v2', async () => {
+    await invokeErrorHandler(new Error('boom'))
+    expect(mockResponseEnd).toHaveBeenCalledWith(expect.stringContaining('"statusCode":500'))
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('does not require the Nitro v3 error handler context', async () => {
+    await testErrorHandler(new Error('boom'), mockEvent)
+    expect(mockResponseEnd).toHaveBeenCalledWith(expect.stringContaining('"statusCode":500'))
   })
 
   it('clears unhandled flag in dev pretty mode', async () => {
@@ -63,7 +92,7 @@ describe('errorHandler', () => {
     resetNitroDevOverlayCache()
     const defaultHandler = vi.fn().mockResolvedValue(undefined)
     const error = new Error('boom')
-    await errorHandler(error, mockEvent, { defaultHandler })
+    await testErrorHandler(error, mockEvent, { defaultHandler })
     expect(defaultHandler).toHaveBeenCalledWith(error, mockEvent, { silent: false })
   })
 
@@ -94,7 +123,7 @@ describe('errorHandler', () => {
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 402)
       expect(mockSetResponseHeader).toHaveBeenCalledWith(mockEvent, 'Content-Type', 'application/json')
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.statusCode).toBe(402)
       expect(sentBody.message).toBe('Payment failed')
       expect(sentBody.url).toBe('/api/test')
@@ -122,7 +151,7 @@ describe('errorHandler', () => {
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 404)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.statusCode).toBe(404)
       expect(sentBody.data).toEqual({ why: 'Resource does not exist' })
     })
@@ -145,7 +174,7 @@ describe('errorHandler', () => {
 
       await invokeErrorHandler(err)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.internal).toBeUndefined()
       expect(JSON.stringify(sentBody)).not.toContain('u-internal')
       expect(JSON.stringify(sentBody)).not.toContain('rawPolicy')
@@ -167,7 +196,7 @@ describe('errorHandler', () => {
 
       expect(mockSetResponseStatus).toHaveBeenCalledWith(mockEvent, 400)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.statusCode).toBe(400)
       expect(sentBody.statusMessage).toBe('Something went wrong')
       expect(sentBody.message).toBe('Something went wrong')
@@ -189,7 +218,7 @@ describe('errorHandler', () => {
 
       await invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.message).toBe('Internal Server Error')
       expect(sentBody.statusMessage).toBe('Internal Server Error')
     })
@@ -203,7 +232,7 @@ describe('errorHandler', () => {
 
       await invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.message).toBe('Internal Server Error')
       expect(sentBody.statusMessage).toBe('Internal Server Error')
     })
@@ -217,7 +246,7 @@ describe('errorHandler', () => {
 
       await invokeErrorHandler(error)
 
-      const sentBody = JSON.parse(defined(mockSend.mock.calls[0]?.[1], 'response body'))
+      const sentBody = readResponseBody()
       expect(sentBody.message).toBe('Invalid email format')
       expect(sentBody.statusMessage).toBe('Invalid email format')
     })


### PR DESCRIPTION
Resolves #374

## Root cause

`evlog` 2.19.0 switched the Nitro v2 error handler to h3's `send()` as the final flush. On h3 v1, `send()` is a no-op once the event is marked handled (`event.handled` checks `_handled`) — and the handler marks the event handled *before* responding, which is required to keep Nitro's chained dev handler (Youch overlay) from running. Result: thrown API errors never ended the Node response and clients hung until `Failed to fetch`.

## Fix

The v2 error handler now ends the Node response directly (`event.node.res.end(body)`), which is synchronous and unconditional — no interaction with the `_handled` flag. `event.node.res` always exists on Nitro v2, so there is no fallback path.

## Tests

- **New Nitro v2 integration suite** (`test/nitro-v2/`): boots a real Nitro v2 dev server with the evlog error handler wired through `nitro.options.errorHandler`, so the real h3 v1 / Node response semantics are exercised. The existing unit tests mock h3 and could not catch #374; this suite was verified to fail with `response was never flushed (regression of #374)` against the pre-fix handler.
- Unit tests updated: response body read from `res.end`, double-end guard covered, handler tolerates a missing `ctx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Nitro v2 error responses would hang after thrown API errors, ensuring clients receive the expected JSON error response promptly.

* **Tests**
  * Added comprehensive integration tests for Nitro v2 error handling to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->