### PR TITLE
fix: type framework loggers as AuditableLogger with required audit

### DIFF
--- a/.changeset/fix-auditable-logger-typing.md
+++ b/.changeset/fix-auditable-logger-typing.md
@@ -1,0 +1,9 @@
+---
+"evlog": patch
+---
+
+# fix: type framework loggers as AuditableLogger with required `.audit()`
+
+`useLogger()`, `c.get('log')`, `req.log`, and other integration surfaces now return `AuditableLogger` instead of `RequestLogger`, so `.audit()` type-checks without optional chaining. Matches runtime behavior from `createRequestLogger()`.
+
+Closes #389

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -1,13 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { Elysia } from 'elysia'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 
-const storage = new AsyncLocalStorage<RequestLogger>()
+const storage = new AsyncLocalStorage<AuditableLogger>()
 
-const activeLoggers = new WeakSet<RequestLogger>()
+const activeLoggers = new WeakSet<AuditableLogger>()
 
 export type EvlogElysiaOptions = BaseEvlogOptions
 
@@ -29,7 +29,7 @@ export type EvlogElysiaOptions = BaseEvlogOptions
  * }
  * ```
  */
-export function useLogger<T extends object = Record<string, unknown>>(): RequestLogger<T> {
+export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
   const logger = storage.getStore()
   if (!logger || !activeLoggers.has(logger)) {
     throw new Error(
@@ -37,7 +37,7 @@ export function useLogger<T extends object = Record<string, unknown>>(): Request
       + 'Make sure app.use(evlog()) is registered before your routes.',
     )
   }
-  return logger as RequestLogger<T>
+  return logger as AuditableLogger<T>
 }
 
 interface ElysiaContext {
@@ -74,7 +74,7 @@ const integration = defineFrameworkIntegration<ElysiaContext>({
 interface RequestState {
   finish: (opts?: { status?: number; error?: Error }) => Promise<unknown>
   skipped: boolean
-  logger: RequestLogger
+  logger: AuditableLogger
 }
 
 /**
@@ -114,7 +114,7 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       requestState.set(request, { finish, skipped, logger })
     })
     .derive({ as: 'global' }, ({ request }) => {
-      return { log: requestState.get(request)?.logger as RequestLogger }
+      return { log: requestState.get(request)?.logger as AuditableLogger }
     })
     .onAfterResponse({ as: 'global' }, async ({ request, set }) => {
       const state = requestState.get(request)
@@ -122,7 +122,7 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       emitted.add(request)
       await state.finish({ status: set.status as number || 200 })
       activeLoggers.delete(state.logger)
-      storage.enterWith(undefined as unknown as RequestLogger)
+      storage.enterWith(undefined as unknown as AuditableLogger)
     })
     .onError({ as: 'global' }, async ({ request, error }) => {
       const state = requestState.get(request)
@@ -132,6 +132,6 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       state.logger.error(err)
       await state.finish({ error: err })
       activeLoggers.delete(state.logger)
-      storage.enterWith(undefined as unknown as RequestLogger)
+      storage.enterWith(undefined as unknown as AuditableLogger)
     })
 }

--- a/packages/evlog/src/express/index.ts
+++ b/packages/evlog/src/express/index.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { bindNodeResponseLifecycle } from '../shared/nodeResponse'
@@ -15,7 +15,7 @@ export { useLogger }
 
 declare module 'express-serve-static-core' {
   interface Request {
-    log?: RequestLogger
+    log?: AuditableLogger
   }
 }
 

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
@@ -14,8 +14,8 @@ export { useLogger }
 
 declare module 'fastify' {
   interface FastifyRequest {
-    // @ts-expect-error intentionally overrides Fastify's built-in pino logger with evlog's RequestLogger
-    log: RequestLogger
+    // @ts-expect-error intentionally overrides Fastify's built-in pino logger with evlog's AuditableLogger
+    log: AuditableLogger
   }
 }
 

--- a/packages/evlog/src/hono/index.ts
+++ b/packages/evlog/src/hono/index.ts
@@ -1,5 +1,5 @@
 import type { Context, MiddlewareHandler } from 'hono'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { shouldDeferEmitForResponse } from '../shared/streamResponse'
@@ -20,7 +20,7 @@ export type EvlogHonoOptions = BaseEvlogOptions
  * })
  * ```
  */
