### PR TITLE
fix(nitro): avoid comment collision when inlining config with glob

### DIFF
--- a/.changeset/fix-nitro-config-replace-comments.md
+++ b/.changeset/fix-nitro-config-replace-comments.md
@@ -1,0 +1,9 @@
+---
+"evlog": patch
+---
+
+# fix(nitro): avoid comment collision when inlining config with `*/` globs
+
+Nitro's textual `nitro.options.replace` substitution was also rewriting JSDoc that mentioned the inline config token. Route globs containing `*/` (for example `/api/graphs/**/changes`) could terminate block comments early and break production builds with Rolldown parse errors.
+
+Closes #397

--- a/packages/evlog/src/shared/nitroConfigBridge.ts
+++ b/packages/evlog/src/shared/nitroConfigBridge.ts
@@ -9,9 +9,9 @@
  *
  * **Strategy**
  *
- * 1. `__EVLOG_CONFIG__` — build-time literal baked in by the evlog Nitro
- *    modules via `nitro.options.replace`. When present, all runtime probing is
- *    skipped (see issue #312: Vercel + Bun crashes if the v3 probe runs).
+ * 1. Build-time inlined config literal — baked in via `nitro.options.replace`
+ *    by the evlog Nitro modules. When present, all runtime probing is skipped
+ *    (see issue #312: Vercel + Bun crashes if the v3 probe runs).
  * 2. `process.env.__EVLOG_CONFIG` — JSON set by evlog Nitro modules during
  *    build; survives into runtime on platforms that propagate build env vars.
  * 3. Computed module IDs — `['a','b'].join('/')` passed to `import()` so emitted
@@ -153,8 +153,9 @@ function evlogSlice(config: Record<string, any>): EvlogConfig | undefined {
  * Options for evlog Nitro plugins (nitropack v2 and Nitro v3).
  *
  * Lookup order:
- * 1. `__EVLOG_CONFIG__` — inlined at build time by the evlog Nitro module.
- *    Hits in every deployed bundle and skips runtime probing entirely.
+ * 1. {@link readEvlogConfigFromInline} — build-time literal inlined by the
+ *    evlog Nitro module. Hits in every deployed bundle and skips runtime
+ *    probing entirely.
  * 2. `process.env.__EVLOG_CONFIG`
  * 3. The active runtime declared by {@link setActiveNitroRuntime} — either
  *    Nitro v3 `runtime-config` or nitropack internal config, never both.
@@ -209,9 +210,9 @@ export async function resolveEvlogConfigForNitroPlugin(): Promise<EvlogConfig | 
  * been declared (standalone use outside Nitro), falls back to the historical
  * order: nitropack v2 first, then Nitro v3.
  *
- * When `__EVLOG_CONFIG__` was inlined at build time, returns a synthetic
- * `{ evlog: <inlined> }` record so adapters can read `runtimeConfig.evlog.*`
- * without triggering the dynamic import (issue #312).
+ * When build-time config was inlined (see {@link readEvlogConfigFromInline}),
+ * returns a synthetic `{ evlog: <inlined> }` record so adapters can read
+ * `runtimeConfig.evlog.*` without triggering the dynamic import (issue #312).
  */
 export async function getNitroRuntimeConfigRecord(): Promise<Record<string, any> | undefined> {
   const inline = readEvlogConfigFromInline()

--- a/packages/evlog/test/nitro/config-inline-replace.test.ts
+++ b/packages/evlog/test/nitro/config-inline-replace.test.ts
@@ -25,12 +25,33 @@ function extractBlockComments(source: string): string[] {
   return comments
 }
 
+const STAR_SLASH_GLOB_CONFIG = {
+  env: { service: 'example' },
+  exclude: ['/api/graphs/**/changes', '/api/graphs/*/changes'],
+} as const
+
 /** JS stand-in for runtime expression sites Nitro replace touches (declare lines are erased). */
 const IDENTIFIER_FRAGMENT = [
   'typeof __EVLOG_CONFIG__ === "undefined"',
   '(__EVLOG_CONFIG__ === null)',
   '(typeof __EVLOG_CONFIG__ !== "object")',
   'void (__EVLOG_CONFIG__)',
+].join('\n')
+
+/** Pre-fix JSDoc shape from issue #397: replace token spelled inside a block comment. */
+const BUGGY_INLINE_COMMENT_FIXTURE = [
+  '/**',
+  ` * 1. \`${INLINE_REPLACE_TOKEN}\` — inlined at build time by the evlog Nitro module.`,
+  ' */',
+  IDENTIFIER_FRAGMENT,
+].join('\n')
+
+/** Post-fix JSDoc shape: inline config documented without spelling the replace token. */
+const FIXED_INLINE_COMMENT_FIXTURE = [
+  '/**',
+  ' * 1. Build-time inlined config literal — baked in via nitro.options.replace.',
+  ' */',
+  IDENTIFIER_FRAGMENT,
 ].join('\n')
 
 /**
@@ -41,7 +62,35 @@ function toJsReplaceFragment(source: string): string {
   return `${extractBlockComments(source).join('\n')}\n${IDENTIFIER_FRAGMENT}`
 }
 
+function assertParseableAfterReplace(source: string, config: Record<string, unknown>): void {
+  const replaced = applyNitroInlineReplace(source, config)
+  expect(() => parse(replaced, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+}
+
 describe('nitro config inline replace (issue #397)', () => {
+  describe('comment collision with star-slash globs', () => {
+    it('breaks parse when the replace token is spelled inside a block comment', () => {
+      const replaced = applyNitroInlineReplace(BUGGY_INLINE_COMMENT_FIXTURE, STAR_SLASH_GLOB_CONFIG)
+
+      expect(() => parse(replaced, { ecmaVersion: 'latest', sourceType: 'module' })).toThrow()
+    })
+
+    it('stays parseable when block comments avoid the replace token', () => {
+      assertParseableAfterReplace(FIXED_INLINE_COMMENT_FIXTURE, STAR_SLASH_GLOB_CONFIG)
+    })
+
+    it('stays parseable via toJsReplaceFragment on comment-bearing fixed input', () => {
+      const fixedCommentSource = [
+        '/**',
+        ' * 1. Build-time inlined config literal — baked in via nitro.options.replace.',
+        ' */',
+        'declare const __EVLOG_CONFIG__: unknown',
+      ].join('\n')
+
+      assertParseableAfterReplace(toJsReplaceFragment(fixedCommentSource), STAR_SLASH_GLOB_CONFIG)
+    })
+  })
+
   for (const relativePath of NITRO_INLINE_SOURCES) {
     const absolutePath = resolve(import.meta.dirname, relativePath)
     const source = readFileSync(absolutePath, 'utf8')
@@ -54,13 +103,7 @@ describe('nitro config inline replace (issue #397)', () => {
     })
 
     it(`${label} stays parseable after Nitro replace with star-slash globs`, () => {
-      const fragment = toJsReplaceFragment(source)
-      const replaced = applyNitroInlineReplace(fragment, {
-        env: { service: 'example' },
-        exclude: ['/api/graphs/**/changes', '/api/graphs/*/changes'],
-      })
-
-      expect(() => parse(replaced, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+      assertParseableAfterReplace(toJsReplaceFragment(source), STAR_SLASH_GLOB_CONFIG)
     })
   }
 })

--- a/packages/evlog/test/nitro/config-inline-replace.test.ts
+++ b/packages/evlog/test/nitro/config-inline-replace.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'acorn'
+import { describe, expect, it } from 'vitest'
+
+const INLINE_REPLACE_TOKEN = '__EVLOG_CONFIG__'
+
+const NITRO_INLINE_SOURCES = [
+  '../../src/shared/nitroConfigBridge.ts',
+  '../../src/logger.ts',
+] as const
+
+/** Simulate Nitro's global textual `nitro.options.replace` substitution. */
+function applyNitroInlineReplace(source: string, config: Record<string, unknown>): string {
+  return source.replaceAll(INLINE_REPLACE_TOKEN, JSON.stringify(config))
+}
+
+/** Extract block comments from source (JSDoc and multiline slash-star comments). */
+function extractBlockComments(source: string): string[] {
+  const comments: string[] = []
+  const pattern = /\/\*[\s\S]*?\*\//g
+  for (const match of source.matchAll(pattern)) {
+    comments.push(match[0])
+  }
+  return comments
+}
+
+/** JS stand-in for runtime expression sites Nitro replace touches (declare lines are erased). */
+const IDENTIFIER_FRAGMENT = [
+  'typeof __EVLOG_CONFIG__ === "undefined"',
+  '(__EVLOG_CONFIG__ === null)',
+  '(typeof __EVLOG_CONFIG__ !== "object")',
+  'void (__EVLOG_CONFIG__)',
+].join('\n')
+
+/**
+ * Build a JS-only fragment mirroring how Nitro replace touches each file:
+ * every block comment plus the identifier guard lines that reference the token.
+ */
+function toJsReplaceFragment(source: string): string {
+  return `${extractBlockComments(source).join('\n')}\n${IDENTIFIER_FRAGMENT}`
+}
+
+describe('nitro config inline replace (issue #397)', () => {
+  for (const relativePath of NITRO_INLINE_SOURCES) {
+    const absolutePath = resolve(import.meta.dirname, relativePath)
+    const source = readFileSync(absolutePath, 'utf8')
+    const label = relativePath.split('/').pop()!
+
+    it(`${label} has no ${INLINE_REPLACE_TOKEN} inside block comments`, () => {
+      for (const comment of extractBlockComments(source)) {
+        expect(comment, `block comment in ${label}`).not.toContain(INLINE_REPLACE_TOKEN)
+      }
+    })
+
+    it(`${label} stays parseable after Nitro replace with star-slash globs`, () => {
+      const fragment = toJsReplaceFragment(source)
+      const replaced = applyNitroInlineReplace(fragment, {
+        env: { service: 'example' },
+        exclude: ['/api/graphs/**/changes', '/api/graphs/*/changes'],
+      })
+
+      expect(() => parse(replaced, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+    })
+  }
+})


### PR DESCRIPTION
Resolves #397 

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed inline config substitution that could collide with block comments when configs include `*/` patterns, potentially causing malformed JavaScript output.
- **Tests**
  - Added a regression test to verify the inline replacement remains parseable and that the inline token isn’t introduced inside comments.
- **Documentation**
  - Refreshed build-time comment guidance to clarify how inline config is handled and when runtime probing is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->