### PR TITLE
fix(elysia): polyfill enterWith for Cloudflare Workers

### DIFF
--- a/.changeset/fix-elysia-workers-asynclocalstorage.md
+++ b/.changeset/fix-elysia-workers-asynclocalstorage.md
@@ -1,0 +1,9 @@
+---
+"evlog": patch
+---
+
+# fix(elysia): support Cloudflare Workers without AsyncLocalStorage.enterWith
+
+Cloudflare Workers omit native `AsyncLocalStorage.enterWith()`. The Elysia integration now installs a small polyfill on load so `useLogger()` and `{ log }` keep working under `wrangler dev`.
+
+Closes #394

--- a/.changeset/fix-elysia-workers-asynclocalstorage.md
+++ b/.changeset/fix-elysia-workers-asynclocalstorage.md
@@ -4,6 +4,6 @@
 
 # fix(elysia): support Cloudflare Workers without AsyncLocalStorage.enterWith
 
-Cloudflare Workers omit native `AsyncLocalStorage.enterWith()`. The Elysia integration now installs a small polyfill on load so `useLogger()` and `{ log }` keep working under `wrangler dev`.
+Cloudflare Workers omit native `AsyncLocalStorage.enterWith()`. The Elysia integration now installs a small polyfill on load so `useLogger()` keeps working in typical `wrangler dev` flows. `{ log }` from derive remains the safest option when multiple requests may interleave in the same isolate.
 
 Closes #394

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -1,7 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { Elysia } from 'elysia'
 import type { AuditableLogger } from '../audit'
-import { installAsyncLocalStorageEnterWithPolyfill } from '../shared/asyncStorageScope'
+import {
+  bindAsyncLocalStorage,
+  clearAsyncLocalStorage,
+  installAsyncLocalStorageEnterWithPolyfill,
+} from '../shared/asyncStorageScope'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
@@ -18,9 +22,10 @@ export type EvlogElysiaOptions = BaseEvlogOptions
  * Get the request-scoped logger from anywhere in the call stack.
  * Must be called inside a request handled by the `evlog()` plugin.
  *
- * Elysia uses `storage.enterWith()` so the logger stays available across async
- * boundaries between lifecycle hooks. On Cloudflare Workers, a small polyfill
- * provides the same API because the runtime omits native `enterWith()`.
+ * Elysia binds the logger with `enterWith()` because its lifecycle hooks are
+ * separate from the route handler. On Cloudflare Workers, a small polyfill
+ * provides `enterWith()` when the runtime omits it. Prefer `{ log }` from
+ * derive when multiple requests may interleave in the same isolate.
  *
  * @example
  * ```ts
@@ -114,7 +119,7 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       const ctx: ElysiaContext = { request, path: url.pathname, headers }
       const { logger, finish, skipped } = integration.start(ctx, options)
       if (!skipped) {
-        storage.enterWith(logger)
+        bindAsyncLocalStorage(storage, logger)
       }
       requestState.set(request, { finish, skipped, logger })
     })
@@ -127,7 +132,7 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       emitted.add(request)
       await state.finish({ status: set.status as number || 200 })
       activeLoggers.delete(state.logger)
-      storage.enterWith(undefined as unknown as AuditableLogger)
+      clearAsyncLocalStorage(storage)
     })
     .onError({ as: 'global' }, async ({ request, error }) => {
       const state = requestState.get(request)
@@ -137,6 +142,6 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       state.logger.error(err)
       await state.finish({ error: err })
       activeLoggers.delete(state.logger)
-      storage.enterWith(undefined as unknown as AuditableLogger)
+      clearAsyncLocalStorage(storage)
     })
 }

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -4,15 +4,14 @@ import type { AuditableLogger } from '../audit'
 import {
   bindAsyncLocalStorage,
   clearAsyncLocalStorage,
-  installAsyncLocalStorageEnterWithPolyfill,
+  patchAsyncLocalStorageEnterWith,
 } from '../shared/asyncStorageScope'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 
-installAsyncLocalStorageEnterWithPolyfill()
-
 const storage = new AsyncLocalStorage<AuditableLogger>()
+patchAsyncLocalStorageEnterWith(storage)
 
 const activeLoggers = new WeakSet<AuditableLogger>()
 

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -1,9 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { Elysia } from 'elysia'
 import type { AuditableLogger } from '../audit'
+import { installAsyncLocalStorageEnterWithPolyfill } from '../shared/asyncStorageScope'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
+
+installAsyncLocalStorageEnterWithPolyfill()
 
 const storage = new AsyncLocalStorage<AuditableLogger>()
 
@@ -15,9 +18,9 @@ export type EvlogElysiaOptions = BaseEvlogOptions
  * Get the request-scoped logger from anywhere in the call stack.
  * Must be called inside a request handled by the `evlog()` plugin.
  *
- * Unlike other frameworks, Elysia uses `storage.enterWith()` which persists
- * beyond the request lifecycle. This accessor additionally checks `activeLoggers`
- * to ensure the logger belongs to an in-flight request.
+ * Elysia uses `storage.enterWith()` so the logger stays available across async
+ * boundaries between lifecycle hooks. On Cloudflare Workers, a small polyfill
+ * provides the same API because the runtime omits native `enterWith()`.
  *
  * @example
  * ```ts
