### PR TITLE
feat(ai): add LanguageModelV4 wrap middleware for AI SDK v7

### DIFF
--- a/.changeset/ai-sdk-v4-wrap-middleware.md
+++ b/.changeset/ai-sdk-v4-wrap-middleware.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+Add AI SDK v7 `LanguageModelV4` wrap/middleware support in `evlog/ai`. `createAILogger().wrap()` and `createAIMiddleware()` now use V4-native middleware (`specificationVersion: 'v4'`) while still accepting V3 models (AI SDK upgrades them via `wrapLanguageModel`). `wrap()` is typed against `LanguageModel` from `ai`, so V3, V4, and gateway model strings all type-check on AI SDK v7.

--- a/apps/docs/content/4.use-cases/2.ai-sdk/01.overview.md
+++ b/apps/docs/content/4.use-cases/2.ai-sdk/01.overview.md
@@ -140,7 +140,7 @@ Your wide event now includes:
 
 | Method | Description |
 |--------|-------------|
-| `wrap(model)` | Wraps a language model with middleware. Accepts a model string (e.g. `'anthropic/claude-sonnet-4.6'`) or a `LanguageModelV3` object. Works with `generateText`, `streamText`, and `ToolLoopAgent`. |
+| `wrap(model)` | Wraps a language model with middleware. Accepts a model string (e.g. `'anthropic/claude-sonnet-4.6'`) or a `LanguageModelV3` / `LanguageModelV4` object. Works with `generateText`, `streamText`, and `ToolLoopAgent`. |
 | `captureEmbed(result)` | Manually captures token usage, model info, and dimensions from `embed()` or `embedMany()` results. |
 | `getMetadata()` | Returns a snapshot of the current execution metadata. See [Access Metadata](/use-cases/ai-sdk/metadata). |
 | `getEstimatedCost()` | Returns the current estimated cost in dollars when a `cost` map is configured. |

--- a/apps/docs/content/4.use-cases/2.ai-sdk/02.usage.md
+++ b/apps/docs/content/4.use-cases/2.ai-sdk/02.usage.md
@@ -211,7 +211,7 @@ const response = await generateText({ model: smart, prompt: detailedPrompt })
 
 ## Model Object Support
 
-`wrap()` also accepts model objects from provider SDKs if you prefer explicit imports:
+`wrap()` accepts model objects from provider SDKs — both `LanguageModelV3` (AI SDK v6) and `LanguageModelV4` (AI SDK v7):
 
 ```typescript [server/api/chat.post.ts]
 import { anthropic } from '@ai-sdk/anthropic'

--- a/packages/evlog/src/ai/index.ts
+++ b/packages/evlog/src/ai/index.ts
@@ -204,12 +204,15 @@ export interface AILogger {
    * Also works with pre-wrapped models (e.g. from supermemory, guardrails):
    * `ai.wrap(withSupermemory(base, orgId))` composes correctly.
    *
-   * @example
+   * @example Gateway model string
    * ```ts
    * const ai = createAILogger(log)
    * const model = ai.wrap('anthropic/claude-sonnet-4.6')
+   * ```
    *
-   * // Also accepts a model object (V3 or V4)
+   * @example Provider model object (V3 or V4)
+   * ```ts
+   * const ai = createAILogger(log)
    * const model = ai.wrap(anthropic('claude-sonnet-4.6'))
    * ```
    */

--- a/packages/evlog/src/ai/index.ts
+++ b/packages/evlog/src/ai/index.ts
@@ -1,7 +1,7 @@
 import * as aiModule from 'ai'
 import { gateway, wrapLanguageModel } from 'ai'
-import type { GatewayModelId } from 'ai'
-import type { LanguageModelV3, LanguageModelV3Middleware, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type { LanguageModel, LanguageModelMiddleware } from 'ai'
+import type { LanguageModelV4StreamPart } from '@ai-sdk/provider'
 import type { RequestLogger } from '../types'
 
 const { bindTelemetryIntegration } = aiModule as {
@@ -194,8 +194,12 @@ export interface AILogger {
    * All `generateText` and `streamText` calls using the wrapped model
    * are captured automatically into the wide event.
    *
-   * Accepts a `LanguageModelV3` object or a model string (e.g. `'anthropic/claude-sonnet-4.6'`).
+   * Accepts a language model object (`LanguageModelV3` or `LanguageModelV4`)
+   * or a model string (e.g. `'anthropic/claude-sonnet-4.6'`).
    * Strings are resolved via the AI SDK gateway.
+   *
+   * On AI SDK v7, the wrapped model is a `LanguageModelV4`. On v6 it remains
+   * a `LanguageModelV3`. Both are accepted as input.
    *
    * Also works with pre-wrapped models (e.g. from supermemory, guardrails):
    * `ai.wrap(withSupermemory(base, orgId))` composes correctly.
@@ -205,11 +209,11 @@ export interface AILogger {
    * const ai = createAILogger(log)
    * const model = ai.wrap('anthropic/claude-sonnet-4.6')
    *
-   * // Also accepts a model object
+   * // Also accepts a model object (V3 or V4)
    * const model = ai.wrap(anthropic('claude-sonnet-4.6'))
    * ```
    */
