### PR TITLE
fix: keep Node built-ins out of the main entrypoint bundle

### DIFF
--- a/.changeset/fix-node-entrypoint-bundle.md
+++ b/.changeset/fix-node-entrypoint-bundle.md
@@ -2,7 +2,7 @@
 "evlog": patch
 ---
 
-fix: keep Node built-ins out of the main entrypoint bundle
+# fix: keep Node built-ins out of the main entrypoint bundle
 
 Non-Node bundlers (Convex, etc.) failed when importing `defineErrorCatalog` from `evlog` because the main bundle transitively referenced `node:crypto` and `pretty-error-snippet.node` (`node:fs`, `node:path`, `node:module`). The audit signer now uses `globalThis.crypto.subtle` only, disk snippet loading is registered from Node-only integration entrypoints instead of `initLogger`, and catalog utilities live in a dedicated `evlog/catalog` subpath backed by a lean `audit-action` module.
 

--- a/.changeset/fix-node-entrypoint-bundle.md
+++ b/.changeset/fix-node-entrypoint-bundle.md
@@ -1,0 +1,9 @@
+---
+"evlog": patch
+---
+
+fix: keep Node built-ins out of the main entrypoint bundle
+
+Non-Node bundlers (Convex, etc.) failed when importing `defineErrorCatalog` from `evlog` because the main bundle transitively referenced `node:crypto` and `pretty-error-snippet.node` (`node:fs`, `node:path`, `node:module`). The audit signer now uses `globalThis.crypto.subtle` only, disk snippet loading is registered from Node-only integration entrypoints instead of `initLogger`, and catalog utilities are available via a dedicated `evlog/catalog` subpath with a lean dependency graph.
+
+Closes #387

--- a/.changeset/fix-node-entrypoint-bundle.md
+++ b/.changeset/fix-node-entrypoint-bundle.md
@@ -4,6 +4,6 @@
 
 fix: keep Node built-ins out of the main entrypoint bundle
 
-Non-Node bundlers (Convex, etc.) failed when importing `defineErrorCatalog` from `evlog` because the main bundle transitively referenced `node:crypto` and `pretty-error-snippet.node` (`node:fs`, `node:path`, `node:module`). The audit signer now uses `globalThis.crypto.subtle` only, disk snippet loading is registered from Node-only integration entrypoints instead of `initLogger`, and catalog utilities are available via a dedicated `evlog/catalog` subpath with a lean dependency graph.
+Non-Node bundlers (Convex, etc.) failed when importing `defineErrorCatalog` from `evlog` because the main bundle transitively referenced `node:crypto` and `pretty-error-snippet.node` (`node:fs`, `node:path`, `node:module`). The audit signer now uses `globalThis.crypto.subtle` only, disk snippet loading is registered from Node-only integration entrypoints instead of `initLogger`, and catalog utilities live in a dedicated `evlog/catalog` subpath backed by a lean `audit-action` module.
 
 Closes #387

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -134,6 +134,11 @@
       "import": "./dist/browser.mjs",
       "default": "./dist/browser.mjs"
     },