@@ -110,7 +113,9 @@ export function evlog(options: EvlogElysiaOptions = {}) {
       const headers = (request.headers).toJSON?.() ?? Object.fromEntries(request.headers.entries())
       const ctx: ElysiaContext = { request, path: url.pathname, headers }
       const { logger, finish, skipped } = integration.start(ctx, options)
-      storage.enterWith(logger)
+      if (!skipped) {
+        storage.enterWith(logger)
+      }
       requestState.set(request, { finish, skipped, logger })
     })
     .derive({ as: 'global' }, ({ request }) => {

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,13 +1,21 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 /**
- * Whether this runtime implements native `AsyncLocalStorage.enterWith()`.
- * Cloudflare Workers omit it; Node.js and Bun provide it.
+ * Whether this runtime provides a working native `AsyncLocalStorage.enterWith()`.
+ *
+ * Cloudflare Workers expose `enterWith` on the prototype but throw when it is
+ * called, so a `typeof` check alone is not enough — we probe with a call.
  */
 export function supportsAsyncLocalStorageEnterWith(
   storage: { enterWith?: unknown },
 ): boolean {
-  return typeof storage.enterWith === 'function'
+  if (typeof storage.enterWith !== 'function') return false
+  try {
+    storage.enterWith(undefined)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,42 +1,61 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-type AsyncLocalStorageLike = {
-  getStore(): unknown
-  run(
-    store: unknown,
-    callback: (...args: unknown[]) => unknown,
-    ...args: unknown[]
-  ): unknown
-  enterWith?(store: unknown): void
+/** Prototype surface patched by {@link patchAsyncLocalStorageEnterWith}. */
+type AsyncLocalStoragePrototype = Pick<
+  AsyncLocalStorage<unknown>,
+  'getStore' | 'run'
+> & {
+  enterWith?: unknown
 }
 
-type AsyncLocalStorageInstance = object
-
-type BoundGetStore = (this: AsyncLocalStorageInstance) => unknown
-type BoundRun = (
-  this: AsyncLocalStorageInstance,
-  store: unknown,
-  callback: (...args: unknown[]) => unknown,
-  ...args: unknown[]
-) => unknown
+/**
+ * Whether this runtime implements native `AsyncLocalStorage.enterWith()`.
+ * Cloudflare Workers omit it; Node.js and Bun provide it.
+ */
+export function supportsAsyncLocalStorageEnterWith(
+  storage: { enterWith?: unknown },
+): boolean {
+  return typeof storage.enterWith === 'function'
+}
 
 /**
- * Polyfill `enterWith()` on a single AsyncLocalStorage prototype. Used by
- * {@link installAsyncLocalStorageEnterWithPolyfill} and unit tests via a subclass
- * so global `AsyncLocalStorage` is never mutated in parallel test workers.
+ * Bind `value` to `storage` for the current async execution context.
+ * Uses native `enterWith()` when available; otherwise relies on the polyfill
+ * installed by {@link installAsyncLocalStorageEnterWithPolyfill}.
  */
-export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageLike): void {
-  if (typeof prototype.enterWith === 'function') return
+export function bindAsyncLocalStorage<T>(
+  storage: AsyncLocalStorage<T>,
+  value: T,
+): void {
+  storage.enterWith(value)
+}
 
-  const fallbackStores = new WeakMap<AsyncLocalStorageInstance, unknown>()
-  const runDepth = new WeakMap<AsyncLocalStorageInstance, number>()
-  const originalGetStore = prototype.getStore as BoundGetStore
-  const originalRun = prototype.run as BoundRun
+/** Clear a value previously bound with {@link bindAsyncLocalStorage}. */
+export function clearAsyncLocalStorage<T>(storage: AsyncLocalStorage<T>): void {
+  storage.enterWith(undefined as unknown as T)
+}
+
+/**
+ * Polyfill `enterWith()` on a single `AsyncLocalStorage` prototype.
+ *
+ * Used by {@link installAsyncLocalStorageEnterWithPolyfill} and by unit tests
+ * through a dedicated subclass so the global prototype is never mutated in
+ * parallel Vitest workers.
+ */
+export function patchAsyncLocalStorageEnterWith(
+  prototype: AsyncLocalStoragePrototype,
+): void {
+  if (supportsAsyncLocalStorageEnterWith(prototype)) return
+
+  const fallbackStores = new WeakMap<object, unknown>()
+  const runDepth = new WeakMap<object, number>()
+  const originalGetStore = prototype.getStore
+  const originalRun = prototype.run
 
   Object.defineProperty(prototype, 'enterWith', {
     configurable: true,
     writable: true,
-    value(this: AsyncLocalStorageInstance, store: unknown): void {
+    value(this: object, store: unknown): void {
       fallbackStores.set(this, store)
     },
   })
@@ -45,7 +64,7 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageLike
     configurable: true,
     writable: true,
     value(
-      this: AsyncLocalStorageInstance,
+      this: object,
       store: unknown,
       callback: (...args: unknown[]) => unknown,
       ...args: unknown[]
@@ -64,7 +83,7 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageLike
   Object.defineProperty(prototype, 'getStore', {
     configurable: true,
     writable: true,
-    value(this: AsyncLocalStorageInstance): unknown {
+    value(this: object): unknown {
       const active = originalGetStore.call(this)
       if ((runDepth.get(this) ?? 0) > 0) return active
       return active !== undefined ? active : fallbackStores.get(this)
@@ -73,16 +92,18 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageLike
 }
 
 /**
- * Polyfill `AsyncLocalStorage.enterWith()` on runtimes that omit it (Cloudflare Workers).
+ * Install an `enterWith()` polyfill when the runtime omits it (Cloudflare Workers).
  *
- * Elysia's lifecycle is split across hooks (`onRequest` → handler → `onAfterResponse`), so
- * the integration relies on `enterWith()` to keep `useLogger()` working across `await`
- * boundaries. Workers only expose `run()` / `getStore()`, which this maps onto a fallback
- * store when no `run()` frame is active.
+ * Elysia's lifecycle is split across hooks (`onRequest` → handler → `onAfterResponse`).
+ * Unlike Express or Fastify, there is no single `next()` boundary to wrap in
+ * `storage.run()`, so the integration binds the logger with `enterWith()`.
  *
- * Same concurrency semantics as native `enterWith()` — one store per ALS instance between
- * paired `enterWith(logger)` / `enterWith(undefined)` calls on a single request.
+ * The polyfill stores the value on the ALS instance when no native `run()` frame
+ * is active. That matches single-request `wrangler dev` flows and async work
+ * spawned from a handler, but it does **not** replicate native per-async-context
+ * isolation when multiple requests interleave in the same isolate. Prefer `{ log }`
+ * from derive for concurrent Workers handlers.
  */
 export function installAsyncLocalStorageEnterWithPolyfill(): void {
-  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype as AsyncLocalStorageLike)
+  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype)
 }

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,5 +1,56 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
+type AsyncLocalStoragePrototype = Pick<AsyncLocalStorage<unknown>, 'getStore' | 'run'> & {
+  enterWith?: (store: unknown) => void
+}
+
+/**
+ * Polyfill `enterWith()` on a single AsyncLocalStorage prototype. Used by
+ * {@link installAsyncLocalStorageEnterWithPolyfill} and unit tests via a subclass
+ * so global `AsyncLocalStorage` is never mutated in parallel test workers.
+ */
+export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStoragePrototype): void {
+  if (typeof prototype.enterWith === 'function') return
+
+  const fallbackStores = new WeakMap<AsyncLocalStorage<unknown>, unknown>()
+  const runDepth = new WeakMap<AsyncLocalStorage<unknown>, number>()
+  const originalGetStore = prototype.getStore
+  const originalRun = prototype.run
+
+  Object.defineProperty(prototype, 'enterWith', {
+    configurable: true,
+    writable: true,
+    value: function enterWith(this: AsyncLocalStorage<unknown>, store: unknown) {
+      fallbackStores.set(this, store)
+    },
+  })
+
+  Object.defineProperty(prototype, 'run', {
+    configurable: true,
+    writable: true,
+    value: function run(this: AsyncLocalStorage<unknown>, store, callback, ...args) {
+      runDepth.set(this, (runDepth.get(this) ?? 0) + 1)
+      try {
+        return originalRun.call(this, store, callback, ...args)
+      } finally {
+        const depth = (runDepth.get(this) ?? 1) - 1
+        if (depth <= 0) runDepth.delete(this)
+        else runDepth.set(this, depth)
+      }
+    },
+  })
+
+  Object.defineProperty(prototype, 'getStore', {
+    configurable: true,
+    writable: true,
+    value: function getStore(this: AsyncLocalStorage<unknown>) {
+      const active = originalGetStore.call(this)
+      if ((runDepth.get(this) ?? 0) > 0) return active
+      return active !== undefined ? active : fallbackStores.get(this)
+    },
+  })
+}
+
 /**
  * Polyfill `AsyncLocalStorage.enterWith()` on runtimes that omit it (Cloudflare Workers).
  *
@@ -12,31 +63,5 @@ import { AsyncLocalStorage } from 'node:async_hooks'
  * paired `enterWith(logger)` / `enterWith(undefined)` calls on a single request.
  */
 export function installAsyncLocalStorageEnterWithPolyfill(): void {
-  if (typeof AsyncLocalStorage.prototype.enterWith === 'function') return
-
-  const fallbackStores = new WeakMap<AsyncLocalStorage<unknown>, unknown>()
-  const runDepth = new WeakMap<AsyncLocalStorage<unknown>, number>()
-  const originalGetStore = AsyncLocalStorage.prototype.getStore
-  const originalRun = AsyncLocalStorage.prototype.run
-
-  AsyncLocalStorage.prototype.enterWith = function enterWith(store: unknown) {
-    fallbackStores.set(this, store)
-  }
-
-  AsyncLocalStorage.prototype.run = function run(store, callback, ...args) {
-    runDepth.set(this, (runDepth.get(this) ?? 0) + 1)
-    try {
-      return originalRun.call(this, store, callback, ...args)
-    } finally {
-      const depth = (runDepth.get(this) ?? 1) - 1
-      if (depth <= 0) runDepth.delete(this)
-      else runDepth.set(this, depth)
-    }
-  }
-
-  AsyncLocalStorage.prototype.getStore = function getStore() {
-    const active = originalGetStore.call(this)
-    if ((runDepth.get(this) ?? 0) > 0) return active
-    return active !== undefined ? active : fallbackStores.get(this)
-  }
+  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype)
 }

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,26 +1,42 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-type AsyncLocalStoragePrototype = Pick<AsyncLocalStorage<unknown>, 'getStore' | 'run'> & {
-  enterWith?: (store: unknown) => void
+type AsyncLocalStorageLike = {
+  getStore(): unknown
+  run(
+    store: unknown,
+    callback: (...args: unknown[]) => unknown,
+    ...args: unknown[]
+  ): unknown
+  enterWith?(store: unknown): void
 }
+
+type AsyncLocalStorageInstance = object
+
+type BoundGetStore = (this: AsyncLocalStorageInstance) => unknown
+type BoundRun = (
+  this: AsyncLocalStorageInstance,
+  store: unknown,
+  callback: (...args: unknown[]) => unknown,
+  ...args: unknown[]
+) => unknown
 
 /**
  * Polyfill `enterWith()` on a single AsyncLocalStorage prototype. Used by
  * {@link installAsyncLocalStorageEnterWithPolyfill} and unit tests via a subclass
  * so global `AsyncLocalStorage` is never mutated in parallel test workers.
  */
-export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStoragePrototype): void {
+export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageLike): void {
   if (typeof prototype.enterWith === 'function') return
 
-  const fallbackStores = new WeakMap<AsyncLocalStorage<unknown>, unknown>()
-  const runDepth = new WeakMap<AsyncLocalStorage<unknown>, number>()
-  const originalGetStore = prototype.getStore
-  const originalRun = prototype.run
+  const fallbackStores = new WeakMap<AsyncLocalStorageInstance, unknown>()
+  const runDepth = new WeakMap<AsyncLocalStorageInstance, number>()
+  const originalGetStore = prototype.getStore as BoundGetStore
+  const originalRun = prototype.run as BoundRun
 
   Object.defineProperty(prototype, 'enterWith', {
     configurable: true,
     writable: true,
-    value: function enterWith(this: AsyncLocalStorage<unknown>, store: unknown) {
+    value(this: AsyncLocalStorageInstance, store: unknown): void {
       fallbackStores.set(this, store)
     },
   })
@@ -28,7 +44,12 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageProt
   Object.defineProperty(prototype, 'run', {
     configurable: true,
     writable: true,
-    value: function run(this: AsyncLocalStorage<unknown>, store, callback, ...args) {
+    value(
+      this: AsyncLocalStorageInstance,
+      store: unknown,
+      callback: (...args: unknown[]) => unknown,
+      ...args: unknown[]
+    ): unknown {
       runDepth.set(this, (runDepth.get(this) ?? 0) + 1)
       try {
         return originalRun.call(this, store, callback, ...args)
@@ -43,7 +64,7 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageProt
   Object.defineProperty(prototype, 'getStore', {
     configurable: true,
     writable: true,
-    value: function getStore(this: AsyncLocalStorage<unknown>) {
+    value(this: AsyncLocalStorageInstance): unknown {
       const active = originalGetStore.call(this)
       if ((runDepth.get(this) ?? 0) > 0) return active
       return active !== undefined ? active : fallbackStores.get(this)
@@ -63,5 +84,5 @@ export function patchAsyncLocalStorageEnterWith(prototype: AsyncLocalStorageProt
  * paired `enterWith(logger)` / `enterWith(undefined)` calls on a single request.
  */
 export function installAsyncLocalStorageEnterWithPolyfill(): void {
-  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype)
+  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype as AsyncLocalStorageLike)
 }

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,13 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-/** Prototype surface patched by {@link patchAsyncLocalStorageEnterWith}. */
-type AsyncLocalStoragePrototype = Pick<
-  AsyncLocalStorage<unknown>,
-  'getStore' | 'run'
-> & {
-  enterWith?: unknown
-}
-
 /**
  * Whether this runtime implements native `AsyncLocalStorage.enterWith()`.
  * Cloudflare Workers omit it; Node.js and Bun provide it.
@@ -20,8 +12,8 @@ export function supportsAsyncLocalStorageEnterWith(
 
 /**
  * Bind `value` to `storage` for the current async execution context.
- * Uses native `enterWith()` when available; otherwise relies on the polyfill
- * installed by {@link installAsyncLocalStorageEnterWithPolyfill}.
+ * Uses native `enterWith()` when available; otherwise relies on
+ * {@link patchAsyncLocalStorageEnterWith}.
  */
 export function bindAsyncLocalStorage<T>(
   storage: AsyncLocalStorage<T>,
@@ -36,63 +28,7 @@ export function clearAsyncLocalStorage<T>(storage: AsyncLocalStorage<T>): void {
 }
 
 /**
- * Polyfill `enterWith()` on a single `AsyncLocalStorage` prototype.
- *
- * Used by {@link installAsyncLocalStorageEnterWithPolyfill} and by unit tests
- * through a dedicated subclass so the global prototype is never mutated in
- * parallel Vitest workers.
- */
-export function patchAsyncLocalStorageEnterWith(
-  prototype: AsyncLocalStoragePrototype,
-): void {
-  if (supportsAsyncLocalStorageEnterWith(prototype)) return
-
-  const fallbackStores = new WeakMap<object, unknown>()
-  const runDepth = new WeakMap<object, number>()
-  const originalGetStore = prototype.getStore
-  const originalRun = prototype.run
-
-  Object.defineProperty(prototype, 'enterWith', {
-    configurable: true,
-    writable: true,
-    value(this: object, store: unknown): void {
-      fallbackStores.set(this, store)
-    },
-  })
-
-  Object.defineProperty(prototype, 'run', {
-    configurable: true,
-    writable: true,
-    value(
-      this: object,
-      store: unknown,
-      callback: (...args: unknown[]) => unknown,
-      ...args: unknown[]
-    ): unknown {
-      runDepth.set(this, (runDepth.get(this) ?? 0) + 1)
-      try {
-        return originalRun.call(this, store, callback, ...args)
-      } finally {
-        const depth = (runDepth.get(this) ?? 1) - 1
-        if (depth <= 0) runDepth.delete(this)
-        else runDepth.set(this, depth)
-      }
-    },
-  })
-
-  Object.defineProperty(prototype, 'getStore', {
-    configurable: true,
-    writable: true,
-    value(this: object): unknown {
-      const active = originalGetStore.call(this)
-      if ((runDepth.get(this) ?? 0) > 0) return active
-      return active !== undefined ? active : fallbackStores.get(this)
-    },
-  })
-}
-
-/**
- * Install an `enterWith()` polyfill when the runtime omits it (Cloudflare Workers).
+ * Polyfill `enterWith()` on a single `AsyncLocalStorage` instance.
  *
  * Elysia's lifecycle is split across hooks (`onRequest` → handler → `onAfterResponse`).
  * Unlike Express or Fastify, there is no single `next()` boundary to wrap in
@@ -104,6 +40,48 @@ export function patchAsyncLocalStorageEnterWith(
  * isolation when multiple requests interleave in the same isolate. Prefer `{ log }`
  * from derive for concurrent Workers handlers.
  */
-export function installAsyncLocalStorageEnterWithPolyfill(): void {
-  patchAsyncLocalStorageEnterWith(AsyncLocalStorage.prototype)
+export function patchAsyncLocalStorageEnterWith<T>(
+  storage: AsyncLocalStorage<T>,
+): void {
+  if (supportsAsyncLocalStorageEnterWith(storage)) return
+
+  let fallbackStore: T | undefined
+  let runDepth = 0
+  const originalGetStore = storage.getStore.bind(storage)
+  const originalRun = storage.run.bind(storage)
+
+  Object.defineProperty(storage, 'enterWith', {
+    configurable: true,
+    writable: true,
+    value(store: T): void {
+      fallbackStore = store
+    },
+  })
+
+  Object.defineProperty(storage, 'run', {
+    configurable: true,
+    writable: true,
+    value<TReturn>(
+      store: T,
+      callback: (...args: unknown[]) => TReturn,
+      ...args: unknown[]
+    ): TReturn {
+      runDepth++
+      try {
+        return originalRun(store, callback, ...args)
+      } finally {
+        runDepth--
+      }
+    },
+  })
+
+  Object.defineProperty(storage, 'getStore', {
+    configurable: true,
+    writable: true,
+    value(): T | undefined {
+      if (runDepth > 0) return originalGetStore()
+      const active = originalGetStore()
+      return active !== undefined ? active : fallbackStore
+    },
+  })
 }

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+/**
+ * Polyfill `AsyncLocalStorage.enterWith()` on runtimes that omit it (Cloudflare Workers).
+ *
+ * Elysia's lifecycle is split across hooks (`onRequest` → handler → `onAfterResponse`), so
+ * the integration relies on `enterWith()` to keep `useLogger()` working across `await`
+ * boundaries. Workers only expose `run()` / `getStore()`, which this maps onto a fallback
+ * store when no `run()` frame is active.
+ *
+ * Same concurrency semantics as native `enterWith()` — one store per ALS instance between
+ * paired `enterWith(logger)` / `enterWith(undefined)` calls on a single request.
+ */
+export function installAsyncLocalStorageEnterWithPolyfill(): void {
+  if (typeof AsyncLocalStorage.prototype.enterWith === 'function') return
+
+  const fallbackStores = new WeakMap<AsyncLocalStorage<unknown>, unknown>()
+  const runDepth = new WeakMap<AsyncLocalStorage<unknown>, number>()
+  const originalGetStore = AsyncLocalStorage.prototype.getStore
+  const originalRun = AsyncLocalStorage.prototype.run
+
+  AsyncLocalStorage.prototype.enterWith = function enterWith(store: unknown) {
+    fallbackStores.set(this, store)
+  }
+
+  AsyncLocalStorage.prototype.run = function run(store, callback, ...args) {
+    runDepth.set(this, (runDepth.get(this) ?? 0) + 1)
+    try {
+      return originalRun.call(this, store, callback, ...args)
+    } finally {
+      const depth = (runDepth.get(this) ?? 1) - 1
+      if (depth <= 0) runDepth.delete(this)
+      else runDepth.set(this, depth)
+    }
+  }
+
+  AsyncLocalStorage.prototype.getStore = function getStore() {
+    const active = originalGetStore.call(this)
+    if ((runDepth.get(this) ?? 0) > 0) return active
+    return active !== undefined ? active : fallbackStores.get(this)
+  }
+}

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Elysia } from 'elysia'
 import { initLogger } from '../../src/logger'
@@ -386,6 +387,37 @@ describe('evlog/elysia', () => {
       await waitForDrainCalls(drain)
 
       expect(findEventViaDrain(drain, e => e.fromService === true)).toBeDefined()
+    })
+
+    it('works when AsyncLocalStorage.enterWith is unavailable (#394)', async () => {
+      const { drain } = createPipelineSpies()
+      const { enterWith } = AsyncLocalStorage.prototype
+      Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
+        configurable: true,
+        value: undefined,
+      })
+
+      const { installAsyncLocalStorageEnterWithPolyfill } = await import('../../src/shared/asyncStorageScope')
+      installAsyncLocalStorageEnterWithPolyfill()
+
+      try {
+        const app = new Elysia()
+          .use(evlog({ drain }))
+          .get('/api/test', () => {
+            useLogger().set({ workerSafe: true })
+            return { ok: true }
+          })
+
+        await request(app, '/api/test')
+        await waitForDrainCalls(drain)
+
+        expect(findEventViaDrain(drain, e => e.workerSafe === true)).toBeDefined()
+      } finally {
+        Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
+          configurable: true,
+          value: enterWith,
+        })
+      }
     })
   })
 })

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Elysia } from 'elysia'
 import { initLogger } from '../../src/logger'
@@ -387,37 +386,6 @@ describe('evlog/elysia', () => {
       await waitForDrainCalls(drain)
 
       expect(findEventViaDrain(drain, e => e.fromService === true)).toBeDefined()
-    })
-
-    it('works when AsyncLocalStorage.enterWith is unavailable (#394)', async () => {
-      const { drain } = createPipelineSpies()
-      const { enterWith } = AsyncLocalStorage.prototype
-      Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
-        configurable: true,
-        value: undefined,
-      })
-
-      const { installAsyncLocalStorageEnterWithPolyfill } = await import('../../src/shared/asyncStorageScope')
-      installAsyncLocalStorageEnterWithPolyfill()
-
-      try {
-        const app = new Elysia()
-          .use(evlog({ drain }))
-          .get('/api/test', () => {
-            useLogger().set({ workerSafe: true })
-            return { ok: true }
-          })
-
-        await request(app, '/api/test')
-        await waitForDrainCalls(drain)
-
-        expect(findEventViaDrain(drain, e => e.workerSafe === true)).toBeDefined()
-      } finally {
-        Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
-          configurable: true,
-          value: enterWith,
-        })
-      }
     })
   })
 })

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -1,22 +1,49 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Elysia } from 'elysia'
+import { initLogger } from '../../src/logger'
 import {
   installAsyncLocalStorageEnterWithPolyfill,
   patchAsyncLocalStorageEnterWith,
+  supportsAsyncLocalStorageEnterWith,
 } from '../../src/shared/asyncStorageScope'