-  wrap: (model: LanguageModelV3 | GatewayModelId) => LanguageModelV3
+  wrap: (model: LanguageModel) => LanguageModel
 
   /**
    * Manually capture token usage from an `embed()` or `embedMany()` result.
@@ -390,7 +394,7 @@ function resolveProviderAndModel(provider: string, modelId: string): { provider:
  * })
  * ```
  */
-export function createAIMiddleware(log: RequestLogger, options?: AILoggerOptions): LanguageModelV3Middleware {
+export function createAIMiddleware(log: RequestLogger, options?: AILoggerOptions): LanguageModelMiddleware {
   return buildMiddleware(log, options)
 }
 
@@ -426,7 +430,7 @@ export function createAILogger(log: RequestLogger, options?: AILoggerOptions): A
   const middleware = buildMiddlewareFromState(log, state)
 
   return {
-    wrap: (model: LanguageModelV3 | GatewayModelId) => {
+    wrap: (model: LanguageModel) => {
       const resolved = typeof model === 'string' ? gateway(model) : model
       return wrapLanguageModel({ model: resolved, middleware })
     },
@@ -705,15 +709,17 @@ function recordError(log: RequestLogger, state: AccumulatorState, model: { provi
   flushState(log, state)
 }
 
-function buildMiddleware(log: RequestLogger, options?: AILoggerOptions): LanguageModelV3Middleware {
+function buildMiddleware(log: RequestLogger, options?: AILoggerOptions): LanguageModelMiddleware {
   const state = createAccumulatorState(options)
   state._log = log
   return buildMiddlewareFromState(log, state)
 }
 
-function buildMiddlewareFromState(log: RequestLogger, state: AccumulatorState): LanguageModelV3Middleware {
+function buildMiddlewareFromState(log: RequestLogger, state: AccumulatorState): LanguageModelMiddleware {
   return {
-    specificationVersion: 'v3',
+    // AI SDK v7 middleware is V4-native; `LanguageModelMiddleware` also
+    // accepts this on v6-compatible installs that relax the version field.
+    specificationVersion: 'v4',
     wrapGenerate: async ({ doGenerate, model }) => {
       try {
         const result = await doGenerate()
@@ -782,8 +788,8 @@ function buildMiddlewareFromState(log: RequestLogger, state: AccumulatorState): 
       const { stream, ...rest } = doStreamResult
 
       const transformStream = new TransformStream<
-        LanguageModelV3StreamPart,
-        LanguageModelV3StreamPart
+        LanguageModelV4StreamPart,
+        LanguageModelV4StreamPart
       >({
         transform(chunk, controller) {
           if (!firstChunkTime && chunk.type === 'text-delta') {

--- a/packages/evlog/test/ai/ai.test.ts
+++ b/packages/evlog/test/ai/ai.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3FinishReason, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type {
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+} from '@ai-sdk/provider'
+import type { LanguageModel } from 'ai'
 import type { RequestLogger } from '../../src/types'
-import { createAILogger, createAIMiddleware, createEvlogIntegration, type EvlogTelemetry } from '../../src/ai'
+import { createAILogger, createAIMiddleware, createEvlogIntegration, type AILogger, type EvlogTelemetry } from '../../src/ai'
 import { createLogger, mergeWideEventFields } from '../../src/logger'
 import { defined } from '../helpers/defined'
 import { withFakeTimers } from '../helpers/timers'
@@ -58,8 +64,8 @@ function createMockUsage(overrides?: Partial<{
   }
 }
 
-type GenerateResult = Awaited<ReturnType<LanguageModelV3['doGenerate']>>
-type StreamResult = Awaited<ReturnType<LanguageModelV3['doStream']>>
+type GenerateResult = Awaited<ReturnType<LanguageModelV4['doGenerate']>>
+type StreamResult = Awaited<ReturnType<LanguageModelV4['doStream']>>
 
 /** AI SDK generate results require many fields — partial mocks cast once here. */
 function asGenerateResult(value: Record<string, unknown>): GenerateResult {
@@ -70,13 +76,61 @@ function asStreamResult(value: Record<string, unknown>): StreamResult {
   return value as StreamResult
 }
 
-type MockLanguageModel = Pick<LanguageModelV3, 'specificationVersion' | 'provider' | 'modelId'> & {
-  doGenerate: ReturnType<typeof vi.fn<LanguageModelV3['doGenerate']>>
-  doStream: ReturnType<typeof vi.fn<LanguageModelV3['doStream']>>
+type MockLanguageModel = {
+  specificationVersion: 'v3' | 'v4'
+  provider: string
+  modelId: string
+  supportedUrls: Record<string, RegExp[]>
+  doGenerate: ReturnType<typeof vi.fn>
+  doStream: ReturnType<typeof vi.fn>
 }
 
-function createMockCallOptions(): LanguageModelV3CallOptions {
-  return { prompt: [] }
+function createMockModel(
+  overrides?: Partial<{ provider: string, modelId: string, specificationVersion: 'v3' | 'v4' }>,
+): MockLanguageModel {
+  return {
+    specificationVersion: overrides?.specificationVersion ?? 'v4',
+    provider: overrides?.provider ?? 'anthropic',
+    modelId: overrides?.modelId ?? 'claude-sonnet-4.6',
+    supportedUrls: {},
+    doGenerate: vi.fn(),
+    doStream: vi.fn(),
+  }
+}
+
+/** wrap() returns LanguageModel (string | V2 | V3 | V4); tests need the V4 instance API. */
+function wrapMock(ai: AILogger, model: MockLanguageModel): LanguageModelV4 {
+  return ai.wrap(model as LanguageModel) as LanguageModelV4
+}
+
+function createMockCallOptions(): LanguageModelV4CallOptions {
+  return { prompt: [] } as LanguageModelV4CallOptions
+}
+
+function createFinishReason(unified: LanguageModelV4FinishReason['unified'] = 'stop'): LanguageModelV4FinishReason {
+  return { unified, raw: undefined }
+}
+
+function makeReadableStream(chunks: LanguageModelV4StreamPart[]): ReadableStream<LanguageModelV4StreamPart> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk)
+      }
+      controller.close()
+    },
+  })
+}
+
+async function consumeStream(stream: ReadableStream<LanguageModelV4StreamPart>): Promise<LanguageModelV4StreamPart[]> {
+  const reader = stream.getReader()
+  const result: LanguageModelV4StreamPart[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result.push(value)
+  }
+  return result
 }
 
 function getLastAiData(log: MockLogger): Record<string, unknown> {
@@ -191,42 +245,6 @@ function callIntegrationOnError(integration: EvlogTelemetry, error: unknown) {
   defined(integration.onError, 'onError')(error)
 }
 
-function createMockModel(overrides?: Partial<{ provider: string, modelId: string }>): MockLanguageModel {
-  return {
-    specificationVersion: 'v3',
-    provider: overrides?.provider ?? 'anthropic',
-    modelId: overrides?.modelId ?? 'claude-sonnet-4.6',
-    doGenerate: vi.fn(),
-    doStream: vi.fn(),
-  }
-}
-
-function createFinishReason(unified: LanguageModelV3FinishReason['unified'] = 'stop'): LanguageModelV3FinishReason {
-  return { unified, raw: undefined }
-}
-
-function makeReadableStream(chunks: LanguageModelV3StreamPart[]): ReadableStream<LanguageModelV3StreamPart> {
-  return new ReadableStream({
-    start(controller) {
-      for (const chunk of chunks) {
-        controller.enqueue(chunk)
-      }
-      controller.close()
-    },
-  })
-}
-
-async function consumeStream(stream: ReadableStream<LanguageModelV3StreamPart>): Promise<LanguageModelV3StreamPart[]> {
-  const reader = stream.getReader()
-  const result: LanguageModelV3StreamPart[] = []
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    result.push(value)
-  }
-  return result
-}
-
 describe('createAILogger', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -238,7 +256,7 @@ describe('createAILogger', () => {
       const ai = createAILogger(log)
       const model = createMockModel()
 
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -267,7 +285,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -289,7 +307,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -311,7 +329,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [
@@ -336,7 +354,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ modelId: 'claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -356,7 +374,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ modelId: 'claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -377,9 +395,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hello ' },
         { type: 'text-delta', id: 't1', delta: 'world' },
@@ -409,9 +427,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -436,9 +454,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'tool-input-start', id: 'tc1', toolName: 'searchWeb' },
         { type: 'tool-input-delta', id: 'tc1', delta: '{}' },
         { type: 'tool-input-end', id: 'tc1' },
@@ -460,10 +478,10 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ modelId: 'claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
-        { type: 'response-metadata', modelId: 'claude-sonnet-4.6-20250514' } as LanguageModelV3StreamPart,
+      const chunks: LanguageModelV4StreamPart[] = [
+        { type: 'response-metadata', modelId: 'claude-sonnet-4.6-20250514' } as LanguageModelV4StreamPart,
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -485,9 +503,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const inputChunks: LanguageModelV3StreamPart[] = [
+      const inputChunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hello' },
         { type: 'text-end', id: 't1' },
@@ -511,7 +529,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
@@ -541,7 +559,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -569,8 +587,8 @@ describe('createAILogger', () => {
       const gemini = createMockModel({ provider: 'google', modelId: 'gemini-3-flash' })
       const claude = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
 
-      const wrappedGemini = ai.wrap(gemini)
-      const wrappedClaude = ai.wrap(claude)
+      const wrappedGemini = wrapMock(ai, gemini)
+      const wrappedClaude = wrapMock(ai, claude)
 
       vi.mocked(gemini.doGenerate).mockResolvedValue({
         content: [],
@@ -600,7 +618,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const mockResult = {
         content: [],
@@ -623,7 +641,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
@@ -650,7 +668,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const tools = ['list-pages', 'get-page', 'get-page', 'get-page', 'get-page', 'get-page']
 
@@ -685,7 +703,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ provider: 'gateway', modelId: 'google/gemini-3-flash' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -704,7 +722,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ provider: 'gateway', modelId: 'anthropic/claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -724,7 +742,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -744,9 +762,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel({ provider: 'gateway', modelId: 'anthropic/claude-sonnet-4.6' })
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -771,9 +789,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
 
-      const wrappedModel = ai.wrap('anthropic/claude-sonnet-4.6')
+      const wrappedModel = ai.wrap('anthropic/claude-sonnet-4.6') as LanguageModelV4
       expect(wrappedModel).toBeDefined()
-      expect(['v3', 'v4']).toContain(wrappedModel.specificationVersion)
+      expect(wrappedModel.specificationVersion).toBe('v4')
     })
   })
 
@@ -782,9 +800,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -809,9 +827,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -837,7 +855,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockRejectedValue(new Error('API rate limit exceeded'))
 
@@ -853,7 +871,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doStream).mockRejectedValue(new Error('Connection timeout'))
 
@@ -869,9 +887,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'error', error: new Error('Content filter triggered') },
         { type: 'finish', finishReason: createFinishReason('content-filter'), usage: createMockUsage() },
@@ -907,7 +925,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       ai.captureEmbed({ usage: { tokens: 30 } })
 
@@ -933,7 +951,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'searchWeb', input: '{"query":"weather"}' }],
@@ -952,7 +970,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: true })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [
@@ -977,7 +995,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: true })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'run', input: 'not-json' }],
@@ -997,9 +1015,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: true })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'tool-input-start', id: 'tc1', toolName: 'searchWeb' },
         { type: 'tool-input-delta', id: 'tc1', delta: '{"que' },
         { type: 'tool-input-delta', id: 'tc1', delta: 'ry":"hello"}' },
@@ -1022,9 +1040,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'tool-input-start', id: 'tc1', toolName: 'searchWeb' },
         { type: 'tool-input-delta', id: 'tc1', delta: '{"query":"test"}' },
         { type: 'tool-input-end', id: 'tc1' },
@@ -1046,7 +1064,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: true })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'run', input: { already: 'parsed' } }],
@@ -1066,7 +1084,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: { maxLength: 20 } })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'queryDB', input: '{"sql":"SELECT * FROM events WHERE status = 200 ORDER BY created_at DESC LIMIT 50"}' },],
@@ -1088,7 +1106,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: { maxLength: 500 } })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"q":"hello"}' },],
@@ -1117,7 +1135,7 @@ describe('createAILogger', () => {
         },
       })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [
@@ -1146,7 +1164,7 @@ describe('createAILogger', () => {
         },
       })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"query":"a very long search query that exceeds the limit"}' },],