+    "./catalog": {
+      "types": "./dist/catalog.d.mts",
+      "import": "./dist/catalog.mjs",
+      "default": "./dist/catalog.mjs"
+    },
     "./next": {
       "types": "./dist/next/index.d.mts",
       "import": "./dist/next/index.mjs",
@@ -285,6 +290,9 @@
       ],
       "browser": [
         "./dist/browser.d.mts"
+      ],
+      "catalog": [
+        "./dist/catalog.d.mts"
       ],
       "next": [
         "./dist/next/index.d.mts"

--- a/packages/evlog/src/audit-action.ts
+++ b/packages/evlog/src/audit-action.ts
@@ -1,4 +1,4 @@
-import type { AuditActionDefinition, AuditActor, AuditFields, AuditTarget } from '../types'
+import type { AuditActionDefinition, AuditActor, AuditFields, AuditTarget } from './types'
 
 /**
  * Input accepted by `log.audit()`, `audit()`, and `withAudit()`.
@@ -19,7 +19,7 @@ export interface AuditInput {
   version?: number
 }
 
-/** Options for {@link defineAuditAction}. Same shape as {@link AuditCatalogEntry}. */
+/** Options for {@link defineAuditAction}. Same shape as {@link AuditActionDefinition}. */
 export type DefineAuditActionOptions = AuditActionDefinition
 
 /**

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -1,32 +1,18 @@
-import type { AuditActor, AuditActionDefinition, AuditFields, AuditPatchOp, AuditTarget, DrainContext, EnrichContext, FieldContext, RedactConfig, RequestLogger, WideEvent } from './types'
+import type { AuditActor, AuditFields, AuditPatchOp, AuditTarget, DrainContext, EnrichContext, FieldContext, RedactConfig, RequestLogger, WideEvent } from './types'
 import { createLogger } from './logger'
 import { compileRedactPathMatchers, redactValueByPaths } from './redact'
 import { getHeader as getSharedHeader } from './shared/headers'
+import { defineAuditAction } from './shared/define-audit-action'
+import type { AuditInput, DefineAuditActionOptions, DefinedAuditAction } from './shared/define-audit-action'
+
+export { defineAuditAction }
+export type { AuditInput, DefineAuditActionOptions, DefinedAuditAction }
 
 /**
  * Current version of the audit envelope. Bumped when `AuditFields` evolves
  * in a backward-incompatible way so downstream pipelines can branch on it.
  */
 export const AUDIT_SCHEMA_VERSION = 1
-
-/**
- * Input accepted by `log.audit()`, `audit()`, and `withAudit()`.
- *
- * `outcome` defaults to `'success'`. Internal fields populated by the audit
- * pipeline (`idempotencyKey`, `context`, `signature`, `prevHash`, `hash`) are
- * stripped — pass them through `log.set({ audit })` if you really need to.
- */
-export interface AuditInput {
-  action: string
-  actor: AuditActor
-  target?: AuditTarget
-  outcome?: AuditFields['outcome']
-  reason?: string
-  changes?: AuditFields['changes']
-  causationId?: string
-  correlationId?: string
-  version?: number
-}
 
 /**
  * @internal Stable JSON stringification with deterministic key order.
@@ -389,85 +375,6 @@ export interface AuditDiffOptions {
   includeAfter?: boolean
 }
 
-/** Options for {@link defineAuditAction}. Same shape as {@link AuditCatalogEntry}. */
-export type DefineAuditActionOptions = AuditActionDefinition
-
-/**
- * Define a typed audit action with optional fixed target type and catalog metadata.
- *
- * Returns a curried helper that fills in the action name (and target shape
- * if provided) so call sites stay terse and the action set is discoverable
- * in one place. Metadata (`description`, `severity`, `requiresChanges`, …)
- * is exposed on the factory for introspection, docs, and review tooling.
- *
- * @example
- * ```ts
- * const refund = defineAuditAction('invoice.refund', {
- *   target: 'invoice',
- *   severity: 'high',
- *   requiresChanges: true,
- *   redactPaths: ['cardNumber'],
- * })
- *
- * log.audit(refund({
- *   actor: { type: 'user', id: user.id },
- *   target: { id: 'inv_889' }, // type inferred as 'invoice'
- *   outcome: 'success',
- * }))
- * ```
- */
-export function defineAuditAction<
-  const TAction extends string,
-  const TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
->(action: TAction, options?: TOptions): DefinedAuditAction<TAction, TOptions> {
-  const targetType = options?.target
-  const factory = ((input) => {
-    const merged: AuditInput = {
-      ...(input as AuditInput),
-      action,
-    }
-    if (targetType && input.target && !input.target.type) {
-      merged.target = { ...input.target, type: targetType } as AuditTarget
-    }
-    return merged
-  }) as DefinedAuditAction<TAction, TOptions>
-
-  Object.defineProperties(factory, {
-    action: { value: action, enumerable: true },
-    target: { value: options?.target, enumerable: true },
-    description: { value: options?.description, enumerable: true },
-    severity: { value: options?.severity, enumerable: true },
-    requiresChanges: { value: options?.requiresChanges, enumerable: true },
-    requiresReason: { value: options?.requiresReason, enumerable: true },
-    redactPaths: { value: options?.redactPaths, enumerable: true },
-  })
-
-  return factory
-}
-
-/**
- * Return type of {@link defineAuditAction}. Accepts a partial input (no
- * `action`, target type pre-filled when provided).
- */
-export type DefinedAuditAction<
-  TAction extends string = string,
-  TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
-> =
-  & ((
-    input: TOptions['target'] extends string
-      ? Omit<AuditInput, 'action' | 'target'> & { target?: Omit<AuditTarget, 'type'> & { type?: TOptions['target'] } }
-      : Omit<AuditInput, 'action'>,
-  ) => AuditInput)
-  & {
-    readonly action: TAction
-    readonly target: TOptions['target']
-    readonly description: TOptions['description']
-    readonly severity: TOptions['severity']
-    readonly requiresChanges: TOptions['requiresChanges']
-    readonly requiresReason: TOptions['requiresReason']
-    readonly redactPaths: TOptions['redactPaths']
-  }
-
 /**
  * Test helper that captures every audit event emitted while it is active.
  *
@@ -794,15 +701,17 @@ export function signed(drain: DrainFn, options: SignedOptions): DrainFn {
 
 /**
  * @internal Resolve the Web Crypto SubtleCrypto interface. Available natively
- * in browsers, Node 19+, Bun, Deno, and Cloudflare Workers. Falls back to
- * Node's `webcrypto` for Node 18 (where `globalThis.crypto` is gated behind
- * a flag). The dynamic import keeps `node:crypto` out of browser bundles.
+ * in browsers, Node 19+, Bun, Deno, Cloudflare Workers, and Convex. Requires
+ * `globalThis.crypto.subtle` — no `node:crypto` fallback so non-Node bundlers
+ * can import the main entrypoint without resolving Node built-ins (#387).
  */
-async function getSubtle(): Promise<SubtleCrypto> {
-  const c = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
-  if (c?.subtle) return c.subtle
-  const mod = await import(/* @vite-ignore */ 'node:crypto') as { webcrypto: { subtle: SubtleCrypto } }
-  return mod.webcrypto.subtle
+function getSubtle(): SubtleCrypto {
+  const subtle = globalThis.crypto?.subtle
+  if (subtle) return subtle
+  throw new Error(
+    '[evlog/audit] Web Crypto is not available. signed() requires globalThis.crypto.subtle '
+    + '(Node 19+, modern browsers, Cloudflare Workers, Convex, Bun, Deno).',
+  )
 }
 
 function normalizeAlgo(algorithm: string): string {
@@ -831,13 +740,12 @@ function bufToHex(buf: ArrayBuffer): string {
 }
 
 async function digestHex(algorithm: string, data: string): Promise<string> {
-  const subtle = await getSubtle()
-  const buf = await subtle.digest(normalizeAlgo(algorithm), new TextEncoder().encode(data))
+  const buf = await getSubtle().digest(normalizeAlgo(algorithm), new TextEncoder().encode(data))
   return bufToHex(buf)
 }
 
 async function hmacHex(algorithm: string, secret: string, data: string): Promise<string> {
-  const subtle = await getSubtle()
+  const subtle = getSubtle()
   const hash = normalizeAlgo(algorithm)
   const key = await subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash }, false, ['sign'])
   const sig = await subtle.sign('HMAC', key, new TextEncoder().encode(data))

--- a/packages/evlog/src/audit.ts
+++ b/packages/evlog/src/audit.ts
@@ -2,11 +2,9 @@ import type { AuditActor, AuditFields, AuditPatchOp, AuditTarget, DrainContext, 
 import { createLogger } from './logger'
 import { compileRedactPathMatchers, redactValueByPaths } from './redact'
 import { getHeader as getSharedHeader } from './shared/headers'
-import { defineAuditAction } from './shared/define-audit-action'
-import type { AuditInput, DefineAuditActionOptions, DefinedAuditAction } from './shared/define-audit-action'
+import type { AuditInput } from './audit-action'
 
-export { defineAuditAction }
-export type { AuditInput, DefineAuditActionOptions, DefinedAuditAction }
+export { defineAuditAction, type AuditInput, type DefineAuditActionOptions, type DefinedAuditAction } from './audit-action'
 
 /**
  * Current version of the audit envelope. Bumped when `AuditFields` evolves

--- a/packages/evlog/src/catalog.ts
+++ b/packages/evlog/src/catalog.ts
@@ -1,5 +1,5 @@
 import type { AuditActionDefinition, AuditTarget } from './types'
-import { defineAuditAction } from './audit'
+import { defineAuditAction, type AuditInput } from './shared/define-audit-action'
 import { EvlogError } from './error'
 
 /**

--- a/packages/evlog/src/catalog.ts
+++ b/packages/evlog/src/catalog.ts
@@ -1,5 +1,5 @@
 import type { AuditActionDefinition, AuditTarget } from './types'
-import { defineAuditAction, type AuditInput } from './shared/define-audit-action'
+import { defineAuditAction, type AuditInput } from './audit-action'
 import { EvlogError } from './error'
 
 /**

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -1,5 +1,7 @@
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify'
 import type { RequestLogger } from '../types'
+import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
+import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
@@ -7,6 +9,8 @@ import { createLoggerStorage } from '../shared/storage'
 const { storage, useLogger } = createLoggerStorage(
   'plugin context. Make sure app.register(evlog) is called before your routes.',
 )
+
+registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
 
 export type EvlogFastifyOptions = BaseEvlogOptions
 

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -1,7 +1,6 @@
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify'
 import type { RequestLogger } from '../types'
-import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
-import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
+import { registerDiskPrettyErrorSnippetReader } from '../shared/register-disk-snippet'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
@@ -10,7 +9,7 @@ const { storage, useLogger } = createLoggerStorage(
   'plugin context. Make sure app.register(evlog) is called before your routes.',
 )
 
-registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+void registerDiskPrettyErrorSnippetReader()
 
 export type EvlogFastifyOptions = BaseEvlogOptions
 

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -4,7 +4,7 @@ import { buildAuditFields, consumeAuditForceKeep, finalizeAudit } from './audit'
 import { markGloballyRedacted, redactEvent, resolveRedactConfig } from './redact'
 import type { PluginRunner } from './shared/plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './shared/plugin'
-import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER, registerPrettyErrorSnippetReader } from './shared/pretty-error'
+import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER } from './shared/pretty-error'
 import type { ResolvedPrettyError } from './shared/dev-terminal'
 import { resolveDevTerminal } from './shared/dev-terminal'
 import { EvlogError } from './error'
@@ -138,14 +138,6 @@ export function initLogger(config: LoggerConfig = {}): void {
 
   if (globalPluginRunner.plugins.length > 0) {
     void globalPluginRunner.runSetup({ env: { ...globalEnv } })
-  }
-
-  if (!isBrowser() && typeof process !== 'undefined' && process.versions?.node) {
-    void import('./shared/pretty-error-snippet.node.js').then((mod) => {
-      registerPrettyErrorSnippetReader(mod.readCodeSnippetFromDisk)
-    }).catch(() => {
-      registerPrettyErrorSnippetReader(null)
-    })
   }
 
   const hasAnyDrain = !!globalDrain || globalPluginRunner.hasDrain

--- a/packages/evlog/src/next/instrumentation-create.ts
+++ b/packages/evlog/src/next/instrumentation-create.ts
@@ -1,3 +1,5 @@
+import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
+import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
 import type { DrainContext, EnvironmentContext, LogLevel, Log, SamplingConfig } from '../types'
 import type {
   NextInstrumentationErrorContext,
@@ -6,14 +8,6 @@ import type {
 
 type LoggerModule = typeof import('../logger')
 type EvlogProcessOutputGlobal = import('../logger').EvlogProcessOutputGlobal
-
-function loadPrettyErrorSnippet(): Promise<void> {
-  return import('../shared/pretty-error-snippet.node.js').then(({ readCodeSnippetFromDisk }) => {
-    return import('../shared/pretty-error.js').then(({ registerPrettyErrorSnippetReader }) => {
-      registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
-    })
-  }).catch(() => undefined)
-}
 
 /** Options for capturing process stdout/stderr as structured log events. */
 export interface CaptureOutputOptions {
@@ -198,7 +192,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
     if (registered) return
     if (registerPromise) return registerPromise
 
-    registerPromise = loadLogger().then(async ({ initLogger, lockLogger, log }) => {
+    registerPromise = loadLogger().then(({ initLogger, lockLogger, log }) => {
       initLogger({
         enabled: options.enabled,
         env: {
@@ -213,7 +207,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
         drain: options.drain,
       })
       lockLogger()
-      await loadPrettyErrorSnippet()
+      registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
 
       if (captureOutputOptions && process.env.NEXT_RUNTIME === 'nodejs') {
         applyCaptureOutput(captureOutputOptions, log, options.silent ?? false)

--- a/packages/evlog/src/next/instrumentation-create.ts
+++ b/packages/evlog/src/next/instrumentation-create.ts
@@ -7,6 +7,14 @@ import type {
 type LoggerModule = typeof import('../logger')
 type EvlogProcessOutputGlobal = import('../logger').EvlogProcessOutputGlobal
 
+function loadPrettyErrorSnippet(): Promise<void> {
+  return import('../shared/pretty-error-snippet.node.js').then(({ readCodeSnippetFromDisk }) => {
+    return import('../shared/pretty-error.js').then(({ registerPrettyErrorSnippetReader }) => {
+      registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+    })
+  }).catch(() => undefined)
+}
+
 /** Options for capturing process stdout/stderr as structured log events. */
 export interface CaptureOutputOptions {
   /** Capture stdout writes. @default true */
@@ -190,7 +198,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
     if (registered) return
     if (registerPromise) return registerPromise
 
-    registerPromise = loadLogger().then(({ initLogger, lockLogger, log }) => {
+    registerPromise = loadLogger().then(async ({ initLogger, lockLogger, log }) => {
       initLogger({
         enabled: options.enabled,
         env: {
@@ -205,6 +213,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
         drain: options.drain,
       })
       lockLogger()
+      await loadPrettyErrorSnippet()
 
       if (captureOutputOptions && process.env.NEXT_RUNTIME === 'nodejs') {
         applyCaptureOutput(captureOutputOptions, log, options.silent ?? false)

--- a/packages/evlog/src/next/instrumentation-create.ts
+++ b/packages/evlog/src/next/instrumentation-create.ts
@@ -1,5 +1,4 @@
-import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
-import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
+import { registerDiskPrettyErrorSnippetReader } from '../shared/register-disk-snippet'
 import type { DrainContext, EnvironmentContext, LogLevel, Log, SamplingConfig } from '../types'
 import type {
   NextInstrumentationErrorContext,
@@ -192,7 +191,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
     if (registered) return
     if (registerPromise) return registerPromise
 
-    registerPromise = loadLogger().then(({ initLogger, lockLogger, log }) => {
+    registerPromise = loadLogger().then(async ({ initLogger, lockLogger, log }) => {
       initLogger({
         enabled: options.enabled,
         env: {
@@ -208,7 +207,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
       })
       lockLogger()
       if (process.env.NEXT_RUNTIME === 'nodejs') {
-        registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+        await registerDiskPrettyErrorSnippetReader()
       }
 
       if (captureOutputOptions && process.env.NEXT_RUNTIME === 'nodejs') {

--- a/packages/evlog/src/next/instrumentation-create.ts
+++ b/packages/evlog/src/next/instrumentation-create.ts
@@ -207,7 +207,9 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
         drain: options.drain,
       })
       lockLogger()
-      registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+      if (process.env.NEXT_RUNTIME === 'nodejs') {
+        registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+      }
 
       if (captureOutputOptions && process.env.NEXT_RUNTIME === 'nodejs') {
         applyCaptureOutput(captureOutputOptions, log, options.silent ?? false)

--- a/packages/evlog/src/shared/define-audit-action.ts
+++ b/packages/evlog/src/shared/define-audit-action.ts
@@ -1,0 +1,99 @@
+import type { AuditActionDefinition, AuditActor, AuditFields, AuditTarget } from '../types'
+
+/**
+ * Input accepted by `log.audit()`, `audit()`, and `withAudit()`.
+ *
+ * `outcome` defaults to `'success'`. Internal fields populated by the audit
+ * pipeline (`idempotencyKey`, `context`, `signature`, `prevHash`, `hash`) are
+ * stripped — pass them through `log.set({ audit })` if you really need to.
+ */
+export interface AuditInput {
+  action: string
+  actor: AuditActor
+  target?: AuditTarget
+  outcome?: AuditFields['outcome']
+  reason?: string
+  changes?: AuditFields['changes']
+  causationId?: string
+  correlationId?: string
+  version?: number
+}
+
+/** Options for {@link defineAuditAction}. Same shape as {@link AuditCatalogEntry}. */
+export type DefineAuditActionOptions = AuditActionDefinition
+
+/**
+ * Define a typed audit action with optional fixed target type and catalog metadata.
+ *
+ * Returns a curried helper that fills in the action name (and target shape
+ * if provided) so call sites stay terse and the action set is discoverable
+ * in one place. Metadata (`description`, `severity`, `requiresChanges`, …)
+ * is exposed on the factory for introspection, docs, and review tooling.
+ *
+ * @example
+ * ```ts
+ * const refund = defineAuditAction('invoice.refund', {
+ *   target: 'invoice',
+ *   severity: 'high',
+ *   requiresChanges: true,
+ *   redactPaths: ['cardNumber'],
+ * })
+ *
+ * log.audit(refund({
+ *   actor: { type: 'user', id: user.id },
+ *   target: { id: 'inv_889' }, // type inferred as 'invoice'
+ *   outcome: 'success',
+ * }))
+ * ```
+ */
+export function defineAuditAction<
+  const TAction extends string,
+  const TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
+>(action: TAction, options?: TOptions): DefinedAuditAction<TAction, TOptions> {
+  const targetType = options?.target
+  const factory = ((input) => {
+    const merged: AuditInput = {
+      ...(input as AuditInput),
+      action,
+    }
+    if (targetType && input.target && !input.target.type) {
+      merged.target = { ...input.target, type: targetType } as AuditTarget
+    }
+    return merged
+  }) as DefinedAuditAction<TAction, TOptions>
+
+  Object.defineProperties(factory, {
+    action: { value: action, enumerable: true },
+    target: { value: options?.target, enumerable: true },
+    description: { value: options?.description, enumerable: true },
+    severity: { value: options?.severity, enumerable: true },
+    requiresChanges: { value: options?.requiresChanges, enumerable: true },
+    requiresReason: { value: options?.requiresReason, enumerable: true },
+    redactPaths: { value: options?.redactPaths, enumerable: true },
+  })
+
+  return factory
+}
+
+/**
+ * Return type of {@link defineAuditAction}. Accepts a partial input (no
+ * `action`, target type pre-filled when provided).
+ */
+export type DefinedAuditAction<
+  TAction extends string = string,
+  TOptions extends DefineAuditActionOptions = DefineAuditActionOptions,
+> =
+  & ((
+    input: TOptions['target'] extends string
+      ? Omit<AuditInput, 'action' | 'target'> & { target?: Omit<AuditTarget, 'type'> & { type?: TOptions['target'] } }
+      : Omit<AuditInput, 'action'>,
+  ) => AuditInput)
+  & {
+    readonly action: TAction
+    readonly target: TOptions['target']
+    readonly description: TOptions['description']
+    readonly severity: TOptions['severity']
+    readonly requiresChanges: TOptions['requiresChanges']
+    readonly requiresReason: TOptions['requiresReason']
+    readonly redactPaths: TOptions['redactPaths']
+  }

--- a/packages/evlog/src/shared/register-disk-snippet.ts
+++ b/packages/evlog/src/shared/register-disk-snippet.ts
@@ -1,0 +1,17 @@
+import { registerPrettyErrorSnippetReader } from './pretty-error'
+
+/**
+ * Register the disk-backed pretty-error snippet reader when Node built-ins are available.
+ *
+ * Uses a dynamic import so Edge and non-Node bundles never parse `pretty-error-snippet.node`.
+ *
+ * @internal
+ */
+export async function registerDiskPrettyErrorSnippetReader(): Promise<void> {
+  try {
+    const { readCodeSnippetFromDisk } = await import('./pretty-error-snippet.node.js')
+    registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+  } catch {
+    registerPrettyErrorSnippetReader(null)
+  }
+}

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -1,6 +1,5 @@
 import type { RequestLogger } from '../types'
-import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
-import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
+import { registerDiskPrettyErrorSnippetReader } from '../shared/register-disk-snippet'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 import { extractSafeHeaders } from '../shared/headers'
@@ -12,7 +11,7 @@ const { storage, useLogger } = createLoggerStorage(
   'handle context. Make sure evlog() handle is added to your hooks.server.ts.',
 )
 
-registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
+void registerDiskPrettyErrorSnippetReader()
 
 export type EvlogSvelteKitOptions = BaseEvlogOptions
 

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -1,4 +1,6 @@
 import type { RequestLogger } from '../types'
+import { registerPrettyErrorSnippetReader } from '../shared/pretty-error'
+import { readCodeSnippetFromDisk } from '../shared/pretty-error-snippet.node'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 import { extractSafeHeaders } from '../shared/headers'
@@ -9,6 +11,8 @@ import { EvlogError } from '../error'
 const { storage, useLogger } = createLoggerStorage(
   'handle context. Make sure evlog() handle is added to your hooks.server.ts.',
 )
+
+registerPrettyErrorSnippetReader(readCodeSnippetFromDisk)
 
 export type EvlogSvelteKitOptions = BaseEvlogOptions
 

--- a/packages/evlog/test/build/node-imports.test.ts
+++ b/packages/evlog/test/build/node-imports.test.ts
@@ -28,21 +28,56 @@ function listDistFiles(): string[] {
   return out
 }
 
+function collectRelativeImports(entryPath: string): string[] {
+  const seen = new Set<string>()
+  const imports: string[] = []
+  const importRe = /from\s+["'](\.[^"']+)["']/g
+
+  const walk = (relativePath: string) => {
+    const abs = resolve(distDir, relativePath)
+    if (seen.has(abs)) return
+    seen.add(abs)
+    const source = readFileSync(abs, 'utf8')
+    let match: RegExpExecArray | null
+    while ((match = importRe.exec(source))) {
+      const next = match[1].replace(/^\.\//, '')
+      imports.push(next)
+      walk(next)
+    }
+  }
+
+  walk(entryPath)
+  return imports
+}
+
+function assertNoNodeBuiltins(source: string, label: string): void {
+  expect(source, label).not.toMatch(/import\s*\(\s*['"]node:(crypto|fs|path|module)['"]/)
+  expect(source, label).not.toMatch(/from\s+['"]node:(crypto|fs|path|module)['"]/)
+  expect(source, label).not.toContain('pretty-error-snippet.node')
+}
+
 describe.skipIf(!distExists)('dist node built-in imports (#387)', () => {
-  it('audit chunk does not reference node:crypto', () => {
-    const auditFile = listDistFiles().find(f => f.includes('audit') && f.endsWith('.mjs') && !f.includes('plugin'))
-    expect(auditFile, 'expected a built audit chunk').toBeDefined()
-    expect(readDist(auditFile!)).not.toContain('node:crypto')
+  it('audit graph does not import Node built-ins', () => {
+    const auditChunk = listDistFiles().find(f => /^audit-[^/]+\.mjs$/.test(f))
+    expect(auditChunk, 'expected hashed audit chunk').toBeDefined()
+    assertNoNodeBuiltins(readDist(auditChunk!), auditChunk!)
   })
 
-  it('catalog entry does not reference node: built-ins or pretty-error-snippet.node', () => {
+  it('audit-action entry stays isomorphic', () => {
+    assertNoNodeBuiltins(readDist('audit-action.mjs'), 'audit-action.mjs')
+  })
+
+  it('catalog entry stays lean and Node-free', () => {
     const source = readDist('catalog.mjs')
-    expect(source).not.toMatch(/node:(crypto|fs|path|module)/)
-    expect(source).not.toContain('pretty-error-snippet.node')
+    assertNoNodeBuiltins(source, 'catalog.mjs')
+    expect(source).toMatch(/from "\.\/audit-action\.mjs"/)
+
+    const graph = collectRelativeImports('catalog.mjs')
+    expect(graph).not.toContain('audit.mjs')
+    expect(graph.some(path => /^audit-/.test(path) && !path.startsWith('audit-action'))).toBe(false)
   })
 
-  it('index entry does not reference pretty-error-snippet.node', () => {
-    const source = readDist('index.mjs')
-    expect(source).not.toContain('pretty-error-snippet.node')
+  it('index entry does not pull pretty-error-snippet.node', () => {
+    assertNoNodeBuiltins(readDist('index.mjs'), 'index.mjs')
   })
 })

--- a/packages/evlog/test/build/node-imports.test.ts
+++ b/packages/evlog/test/build/node-imports.test.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const distDir = resolve(import.meta.dirname, '../../dist')
+const catalogDist = resolve(distDir, 'catalog.mjs')
+const distExists = existsSync(catalogDist)
+
+if (!distExists) {
+  console.warn('[evlog test] Skipping dist node imports: dist/ not found. Run `pnpm --filter evlog run build` first.')
+}
+
+function readDist(relativePath: string): string {
+  return readFileSync(resolve(distDir, relativePath), 'utf8')
+}
+
+function listDistFiles(): string[] {
+  const out: string[] = []
+  const walk = (dir: string, prefix = '') => {
+    for (const entry of readdirSync(dir)) {
+      const rel = prefix ? `${prefix}/${entry}` : entry
+      const abs = resolve(dir, entry)
+      if (statSync(abs).isDirectory()) walk(abs, rel)
+      else if (entry.endsWith('.mjs')) out.push(rel)
+    }
+  }
+  walk(distDir)
+  return out
+}
+
+describe.skipIf(!distExists)('dist node built-in imports (#387)', () => {
+  it('audit chunk does not reference node:crypto', () => {
+    const auditFile = listDistFiles().find(f => f.includes('audit') && f.endsWith('.mjs') && !f.includes('plugin'))
+    expect(auditFile, 'expected a built audit chunk').toBeDefined()
+    expect(readDist(auditFile!)).not.toContain('node:crypto')
+  })
+
+  it('catalog entry does not reference node: built-ins or pretty-error-snippet.node', () => {
+    const source = readDist('catalog.mjs')
+    expect(source).not.toMatch(/node:(crypto|fs|path|module)/)
+    expect(source).not.toContain('pretty-error-snippet.node')
+  })
+
+  it('index entry does not reference pretty-error-snippet.node', () => {
+    const source = readDist('index.mjs')
+    expect(source).not.toContain('pretty-error-snippet.node')
+  })
+})

--- a/packages/evlog/test/build/node-imports.test.ts
+++ b/packages/evlog/test/build/node-imports.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const distDir = resolve(import.meta.dirname, '../../dist')
@@ -33,16 +33,17 @@ function collectRelativeImports(entryPath: string): string[] {
   const imports: string[] = []
   const importRe = /from\s+["'](\.[^"']+)["']/g
 
-  const walk = (relativePath: string) => {
-    const abs = resolve(distDir, relativePath)
+  const walk = (relativePath: string, fromDir = distDir) => {
+    const abs = resolve(fromDir, relativePath)
     if (seen.has(abs)) return
     seen.add(abs)
     const source = readFileSync(abs, 'utf8')
     let match: RegExpExecArray | null
+    const currentDir = dirname(abs)
     while ((match = importRe.exec(source))) {
       const next = match[1].replace(/^\.\//, '')
       imports.push(next)
-      walk(next)
+      walk(next, currentDir)
     }
   }
 

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -65,6 +65,11 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "createBrowserDrain",
     "createBrowserLogDrain",
   ],
+  "./catalog": [
+    "defineAuditCatalog",
+    "defineError",
+    "defineErrorCatalog",
+  ],
   "./client": [
     "clearIdentity",
     "initLog",

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'runtime/server/routes/_evlog/stream-info.get': 'src/runtime/server/routes/_evlog/stream-info.get.ts',
     'runtime/utils/parseError': 'src/runtime/utils/parseError.ts',
     'error': 'src/error.ts',
+    'catalog': 'src/catalog.ts',
     'logger': 'src/logger.ts',
     'utils': 'src/utils.ts',
     'types': 'src/types.ts',

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     'runtime/server/routes/_evlog/stream-info.get': 'src/runtime/server/routes/_evlog/stream-info.get.ts',
     'runtime/utils/parseError': 'src/runtime/utils/parseError.ts',
     'error': 'src/error.ts',
+    'audit': 'src/audit.ts',
+    'audit-action': 'src/audit-action.ts',
     'catalog': 'src/catalog.ts',
     'logger': 'src/logger.ts',
     'utils': 'src/utils.ts',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `evlog/catalog` subpath export to access catalog utilities directly.

* **Bug Fixes**
  * Fixed packaging/bundling so Node built-ins are no longer pulled into the main `evlog` entrypoint bundle, preventing import failures in non-Node bundlers.
  * Improved pretty-error snippet handling across Next.js, Fastify, and SvelteKit, with disk-based snippets enabled for Node.js runtimes only.

* **Tests**
  * Added a distribution test to verify Node built-ins and Node-only pretty-error snippet modules are not included in built artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #387