### PR TITLE
fix(docs): move Script chip toward end of landing compat

### DIFF
--- a/apps/docs/app/components/features/FeatureFrameworks.vue
+++ b/apps/docs/app/components/features/FeatureFrameworks.vue
@@ -13,7 +13,6 @@ const activeTab = ref(0)
 const frameworkRows = [
   [
     { name: 'Nuxt', icon: 'i-simple-icons-nuxtdotjs', tab: 0 },
-    { name: 'Script', icon: 'i-lucide-terminal', tab: 12 },
     { name: 'Next.js', icon: 'i-simple-icons-nextdotjs', tab: 1 },
     { name: 'SvelteKit', icon: 'i-simple-icons-svelte', tab: 2 },
     { name: 'Nitro', icon: 'i-custom-nitro', tab: 3 },
@@ -28,6 +27,7 @@ const frameworkRows = [
     { name: 'Elysia', icon: 'i-custom-elysia', tab: 10 },
     { name: 'oRPC', icon: 'i-lucide-network', tab: 13 },
     { name: 'Cloudflare', icon: 'i-simple-icons-cloudflare', tab: 11 },
+    { name: 'Script', icon: 'i-lucide-terminal', tab: 12 },
     { name: 'Vite', icon: 'i-custom-vite', link: '/reference/vite-plugin' },
   ],
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On the docs landing page, the Script chip sat between Nuxt and Next.js in the framework compat section. Moved it near the end of the second row (after Cloudflare, before Vite) so frameworks stay grouped and standalone/scripts sits at the end.

No changeset — docs UI only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f602b-590a-7bd5-bb63-5d37aa2fa493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f602b-590a-7bd5-bb63-5d37aa2fa493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered the “Script” framework icon within the frameworks grid for improved visual grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->