### PR TITLE
fix(next): apply createEvlog redact to main request events

### DIFF
--- a/.changeset/fix-next-createevlog-redact.md
+++ b/.changeset/fix-next-createevlog-redact.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix `createEvlog({ redact })` / `withEvlog` so custom `redact` rules apply to the main Next.js request wide event (console output and drain), not only forked child events.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ TypeScript logging library focused on wide events and structured error handling.
 
 ```bash
 pnpm install                       # install deps
+pnpm run dev:prepare               # generate types (required before lint/typecheck after a fresh install)
 pnpm run dev                       # start playground
-pnpm run dev:prepare               # generate types
 pnpm run build:package             # build the package
 pnpm run test                      # run tests (vitest)
 pnpm run lint                      # lint all packages
@@ -17,6 +17,8 @@ cd packages/evlog && pnpm run release  # publish
 ```
 
 > Use `corepack enable` once so the `packageManager` field in `package.json` pins the right pnpm version automatically.
+>
+> After a clean `pnpm install`, run `pnpm run dev:prepare` before `pnpm run lint` / `typecheck`. Packages like `@evlog/nuxthub` extend generated `.nuxt/tsconfig.json` files; without prepare, turbo lint fails on missing extends.
 
 ## Monorepo Structure
 

--- a/packages/evlog/src/next/handler.ts
+++ b/packages/evlog/src/next/handler.ts
@@ -42,6 +42,7 @@ export function configureHandler(options: NextEvlogOptions): void {
     sampling: options.sampling,
     minLevel: options.minLevel,
     stringify: options.stringify,
+    redact: options.redact,
     _suppressDrainWarning: true,
   })
 }

--- a/packages/evlog/test/next/handler.test.ts
+++ b/packages/evlog/test/next/handler.test.ts
@@ -150,6 +150,35 @@ describe('withEvlog', () => {
     expect(drainCtx.request.path).toBe('/api/test')
   })
 
+  it('applies createEvlog redact.paths to the main request event (#408)', async () => {
+    const drainMock = vi.fn()
+    const withEvlog = createWithEvlog({
+      pretty: false,
+      redact: {
+        builtins: false,
+        paths: ['secret'],
+      },
+      drain: drainMock,
+    })
+
+    const handler = withEvlog((_: Request) => {
+      const logger = defined(evlogStorage.getStore(), 'request logger')
+      logger.set({ secret: 'must-not-leak' })
+      return new Response('ok')
+    })
+
+    await handler(new Request('http://localhost/api/redaction', { method: 'POST' }))
+
+    expect(drainMock).toHaveBeenCalledTimes(1)
+    const [[drainCtx]] = drainMock.mock.calls
+    expect(drainCtx.event.secret).toBe('[REDACTED]')
+
+    expect(consoleSpy).toHaveBeenCalled()
+    const [[output]] = consoleSpy.mock.calls
+    const parsed = JSON.parse(output)
+    expect(parsed.secret).toBe('[REDACTED]')
+  })
+
   it('calls enrich callback before drain', async () => {
     const callOrder: string[] = []
     const withEvlog = createWithEvlog({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #408

`createEvlog({ redact })` / `withEvlog` now forwards `redact` to `initLogger()`, so custom path rules apply to the main Next.js request wide event (console + drain), not only forked child events.

Adds a regression test covering drain and console output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b187d492-9ed7-4045-a984-a4460f2b31fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b187d492-9ed7-4045-a984-a4460f2b31fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom redaction rules now apply consistently to Next.js request events, including console output and drained event data.
  * Sensitive fields are replaced with `[REDACTED]` as configured.

* **Documentation**
  * Updated setup instructions to include the required preparation step before linting and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->