### PR TITLE
fix(core): include timestamp in dev pretty wide events

### DIFF
--- a/.changeset/fix-pretty-dev-timestamp.md
+++ b/.changeset/fix-pretty-dev-timestamp.md
@@ -1,0 +1,7 @@
+---
+"evlog": patch
+---
+
+Fix dev pretty output so structured wide events include a timestamp, matching tagged logs.
+
+Closes #396

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -605,11 +605,7 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
     styles.push(cssColors.dim, cssColors.reset, lc, cssColors.reset, cssColors.cyan, cssColors.reset)
   } else {
     const lc = getLevelColor(levelLabel)
-    if (isDev()) {
-      parts.push(`${lc}${levelLabel.toUpperCase()}${colors.reset} ${colors.cyan}[${service}]${colors.reset}`)
-    } else {
-      parts.push(`${colors.dim}${ts}${colors.reset} ${lc}${levelLabel.toUpperCase()}${colors.reset} ${colors.cyan}[${service}]${colors.reset}`)
-    }
+    parts.push(`${colors.dim}${ts}${colors.reset} ${lc}${levelLabel.toUpperCase()}${colors.reset} ${colors.cyan}[${service}]${colors.reset}`)
   }
 
   if (rest.method && rest.path) {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -1151,6 +1151,36 @@ describe('silent option', () => {
   })
 })
 
+describe('pretty dev timestamp consistency', () => {
+  const timestampPattern = /\d{2}:\d{2}:\d{2}\.\d{3}/
+
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    initLogger({ pretty: true })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('includes timestamp in dev pretty wide event and tagged log headers', () => {
+    const logSpy = vi.mocked(console.log)
+
+    log.info({ message: 'Test' })
+    log.warn('server', 'test')
+
+    expect(logSpy).toHaveBeenCalledTimes(2)
+
+    const wideOutput = String(logSpy.mock.calls[0]![0])
+    const taggedOutput = String(logSpy.mock.calls[1]![0])
+
+    expect(wideOutput).toMatch(timestampPattern)
+    expect(taggedOutput).toMatch(timestampPattern)
+  })
+})
+
 describe('pretty-print tool input serialization', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => {})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

Resolves #396 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pretty-formatted development logs now consistently include a timestamp for wide events and tagged log entries.
  * Log styling has been aligned so output formatting is consistent across these message types.

* **Tests**
  * Added coverage to verify timestamp display in development pretty logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->