@@ -1167,9 +1185,9 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log, { toolInputs: { maxLength: 15 } })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
+      const chunks: LanguageModelV4StreamPart[] = [
         { type: 'tool-input-start', id: 'tc1', toolName: 'queryDB' },
         { type: 'tool-input-delta', id: 'tc1', delta: '{"sql":"SELECT * FROM events' },
         { type: 'tool-input-delta', id: 'tc1', delta: ' WHERE id = 1"}' },
@@ -1196,7 +1214,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1215,10 +1233,10 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks: LanguageModelV3StreamPart[] = [
-        { type: 'response-metadata', id: 'msg_stream_123', modelId: 'claude-sonnet-4.6' } as LanguageModelV3StreamPart,
+      const chunks: LanguageModelV4StreamPart[] = [
+        { type: 'response-metadata', id: 'msg_stream_123', modelId: 'claude-sonnet-4.6' } as LanguageModelV4StreamPart,
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Hi' },
         { type: 'text-end', id: 't1' },
@@ -1240,7 +1258,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1261,7 +1279,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1281,7 +1299,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate)
         .mockResolvedValueOnce({
@@ -1321,16 +1339,16 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
-      const chunks1: LanguageModelV3StreamPart[] = [
+      const chunks1: LanguageModelV4StreamPart[] = [
         { type: 'tool-input-start', id: 'tc1', toolName: 'search' },
         { type: 'tool-input-delta', id: 'tc1', delta: '{}' },
         { type: 'tool-input-end', id: 'tc1' },
         { type: 'finish', finishReason: createFinishReason('tool-calls'), usage: createMockUsage({ inputTotal: 150, outputTotal: 80 }) },
       ]
 
-      const chunks2: LanguageModelV3StreamPart[] = [
+      const chunks2: LanguageModelV4StreamPart[] = [
         { type: 'text-start', id: 't1' },
         { type: 'text-delta', id: 't1', delta: 'Done' },
         { type: 'text-end', id: 't1' },
@@ -1369,8 +1387,8 @@ describe('createAILogger', () => {
       const fast = createMockModel({ provider: 'anthropic', modelId: 'claude-haiku-4.5' })
       const smart = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
 
-      const wrappedFast = ai.wrap(fast)
-      const wrappedSmart = ai.wrap(smart)
+      const wrappedFast = wrapMock(ai, fast)
+      const wrappedSmart = wrapMock(ai, smart)
 
       vi.mocked(fast.doGenerate).mockResolvedValue({
         content: [],
@@ -1402,6 +1420,7 @@ describe('createAILogger', () => {
       const middleware = createAIMiddleware(log)
 
       expect(middleware).toBeDefined()
+      expect(middleware.specificationVersion).toBe('v4')
       expect(middleware.wrapGenerate).toBeTypeOf('function')
       expect(middleware.wrapStream).toBeTypeOf('function')
     })
@@ -1412,7 +1431,10 @@ describe('createAILogger', () => {
       const middleware = createAIMiddleware(log, { toolInputs: true })
       const model = createMockModel()
 
-      const wrappedModel = wrapLanguageModel({ model, middleware })
+      const wrappedModel = wrapLanguageModel({
+        model: model as LanguageModelV4,
+        middleware,
+      })
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"q":"test"}' }],
@@ -1427,6 +1449,82 @@ describe('createAILogger', () => {
       expect(aiData.calls).toBe(1)
       expect(aiData.toolCalls).toEqual([{ name: 'search', input: { q: 'test' } }])
       expect(aiData.responseId).toBe('msg_abc')
+    })
+  })
+
+  describe('LanguageModelV4 wrap support (#406)', () => {
+    it('wraps a native V4 model and captures generate usage', async () => {
+      const log = createMockLogger()
+      const ai = createAILogger(log)
+      const model = createMockModel({ specificationVersion: 'v4', modelId: 'claude-sonnet-4.6' })
+      const wrappedModel = wrapMock(ai, model)
+
+      expect(wrappedModel.specificationVersion).toBe('v4')
+
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult({
+        content: [],
+        finishReason: createFinishReason(),
+        usage: createMockUsage({ inputTotal: 120, outputTotal: 40 }),
+        response: { modelId: 'claude-sonnet-4.6' },
+      }))
+
+      await wrappedModel.doGenerate(createMockCallOptions())
+
+      const aiData = getLastAiData(log)
+      expect(aiData.calls).toBe(1)
+      expect(aiData.inputTokens).toBe(120)
+      expect(aiData.outputTokens).toBe(40)
+      expect(aiData.model).toBe('claude-sonnet-4.6')
+    })
+
+    it('still accepts a V3 model and upgrades the wrapped result to V4', async () => {
+      const log = createMockLogger()
+      const ai = createAILogger(log)
+      const model = createMockModel({ specificationVersion: 'v3' })
+      const wrappedModel = wrapMock(ai, model)
+
+      expect(wrappedModel.specificationVersion).toBe('v4')
+
+      vi.mocked(model.doGenerate).mockResolvedValue(asGenerateResult({
+        content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{"q":"v3"}' }],
+        finishReason: createFinishReason('tool-calls'),
+        usage: createMockUsage({ inputTotal: 80, outputTotal: 20 }),
+        response: { modelId: 'claude-sonnet-4.6', id: 'msg_v3' },
+      }))
+
+      await wrappedModel.doGenerate(createMockCallOptions())
+
+      const aiData = getLastAiData(log)
+      expect(aiData.calls).toBe(1)
+      expect(aiData.inputTokens).toBe(80)
+      expect(aiData.responseId).toBe('msg_v3')
+    })
+
+    it('captures V4 stream finish usage and TTFT', async () => {
+      const log = createMockLogger()
+      const ai = createAILogger(log)
+      const model = createMockModel({ specificationVersion: 'v4' })
+      const wrappedModel = wrapMock(ai, model)
+
+      const chunks: LanguageModelV4StreamPart[] = [
+        { type: 'text-start', id: 't1' },
+        { type: 'text-delta', id: 't1', delta: 'hello' },
+        { type: 'text-end', id: 't1' },
+        { type: 'finish', finishReason: createFinishReason(), usage: createMockUsage({ inputTotal: 10, outputTotal: 5 }) },
+      ]
+
+      vi.mocked(model.doStream).mockResolvedValue(asStreamResult({
+        stream: makeReadableStream(chunks),
+      }))
+
+      const { stream } = await wrappedModel.doStream(createMockCallOptions())
+      await consumeStream(stream)
+
+      const aiData = getLastAiData(log)
+      expect(aiData.calls).toBe(1)
+      expect(aiData.inputTokens).toBe(10)
+      expect(aiData.outputTokens).toBe(5)
+      expect(aiData.msToFirstChunk).toBeTypeOf('number')
     })
   })
 
@@ -1497,7 +1595,7 @@ describe('createAILogger', () => {
         },
       })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1521,7 +1619,7 @@ describe('createAILogger', () => {
         },
       })
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1540,7 +1638,7 @@ describe('createAILogger', () => {
       const log = createMockLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [],
@@ -1652,7 +1750,7 @@ describe('createAILogger', () => {
       const ai = createAILogger(log)
       const integration = createEvlogIntegration(ai)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       vi.mocked(model.doGenerate).mockResolvedValue({
         content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'getWeather', input: '{}' }],
@@ -1857,7 +1955,7 @@ describe('createAILogger', () => {
           cost: { 'claude-sonnet-4.6': { input: 3, output: 15 } },
         })
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockResolvedValue({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{}' }],
@@ -1888,7 +1986,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockResolvedValue({
           content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'search', input: '{}' }],
@@ -1912,7 +2010,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate)
           .mockResolvedValueOnce({
@@ -1959,7 +2057,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockRejectedValue(new Error('quota exceeded'))
 
@@ -1976,7 +2074,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
@@ -1995,7 +2093,7 @@ describe('createAILogger', () => {
           cost: { 'claude-sonnet-4.6': { input: 3, output: 15 } },
         })
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
@@ -2014,7 +2112,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log, { cost: { 'gpt-4o': { input: 2.5, output: 10 } } })
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         vi.mocked(model.doGenerate).mockResolvedValue({
           content: [],
@@ -2033,7 +2131,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         const updates: Array<ReturnType<typeof ai.getMetadata>> = []
         ai.onUpdate((metadata) => {
@@ -2081,7 +2179,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         const updates: Array<ReturnType<typeof ai.getMetadata>> = []
         ai.onUpdate(metadata => updates.push(metadata))
@@ -2099,7 +2197,7 @@ describe('createAILogger', () => {
         const ai = createAILogger(log)
         const integration = createEvlogIntegration(ai)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         const updates: Array<ReturnType<typeof ai.getMetadata>> = []
         ai.onUpdate(metadata => updates.push(metadata))
@@ -2131,7 +2229,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         let count = 0
         const off = ai.onUpdate(() => {
@@ -2178,7 +2276,7 @@ describe('createAILogger', () => {
         const log = createMockLogger()
         const ai = createAILogger(log)
         const model = createMockModel()
-        const wrappedModel = ai.wrap(model)
+        const wrappedModel = wrapMock(ai, model)
 
         ai.onUpdate(() => {
           throw new Error('listener crashed')
@@ -2222,7 +2320,7 @@ describe('createAILogger', () => {
       const log = createLogger()
       const ai = createAILogger(log)
       const model = createMockModel()
-      const wrappedModel = ai.wrap(model)
+      const wrappedModel = wrapMock(ai, model)
 
       const tools = ['list-pages', 'get-page', 'get-page', 'get-page', 'get-page', 'get-page']
       const doGenerate = vi.mocked(model.doGenerate)
@@ -2254,8 +2352,8 @@ describe('createAILogger', () => {
 
       const gemini = createMockModel({ provider: 'google', modelId: 'gemini-3-flash' })
       const claude = createMockModel({ provider: 'anthropic', modelId: 'claude-sonnet-4.6' })
-      const wrappedGemini = ai.wrap(gemini)
-      const wrappedClaude = ai.wrap(claude)
+      const wrappedGemini = wrapMock(ai, gemini)
+      const wrappedClaude = wrapMock(ai, claude)
 
       const baseResult = (modelId: string) => ({
         content: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

Closes #406

### 📚 Description

`createAILogger().wrap()` and `createAIMiddleware()` now use V4-native middleware (`specificationVersion: 'v4'`) so AI SDK v7 `LanguageModelV4` models type-check and run through the wrap path.

V3 models remain accepted — `wrapLanguageModel` upgrades them. Public types use `LanguageModel` / `LanguageModelMiddleware` from `ai`.

Adds regression tests for native V4 generate/stream capture and V3→V4 wrap.

Also splits the `wrap()` JSDoc examples so the string and provider-object forms no longer redeclare `const model` in the same scope (CodeRabbit).

### 📝 Checklist

- [x] I have linked an issue or discussion
- [x] I have added tests (if possible)
- [x] I have updated the documentation (if necessary)
- [x] I have followed conventional commits for PR title

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b187d492-9ed7-4045-a984-a4460f2b31fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b187d492-9ed7-4045-a984-a4460f2b31fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AI SDK v7 `LanguageModelV4` models in AI logging and middleware, using v4-native wrapping behavior.
  * Continued support for AI SDK v6 models and gateway model strings, with v3 models automatically upgraded for v4 handling.

* **Documentation**
  * Updated `wrap()` documentation to explicitly support both `LanguageModelV3` and `LanguageModelV4`, including clarified model-object usage.

* **Tests**
  * Migrated AI logging/middleware tests to `LanguageModelV4` and added coverage for native v4 wrapping and v3-to-v4 upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->