### PR TITLE
fix(hono): assign c.res directly for streaming responses to bypass finalized check

### DIFF
--- a/packages/evlog/src/hono/index.ts
+++ b/packages/evlog/src/hono/index.ts
@@ -63,11 +63,8 @@ export function evlog(options: EvlogHonoOptions = {}): MiddlewareHandler {
     try {
       await next()
       if (shouldDeferEmitForResponse(c.res)) {
-        const response = new Response(c.res.body, {
-          status: c.res.status,
-          headers: c.res.headers,
-        })
-        return finishResponse(response, { status: response.status })
+        c.res = await finishResponse(c.res, { status: c.res.status })
+        return
       }
       await finish({ status: c.res.status })
     } catch (error) {

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -176,6 +176,61 @@ describe('evlog/hono', () => {
     expect(logValue).toBeUndefined()
   })
 
+  describe('streaming responses', () => {
+    it('can consume a streaming response body after middleware wraps it', async () => {
+      const { drain } = createPipelineSpies()
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+
+      app.get('/api/stream', () => {
+        const encoder = new TextEncoder()
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('chunk1'))
+            controller.enqueue(encoder.encode('chunk2'))
+            controller.close()
+          },
+        })
+        return new Response(stream, {
+          headers: { 'content-type': 'text/event-stream', 'x-vercel-ai-ui-message-stream': 'v1' },
+        })
+      })
+
+      const res = await app.request('/api/stream')
+      expect(res.status).toBe(200)
+      // Body must not be locked — consuming it should succeed
+      const text = await res.text()
+      expect(text).toBe('chunk1chunk2')
+
+      await waitForDrainCalls(drain)
+      assertHttpEventEmitted(drain, { path: '/api/stream', status: 200 })
+    })
+
+    it('defers drain until stream completes', async () => {
+      const { drain } = createPipelineSpies()
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+
+      const { createDeferredStream } = await import('../helpers/stream')
+      const source = createDeferredStream()
+
+      app.get('/api/defer', () => {
+        return new Response(source.stream, {
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      })
+
+      const res = await app.request('/api/defer')
+      expect(res.status).toBe(200)
+      expect(drain).not.toHaveBeenCalled()
+
+      source.close()
+      await res.text()
+      await waitForDrainCalls(drain)
+      assertHttpEventEmitted(drain, { path: '/api/defer', status: 200 })
+    })
+  })
+
   describe('drain / enrich / keep', () => {
     it('calls drain with emitted event (shared helpers)', async () => {
       const { drain } = createPipelineSpies()


### PR DESCRIPTION
When using `createUIMessageStreamResponse` (or any streaming response) with the Hono middleware, the request crashed with `TypeError: ReadableStream is locked`.

**Root cause:** Hono's `compose` function guards `context.res` updates behind a `finalized` check:
```js
if (res && (context.finalized === false || isError)) {
  context.res = res;
}
```
The route handler sets `c.res` first, making `context.finalized = true`. When the evlog middleware later *returned* the wrapped Response, Hono silently discarded it. `app.fetch()` returned the original `c.res` whose body had already been locked by `createObservedBody`'s `getReader()` call, so `@hono/node-server` crashed trying to read it.

**Fix:** Directly assign `c.res` with the result of `finishResponse()` instead of returning it from the middleware handler. This bypasses the `finalized` guard entirely.

Two tests added: one verifies the response body remains consumable after middleware wraps it, and one confirms drain is deferred until the stream completes.