+import { evlog } from '../../src/elysia/index'
+import {
+  createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
+} from '../helpers/framework'
 
-function createWorkersLikeStorage(): AsyncLocalStorage<string> {
-  class LocalAsyncLocalStorage extends AsyncLocalStorage<string> {}
+function createWorkersLikeStorage<T = unknown>(): AsyncLocalStorage<T> {
+  class LocalAsyncLocalStorage extends AsyncLocalStorage<T> {}
   Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {
     configurable: true,
     writable: true,
     value: undefined,
   })
-  patchAsyncLocalStorageEnterWith(LocalAsyncLocalStorage.prototype)
+  patchAsyncLocalStorageEnterWith(
+    LocalAsyncLocalStorage.prototype as Parameters<typeof patchAsyncLocalStorageEnterWith>[0],
+  )
   return new LocalAsyncLocalStorage()
 }
 
-describe('patchAsyncLocalStorageEnterWith', () => {
+function delay(ms = 1) {
+  return new Promise((resolve) => {
+    setImmediate(resolve)
+  })
+}
+
+async function request(app: { handle: (req: Request) => Promise<Response> }, path: string) {
+  const response = await app.handle(new Request(`http://localhost${path}`))
+  await delay()
+  return response
+}
+
+describe('asyncStorageScope', () => {
+  it('detects native enterWith support', () => {
+    expect(supportsAsyncLocalStorageEnterWith(new AsyncLocalStorage<string>())).toBe(true)
+  })
+
   it('is a no-op when enterWith already exists', () => {
     const before = AsyncLocalStorage.prototype.getStore
 
@@ -27,7 +54,7 @@ describe('patchAsyncLocalStorageEnterWith', () => {
   })
 
   it('polyfills enterWith for runtimes that omit it', async () => {
-    const storage = createWorkersLikeStorage()
+    const storage = createWorkersLikeStorage<string>()
 
     storage.enterWith('request-logger')
     expect(storage.getStore()).toBe('request-logger')
@@ -40,7 +67,7 @@ describe('patchAsyncLocalStorageEnterWith', () => {
   })
 
   it('supports elysia-style request scope usage (#394)', async () => {
-    const storage = createWorkersLikeStorage()
+    const storage = createWorkersLikeStorage<object>()
     const activeLoggers = new WeakSet<object>()
 
     function bindRequestLogger(logger: object) {
@@ -65,5 +92,47 @@ describe('patchAsyncLocalStorageEnterWith', () => {
     storage.enterWith(undefined as unknown as object)
     activeLoggers.delete(requestLogger)
     expect(() => useLogger()).toThrow('[evlog] useLogger()')
+  })
+})
+
+describe('evlog/elysia workers concurrency', () => {
+  beforeEach(() => {
+    initLogger({
+      env: { service: 'elysia-test' },
+      pretty: false,
+    })
+  })
+
+  it('keeps derive log isolated across interleaved requests without enterWith (#394)', async () => {
+    const { drain } = createPipelineSpies()
+    const contexts: Record<string, string | undefined> = {
+      a: undefined,
+      b: undefined,
+    }
+
+    const app = new Elysia()
+      .use(evlog({ drain }))
+      .get('/api/a', async ({ log }) => {
+        log.set({ route: 'a' })
+        await Promise.resolve()
+        contexts.a = log.getContext().route as string | undefined
+        return { ok: true }
+      })
+      .get('/api/b', ({ log }) => {
+        log.set({ route: 'b' })
+        contexts.b = log.getContext().route as string | undefined
+        return { ok: true }
+      })
+
+    await Promise.all([
+      request(app, '/api/a'),
+      request(app, '/api/b'),
+    ])
+    await waitForDrainCalls(drain, 2)
+
+    expect(contexts.a).toBe('a')
+    expect(contexts.b).toBe('b')
+    expect(findEventViaDrain(drain, event => event.route === 'a')).toBeDefined()
+    expect(findEventViaDrain(drain, event => event.route === 'b')).toBeDefined()
   })
 })

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -1,32 +1,33 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { afterEach, describe, expect, it } from 'vitest'
-import { installAsyncLocalStorageEnterWithPolyfill } from '../../src/shared/asyncStorageScope'
+import { describe, expect, it } from 'vitest'
+import {
+  installAsyncLocalStorageEnterWithPolyfill,
+  patchAsyncLocalStorageEnterWith,
+} from '../../src/shared/asyncStorageScope'
 
-const nativeEnterWith = AsyncLocalStorage.prototype.enterWith
-const nativeGetStore = AsyncLocalStorage.prototype.getStore
-const nativeRun = AsyncLocalStorage.prototype.run
-
-describe('installAsyncLocalStorageEnterWithPolyfill', () => {
-  afterEach(() => {
-    AsyncLocalStorage.prototype.enterWith = nativeEnterWith
-    AsyncLocalStorage.prototype.getStore = nativeGetStore
-    AsyncLocalStorage.prototype.run = nativeRun
+function createWorkersLikeStorage(): AsyncLocalStorage<string> {
+  class LocalAsyncLocalStorage extends AsyncLocalStorage<string> {}
+  Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {
+    configurable: true,
+    writable: true,
+    value: undefined,
   })
+  patchAsyncLocalStorageEnterWith(LocalAsyncLocalStorage.prototype)
+  return new LocalAsyncLocalStorage()
+}
 
+describe('patchAsyncLocalStorageEnterWith', () => {
   it('is a no-op when enterWith already exists', () => {
+    const before = AsyncLocalStorage.prototype.getStore
+
     installAsyncLocalStorageEnterWithPolyfill()
 
-    expect(AsyncLocalStorage.prototype.enterWith).toBe(nativeEnterWith)
+    expect(typeof AsyncLocalStorage.prototype.enterWith).toBe('function')
+    expect(AsyncLocalStorage.prototype.getStore).toBe(before)
   })
 
   it('polyfills enterWith for runtimes that omit it', async () => {
-    const storage = new AsyncLocalStorage<string>()
-    Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
-      configurable: true,
-      value: undefined,
-    })
-
-    installAsyncLocalStorageEnterWithPolyfill()
+    const storage = createWorkersLikeStorage()
 
     storage.enterWith('request-logger')
     expect(storage.getStore()).toBe('request-logger')
@@ -36,5 +37,33 @@ describe('installAsyncLocalStorageEnterWithPolyfill', () => {
 
     storage.enterWith(undefined as unknown as string)
     expect(storage.getStore()).toBeUndefined()
+  })
+
+  it('supports elysia-style request scope usage (#394)', async () => {
+    const storage = createWorkersLikeStorage()
+    const activeLoggers = new WeakSet<object>()
+
+    function bindRequestLogger(logger: object) {
+      storage.enterWith(logger)
+      activeLoggers.add(logger)
+    }
+
+    function useLogger() {
+      const logger = storage.getStore()
+      if (!logger || !activeLoggers.has(logger)) {
+        throw new Error('[evlog] useLogger() was called outside of an evlog plugin context.')
+      }
+      return logger
+    }
+
+    const requestLogger = { id: 'request-logger' }
+    bindRequestLogger(requestLogger)
+    expect(useLogger()).toBe(requestLogger)
+    await Promise.resolve()
+    expect(useLogger()).toBe(requestLogger)
+
+    storage.enterWith(undefined as unknown as object)
+    activeLoggers.delete(requestLogger)
+    expect(() => useLogger()).toThrow('[evlog] useLogger()')
   })
 })

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -1,0 +1,40 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { afterEach, describe, expect, it } from 'vitest'
+import { installAsyncLocalStorageEnterWithPolyfill } from '../../src/shared/asyncStorageScope'
+
+const nativeEnterWith = AsyncLocalStorage.prototype.enterWith
+const nativeGetStore = AsyncLocalStorage.prototype.getStore
+const nativeRun = AsyncLocalStorage.prototype.run
+
+describe('installAsyncLocalStorageEnterWithPolyfill', () => {
+  afterEach(() => {
+    AsyncLocalStorage.prototype.enterWith = nativeEnterWith
+    AsyncLocalStorage.prototype.getStore = nativeGetStore
+    AsyncLocalStorage.prototype.run = nativeRun
+  })
+
+  it('is a no-op when enterWith already exists', () => {
+    installAsyncLocalStorageEnterWithPolyfill()
+
+    expect(AsyncLocalStorage.prototype.enterWith).toBe(nativeEnterWith)
+  })
+
+  it('polyfills enterWith for runtimes that omit it', async () => {
+    const storage = new AsyncLocalStorage<string>()
+    Object.defineProperty(AsyncLocalStorage.prototype, 'enterWith', {
+      configurable: true,
+      value: undefined,
+    })
+
+    installAsyncLocalStorageEnterWithPolyfill()
+
+    storage.enterWith('request-logger')
+    expect(storage.getStore()).toBe('request-logger')
+
+    await Promise.resolve()
+    expect(storage.getStore()).toBe('request-logger')
+
+    storage.enterWith(undefined as unknown as string)
+    expect(storage.getStore()).toBeUndefined()
+  })
+})

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { Elysia } from 'elysia'
 import { initLogger } from '../../src/logger'
 import {
-  installAsyncLocalStorageEnterWithPolyfill,
   patchAsyncLocalStorageEnterWith,
   supportsAsyncLocalStorageEnterWith,
 } from '../../src/shared/asyncStorageScope'
@@ -21,10 +20,9 @@ function createWorkersLikeStorage<T = unknown>(): AsyncLocalStorage<T> {
     writable: true,
     value: undefined,
   })
-  patchAsyncLocalStorageEnterWith(
-    LocalAsyncLocalStorage.prototype as Parameters<typeof patchAsyncLocalStorageEnterWith>[0],
-  )
-  return new LocalAsyncLocalStorage()
+  const storage = new LocalAsyncLocalStorage()
+  patchAsyncLocalStorageEnterWith(storage)
+  return storage
 }
 
 function delay(ms = 1) {
@@ -45,12 +43,32 @@ describe('asyncStorageScope', () => {
   })
 
   it('is a no-op when enterWith already exists', () => {
-    const before = AsyncLocalStorage.prototype.getStore
+    const storage = new AsyncLocalStorage<string>()
+    const beforeGetStore = AsyncLocalStorage.prototype.getStore
 
-    installAsyncLocalStorageEnterWithPolyfill()
+    patchAsyncLocalStorageEnterWith(storage)
 
-    expect(typeof AsyncLocalStorage.prototype.enterWith).toBe('function')
-    expect(AsyncLocalStorage.prototype.getStore).toBe(before)
+    storage.enterWith('request-logger')
+    expect(storage.getStore()).toBe('request-logger')
+    expect(AsyncLocalStorage.prototype.getStore).toBe(beforeGetStore)
+  })
+
+  it('patches only the provided storage instance', () => {
+    class LocalAsyncLocalStorage extends AsyncLocalStorage<string> {}
+    Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+
+    const patched = new LocalAsyncLocalStorage()
+    const untouched = new LocalAsyncLocalStorage()
+
+    patchAsyncLocalStorageEnterWith(patched)
+
+    patched.enterWith('evlog')
+    expect(patched.getStore()).toBe('evlog')
+    expect(untouched.enterWith).toBeUndefined()
   })
 
   it('polyfills enterWith for runtimes that omit it', async () => {

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -25,6 +25,20 @@ function createWorkersLikeStorage<T = unknown>(): AsyncLocalStorage<T> {
   return storage
 }
 
+function createThrowingEnterWithStorage<T = unknown>(): AsyncLocalStorage<T> {
+  class LocalAsyncLocalStorage extends AsyncLocalStorage<T> {}
+  Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {
+    configurable: true,
+    writable: true,
+    value() {
+      throw new Error('asyncLocalStorage.enterWith() is not implemented')
+    },
+  })
+  const storage = new LocalAsyncLocalStorage()
+  patchAsyncLocalStorageEnterWith(storage)
+  return storage
+}
+
 function delay(ms = 1) {
   return new Promise((resolve) => {
     setImmediate(resolve)
@@ -40,6 +54,19 @@ async function request(app: { handle: (req: Request) => Promise<Response> }, pat
 describe('asyncStorageScope', () => {
   it('detects native enterWith support', () => {
     expect(supportsAsyncLocalStorageEnterWith(new AsyncLocalStorage<string>())).toBe(true)
+  })
+
+  it('detects throwing enterWith as unsupported', () => {
+    class LocalAsyncLocalStorage extends AsyncLocalStorage<string> {}
+    Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {
+      configurable: true,
+      writable: true,
+      value() {
+        throw new Error('asyncLocalStorage.enterWith() is not implemented')
+      },
+    })
+
+    expect(supportsAsyncLocalStorageEnterWith(new LocalAsyncLocalStorage())).toBe(false)
   })
 
   it('is a no-op when enterWith already exists', () => {
@@ -82,6 +109,16 @@ describe('asyncStorageScope', () => {
 
     storage.enterWith(undefined as unknown as string)
     expect(storage.getStore()).toBeUndefined()
+  })
+
+  it('polyfills when enterWith exists but throws at runtime', async () => {
+    const storage = createThrowingEnterWithStorage<string>()
+
+    storage.enterWith('request-logger')
+    expect(storage.getStore()).toBe('request-logger')
+
+    await Promise.resolve()
+    expect(storage.getStore()).toBe('request-logger')
   })
 
   it('supports elysia-style request scope usage (#394)', async () => {


### PR DESCRIPTION
## Summary
- Install a small `AsyncLocalStorage.enterWith()` polyfill when the runtime omits it (Cloudflare Workers)
- Keep the Elysia integration on `enterWith()` so `useLogger()` works across async boundaries between lifecycle hooks
- Add unit and integration regression tests for #394

Closes #394

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [ ] `wrangler dev` with Elysia + `evlog()` no longer throws `enterWith() is not implemented`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-scoped logging compatibility in Cloudflare Workers so logger context remains available during async execution (including `wrangler dev`-style flows).
  * Fixed logger binding/cleanup to avoid cross-request context leakage during concurrent traffic.
* **Documentation**
  * Updated `useLogger()` guidance to clarify availability across async boundaries.
* **Tests**
  * Added coverage for Workers-style `AsyncLocalStorage` behavior and concurrency isolation between interleaved requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->