-export type EvlogVariables = { Variables: { log: RequestLogger } }
+export type EvlogVariables = { Variables: { log: AuditableLogger } }
 
 const integration = defineFrameworkIntegration<Context>({
   name: 'hono',

--- a/packages/evlog/src/nestjs/index.ts
+++ b/packages/evlog/src/nestjs/index.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse } from 'node:http'
 import type { Request } from 'express'
 import type { DynamicModule, MiddlewareConsumer, NestModule } from '@nestjs/common'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 import { extractSafeNodeHeaders } from '../shared/headers'
@@ -27,13 +27,13 @@ export interface EvlogModuleAsyncOptions {
 
 declare module 'http' {
   interface IncomingMessage {
-    log?: RequestLogger
+    log?: AuditableLogger
   }
 }
 
 declare module 'express-serve-static-core' {
   interface Request {
-    log?: RequestLogger
+    log?: AuditableLogger
   }
 }
 

--- a/packages/evlog/src/next/storage.ts
+++ b/packages/evlog/src/next/storage.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 
-export const evlogStorage = new AsyncLocalStorage<RequestLogger>()
+export const evlogStorage = new AsyncLocalStorage<AuditableLogger>()
 
 /**
  * Get the current request-scoped logger.
@@ -18,7 +18,7 @@ export const evlogStorage = new AsyncLocalStorage<RequestLogger>()
  * })
  * ```
  */
-export function useLogger<T extends object = Record<string, unknown>>(): RequestLogger<T> {
+export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
   const logger = evlogStorage.getStore()
   if (!logger) {
     throw new Error(
@@ -26,5 +26,5 @@ export function useLogger<T extends object = Record<string, unknown>>(): Request
       + 'Wrap your route handler or server action with withEvlog().',
     )
   }
-  return logger as RequestLogger<T>
+  return logger as AuditableLogger<T>
 }

--- a/packages/evlog/src/nitro-v3/useLogger.ts
+++ b/packages/evlog/src/nitro-v3/useLogger.ts
@@ -1,5 +1,5 @@
 import type { HTTPEvent } from 'nitro/h3'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 
 /**
  * Returns the request logger attached to the given Nitro v3 HTTP event.
@@ -17,9 +17,9 @@ import type { RequestLogger } from '../types'
  *   log.set({ foo: 'bar' })
  * })
  */
-export function useLogger<T extends object = Record<string, unknown>>(event: HTTPEvent, service?: string): RequestLogger<T> {
+export function useLogger<T extends object = Record<string, unknown>>(event: HTTPEvent, service?: string): AuditableLogger<T> {
   const ctx = event.req.context as Record<string, unknown> | undefined
-  const log = ctx?.log as RequestLogger<T> | undefined
+  const log = ctx?.log as AuditableLogger<T> | undefined
 
   if (!log) {
     throw new Error(
@@ -29,8 +29,7 @@ export function useLogger<T extends object = Record<string, unknown>>(event: HTT
   }
 
   if (service) {
-    const untyped = log as unknown as RequestLogger
-    untyped.set({ service })
+    log.set({ service })
   }
 
   return log

--- a/packages/evlog/src/orpc/index.ts
+++ b/packages/evlog/src/orpc/index.ts
@@ -1,5 +1,5 @@
 import { ORPCError, type Context, type MiddlewareOptions, type MiddlewareResult } from '@orpc/server'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { EvlogError } from '../error'
 import { parseError } from '../runtime/utils/parseError'
 import { defineFrameworkIntegration } from '../shared/integration'
@@ -32,7 +32,7 @@ export { useLogger }
  * ```
  */
 export interface EvlogOrpcContext {
-  log: RequestLogger
+  log: AuditableLogger
 }
 
 /**

--- a/packages/evlog/src/react-router/index.ts
+++ b/packages/evlog/src/react-router/index.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react-router'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 import { extractSafeHeaders } from '../shared/headers'
@@ -23,7 +23,7 @@ const { storage, useLogger } = createLoggerStorage(
  * }
  * ```
  */
-export const loggerContext = createContext<RequestLogger>()
+export const loggerContext = createContext<AuditableLogger>()
 
 export type EvlogReactRouterOptions = BaseEvlogOptions
 

--- a/packages/evlog/src/runtime/server/useLogger.ts
+++ b/packages/evlog/src/runtime/server/useLogger.ts
@@ -1,4 +1,5 @@
-import type { RequestLogger, ServerEvent } from '../../types'
+import type { AuditableLogger } from '../../audit'
+import type { ServerEvent } from '../../types'
 
 /**
  * Returns the request logger attached to the given server event.
@@ -32,8 +33,8 @@ import type { RequestLogger, ServerEvent } from '../../types'
  * log.set({ user: { id: '123', plan: 'pro' } }) // OK
  * log.set({ foo: 'bar' })                        // TS error
  */
-export function useLogger<T extends object = Record<string, unknown>>(event: ServerEvent, service?: string): RequestLogger<T> {
-  const log = event.context.log as RequestLogger<T> | undefined
+export function useLogger<T extends object = Record<string, unknown>>(event: ServerEvent, service?: string): AuditableLogger<T> {
+  const log = event.context.log as AuditableLogger<T> | undefined
 
   if (!log) {
     throw new Error(
@@ -43,8 +44,7 @@ export function useLogger<T extends object = Record<string, unknown>>(event: Ser
   }
 
   if (service) {
-    const untyped = log as unknown as RequestLogger
-    untyped.set({ service })
+    log.set({ service })
   }
 
   return log

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -1,4 +1,5 @@
 import type { DrainContext, EnrichContext, RedactConfig, RequestLogger, RouteConfig, TailSamplingContext, WideEvent } from '../types'
+import type { AuditableLogger } from '../audit'
 import { createRequestLogger, getGlobalDrain, getGlobalPluginRunner, isEnabled, markWideEventDrainStarted, shouldKeep } from '../logger'
 import { isGloballyRedacted, redactEvent, resolveRedactConfig } from '../redact'
 import { extractErrorStatus } from './errors'
@@ -43,7 +44,7 @@ export interface MiddlewareLoggerOptions extends BaseEvlogOptions {
 }
 
 export interface MiddlewareLoggerResult {
-  logger: RequestLogger
+  logger: AuditableLogger
   finish: (opts?: { status?: number; error?: Error }) => Promise<WideEvent | null>
   /**
    * Finish request logging, deferring emit until a streaming response body completes.

--- a/packages/evlog/src/shared/storage.ts
+++ b/packages/evlog/src/shared/storage.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 
 /**
  * Create a request-scoped `AsyncLocalStorage` and matching `useLogger`
@@ -11,9 +11,9 @@ import type { RequestLogger } from '../types'
  *   app.use(evlog()) is registered before your routes."`.
  */
 export function createLoggerStorage(contextHint: string) {
-  const storage = new AsyncLocalStorage<RequestLogger>()
+  const storage = new AsyncLocalStorage<AuditableLogger>()
 
-  function useLogger<T extends object = Record<string, unknown>>(): RequestLogger<T> {
+  function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
     const logger = storage.getStore()
     if (!logger) {
       throw new Error(
@@ -21,7 +21,7 @@ export function createLoggerStorage(contextHint: string) {
       )
     }
     /** @internal ALS store is untyped; cast satisfies the caller's generic `T`. */
-    return logger as RequestLogger<T>
+    return logger as AuditableLogger<T>
   }
 
   return { storage, useLogger }

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -747,6 +747,9 @@ export interface RequestLogger<T extends object = Record<string, unknown>> {
    * Available on every logger returned by `createLogger()` / `createRequestLogger()`
    * and on framework loggers exposed via `useLogger()` / `c.get('log')` etc.
    *
+   * Optional on the base {@link RequestLogger} interface for structural typing;
+   * always present (required) on {@link import('./audit').AuditableLogger}.
+   *
    * @example
    * ```ts
    * log.audit({
@@ -921,7 +924,7 @@ export interface RequestLoggerOptions {
  * H3 event context with evlog logger attached
  */
 export interface H3EventContext {
-  log?: RequestLogger
+  log?: import('./audit').AuditableLogger
   requestId?: string
   status?: number
   /** Internal: start time for duration calculation in tail sampling */

--- a/packages/evlog/src/workers/index.ts
+++ b/packages/evlog/src/workers/index.ts
@@ -1,5 +1,6 @@
 import { initLogger, createRequestLogger } from '../logger'
-import type { LoggerConfig, RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
+import type { LoggerConfig } from '../types'
 
 /**
  * Minimal Cloudflare Workers execution context (`fetch` third argument).
@@ -96,7 +97,7 @@ export function defineWorkerFetch<TEnv = unknown>(
     request: Request,
     env: TEnv,
     ctx: WorkerExecutionContext,
-    log: RequestLogger,
+    log: AuditableLogger,
   ) => Response | Promise<Response>,
 ): {
   fetch: (request: Request, env: TEnv, ctx: WorkerExecutionContext) => Promise<Response>
@@ -138,7 +139,7 @@ function pickCfContext(request: Request): Record<string, unknown> {
  * }
  * ```
  */
-export function createWorkersLogger<T extends object = Record<string, unknown>>(request: Request, options: WorkersLoggerOptions = {}): RequestLogger<T> {
+export function createWorkersLogger<T extends object = Record<string, unknown>>(request: Request, options: WorkersLoggerOptions = {}): AuditableLogger<T> {
   const url = new URL(request.url)
   const cfRay = request.headers.get('cf-ray') ?? undefined
   const traceparent = request.headers.get('traceparent') ?? undefined
@@ -157,7 +158,7 @@ export function createWorkersLogger<T extends object = Record<string, unknown>>(
   })
 
   // Cast needed: CF-specific enrichment fields (cfRay, traceparent, etc.) aren't in user's T
-  const untyped = log as unknown as RequestLogger
+  const untyped = log as unknown as AuditableLogger
   untyped.set({
     cfRay,
     traceparent,

--- a/packages/evlog/test/core/auditable-logger-typing.test.ts
+++ b/packages/evlog/test/core/auditable-logger-typing.test.ts
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { AuditableLogger } from '../../src/audit'
+import type { EvlogVariables } from '../../src/hono'
+import { useLogger as useExpressLogger } from '../../src/express'
+import { useLogger as useNextLogger } from '../../src/next/storage'
+import type { EvlogOrpcContext } from '../../src/orpc'
+import { createRequestLogger } from '../../src/logger'
+
+describe('AuditableLogger framework typing (#389)', () => {
+  it('types Hono context log with required audit', () => {
+    type HonoLog = EvlogVariables['Variables']['log']
+    expectTypeOf<HonoLog>().toEqualTypeOf<AuditableLogger>()
+  })
+
+  it('types oRPC context log with required audit', () => {
+    type OrpcLog = EvlogOrpcContext['log']
+    expectTypeOf<OrpcLog>().toEqualTypeOf<AuditableLogger>()
+  })
+
+  it('types useLogger() return values with required audit', () => {
+    expectTypeOf(useExpressLogger).returns.toEqualTypeOf<AuditableLogger>()
+    expectTypeOf(useNextLogger).returns.toEqualTypeOf<AuditableLogger>()
+  })
+
+  it('createRequestLogger matches AuditableLogger and audit is callable', () => {
+    const log = createRequestLogger({ method: 'GET', path: '/api/users' })
+    expectTypeOf(log).toEqualTypeOf<AuditableLogger>()
+    log.audit({
+      action: 'users.list',
+      actor: { type: 'user', id: 'u1' },
+      outcome: 'success',
+    })
+    log.audit.deny('Insufficient permissions', {
+      action: 'users.list',
+      actor: { type: 'user', id: 'u1' },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Framework integration surfaces (`useLogger()`, `c.get('log')`, `req.log`, `event.context.log`, oRPC/React Router context) now return `AuditableLogger` instead of `RequestLogger`, matching runtime behavior from `createRequestLogger()`.
- `.audit()` and `.audit.deny()` type-check without optional chaining or non-null assertions.
- Adds regression type tests for Hono, oRPC, Express/Next `useLogger()`, and `createRequestLogger()`.

Closes #389

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`