### PR TITLE
feat: add `@evlog/telemetry` package

### DIFF
--- a/.changeset/telemetry-package.md
+++ b/.changeset/telemetry-package.md
@@ -1,0 +1,5 @@
+---
+"@evlog/telemetry": minor
+---
+
+Initial release of `@evlog/telemetry` — evlog's wide-event model for CLIs and automation. One structured event per command via citty `withTelemetry` or `createTelemetry()`, privacy-safe flag capture, disk-buffered outbox, auto-generated disclosure, and GitHub Actions helper. Opt-out via `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or persisted preference.

--- a/.changeset/telemetry-package.md
+++ b/.changeset/telemetry-package.md
@@ -2,4 +2,6 @@
 "@evlog/telemetry": minor
 ---
 
+# @evlog/telemetry
+
 Initial release of `@evlog/telemetry` — evlog's wide-event model for CLIs and automation. One structured event per command via citty `withTelemetry` or `createTelemetry()`, privacy-safe flag capture, disk-buffered outbox, auto-generated disclosure, GitHub Actions helper, and `@evlog/telemetry/ingest` with `parseIngestBody()` for server endpoints. Opt-out via `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or persisted preference.

--- a/.changeset/telemetry-package.md
+++ b/.changeset/telemetry-package.md
@@ -2,4 +2,4 @@
 "@evlog/telemetry": minor
 ---
 
-Initial release of `@evlog/telemetry` — evlog's wide-event model for CLIs and automation. One structured event per command via citty `withTelemetry` or `createTelemetry()`, privacy-safe flag capture, disk-buffered outbox, auto-generated disclosure, and GitHub Actions helper. Opt-out via `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or persisted preference.
+Initial release of `@evlog/telemetry` — evlog's wide-event model for CLIs and automation. One structured event per command via citty `withTelemetry` or `createTelemetry()`, privacy-safe flag capture, disk-buffered outbox, auto-generated disclosure, GitHub Actions helper, and `@evlog/telemetry/ingest` with `parseIngestBody()` for server endpoints. Opt-out via `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or persisted preference.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,6 +55,7 @@ scope.
 - stream (in-process stream + stream server)
 - sveltekit (SvelteKit integration)
 - tanstack-start (TanStack Start integration)
+- telemetry (`@evlog/telemetry` package)
 - vite (Vite plugin)
 - workers (Cloudflare Workers adapter)
 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,4 @@ jobs:
       - name: Build package
         run: pnpm run build:package
       - name: Publish
-        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub'
+        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub' './packages/telemetry'

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -54,6 +54,7 @@ jobs:
             stream
             sveltekit
             tanstack-start
+            telemetry
             vite
             workers
           types: |

--- a/apps/docs/content/4.use-cases/0.overview.md
+++ b/apps/docs/content/4.use-cases/0.overview.md
@@ -22,7 +22,7 @@ links:
     variant: subtle
   - label: Tool Telemetry
     icon: i-lucide-gauge
-    to: /use-cases/telemetry/overview
+    to: /use-cases/telemetry
     color: neutral
     variant: subtle
 ---
@@ -35,7 +35,7 @@ Use Cases are **recipes**, not features. Each one solves a specific problem with
 | Capture every AI SDK call with token usage, tool calls, streaming metrics, and cost | [AI SDK](/use-cases/ai-sdk/overview) |
 | Identify the authenticated user (and their org / role) on every wide event | [Better Auth](/use-cases/better-auth/overview) |
 | Build a tamper-evident audit trail with hash chains, denials, redaction-aware diffs | [Audit Logs](/use-cases/audit/overview) |
-| Instrument CLIs and automation with one wide event per run, consent, and disclosure | [Tool Telemetry](/use-cases/telemetry/overview) |
+| Instrument CLIs and automation with one wide event per run, consent, and disclosure | [Tool Telemetry](/use-cases/telemetry) |
 | Export wide events from [eve](https://eve.dev) agent turns (tokens, tools, drains) | [eve](/use-cases/eve) |
 | Add derived context (User-Agent, geo, request size, trace context) to every event | [Enrichers](/use-cases/enrichers) |
 

--- a/apps/docs/content/4.use-cases/0.overview.md
+++ b/apps/docs/content/4.use-cases/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: Recipes that solve a specific problem with evlog — capture browser logs, observe AI SDK calls, identify users from Better Auth, build a tamper-evident audit trail, enrich every event with derived context.
+description: Recipes that solve a specific problem with evlog — capture browser logs, observe AI SDK calls, identify users from Better Auth, build a tamper-evident audit trail, instrument tool telemetry, enrich every event with derived context.
 navigation:
   title: Overview
   icon: i-lucide-list-checks
@@ -20,6 +20,11 @@ links:
     to: /use-cases/audit/overview
     color: neutral
     variant: subtle
+  - label: Tool Telemetry
+    icon: i-lucide-gauge
+    to: /use-cases/telemetry/overview
+    color: neutral
+    variant: subtle
 ---
 
 Use Cases are **recipes**, not features. Each one solves a specific problem with the same evlog primitives you already know — wide events, structured errors, drains, enrichers. They live as their own section because they have enough surface area (multiple pages each, dedicated examples) to deserve direct navigation, but they're not a separate runtime — same logger, same drain pipeline, same types.
@@ -30,6 +35,7 @@ Use Cases are **recipes**, not features. Each one solves a specific problem with
 | Capture every AI SDK call with token usage, tool calls, streaming metrics, and cost | [AI SDK](/use-cases/ai-sdk/overview) |
 | Identify the authenticated user (and their org / role) on every wide event | [Better Auth](/use-cases/better-auth/overview) |
 | Build a tamper-evident audit trail with hash chains, denials, redaction-aware diffs | [Audit Logs](/use-cases/audit/overview) |
+| Instrument CLIs and automation with one wide event per run, consent, and disclosure | [Tool Telemetry](/use-cases/telemetry/overview) |
 | Export wide events from [eve](https://eve.dev) agent turns (tokens, tools, drains) | [eve](/use-cases/eve) |
 | Add derived context (User-Agent, geo, request size, trace context) to every event | [Enrichers](/use-cases/enrichers) |
 

--- a/apps/docs/content/4.use-cases/6.telemetry.md
+++ b/apps/docs/content/4.use-cases/6.telemetry.md
@@ -20,6 +20,242 @@ pnpm add @evlog/telemetry
 
 You get command name, sanitized flags, duration, and outcome automatically. Call `telemetry.set()` only when you have extra counters — numbers and booleans by default. Raw `argv` is never read; disclosure is generated from your runtime config so it cannot drift from what you actually collect.
 
+::prompt
+---
+description: Add anonymous telemetry to my CLI or script
+icon: i-lucide-gauge
+actions:
+  - copy
+  - cursor
+  - windsurf
+---
+
+Add privacy-respecting telemetry to my CLI, script, or GitHub Action with @evlog/telemetry.
+
+- Detect my entrypoint: citty CLI (`withTelemetry`), standalone script (`createTelemetry`), or GitHub Actions (`createGitHubActionsTelemetry`)
+- Install: `pnpm add @evlog/telemetry`
+- Citty: wrap the root command in `withTelemetry()` in `src/index.ts` and add `defineTelemetryCommands({ name: TOOL })`
+- Script / migrator: `createTelemetry({ name, version })` and wrap each logical unit with `t.run('command', fn)`
+- GitHub Actions: `createGitHubActionsTelemetry()` — only `GITHUB_ACTION` / `GITHUB_EVENT_NAME` are injected into `custom`
+- Declare `collect.flags` / `collect.fields` for any string values you need beyond presence-only capture
+- Call `telemetry.set()` for business counters (numbers/booleans) inside handlers or helpers on the same async stack
+- Run `generateDisclosure()` and commit `TELEMETRY.md` beside the tool
+- Bake an ingestion URL in `endpoint` (or `EVLOG_TELEMETRY_ENDPOINT`) — the local outbox is a buffer, not the destination
+- Ship `POST /api/telemetry/ingest` on my app: use `parseIngestBody()` from `@evlog/telemetry/ingest` with `allowedTools` + `allowedCustomKeys`, dedupe on `idempotencyKey`, return 204 on success
+
+Docs: https://www.evlog.dev/use-cases/telemetry
+
+::
+
+## From CLI to your backend
+
+The disk outbox (`~/.config/{toolName}/telemetry/outbox.ndjson`) is a **reliability buffer**, not where telemetry lives long-term. Each run appends one event locally, then the HTTP drain POSTs the backlog to **your** ingestion endpoint. Short-lived CI jobs and offline machines drain on the next invocation.
+
+```text
+my-tool doctor
+     │
+     ▼
+┌─────────────────────────────────────────┐
+│  @evlog/telemetry (on the user's machine) │
+│  sanitize flags · consent · one RunEvent   │
+└─────────────────────────────────────────┘
+     │ append (always)
+     ▼
+  outbox.ndjson          POST { events: RunEvent[] }
+     │ flush ───────────────────────────────►  your /api/telemetry/ingest
+     │                                              │
+     │                                              ▼
+     │                                    validate · allowlist · dedupe
+     │                                              │
+     │                                              ▼
+     │                                    DB · warehouse · evlog drain
+     ▼
+  remove delivered keys on 2xx
+```
+
+Nothing is sent until you configure an endpoint and the server returns a success status. Until then, events stay in the outbox (or are purged on opt-out).
+
+## Configure delivery
+
+Point the CLI at your ingestion URL when you ship it — baked into the binary, overridable per environment:
+
+```ts [src/index.ts]
+withTelemetry(command, {
+  name: TOOL,
+  version: VERSION,
+  endpoint: 'https://telemetry.my-tool.dev/api/telemetry/ingest',
+})
+```
+
+| Override | Effect |
+| --- | --- |
+| `EVLOG_TELEMETRY_ENDPOINT` | Replaces the baked-in URL (staging, self-hosted) |
+| `EVLOG_TELEMETRY=0` / `DO_NOT_TRACK=1` | No recording, no send |
+| `EVLOG_TELEMETRY_DEBUG=1` | Print payloads to stderr without sending |
+
+The built-in HTTP drain POSTs `Content-Type: application/json` with body `{ events: RunEvent[] }` and a 400ms timeout. On success (`res.ok`), delivered keys are removed from the outbox. `flush()` is capped at 500ms and never throws.
+
+## Build an ingestion endpoint
+
+You ship a CLI. Users run it on their machines. You want to know *which commands run, how often they fail, and which versions are out there* — without building a separate analytics SDK or reading raw `argv`.
+
+That means a **server endpoint** your CLI POSTs to. The local outbox is only there so short CI jobs and offline runs do not lose data before the POST succeeds.
+
+### The security question (read this first)
+
+::tip
+**CLI telemetry is not a vault.** You are collecting anonymous usage counters (command name, duration, outcome, a few numbers) — not passwords, not file paths, not tokens. Design for that threat model and you do not need impossible client-side secrets.
+::
+
+**"I put the ingest URL in my CLI — isn't that a secret?"**
+
+No. The URL lives in your npm package or binary. Anyone can read it with `strings`, by installing the package, or by watching network traffic. The same applies to an API key or `Authorization` header baked into the CLI — extractable, not a real barrier.
+
+**"So can't anyone send fake events?"**
+
+In theory, yes — someone could `curl` your endpoint with forged JSON. That is why you treat the endpoint as **semi-public** (like a browser analytics key) and defend on the server:
+
+| What you might worry about | Practical answer |
+| --- | --- |
+| Random internet bots | Validate the payload shape; reject garbage with `400` |
+| Someone spamming fake `doctor` runs | Rate-limit by IP; data is low-value counters, not money |
+| Forged `tool.name` | Allowlist only your published tool names server-side |
+| Unexpected fields in `custom` | Filter to the keys you declared — same list as `collect` on the CLI |
+| Double-counting on retry | Dedupe on `idempotencyKey` when storing |
+| Leaking user secrets | CLI never reads raw `argv`; you only allowlisted flags and `telemetry.set()` counters |
+
+**What "good enough" looks like:** validate every POST, store idempotently, rate-limit at the edge (CDN, API gateway, or middleware), and keep the payload boring (no PII by design). That is the same playbook as client-side analytics — not banking-grade auth, but reliable product insight.
+
+::callout{icon="i-lucide-shield-check" color="info"}
+`@evlog/telemetry` ships **`parseIngestBody()`** for your server — the same validation rules documented here, so you do not copy-paste a validator from the docs. Pair it with your framework route and your database or evlog drain.
+::
+
+### Step 1 — Validate with `parseIngestBody()`
+
+Mirror the CLI config on the server: same `name`, same custom keys you allow via `collect` / `telemetry.set()`.
+
+```ts [lib/telemetry-ingest.ts]
+import { parseIngestBody } from '@evlog/telemetry/ingest'
+
+export const ingestOptions = {
+  allowedTools: ['my-tool'],
+  allowedCustomKeys: {
+    'my-tool': ['checksFailed', 'checksWarn', 'itemsSynced'],
+  },
+} as const
+
+export function parseTelemetryBody(raw: string) {
+  return parseIngestBody(raw, ingestOptions)
+}
+```
+
+`parseIngestBody()` checks batch size, JSON shape, `event: 'run'`, tool allowlist, envelope types, ISO timestamp, and strips `custom` keys you did not declare. Throws `IngestValidationError` on failure — return `400` from your route.
+
+### Step 2 — Wire your route
+
+Same contract for any framework — read the raw body, validate, store, return **204** so the CLI clears its outbox:
+
+::code-group
+```ts [server/api/telemetry/ingest.post.ts (Nitro)]
+import { defineEventHandler, readRawBody, setResponseStatus } from 'h3'
+import { IngestValidationError } from '@evlog/telemetry/ingest'
+import { parseTelemetryBody } from '~/lib/telemetry-ingest'
+import { storeRunEvents } from '~/lib/telemetry-store'
+
+export default defineEventHandler(async (event) => {
+  const raw = await readRawBody(event, 'utf8')
+  if (!raw) {
+    setResponseStatus(event, 400)
+    return { error: 'empty body' }
+  }
+
+  try {
+    const events = parseTelemetryBody(raw)
+    await storeRunEvents(events)
+    setResponseStatus(event, 204)
+    return null
+  } catch (err) {
+    setResponseStatus(event, err instanceof IngestValidationError ? 400 : 500)
+    return { error: 'invalid payload' }
+  }
+})
+```
+```ts [app/api/telemetry/ingest/route.ts (Next.js App Router)]
+import { IngestValidationError } from '@evlog/telemetry/ingest'
+import { parseTelemetryBody } from '@/lib/telemetry-ingest'
+import { storeRunEvents } from '@/lib/telemetry-store'
+
+export async function POST(request: Request) {
+  const raw = await request.text()
+  try {
+    const events = parseTelemetryBody(raw)
+    await storeRunEvents(events)
+    return new Response(null, { status: 204 })
+  } catch (err) {
+    const status = err instanceof IngestValidationError ? 400 : 500
+    return Response.json({ error: 'invalid payload' }, { status })
+  }
+}
+```
+```ts [src/routes/telemetry.ts (Hono)]
+import { Hono } from 'hono'
+import { IngestValidationError } from '@evlog/telemetry/ingest'
+import { parseTelemetryBody } from '../lib/telemetry-ingest'
+import { storeRunEvents } from '../lib/telemetry-store'
+
+const app = new Hono()
+
+app.post('/api/telemetry/ingest', async (c) => {
+  const raw = await c.req.text()
+  try {
+    const events = parseTelemetryBody(raw)
+    await storeRunEvents(events)
+    return c.body(null, 204)
+  } catch (err) {
+    const status = err instanceof IngestValidationError ? 400 : 500
+    return c.json({ error: 'invalid payload' }, status)
+  }
+})
+
+export default app
+```
+::
+
+### Step 3 — Store idempotently
+
+Retries and backlog drains can POST the same `idempotencyKey` twice. Upsert (or skip) so metrics stay correct:
+
+```ts [lib/telemetry-store.ts]
+import type { RunEvent } from '@evlog/telemetry'
+
+export async function storeRunEvents(events: RunEvent[]): Promise<void> {
+  for (const run of events) {
+    await db.telemetryRun.upsert({
+      where: { idempotencyKey: run.idempotencyKey },
+      create: {
+        tool: run.tool.name,
+        version: run.tool.version,
+        command: run.command,
+        outcome: run.outcome,
+        durationMs: run.durationMs,
+        custom: run.custom,
+        recordedAt: run.timestamp,
+      },
+      update: {},
+    })
+  }
+
+  // Or forward into evlog's drain pipeline for Axiom / Datadog / OTLP:
+  // await ingestWideEvents(events.map(run => ({ source: 'telemetry', ...run })))
+}
+```
+
+### Step 4 — Rate-limit at the edge
+
+`parseIngestBody()` is your last line of schema defense, not your only one. Add rate limits where traffic enters — CDN, API gateway, or middleware — especially per IP. Optional: also bucket by `machineId` hash inside the handler if you need tighter control.
+
+Non-2xx responses keep events in the user's outbox; they will retry on the next CLI invocation. Return **204** (or any `2xx`) only when storage succeeded.
+
 ## Setup with citty
 
 Wrap your root command in `withTelemetry()` — typically in `src/index.ts`, the file that calls `runMain()`. Subcommands can live in the same file or in `src/commands/*.ts`; only the entrypoint needs the wrapper.
@@ -45,7 +281,7 @@ export const main = withTelemetry(
   {
     name: TOOL,
     version: VERSION,
-    // endpoint optional — omit for outbox-only until you ship ingestion
+    endpoint: 'https://telemetry.my-tool.dev/api/telemetry/ingest',
     collect: {
       flags: { format: ['json', 'csv'] },
       fields: { framework: ['nuxt', 'next'] },
@@ -232,9 +468,9 @@ Users can also read it at runtime via `my-tool telemetry status` when you wire `
 
 **Never harms the host:** telemetry never throws, never blocks exit; `flush()` has a 500ms hard cap.
 
-**Outbox:** events append to `~/.config/{toolName}/telemetry/outbox.ndjson` before any network send. Short-lived runs and offline machines drain the backlog on the next invocation.
+**Outbox:** events append locally before any network attempt. Offline machines and CI matrix jobs drain the backlog on the next invocation once your ingestion endpoint returns `2xx`.
 
-**Endpoint:** `EVLOG_TELEMETRY_ENDPOINT` env → `endpoint` option → outbox-only (default until you ship ingestion).
+**Endpoint:** `EVLOG_TELEMETRY_ENDPOINT` env → `endpoint` option baked into the CLI. Omit both during local development; ship the URL when your ingest handler is live.
 
 ## Debug
 
@@ -245,6 +481,58 @@ EVLOG_TELEMETRY=0 my-tool sync
 
 Debug mode prints would-be payloads to stderr. Nothing is sent unless an endpoint is configured and delivery succeeds.
 
+## Why install it
+
+You can wire anonymous usage telemetry yourself — outbox file, consent flags, flag sanitization, disclosure markdown, ingest validation, first-run notice. Or you add one dependency and get the evlog playbook baked in.
+
+### What you get for ~28 KB
+
+| | |
+| --- | --- |
+| **Published size** | ~28 KB ESM (`@evlog/telemetry`), ~8.6 KB gzip — standalone, no dependency on `evlog` core |
+| **Server ingest only** | `@evlog/telemetry/ingest` ~5 KB (~1.7 KB gzip) — `parseIngestBody()` without pulling citty wiring into your API |
+| **Runtime deps** | `citty` + `std-env` only — both `sideEffects: false`, tree-shakeable ESM |
+| **Node** | 18+ · ESM · `sideEffects: false` on the package |
+
+### Fits wherever your code runs
+
+| Surface | Entry | Lines of integration |
+| --- | --- | --- |
+| **citty CLI** | `withTelemetry()` on the root command | One wrapper + optional `defineTelemetryCommands()` |
+| **Script / migrator** | `createTelemetry()` + `t.run()` | Wrap each logical run |
+| **GitHub Actions** | `createGitHubActionsTelemetry()` | Same as script; `ghaAction` / `ghaEvent` auto-injected |
+| **Your API (ingest)** | `parseIngestBody()` from `@evlog/telemetry/ingest` | One validator + one POST route |
+
+No framework lock-in. No PostHog / Segment / custom analytics SDK. No second schema to maintain — disclosure is generated from the same `collect` config the CLI uses at runtime.
+
+### What you skip building
+
+- Privacy-safe flag capture (never reads raw `argv`)
+- `DO_NOT_TRACK` / `EVLOG_TELEMETRY` / persisted opt-out with outbox purge
+- Disk outbox with lockfile, stale-lock recovery, and backlog drain
+- Auto-generated disclosure (`TELEMETRY.md` + `telemetry status`)
+- First-run notice with opt-out instructions
+- Typed `telemetry.set()` with allowlisted string fields
+- Server-side ingest validation aligned with the CLI envelope
+- Hard guarantee: **telemetry never throws, never blocks exit**
+
+### The payoff
+
+Once ingest is live you can answer product questions that CLI authors usually guess at:
+
+- Which commands are actually used (`doctor` vs `sync` vs `telemetry status`)
+- Where runs fail (`outcome`, `errorCode`, version breakdown)
+- How long operations take (`durationMs` per command)
+- Which versions are still in the wild (`tool.version` on every event)
+- Whether CI or local dev dominates (`env.ci`, `env.agent`, `env.tty`)
+
+All from one wide event per run — the same mental model as evlog on the server, without bolting a browser analytics stack onto a terminal tool.
+
+::callout{icon="i-lucide-package" color="neutral"}
+Try it locally: [`examples/telemetry-playground`](https://github.com/HugoRCD/evlog/tree/main/examples/telemetry-playground) — `pnpm run cli -- doctor`, `EVLOG_TELEMETRY_DEBUG=1` to inspect payloads, `telemetry status` for disclosure.
+::
+
 ## See also
 
 - [Audit](/use-cases/audit/overview) — wide events for security-sensitive actions
+- [Drain pipeline](/extend/drain-pipeline) — forward ingested events into Axiom, Datadog, OTLP, or a custom store

--- a/apps/docs/content/4.use-cases/6.telemetry.md
+++ b/apps/docs/content/4.use-cases/6.telemetry.md
@@ -26,7 +26,9 @@ Wrap your root command in `withTelemetry()` — typically in `src/index.ts`, the
 
 ```ts [src/index.ts]
 import { defineCommand, runMain } from 'citty'
-import { withTelemetry, defineTelemetryCommands, telemetry } from '@evlog/telemetry'
+import { withTelemetry, defineTelemetryCommands } from '@evlog/telemetry'
+import { doctorCommand } from './commands/doctor'
+import { syncCommand } from './commands/sync'
 
 const TOOL = 'my-tool'
 const VERSION = '1.0.0'
@@ -35,28 +37,8 @@ export const main = withTelemetry(
   defineCommand({
     meta: { name: 'my-tool', description: '…', version: VERSION },
     subCommands: {
-      doctor: {
-        meta: { name: 'doctor', description: 'Check environment' },
-        args: {
-          json: { type: 'boolean', alias: 'j' },
-        },
-        async run({ args }) {
-          const checksFailed = 0 // your logic…
-          telemetry.set({ checksFailed })
-          if (!args.json) process.stdout.write('ok\n')
-        },
-      },
-      sync: {
-        meta: { name: 'sync', description: 'Pull remote state' },
-        args: {
-          dryRun: { type: 'boolean' },
-          output: { type: 'string', description: 'Output path' },
-        },
-        async run({ args }) {
-          telemetry.set({ itemsSynced: 42 })
-          // …
-        },
-      },
+      doctor: doctorCommand,
+      sync: syncCommand,
       telemetry: defineTelemetryCommands({ name: TOOL }),
     },
   }),
@@ -90,35 +72,101 @@ The root `meta.name` is not prefixed when the root only delegates to `subCommand
 
 ### Enriching a run
 
-Call `telemetry.set()` anywhere inside a command handler (or any code that runs within that handler's async stack):
+Call `telemetry.set()` anywhere inside a command handler — or in helpers that run on the same async stack (the run context is preserved via AsyncLocalStorage).
 
-```ts
-telemetry.set({ checksFailed: 2, cacheHit: true })
+```ts [src/commands/doctor.ts]
+import { telemetry } from '@evlog/telemetry'
+import { existsSync } from 'node:fs'
+import { resolveConfigPath } from '../lib/config'
+
+async function runHealthChecks() {
+  let checksFailed = 0
+  let checksWarn = 0
+
+  const configPath = resolveConfigPath()
+  if (!existsSync(configPath)) {
+    checksFailed++
+  }
+
+  try {
+    await fetch('https://registry.npmjs.org/my-tool')
+  } catch {
+    checksWarn++
+  }
+
+  // Counters land in event.custom on the wide event for this run
+  telemetry.set({ checksFailed, checksWarn })
+  return checksFailed === 0
+}
+
+export const doctorCommand = {
+  meta: { name: 'doctor', description: 'Check environment' },
+  args: {
+    json: { type: 'boolean', alias: 'j' },
+  },
+  async run({ args }: { args: { json?: boolean } }) {
+    const ok = await runHealthChecks()
+    if (!ok) {
+      throw Object.assign(new Error('Health checks failed'), { code: 'DOCTOR_FAILED' })
+    }
+    if (!args.json) process.stdout.write('ok\n')
+  },
+}
 ```
 
 Throw an error with a `code` property and `outcome: "error"` plus `errorCode` are recorded automatically:
 
-```ts
+```ts [src/commands/doctor.ts]
 throw Object.assign(new Error('Config missing'), { code: 'CONFIG_NOT_FOUND' })
+```
+
+A minimal sync handler for comparison — flags are auto-captured, you only `set()` business counters:
+
+```ts [src/commands/sync.ts]
+import { telemetry } from '@evlog/telemetry'
+
+export const syncCommand = {
+  meta: { name: 'sync', description: 'Pull remote state' },
+  args: {
+    dryRun: { type: 'boolean' },
+    output: { type: 'string', description: 'Output path' },
+  },
+  async run() {
+    const itemsSynced = await pullRemoteState()
+    telemetry.set({ itemsSynced })
+  },
+}
 ```
 
 ## Setup without citty
 
 For scripts, migrators, or custom CLIs, use `createTelemetry()` and wrap each logical run with `t.run()`:
 
-```ts
+```ts [scripts/migrate.ts]
 import { createTelemetry, telemetry } from '@evlog/telemetry'
 
 const t = createTelemetry({ name: 'my-migrator', version: '2.0.0' })
 
 await t.run('migrate', async () => {
-  telemetry.set({ rowsMigrated: 120 })
+  const rows = await migrateBatch()
+  telemetry.set({ rowsMigrated: rows.length, batchSize: 500 })
 })
 
 await t.flush() // optional — also runs at end of each t.run()
 ```
 
-GitHub Actions: swap `createTelemetry` for `createGitHubActionsTelemetry()` — it adds `ghaAction` and `ghaEvent` to `custom` from `GITHUB_ACTION` / `GITHUB_EVENT_NAME` only (never repo content).
+GitHub Actions: swap `createTelemetry` for `createGitHubActionsTelemetry()` in the same file — it adds `ghaAction` and `ghaEvent` to `custom` from `GITHUB_ACTION` / `GITHUB_EVENT_NAME` only (never repo content).
+
+```ts [scripts/ci-report.ts]
+import { createGitHubActionsTelemetry, telemetry } from '@evlog/telemetry'
+
+const t = createGitHubActionsTelemetry({ name: 'my-action', version: '1.0.0' })
+
+await t.run('report', async () => {
+  const artifacts = await collectArtifacts()
+  telemetry.set({ artifactCount: artifacts.length })
+})
+```
 
 ## Standard envelope
 
@@ -152,7 +200,7 @@ Raw `argv` is never read. Sanitization applies to **citty-parsed** flags only:
 - **Strings** → presence only (`output: true`) unless allowlisted in `collect.flags`
 - **`telemetry.set()`** → numbers and booleans always; strings only via `collect.fields` (undeclared values are dropped at runtime, never thrown)
 
-```ts
+```ts [src/index.ts]
 collect: {
   flags: { format: ['json', 'csv'] },           // --format json → "json"; --format yaml → true
   fields: { framework: ['nuxt', 'next'] },      // telemetry.set({ framework: 'nuxt' }) ok
@@ -165,12 +213,15 @@ Declare allowlists in the same `withTelemetry()` / `createTelemetry()` call as `
 
 `generateDisclosure()` produces markdown + JSON from the standard envelope plus your `collect` extensions. Commit the output (e.g. `TELEMETRY.md`) so it stays in sync with releases:
 
-```ts
+```ts [scripts/generate-disclosure.ts]
+import { writeFile } from 'node:fs/promises'
 import { generateDisclosure } from '@evlog/telemetry'
 
 const { markdown } = generateDisclosure('my-tool', {
   flags: { format: ['json', 'csv'] },
 })
+
+await writeFile('TELEMETRY.md', markdown)
 ```
 
 Users can also read it at runtime via `my-tool telemetry status` when you wire `defineTelemetryCommands()`.

--- a/apps/docs/content/4.use-cases/6.telemetry.md
+++ b/apps/docs/content/4.use-cases/6.telemetry.md
@@ -38,6 +38,7 @@ Add privacy-respecting telemetry to my CLI, script, or GitHub Action with @evlog
 - Script / migrator: `createTelemetry({ name, version })` and wrap each logical unit with `t.run('command', fn)`
 - GitHub Actions: `createGitHubActionsTelemetry()` — only `GITHUB_ACTION` / `GITHUB_EVENT_NAME` are injected into `custom`
 - Declare `collect.flags` / `collect.fields` for any string values you need beyond presence-only capture
+- Put your product schema in `custom` via `telemetry.set()` — see "Extending the schema" on the docs page
 - Call `telemetry.set()` for business counters (numbers/booleans) inside handlers or helpers on the same async stack
 - Run `generateDisclosure()` and commit `TELEMETRY.md` beside the tool
 - Bake an ingestion URL in `endpoint` (or `EVLOG_TELEMETRY_ENDPOINT`) — the local outbox is a buffer, not the destination
@@ -427,6 +428,187 @@ Every run shares the same shape. You do not declare per-command schemas.
   "custom": { "itemsSynced": 42 }
 }
 ```
+
+## Extending the schema
+
+The envelope above is **fixed** — every tool sends the same top-level shape so `parseIngestBody()` and disclosure stay predictable. You do not add fields next to `command` or `durationMs`.
+
+Your product schema lives in two extension zones:
+
+| Zone | Who sets it | What goes there |
+| --- | --- | --- |
+| `flags` | citty (auto) + `collect.flags` | CLI switches — booleans/numbers as values, strings only when allowlisted |
+| `custom` | you via `telemetry.set()` + `collect.fields` | Business counters, categorical dimensions, schema version |
+
+Think of it as two contracts:
+
+- **Transport contract** (`RunEvent`) — owned by `@evlog/telemetry`, stable across tools
+- **Product contract** (`custom` + declared `flags`) — owned by you, declared in `collect`, mirrored on the server
+
+### Declare your extensions once
+
+Everything you collect beyond the standard envelope is declared inline in the same `withTelemetry()` / `createTelemetry()` call:
+
+```ts [src/index.ts]
+withTelemetry(command, {
+  name: 'acme-cli',
+  version: '2.1.0',
+  endpoint: 'https://telemetry.acme.dev/api/ingest',
+  collect: {
+    flags: {
+      format: ['json', 'yaml', 'table'],
+      target: ['staging', 'production'],
+    },
+    fields: {
+      product: ['cli', 'action', 'migrator'],
+      plan: ['free', 'pro', 'enterprise'],
+      framework: ['nuxt', 'next', 'remix'],
+    },
+  },
+})
+```
+
+Inside handlers, add counters and dimensions:
+
+```ts [src/commands/deploy.ts]
+await t.run('deploy', async () => {
+  const result = await deployServices()
+  telemetry.set({
+    servicesDeployed: result.count,   // number — always allowed
+    rollbackUsed: false,              // boolean — always allowed
+    framework: 'nuxt',                // string — allowed (in collect.fields)
+    schemaVersion: 2,                 // number — version your custom shape
+  })
+})
+```
+
+Undeclared strings are **dropped at runtime**, never thrown. That is the privacy guarantee — no accidental paths, tokens, or free-form PII in `custom`.
+
+::note
+**Typing:** `TelemetryHandle.set()` autocomplete covers declared `collect.fields` keys. Use the ambient `telemetry.set()` for extra numeric/boolean counters in the same run — both merge into `custom` before the event is recorded.
+::
+
+### Mirror on the server
+
+Your ingest handler is the second gate. Pass the same tool name and custom keys you declared on the CLI:
+
+```ts [app/api/telemetry/ingest/route.ts]
+import { parseIngestBody } from '@evlog/telemetry/ingest'
+
+const ALLOWED_CUSTOM = [
+  'servicesDeployed', 'rollbackUsed', 'framework',
+  'product', 'plan', 'schemaVersion',
+  'ghaAction', 'ghaEvent',
+] as const
+
+export async function POST(req: Request) {
+  const raw = await req.text()
+  const events = parseIngestBody(raw, {
+    allowedTools: ['acme-cli'],
+    allowedCustomKeys: { 'acme-cli': ALLOWED_CUSTOM },
+  })
+  // dedupe on idempotencyKey, then persist
+}
+```
+
+`parseIngestBody()` strips any `custom` key you did not list — even if a client somehow sent it.
+
+### Map to your warehouse schema
+
+After validation, shape the event for **your** database. The evlog envelope is the wire format; your tables are your choice:
+
+```ts [lib/telemetry-store.ts]
+function toRow(event: RunEvent) {
+  return {
+    command: event.command,
+    duration_ms: event.durationMs,
+    outcome: event.outcome,
+    tool_version: event.tool.version,
+    format: event.flags.format,
+    target: event.flags.target,
+    services_deployed: event.custom.servicesDeployed,
+    framework: event.custom.framework,
+    plan: event.custom.plan,
+    schema_version: event.custom.schemaVersion ?? 1,
+    is_ci: event.env.ci,
+    node: event.env.node,
+    received_at: new Date(),
+  }
+}
+```
+
+This is where a company "modifies the schema" in practice — not by changing `RunEvent`, but by defining how `custom` maps into internal analytics tables.
+
+### Version breaking changes in `custom`
+
+When your product counters evolve, bump a numeric `schemaVersion` in `custom` (no allowlist needed) and branch in the ingest mapper:
+
+```ts
+const version = (event.custom.schemaVersion as number | undefined) ?? 1
+if (version === 1) return mapV1(event)
+return mapV2(event)
+```
+
+Commit an updated `TELEMETRY.md` whenever `collect` changes so disclosure stays aligned with releases.
+
+### Multiple tools, one endpoint
+
+If several CLIs POST to the same ingest URL, namespace custom keys or rely on `tool.name`:
+
+```ts
+// Option A — prefix keys per product line
+telemetry.set({ acme_product: 'cli', deployCount: 3 })
+
+// Option B — separate allowedCustomKeys per tool.name in parseIngestBody
+allowedCustomKeys: {
+  'acme-cli': ['deployCount', 'framework'],
+  'acme-action': ['jobDuration', 'ghaAction', 'ghaEvent'],
+}
+```
+
+### What v1 does not support
+
+| Need | v1 answer | Workaround |
+| --- | --- | --- |
+| New top-level field (`tenantId`) | Not on the wire | Flat key in `custom` + allowlist, or map server-side from `machineId` |
+| Nested objects (`custom.user.plan`) | Flat records only | Flatten: `userPlan: 'pro'` with `collect.fields` |
+| Free-form strings (paths, emails) | Blocked by design | Presence-only on flags (`output: true`) or hash before `telemetry.set()` |
+| Different schema per command | One envelope per run | Convention: only set relevant keys per command |
+| Transform before outbox | No hook yet | Map on the server (recommended) or see planned v2 below |
+
+::tip
+**Rule of thumb:** if it is safe to print in `TELEMETRY.md` and fits a closed set or a number, it belongs in `collect` + `custom`. Everything else stays server-side.
+::
+
+### Planned v2 extensions
+
+Not shipped yet — design targets for when the v1 extension zones are not enough:
+
+**`enrich` hook** — run after sanitization, before the outbox append. Lets you inject computed fields without forking the package:
+
+```ts
+// Planned API — not available in v1
+createTelemetry({
+  name: 'acme-cli',
+  version: '3.0.0',
+  collect: { fields: { product: ['cli', 'action'] } },
+  enrich(event) {
+    return {
+      ...event,
+      custom: {
+        ...event.custom,
+        schemaVersion: 2,
+      },
+    }
+  },
+})
+```
+
+The hook cannot bypass sanitization rules — strings still require `collect.fields`. Server-side `allowedCustomKeys` stays the source of truth.
+
+**Namespaced keys** — optional `acme.product` convention for multi-tool endpoints without prefix collisions. Would be documented in disclosure as `acme.product: cli | action`.
+
+If you need one of these before v2 lands, open a discussion on the repo — the v1 path (`custom` + server mapping) covers most product analytics needs.
 
 ## Privacy
 

--- a/apps/docs/content/4.use-cases/6.telemetry/01.overview.md
+++ b/apps/docs/content/4.use-cases/6.telemetry/01.overview.md
@@ -1,0 +1,199 @@
+---
+title: Tool telemetry
+description: Wide-event telemetry for CLIs and automation — evlog's one-event-per-run model for tools on user machines, with privacy-safe flags, consent, outbox, and auto-generated disclosure.
+navigation:
+  title: Telemetry
+  icon: i-lucide-gauge
+links:
+  - label: Audit
+    icon: i-lucide-shield-check
+    to: /use-cases/audit/overview
+    color: neutral
+    variant: subtle
+---
+
+`@evlog/telemetry` brings [evlog](https://evlog.dev)'s wide-event model to tools that run on other people's machines — CLIs, GitHub Actions, dev scripts, and CI jobs. Same philosophy as HTTP logging: **one command execution → one structured event**, not a stream of analytics calls.
+
+```bash
+pnpm add @evlog/telemetry
+```
+
+You get command name, sanitized flags, duration, and outcome automatically. Call `telemetry.set()` only when you have extra counters — numbers and booleans by default. Raw `argv` is never read; disclosure is generated from your runtime config so it cannot drift from what you actually collect.
+
+## Setup with citty
+
+Wrap your root command in `withTelemetry()` — typically in `src/index.ts`, the file that calls `runMain()`. Subcommands can live in the same file or in `src/commands/*.ts`; only the entrypoint needs the wrapper.
+
+```ts [src/index.ts]
+import { defineCommand, runMain } from 'citty'
+import { withTelemetry, defineTelemetryCommands, telemetry } from '@evlog/telemetry'
+
+const TOOL = 'my-tool'
+const VERSION = '1.0.0'
+
+export const main = withTelemetry(
+  defineCommand({
+    meta: { name: 'my-tool', description: '…', version: VERSION },
+    subCommands: {
+      doctor: {
+        meta: { name: 'doctor', description: 'Check environment' },
+        args: {
+          json: { type: 'boolean', alias: 'j' },
+        },
+        async run({ args }) {
+          const checksFailed = 0 // your logic…
+          telemetry.set({ checksFailed })
+          if (!args.json) process.stdout.write('ok\n')
+        },
+      },
+      sync: {
+        meta: { name: 'sync', description: 'Pull remote state' },
+        args: {
+          dryRun: { type: 'boolean' },
+          output: { type: 'string', description: 'Output path' },
+        },
+        async run({ args }) {
+          telemetry.set({ itemsSynced: 42 })
+          // …
+        },
+      },
+      telemetry: defineTelemetryCommands({ name: TOOL }),
+    },
+  }),
+  {
+    name: TOOL,
+    version: VERSION,
+    // endpoint optional — omit for outbox-only until you ship ingestion
+    collect: {
+      flags: { format: ['json', 'csv'] },
+      fields: { framework: ['nuxt', 'next'] },
+    },
+  },
+)
+
+runMain(main)
+```
+
+### What gets recorded automatically
+
+`withTelemetry` walks your citty tree. Each `run` handler produces one event — no per-command telemetry boilerplate.
+
+| Invocation | `event.command` | Notes on `flags` |
+| --- | --- | --- |
+| `my-tool doctor` | `doctor` | `{ json: true }` — booleans captured as values |
+| `my-tool doctor --json` | `doctor` | `{ json: true }` |
+| `my-tool sync --dry-run --output ./out` | `sync` | `{ dryRun: true, output: true }` — string path is **presence only** |
+| `my-tool sync --format json` | `sync` | `{ format: "json" }` only if allowlisted in `collect.flags` |
+| `my-tool telemetry status` | `telemetry status` | nested subcommands join with a space |
+
+The root `meta.name` is not prefixed when the root only delegates to `subCommands`.
+
+### Enriching a run
+
+Call `telemetry.set()` anywhere inside a command handler (or any code that runs within that handler's async stack):
+
+```ts
+telemetry.set({ checksFailed: 2, cacheHit: true })
+```
+
+Throw an error with a `code` property and `outcome: "error"` plus `errorCode` are recorded automatically:
+
+```ts
+throw Object.assign(new Error('Config missing'), { code: 'CONFIG_NOT_FOUND' })
+```
+
+## Setup without citty
+
+For scripts, migrators, or custom CLIs, use `createTelemetry()` and wrap each logical run with `t.run()`:
+
+```ts
+import { createTelemetry, telemetry } from '@evlog/telemetry'
+
+const t = createTelemetry({ name: 'my-migrator', version: '2.0.0' })
+
+await t.run('migrate', async () => {
+  telemetry.set({ rowsMigrated: 120 })
+})
+
+await t.flush() // optional — also runs at end of each t.run()
+```
+
+GitHub Actions: swap `createTelemetry` for `createGitHubActionsTelemetry()` — it adds `ghaAction` and `ghaEvent` to `custom` from `GITHUB_ACTION` / `GITHUB_EVENT_NAME` only (never repo content).
+
+## Standard envelope
+
+Every run shares the same shape. You do not declare per-command schemas.
+
+```jsonc
+{
+  "event": "run",
+  "command": "sync",
+  "durationMs": 412,
+  "outcome": "success",
+  "flags": { "dryRun": true, "output": true },
+  "tool": { "name": "my-tool", "version": "1.0.0" },
+  "env": {
+    "node": "20.11",
+    "ci": false,
+    "provider": null,
+    "tty": true,
+    "agent": "cursor"   // std-env: cursor, claude, codex, … or null
+  },
+  "machineId": "ab3f…", // hashed; omitted in ephemeral CI
+  "custom": { "itemsSynced": 42 }
+}
+```
+
+## Privacy
+
+Raw `argv` is never read. Sanitization applies to **citty-parsed** flags only:
+
+- **Booleans / numbers** → value stored (`json: true`, `limit: 50`)
+- **Strings** → presence only (`output: true`) unless allowlisted in `collect.flags`
+- **`telemetry.set()`** → numbers and booleans always; strings only via `collect.fields` (undeclared values are dropped at runtime, never thrown)
+
+```ts
+collect: {
+  flags: { format: ['json', 'csv'] },           // --format json → "json"; --format yaml → true
+  fields: { framework: ['nuxt', 'next'] },      // telemetry.set({ framework: 'nuxt' }) ok
+}
+```
+
+Declare allowlists in the same `withTelemetry()` / `createTelemetry()` call as `collect` — no separate config file.
+
+## Disclosure
+
+`generateDisclosure()` produces markdown + JSON from the standard envelope plus your `collect` extensions. Commit the output (e.g. `TELEMETRY.md`) so it stays in sync with releases:
+
+```ts
+import { generateDisclosure } from '@evlog/telemetry'
+
+const { markdown } = generateDisclosure('my-tool', {
+  flags: { format: ['json', 'csv'] },
+})
+```
+
+Users can also read it at runtime via `my-tool telemetry status` when you wire `defineTelemetryCommands()`.
+
+## Consent and reliability
+
+**Opt-out priority:** `DO_NOT_TRACK=1` → `EVLOG_TELEMETRY=0` → persisted preference (`disableTelemetry()` / `telemetry disable`). Opt-out purges the undelivered outbox.
+
+**Never harms the host:** telemetry never throws, never blocks exit; `flush()` has a 500ms hard cap.
+
+**Outbox:** events append to `~/.config/{toolName}/telemetry/outbox.ndjson` before any network send. Short-lived runs and offline machines drain the backlog on the next invocation.
+
+**Endpoint:** `EVLOG_TELEMETRY_ENDPOINT` env → `endpoint` option → outbox-only (default until you ship ingestion).
+
+## Debug
+
+```bash
+EVLOG_TELEMETRY_DEBUG=1 my-tool doctor
+EVLOG_TELEMETRY=0 my-tool sync
+```
+
+Debug mode prints would-be payloads to stderr. Nothing is sent unless an endpoint is configured and delivery succeeds.
+
+## See also
+
+- [Audit](/use-cases/audit/overview) — wide events for security-sensitive actions

--- a/examples/telemetry-playground/cli.ts
+++ b/examples/telemetry-playground/cli.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env tsx
+/**
+ * Minimal citty CLI to manually exercise @evlog/telemetry (withTelemetry path).
+ *
+ * Usage:
+ *   pnpm run cli -- doctor
+ *   pnpm run cli -- ping --name world
+ *   pnpm run cli -- telemetry status
+ *
+ * Debug payloads on stderr:
+ *   EVLOG_TELEMETRY_DEBUG=1 pnpm run cli -- doctor
+ *
+ * Reset first-run notice:
+ *   rm ~/.config/evlog-telemetry-playground/telemetry/notice-shown
+ */
+import { defineCommand, runMain } from 'citty'
+import { defineTelemetryCommands, telemetry, withTelemetry } from '@evlog/telemetry'
+
+const TOOL = 'evlog-telemetry-playground'
+const VERSION = '0.0.0'
+
+const main = withTelemetry(
+  defineCommand({
+    meta: {
+      name: 'evlog-telemetry',
+      description: 'Playground CLI for @evlog/telemetry',
+      version: VERSION,
+    },
+    subCommands: {
+      doctor: {
+        meta: { name: 'doctor', description: 'Smoke-check telemetry wiring' },
+        args: {
+          json: { type: 'boolean', alias: 'j', description: 'JSON on stdout' },
+        },
+        run({ args }) {
+          telemetry.set({ checksFailed: 0, checksWarn: 0 })
+          const payload = { ok: true, tool: TOOL, version: VERSION }
+          if (args.json) {
+            process.stdout.write(`${JSON.stringify(payload)}\n`)
+          } else {
+            process.stdout.write('telemetry playground: ok\n')
+          }
+        },
+      },
+      ping: {
+        meta: { name: 'ping', description: 'Echo a name (string flag → presence only)' },
+        args: {
+          name: { type: 'string', description: 'Name to greet' },
+          loud: { type: 'boolean', description: 'Shout' },
+        },
+        run({ args }) {
+          telemetry.set({ loud: Boolean(args.loud) })
+          const who = args.name ?? 'telemetry'
+          process.stdout.write(args.loud ? `PONG ${who}!\n` : `pong ${who}\n`)
+        },
+      },
+      telemetry: defineTelemetryCommands({ name: TOOL }),
+    },
+  }),
+  {
+    name: TOOL,
+    version: VERSION,
+    collect: {
+      flags: { format: ['json', 'text'] },
+    },
+  },
+)
+
+runMain(main)

--- a/examples/telemetry-playground/package.json
+++ b/examples/telemetry-playground/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "evlog-telemetry-playground-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "cli": "tsx cli.ts",
+    "smoke": "tsx smoke.ts"
+  },
+  "dependencies": {
+    "citty": "^0.1.6",
+    "@evlog/telemetry": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.7"
+  }
+}

--- a/examples/telemetry-playground/smoke.ts
+++ b/examples/telemetry-playground/smoke.ts
@@ -15,7 +15,7 @@ import { createTelemetry, generateDisclosure, telemetry } from '@evlog/telemetry
 const TOOL = 'evlog-telemetry-playground'
 
 function outboxPath(): string {
-  const base = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config')
+  const base = process.env.XDG_CONFIG_HOME || join(homedir(), '.config')
   return join(base, TOOL, 'telemetry', 'outbox.ndjson')
 }
 

--- a/examples/telemetry-playground/smoke.ts
+++ b/examples/telemetry-playground/smoke.ts
@@ -33,8 +33,8 @@ async function main() {
   try {
     const raw = await readFile(outbox, 'utf-8')
     lines = raw.trim().split('\n').filter(Boolean).length
-  } catch {
-    // opt-out or first run
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
   }
 
   process.stderr.write(`\n[telemetry:smoke] outbox: ${outbox}\n`)

--- a/examples/telemetry-playground/smoke.ts
+++ b/examples/telemetry-playground/smoke.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env tsx
+/**
+ * Smoke script for createTelemetry() (non-citty path).
+ *
+ * Usage:
+ *   pnpm run smoke
+ *   EVLOG_TELEMETRY_DEBUG=1 pnpm run smoke
+ *   XDG_CONFIG_HOME=/tmp/evlog-smoke pnpm run smoke
+ */
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { createTelemetry, generateDisclosure, telemetry } from '@evlog/telemetry'
+
+const TOOL = 'evlog-telemetry-playground'
+
+function outboxPath(): string {
+  const base = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config')
+  return join(base, TOOL, 'telemetry', 'outbox.ndjson')
+}
+
+async function main() {
+  const t = createTelemetry({ name: TOOL, version: '0.0.0' })
+
+  await t.run('smoke', async () => {
+    telemetry.set({ step: 1, ok: true })
+  })
+
+  await t.flush()
+
+  const outbox = outboxPath()
+  let lines = 0
+  try {
+    const raw = await readFile(outbox, 'utf-8')
+    lines = raw.trim().split('\n').filter(Boolean).length
+  } catch {
+    // opt-out or first run
+  }
+
+  process.stderr.write(`\n[telemetry:smoke] outbox: ${outbox}\n`)
+  process.stderr.write(`[telemetry:smoke] buffered events: ${lines}\n`)
+  process.stderr.write(`[telemetry:smoke] disclosure lines: ${generateDisclosure(TOOL).markdown.split('\n').length}\n`)
+  process.stderr.write('[telemetry:smoke] done — use EVLOG_TELEMETRY_DEBUG=1 to print payloads\n')
+}
+
+await main()

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "example:bun-script": "dotenv -- turbo run dev --filter=evlog-bun-script-example",
     "example:tanstack-start": "dotenv -- turbo run dev --filter=evlog-tanstack-start-example",
     "example:vite": "dotenv -- turbo run dev --filter=evlog-vite-example",
+    "example:telemetry-playground": "pnpm --filter evlog-telemetry-playground-example",
     "build": "turbo run build",
     "build:package": "turbo run build --filter='./packages/*'",
     "build:docs": "turbo run build --filter=evlog-docs",

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,72 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/HugoRCD/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
+</p>
+
+# @evlog/telemetry
+
+[![npm version](https://img.shields.io/npm/v/@evlog/telemetry?color=black)](https://npmjs.com/package/@evlog/telemetry)
+[![npm downloads](https://img.shields.io/npm/dm/@evlog/telemetry?color=black)](https://npm.chart.dev/@evlog/telemetry)
+[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev/use-cases/telemetry/overview)
+[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+
+**Digging through logs is not observability. It's hope.**
+
+**Wide-event telemetry for CLIs and automation** — the same one-event-per-run model as [evlog](https://evlog.dev), built for tools that run on someone else's machine.
+
+Ship usage insight without shipping a analytics SDK: wrap your [citty](https://github.com/unjs/citty) command tree (or call `createTelemetry()` in scripts) and get **one structured event per command** — command name, sanitized flags, duration, outcome, and optional counters via `telemetry.set()`.
+
+## Why evlog telemetry
+
+| Problem | How this package solves it |
+| --- | --- |
+| Per-command analytics boilerplate | `withTelemetry()` walks your citty tree — one event per `run` handler |
+| Leaking paths, tokens, or raw `argv` | Privacy by shape: booleans/numbers captured, strings presence-only unless allowlisted |
+| Short-lived CI runs losing data | Disk-buffered NDJSON outbox drains on the next invocation |
+| Disclosure drift | `generateDisclosure()` derives markdown + JSON from your runtime config |
+| Telemetry breaking the host tool | Never throws, never blocks exit; `flush()` hard-capped at 500ms |
+
+Opt-out is first-class: `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or a persisted `telemetry disable` that purges undelivered data.
+
+## Install
+
+```bash
+pnpm add @evlog/telemetry
+```
+
+## Quick start (citty)
+
+```ts
+import { defineCommand, runMain } from 'citty'
+import { withTelemetry, defineTelemetryCommands, telemetry } from '@evlog/telemetry'
+
+const TOOL = 'my-tool'
+const VERSION = '1.0.0'
+
+const main = withTelemetry(
+  defineCommand({
+    meta: { name: TOOL, version: VERSION },
+    subCommands: {
+      doctor: {
+        meta: { name: 'doctor' },
+        run() {
+          telemetry.set({ checksFailed: 0 })
+        },
+      },
+      telemetry: defineTelemetryCommands({ name: TOOL }),
+    },
+  }),
+  { name: TOOL, version: VERSION },
+)
+
+runMain(main)
+```
+
+Scripts and GitHub Actions: `createTelemetry()` / `createGitHubActionsTelemetry()` — see the [docs](https://evlog.dev/use-cases/telemetry/overview).
+
+## Docs
+
+Full guide: [evlog.dev — Tool telemetry](https://evlog.dev/use-cases/telemetry/overview)
+
+Example playground: [`examples/telemetry-playground`](../../examples/telemetry-playground) in the evlog monorepo.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -8,7 +8,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/@evlog/telemetry?color=black)](https://npm.chart.dev/@evlog/telemetry)
 [![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev/use-cases/telemetry/overview)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev/use-cases/telemetry)
 [![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
 
 **Digging through logs is not observability. It's hope.**
@@ -63,10 +63,10 @@ const main = withTelemetry(
 runMain(main)
 ```
 
-Scripts and GitHub Actions: `createTelemetry()` / `createGitHubActionsTelemetry()` — see the [docs](https://evlog.dev/use-cases/telemetry/overview).
+Scripts and GitHub Actions: `createTelemetry()` / `createGitHubActionsTelemetry()` — see the [docs](https://evlog.dev/use-cases/telemetry).
 
 ## Docs
 
-Full guide: [evlog.dev — Tool telemetry](https://evlog.dev/use-cases/telemetry/overview)
+Full guide: [evlog.dev — Tool telemetry](https://evlog.dev/use-cases/telemetry)
 
 Example playground: [`examples/telemetry-playground`](../../examples/telemetry-playground) in the evlog monorepo.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -15,7 +15,7 @@
 
 **Wide-event telemetry for CLIs and automation** — the same one-event-per-run model as [evlog](https://evlog.dev), built for tools that run on someone else's machine.
 
-Ship usage insight without shipping a analytics SDK: wrap your [citty](https://github.com/unjs/citty) command tree (or call `createTelemetry()` in scripts) and get **one structured event per command** — command name, sanitized flags, duration, outcome, and optional counters via `telemetry.set()`.
+Ship usage insight without shipping an analytics SDK: wrap your [citty](https://github.com/unjs/citty) command tree (or call `createTelemetry()` in scripts) and get **one structured event per command** — command name, sanitized flags, duration, outcome, and optional counters via `telemetry.set()`.
 
 ## Why evlog telemetry
 

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -25,9 +25,12 @@ Ship usage insight without shipping a analytics SDK: wrap your [citty](https://g
 | Leaking paths, tokens, or raw `argv` | Privacy by shape: booleans/numbers captured, strings presence-only unless allowlisted |
 | Short-lived CI runs losing data | Disk-buffered NDJSON outbox drains on the next invocation |
 | Disclosure drift | `generateDisclosure()` derives markdown + JSON from your runtime config |
+| Ingestion endpoint | `parseIngestBody()` validates POST bodies server-side — tool allowlist, envelope checks, custom key filter |
 | Telemetry breaking the host tool | Never throws, never blocks exit; `flush()` hard-capped at 500ms |
 
 Opt-out is first-class: `DO_NOT_TRACK`, `EVLOG_TELEMETRY=0`, or a persisted `telemetry disable` that purges undelivered data.
+
+**Size:** ~28 KB ESM (~8.6 KB gzip) · server ingest subpath `@evlog/telemetry/ingest` ~5 KB · `sideEffects: false` · no `evlog` core dependency.
 
 ## Install
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -23,6 +23,11 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./ingest": {
+      "types": "./dist/ingest.d.mts",
+      "import": "./dist/ingest.mjs",
+      "default": "./dist/ingest.mjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@evlog/telemetry",
+  "version": "0.0.0",
+  "description": "Wide-event telemetry for CLIs and automation — evlog's one-event-per-run model for tools on user machines, with privacy-safe flags, consent, outbox, and auto disclosure",
+  "author": "HugoRCD <contact@hrcd.fr>",
+  "homepage": "https://evlog.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "directory": "packages/telemetry"
+  },
+  "bugs": {
+    "url": "https://github.com/HugoRCD/evlog/issues"
+  },
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "evlog",
+    "wide-events",
+    "telemetry",
+    "cli",
+    "citty",
+    "structured-logging",
+    "privacy",
+    "consent",
+    "do-not-track",
+    "github-actions"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "dev:prepare": "tsdown",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "echo 'Typecheck handled by build'"
+  },
+  "dependencies": {
+    "citty": "^0.1.6",
+    "std-env": "^4.1.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsdown": "^0.21.10",
+    "tsx": "^4.20.7",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/telemetry/src/citty.ts
+++ b/packages/telemetry/src/citty.ts
@@ -1,0 +1,58 @@
+import type { CommandDef } from 'citty'
+import { createTelemetry } from './create'
+import type { CollectFields, CollectFlags, TelemetryOptions } from './types'
+
+type AnyCommand = CommandDef & {
+  subCommands?: Record<string, AnyCommand>
+}
+
+function wrapCommand(
+  command: AnyCommand,
+  telemetry: ReturnType<typeof createTelemetry>,
+  path: string[],
+  isRoot = false,
+): AnyCommand {
+  const segment = command.meta?.name
+  const commandPath = isRoot && command.subCommands
+    ? path
+    : segment
+      ? [...path, segment]
+      : path
+
+  const wrappedSub = command.subCommands
+    ? Object.fromEntries(
+      Object.entries(command.subCommands).map(([key, sub]) => [
+        key,
+        wrapCommand(sub, telemetry, commandPath, false),
+      ]),
+    )
+    : undefined
+
+  return {
+    ...command,
+    subCommands: wrappedSub,
+    run: command.run
+      ? (ctx) => {
+        const name = commandPath.join(' ') || segment || 'run'
+        return telemetry.run(name, () => command.run!(ctx), {
+          flags: ctx.args as Record<string, unknown>,
+        })
+      }
+      : command.run,
+  }
+}
+
+/**
+ * Wrap a citty command tree with telemetry — one wide event per command execution.
+ * Returns the wrapped command for `runMain()`.
+ */
+export function withTelemetry<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+>(
+  command: CommandDef,
+  options: TelemetryOptions<TFlags, TFields>,
+): CommandDef {
+  const instance = createTelemetry(options)
+  return wrapCommand(command as AnyCommand, instance, [], true)
+}

--- a/packages/telemetry/src/commands.ts
+++ b/packages/telemetry/src/commands.ts
@@ -1,0 +1,46 @@
+import { defineCommand } from 'citty'
+import { disableTelemetry, enableTelemetry } from './create'
+import { generateDisclosure } from './disclosure'
+import { readPreferenceSync, resolveConsent } from './consent'
+import type { TelemetryOptions } from './types'
+
+/**
+ * Reusable citty subcommands: `telemetry status`, `telemetry enable`, `telemetry disable`.
+ */
+export function defineTelemetryCommands(options: Pick<TelemetryOptions, 'name' | 'collect'>) {
+  const disclosure = generateDisclosure(options.name, options.collect)
+
+  return defineCommand({
+    meta: {
+      name: 'telemetry',
+      description: 'View or change anonymous usage telemetry settings',
+    },
+    subCommands: {
+      status: {
+        meta: { name: 'status', description: 'Show telemetry status and disclosure link' },
+        run() {
+          const enabled = resolveConsent(options.name)
+          const pref = readPreferenceSync(options.name)
+          process.stderr.write(`Telemetry: ${enabled ? 'enabled' : 'disabled'} (preference: ${pref})\n`)
+          process.stderr.write('\n')
+          process.stderr.write(disclosure.markdown)
+          process.stderr.write('\n')
+        },
+      },
+      enable: {
+        meta: { name: 'enable', description: 'Enable anonymous usage telemetry' },
+        async run() {
+          await enableTelemetry(options.name)
+          process.stderr.write(`Telemetry enabled for ${options.name}.\n`)
+        },
+      },
+      disable: {
+        meta: { name: 'disable', description: 'Disable telemetry and purge undelivered data' },
+        async run() {
+          await disableTelemetry(options.name)
+          process.stderr.write(`Telemetry disabled for ${options.name}. Local buffer purged.\n`)
+        },
+      },
+    },
+  })
+}

--- a/packages/telemetry/src/consent.ts
+++ b/packages/telemetry/src/consent.ts
@@ -1,8 +1,15 @@
 import { readFileSync } from 'node:fs'
-import { mkdir, writeFile, unlink } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getTelemetryDir } from './paths'
+import { TelemetryOutbox } from './outbox'
 
+/**
+ * Persisted telemetry consent state for a tool.
+ * - `unset` — no explicit choice; default consent applies.
+ * - `enabled` — user opted in via `telemetry enable`.
+ * - `disabled` — user opted out via `telemetry disable`.
+ */
 export type TelemetryPreference = 'enabled' | 'disabled' | 'unset'
 
 interface PreferenceFile {
@@ -43,9 +50,5 @@ export async function writePreference(toolName: string, preference: TelemetryPre
 
 /** Remove the outbox on opt-out (retroactive on undelivered data). */
 export async function purgeOutbox(toolName: string): Promise<void> {
-  try {
-    await unlink(join(getTelemetryDir(toolName), 'outbox.ndjson'))
-  } catch {
-    // absent is fine
-  }
+  await new TelemetryOutbox({ toolName }).purge()
 }

--- a/packages/telemetry/src/consent.ts
+++ b/packages/telemetry/src/consent.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { mkdir, writeFile, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getTelemetryDir } from './paths'
+
+export type TelemetryPreference = 'enabled' | 'disabled' | 'unset'
+
+interface PreferenceFile {
+  preference: TelemetryPreference
+}
+
+/** Resolve consent: `DO_NOT_TRACK` → `EVLOG_TELEMETRY` → persisted preference. */
+export function resolveConsent(toolName: string): boolean {
+  if (process.env.DO_NOT_TRACK === '1') return false
+  if (process.env.EVLOG_TELEMETRY === '0') return false
+  if (process.env.EVLOG_TELEMETRY === '1') return true
+
+  const pref = readPreferenceSync(toolName)
+  if (pref === 'disabled') return false
+  if (pref === 'enabled') return true
+
+  // Default: enabled (first-run notice handles disclosure)
+  return true
+}
+
+/** Read persisted preference without throwing. */
+export function readPreferenceSync(toolName: string): TelemetryPreference {
+  try {
+    const raw = readFileSync(join(getTelemetryDir(toolName), 'preference.json'), 'utf-8')
+    const parsed = JSON.parse(raw) as PreferenceFile
+    return parsed.preference ?? 'unset'
+  } catch {
+    return 'unset'
+  }
+}
+
+/** Persist user telemetry preference. */
+export async function writePreference(toolName: string, preference: TelemetryPreference): Promise<void> {
+  const dir = getTelemetryDir(toolName)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'preference.json'), JSON.stringify({ preference }), 'utf-8')
+}
+
+/** Remove the outbox on opt-out (retroactive on undelivered data). */
+export async function purgeOutbox(toolName: string): Promise<void> {
+  try {
+    await unlink(join(getTelemetryDir(toolName), 'outbox.ndjson'))
+  } catch {
+    // absent is fine
+  }
+}

--- a/packages/telemetry/src/create.ts
+++ b/packages/telemetry/src/create.ts
@@ -27,21 +27,24 @@ import type {
 import { getTelemetryDir } from './paths'
 import { formatTelemetryNotice, isInteractiveTerminal, wasNoticeShown } from './notice'
 
-let activeHandle: InternalTelemetry | null = null
+let activeHandle: InternalTelemetry<any, any> | null = null
 
 function isCliError(err: unknown): err is TelemetryCliError {
   return typeof err === 'object' && err !== null && typeof (err as TelemetryCliError).code === 'string'
 }
 
-class InternalTelemetry implements TelemetryHandle {
+class InternalTelemetry<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+> implements TelemetryHandle<TFlags, TFields> {
   private _enabled: boolean
-  readonly options: TelemetryOptions
+  readonly options: TelemetryOptions<TFlags, TFields>
   private readonly outbox: TelemetryOutbox
   private readonly drain: TelemetryDrain
   private machineId?: string
   private noticeShown = false
 
-  constructor(options: TelemetryOptions, enabled: boolean) {
+  constructor(options: TelemetryOptions<TFlags, TFields>, enabled: boolean) {
     this.options = options
     this._enabled = enabled
     this.outbox = new TelemetryOutbox({
@@ -59,6 +62,16 @@ class InternalTelemetry implements TelemetryHandle {
 
   get enabled(): boolean {
     return this._enabled
+  }
+
+  set(fields: CustomFields<TFields>): void {
+    const ctx = getRunContext()
+    if (!ctx) return
+    ctx.custom = sanitizeCustom(
+      fields as Record<string, unknown>,
+      ctx.custom,
+      ctx.collect,
+    )
   }
 
   /** @internal Update runtime consent for the active instance. */
@@ -195,9 +208,9 @@ class InternalTelemetry implements TelemetryHandle {
 export function createTelemetry<
   TFlags extends CollectFlags = {},
   TFields extends CollectFields = {},
->(options: TelemetryOptions<TFlags, TFields>): TelemetryHandle {
+>(options: TelemetryOptions<TFlags, TFields>): TelemetryHandle<TFlags, TFields> {
   const enabled = resolveConsent(options.name)
-  const instance = new InternalTelemetry(options, enabled)
+  const instance = new InternalTelemetry<TFlags, TFields>(options, enabled)
   activeHandle = instance
   void instance.init()
   return instance
@@ -206,6 +219,8 @@ export function createTelemetry<
 /**
  * Ambient custom-field setter — works anywhere inside an active `run()` scope.
  * Accepts numbers and booleans by default; strings require `collect.fields`.
+ * Prefer {@link TelemetryHandle.set} on the handle returned by {@link createTelemetry}
+ * for allowlisted string autocomplete.
  */
 export const telemetry = {
   set(fields: CustomFields): void {
@@ -245,6 +260,6 @@ export function _resetActiveTelemetryForTests(): void {
 
 /** @internal Test hook */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function _getActiveTelemetryForTests(): InternalTelemetry | null {
+export function _getActiveTelemetryForTests(): InternalTelemetry<any, any> | null {
   return activeHandle
 }

--- a/packages/telemetry/src/create.ts
+++ b/packages/telemetry/src/create.ts
@@ -1,0 +1,234 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { readPreferenceSync, resolveConsent, writePreference, purgeOutbox } from './consent'
+import {
+  composeDrains,
+  createDebugDrain,
+  createHttpDrain,
+  createNoopDrain,
+  resolveEndpoint,
+  type TelemetryDrain,
+} from './drain'
+import { buildEnvInfo, resolveMachineId } from './enrich'
+import { computeRunIdempotencyKey } from './idempotency'
+import { TelemetryOutbox } from './outbox'
+import { sanitizeCustom, sanitizeFlags } from './sanitize'
+import { getRunContext, runWithContext } from './storage'
+import type {
+  CollectFields,
+  CollectFlags,
+  CustomFields,
+  RunEvent,
+  RunOutcome,
+  TelemetryCliError,
+  TelemetryHandle,
+  TelemetryOptions,
+} from './types'
+import { getTelemetryDir } from './paths'
+import { formatTelemetryNotice, isInteractiveTerminal, wasNoticeShown } from './notice'
+
+let activeHandle: InternalTelemetry | null = null
+
+function isCliError(err: unknown): err is TelemetryCliError {
+  return typeof err === 'object' && err !== null && typeof (err as TelemetryCliError).code === 'string'
+}
+
+class InternalTelemetry implements TelemetryHandle {
+  readonly enabled: boolean
+  private readonly options: TelemetryOptions
+  private readonly outbox: TelemetryOutbox
+  private readonly drain: TelemetryDrain
+  private machineId?: string
+  private noticeShown = false
+
+  constructor(options: TelemetryOptions, enabled: boolean) {
+    this.options = options
+    this.enabled = enabled
+    this.outbox = new TelemetryOutbox({
+      toolName: options.name,
+      maxBufferBytes: options.maxBufferBytes,
+      maxEventAgeMs: options.maxEventAgeMs,
+    })
+
+    const endpoint = resolveEndpoint(options.endpoint)
+    const drains = [createDebugDrain()]
+    if (endpoint) drains.push(createHttpDrain(endpoint))
+    else drains.push(createNoopDrain())
+    this.drain = composeDrains(...drains)
+  }
+
+  async init(): Promise<void> {
+    if (!this.enabled) return
+    this.machineId = await resolveMachineId(this.options.name)
+    await this.flushBacklog()
+  }
+
+  async run<T>(
+    command: string,
+    fn: () => T | Promise<T>,
+    opts?: { flags?: Record<string, unknown>, systemCustom?: Record<string, string> },
+  ): Promise<T> {
+    if (!this.enabled) return fn()
+
+    await this.maybeShowNotice()
+    const started = Date.now()
+    const timestamp = new Date().toISOString()
+    const ctx = {
+      custom: { ...(opts?.systemCustom ?? {}) } as Record<string, boolean | number | string>,
+      collect: this.options.collect,
+    }
+    let outcome: RunOutcome = 'success'
+    let errorCode: string | undefined
+
+    try {
+      return await runWithContext(ctx, async () => await fn())
+    } catch (err) {
+      outcome = 'error'
+      if (isCliError(err)) errorCode = err.code
+      throw err
+    } finally {
+      const event = this.buildEvent({
+        command,
+        durationMs: Date.now() - started,
+        outcome,
+        errorCode,
+        flags: sanitizeFlags(opts?.flags, this.options.collect),
+        custom: ctx.custom,
+        timestamp,
+      })
+      await this.record(event)
+      await this.flush()
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (!this.enabled) return
+    const timeoutMs = this.options.flushTimeoutMs ?? 500
+    try {
+      await Promise.race([
+        this.flushBacklog(),
+        new Promise<void>(resolve => {
+          const t = setTimeout(resolve, timeoutMs)
+          ;(t as { unref?: () => void }).unref?.()
+        }),
+      ])
+    } catch {
+      // never throw
+    }
+  }
+
+  private async flushBacklog(): Promise<void> {
+    const pending = await this.outbox.readAll()
+    if (pending.length === 0) return
+    const ok = await this.drain(pending)
+    if (ok) {
+      await this.outbox.removeDelivered(new Set(pending.map(e => e.idempotencyKey)))
+    }
+  }
+
+  private buildEvent(parts: {
+    command: string
+    durationMs: number
+    outcome: RunOutcome
+    errorCode?: string
+    flags: Record<string, boolean | number | string>
+    custom: Record<string, boolean | number | string>
+    timestamp: string
+  }): RunEvent {
+    const tool = { name: this.options.name, version: this.options.version }
+    const idempotencyKey = computeRunIdempotencyKey({
+      command: parts.command,
+      tool,
+      timestamp: parts.timestamp,
+      machineId: this.machineId,
+    })
+    return {
+      event: 'run',
+      command: parts.command,
+      durationMs: parts.durationMs,
+      outcome: parts.outcome,
+      errorCode: parts.errorCode,
+      flags: parts.flags,
+      tool,
+      env: buildEnvInfo(),
+      machineId: this.machineId,
+      custom: parts.custom,
+      idempotencyKey,
+      timestamp: parts.timestamp,
+    }
+  }
+
+  private async record(event: RunEvent): Promise<void> {
+    await this.outbox.append(event)
+  }
+
+  private async maybeShowNotice(): Promise<void> {
+    if (this.noticeShown) return
+    if (!isInteractiveTerminal()) return
+    if (readPreferenceSync(this.options.name) !== 'unset') return
+    if (wasNoticeShown(this.options.name)) return
+    this.noticeShown = true
+    const dir = getTelemetryDir(this.options.name)
+    process.stderr.write(formatTelemetryNotice(this.options.name))
+    try {
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'notice-shown'), '', 'utf-8')
+    } catch {
+      // silent
+    }
+  }
+}
+
+/**
+ * Create a telemetry instance for non-citty tools.
+ * Use {@link withTelemetry} when integrating with citty.
+ */
+export function createTelemetry<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+>(options: TelemetryOptions<TFlags, TFields>): TelemetryHandle {
+  const enabled = resolveConsent(options.name)
+  const instance = new InternalTelemetry(options, enabled)
+  activeHandle = instance
+  void instance.init()
+  return instance
+}
+
+/**
+ * Ambient custom-field setter — works anywhere inside an active `run()` scope.
+ * Accepts numbers and booleans by default; strings require `collect.fields`.
+ */
+export const telemetry = {
+  set(fields: CustomFields): void {
+    const ctx = getRunContext()
+    if (!ctx) return
+    ctx.custom = sanitizeCustom(
+      fields as Record<string, unknown>,
+      ctx.custom,
+      ctx.collect,
+    )
+  },
+}
+
+/** Disable telemetry and purge the local outbox. */
+export async function disableTelemetry(toolName: string): Promise<void> {
+  await writePreference(toolName, 'disabled')
+  await purgeOutbox(toolName)
+}
+
+/** Enable telemetry (persisted preference). */
+export async function enableTelemetry(toolName: string): Promise<void> {
+  await writePreference(toolName, 'enabled')
+}
+
+/** @internal Test hook */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function _resetActiveTelemetryForTests(): void {
+  activeHandle = null
+}
+
+/** @internal Test hook */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function _getActiveTelemetryForTests(): InternalTelemetry | null {
+  return activeHandle
+}

--- a/packages/telemetry/src/create.ts
+++ b/packages/telemetry/src/create.ts
@@ -12,7 +12,7 @@ import {
 import { buildEnvInfo, resolveMachineId } from './enrich'
 import { computeRunIdempotencyKey } from './idempotency'
 import { TelemetryOutbox } from './outbox'
-import { sanitizeCustom, sanitizeFlags } from './sanitize'
+import { sanitizeCustom, sanitizeFlags, sanitizeSystemCustom } from './sanitize'
 import { getRunContext, runWithContext } from './storage'
 import type {
   CollectFields,
@@ -34,8 +34,8 @@ function isCliError(err: unknown): err is TelemetryCliError {
 }
 
 class InternalTelemetry implements TelemetryHandle {
-  readonly enabled: boolean
-  private readonly options: TelemetryOptions
+  private _enabled: boolean
+  readonly options: TelemetryOptions
   private readonly outbox: TelemetryOutbox
   private readonly drain: TelemetryDrain
   private machineId?: string
@@ -43,7 +43,7 @@ class InternalTelemetry implements TelemetryHandle {
 
   constructor(options: TelemetryOptions, enabled: boolean) {
     this.options = options
-    this.enabled = enabled
+    this._enabled = enabled
     this.outbox = new TelemetryOutbox({
       toolName: options.name,
       maxBufferBytes: options.maxBufferBytes,
@@ -57,8 +57,17 @@ class InternalTelemetry implements TelemetryHandle {
     this.drain = composeDrains(...drains)
   }
 
+  get enabled(): boolean {
+    return this._enabled
+  }
+
+  /** @internal Update runtime consent for the active instance. */
+  setEnabled(enabled: boolean): void {
+    this._enabled = enabled
+  }
+
   async init(): Promise<void> {
-    if (!this.enabled) return
+    if (!this._enabled) return
     this.machineId = await resolveMachineId(this.options.name)
     await this.flushBacklog()
   }
@@ -68,13 +77,13 @@ class InternalTelemetry implements TelemetryHandle {
     fn: () => T | Promise<T>,
     opts?: { flags?: Record<string, unknown>, systemCustom?: Record<string, string> },
   ): Promise<T> {
-    if (!this.enabled) return fn()
+    if (!this._enabled) return fn()
 
     await this.maybeShowNotice()
     const started = Date.now()
     const timestamp = new Date().toISOString()
     const ctx = {
-      custom: { ...(opts?.systemCustom ?? {}) } as Record<string, boolean | number | string>,
+      custom: sanitizeSystemCustom(opts?.systemCustom) as Record<string, boolean | number | string>,
       collect: this.options.collect,
     }
     let outcome: RunOutcome = 'success'
@@ -102,7 +111,7 @@ class InternalTelemetry implements TelemetryHandle {
   }
 
   async flush(): Promise<void> {
-    if (!this.enabled) return
+    if (!this._enabled) return
     const timeoutMs = this.options.flushTimeoutMs ?? 500
     try {
       await Promise.race([
@@ -212,6 +221,9 @@ export const telemetry = {
 
 /** Disable telemetry and purge the local outbox. */
 export async function disableTelemetry(toolName: string): Promise<void> {
+  if (activeHandle?.options.name === toolName) {
+    activeHandle.setEnabled(false)
+  }
   await writePreference(toolName, 'disabled')
   await purgeOutbox(toolName)
 }
@@ -219,6 +231,10 @@ export async function disableTelemetry(toolName: string): Promise<void> {
 /** Enable telemetry (persisted preference). */
 export async function enableTelemetry(toolName: string): Promise<void> {
   await writePreference(toolName, 'enabled')
+  if (activeHandle?.options.name === toolName) {
+    activeHandle.setEnabled(true)
+    void activeHandle.init()
+  }
 }
 
 /** @internal Test hook */

--- a/packages/telemetry/src/disclosure.ts
+++ b/packages/telemetry/src/disclosure.ts
@@ -1,0 +1,114 @@
+import type { CollectConfig, RunEvent } from './types'
+
+const STANDARD_FIELDS: Array<{ field: string, type: string, description: string }> = [
+  { field: 'event', type: 'string', description: 'Always `run`.' },
+  { field: 'command', type: 'string', description: 'Command name, auto-captured from citty.' },
+  { field: 'durationMs', type: 'number', description: 'Run duration in milliseconds.' },
+  { field: 'outcome', type: 'string', description: '`success` or `error`.' },
+  { field: 'errorCode', type: 'string', description: 'From typed CLI errors when present.' },
+  { field: 'flags', type: 'object', description: 'Parsed flags — booleans/numbers as values, strings as presence unless allowlisted.' },
+  { field: 'tool.name', type: 'string', description: 'Tool name declared at setup.' },
+  { field: 'tool.version', type: 'string', description: 'Tool version declared at setup.' },
+  { field: 'env.node', type: 'string', description: 'Node.js version.' },
+  { field: 'env.ci', type: 'boolean', description: 'Whether running in CI.' },
+  { field: 'env.provider', type: 'string | null', description: 'CI provider when detected.' },
+  { field: 'env.tty', type: 'boolean', description: 'Whether stdout is a TTY.' },
+  { field: 'env.agent', type: 'string | null', description: 'AI coding agent when detected (claude, cursor, codex, …).' },
+  { field: 'machineId', type: 'string', description: 'Hashed anonymous machine id; omitted in ephemeral CI.' },
+  { field: 'custom', type: 'object', description: 'Consumer-provided fields via telemetry.set() — numbers/booleans by default.' },
+]
+
+export interface DisclosureDocument {
+  version: 1
+  standard: typeof STANDARD_FIELDS
+  extensions: {
+    flags: Record<string, string[]>
+    fields: Record<string, string[]>
+  }
+  markdown: string
+}
+
+/**
+ * Generate a disclosure document from the standard envelope plus declared `collect` extensions.
+ * The output cannot drift from runtime behaviour when `collect` is accurate.
+ */
+export function generateDisclosure(
+  toolName: string,
+  collect?: CollectConfig,
+): DisclosureDocument {
+  const flagExtensions: Record<string, string[]> = {}
+  const fieldExtensions: Record<string, string[]> = {}
+
+  if (collect?.flags) {
+    for (const [key, values] of Object.entries(collect.flags)) {
+      flagExtensions[key] = [...values]
+    }
+  }
+  if (collect?.fields) {
+    for (const [key, values] of Object.entries(collect.fields)) {
+      fieldExtensions[key] = [...values]
+    }
+  }
+
+  const lines = [
+    `# Telemetry disclosure — ${toolName}`,
+    '',
+    '## Standard envelope (always collected)',
+    '',
+    '| Field | Type | Description |',
+    '| --- | --- | --- |',
+    ...STANDARD_FIELDS.map(f => `| \`${f.field}\` | ${f.type} | ${f.description} |`),
+  ]
+
+  if (Object.keys(flagExtensions).length > 0) {
+    lines.push('', '## Allowlisted flag values', '')
+    for (const [flag, values] of Object.entries(flagExtensions)) {
+      lines.push(`- \`--${flag}\`: ${values.map(v => `\`${v}\``).join(', ')}`)
+    }
+  }
+
+  if (Object.keys(fieldExtensions).length > 0) {
+    lines.push('', '## Allowlisted custom fields', '')
+    for (const [field, values] of Object.entries(fieldExtensions)) {
+      lines.push(`- \`${field}\`: ${values.map(v => `\`${v}\``).join(', ')}`)
+    }
+  }
+
+  lines.push(
+    '',
+    '## Opt out',
+    '',
+    '- `DO_NOT_TRACK=1`',
+    '- `EVLOG_TELEMETRY=0`',
+    '- `evlog telemetry disable` (persisted preference)',
+    '',
+    '## Debug',
+    '',
+    'Set `EVLOG_TELEMETRY_DEBUG=1` to print would-be payloads to stderr.',
+  )
+
+  return {
+    version: 1,
+    standard: STANDARD_FIELDS,
+    extensions: { flags: flagExtensions, fields: fieldExtensions },
+    markdown: lines.join('\n'),
+  }
+}
+
+/** Example enriched payload for snapshots and docs. */
+export function exampleRunEvent(overrides?: Partial<RunEvent>): RunEvent {
+  return {
+    event: 'run',
+    command: 'doctor',
+    durationMs: 42,
+    outcome: 'success',
+    flags: { json: true },
+    tool: { name: 'evlog-cli', version: '0.1.0' },
+    env: { node: '20.11', ci: false, provider: null, tty: true, agent: null },
+    machineId: 'ab3f0123456789ab',
+    custom: { checksFailed: 0 },
+    idempotencyKey: '00000000000000000000000000000000',
+    timestamp: '2026-07-14T12:00:00.000Z',
+    ...overrides,
+  }
+}

--- a/packages/telemetry/src/disclosure.ts
+++ b/packages/telemetry/src/disclosure.ts
@@ -18,6 +18,7 @@ const STANDARD_FIELDS: Array<{ field: string, type: string, description: string 
   { field: 'custom', type: 'object', description: 'Consumer-provided fields via telemetry.set() — numbers/booleans by default.' },
 ]
 
+/** Machine-readable disclosure schema plus rendered markdown for docs/CLI. */
 export interface DisclosureDocument {
   version: 1
   standard: typeof STANDARD_FIELDS

--- a/packages/telemetry/src/drain.ts
+++ b/packages/telemetry/src/drain.ts
@@ -1,5 +1,9 @@
 import type { RunEvent } from './types'
 
+/**
+ * Drain function that attempts delivery for buffered run events.
+ * @returns `true` when at least one downstream sink reports successful delivery.
+ */
 export type TelemetryDrain = (events: RunEvent[]) => Promise<boolean>
 
 /** Resolve endpoint: env override → baked-in option → undefined (outbox-only). */

--- a/packages/telemetry/src/drain.ts
+++ b/packages/telemetry/src/drain.ts
@@ -1,0 +1,58 @@
+import type { RunEvent } from './types'
+
+export type TelemetryDrain = (events: RunEvent[]) => Promise<boolean>
+
+/** Resolve endpoint: env override → baked-in option → undefined (outbox-only). */
+export function resolveEndpoint(option?: string): string | undefined {
+  return process.env.EVLOG_TELEMETRY_ENDPOINT ?? option
+}
+
+/** No-op drain — outbox-only mode. */
+export function createNoopDrain(): TelemetryDrain {
+  return () => Promise.resolve(false)
+}
+
+/** Print would-be payloads to stderr when `EVLOG_TELEMETRY_DEBUG=1`. */
+export function createDebugDrain(): TelemetryDrain {
+  return (events) => {
+    if (process.env.EVLOG_TELEMETRY_DEBUG !== '1') return Promise.resolve(false)
+    for (const event of events) {
+      process.stderr.write(`[@evlog/telemetry] ${JSON.stringify(event)}\n`)
+    }
+    return Promise.resolve(false)
+  }
+}
+
+/** HTTP ingestion drain with timeout. Returns true when delivery succeeds. */
+export function createHttpDrain(endpoint: string, timeoutMs = 400): TelemetryDrain {
+  return async (events) => {
+    if (events.length === 0) return true
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ events }),
+        signal: controller.signal,
+      })
+      return res.ok
+    } catch {
+      return false
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+
+/** Compose drains — debug runs first; HTTP result wins for delivery tracking. */
+export function composeDrains(...drains: TelemetryDrain[]): TelemetryDrain {
+  return async (events) => {
+    let delivered = false
+    for (const drain of drains) {
+      const ok = await drain(events)
+      if (ok) delivered = true
+    }
+    return delivered
+  }
+}

--- a/packages/telemetry/src/enrich.ts
+++ b/packages/telemetry/src/enrich.ts
@@ -1,0 +1,53 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { agent, hasTTY, isCI, nodeVersion, provider } from 'std-env'
+import type { EnvInfo } from './types'
+import { getTelemetryDir } from './paths'
+
+/** Build the standard `env` block from std-env. */
+export function buildEnvInfo(): EnvInfo {
+  return {
+    node: nodeVersion ?? process.version.replace(/^v/, ''),
+    ci: isCI,
+    provider: provider ?? null,
+    tty: hasTTY,
+    agent: agent ?? null,
+  }
+}
+
+/**
+ * Ephemeral CI environments skip machine id (no stable cross-run identity).
+ */
+function isEphemeralCI(): boolean {
+  return isCI && !process.env.EVLOG_TELEMETRY_MACHINE_ID
+}
+
+/**
+ * Anonymous hashed machine id, persisted in the user config dir.
+ * Skipped in ephemeral CI.
+ */
+export async function resolveMachineId(toolName: string): Promise<string | undefined> {
+  if (isEphemeralCI()) return undefined
+
+  const dir = getTelemetryDir(toolName)
+  const idPath = join(dir, 'machine-id')
+
+  try {
+    const existing = await readFile(idPath, 'utf-8')
+    if (existing.trim()) {
+      return hashMachineId(existing.trim())
+    }
+  } catch {
+    // generate below
+  }
+
+  const raw = randomUUID()
+  await mkdir(dir, { recursive: true })
+  await writeFile(idPath, raw, 'utf-8')
+  return hashMachineId(raw)
+}
+
+function hashMachineId(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16)
+}

--- a/packages/telemetry/src/github-actions.ts
+++ b/packages/telemetry/src/github-actions.ts
@@ -1,7 +1,10 @@
-import type { TelemetryHandle, TelemetryOptions } from './types'
+import type { CollectFields, CollectFlags, TelemetryHandle, TelemetryOptions } from './types'
 import { createTelemetry } from './create'
 
-export interface GitHubActionsTelemetryOptions extends TelemetryOptions {
+export interface GitHubActionsTelemetryOptions<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+> extends TelemetryOptions<TFlags, TFields> {
   /** Override detected action name. Defaults to `GITHUB_ACTION`. */
   actionName?: string
   /** Override detected event type. Defaults to `GITHUB_EVENT_NAME`. */
@@ -12,9 +15,12 @@ export interface GitHubActionsTelemetryOptions extends TelemetryOptions {
  * Thin helper for GitHub Actions — enriches with action metadata from env only.
  * Never reads repository content.
  */
-export function createGitHubActionsTelemetry(
-  options: GitHubActionsTelemetryOptions,
-): TelemetryHandle {
+export function createGitHubActionsTelemetry<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+>(
+  options: GitHubActionsTelemetryOptions<TFlags, TFields>,
+): TelemetryHandle<TFlags, TFields> {
   const base = createTelemetry(options)
   const action = options.actionName ?? process.env.GITHUB_ACTION ?? 'unknown'
   const eventType = options.eventType ?? process.env.GITHUB_EVENT_NAME ?? 'unknown'

--- a/packages/telemetry/src/github-actions.ts
+++ b/packages/telemetry/src/github-actions.ts
@@ -1,0 +1,34 @@
+import type { TelemetryHandle, TelemetryOptions } from './types'
+import { createTelemetry } from './create'
+
+export interface GitHubActionsTelemetryOptions extends TelemetryOptions {
+  /** Override detected action name. Defaults to `GITHUB_ACTION`. */
+  actionName?: string
+  /** Override detected event type. Defaults to `GITHUB_EVENT_NAME`. */
+  eventType?: string
+}
+
+/**
+ * Thin helper for GitHub Actions — enriches with action metadata from env only.
+ * Never reads repository content.
+ */
+export function createGitHubActionsTelemetry(
+  options: GitHubActionsTelemetryOptions,
+): TelemetryHandle {
+  const base = createTelemetry(options)
+  const action = options.actionName ?? process.env.GITHUB_ACTION ?? 'unknown'
+  const eventType = options.eventType ?? process.env.GITHUB_EVENT_NAME ?? 'unknown'
+
+  return {
+    ...base,
+    run(command, fn, opts) {
+      return base.run(command, fn, {
+        ...opts,
+        systemCustom: {
+          ghaAction: action,
+          ghaEvent: eventType,
+        },
+      })
+    },
+  }
+}

--- a/packages/telemetry/src/idempotency.ts
+++ b/packages/telemetry/src/idempotency.ts
@@ -1,0 +1,51 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (Object.prototype.toString.call(value) !== '[object Object]') return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || value.constructor === Object
+}
+
+function stableStringify(value: unknown, ancestors = new WeakSet<object>()): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (ancestors.has(value)) return '"[Circular]"'
+  if (!Array.isArray(value) && !isPlainObject(value)) return JSON.stringify(value)
+  ancestors.add(value)
+  const out = Array.isArray(value)
+    ? `[${value.map(v => stableStringify(v, ancestors)).join(',')}]`
+    : `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${stableStringify(value[k], ancestors)}`).join(',')}}`
+  ancestors.delete(value)
+  return out
+}
+
+function fnv1a32(input: string, seed: number): number {
+  let h = seed >>> 0
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i) & 0xff
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h >>> 0
+}
+
+/**
+ * Derive a deterministic idempotency key for a telemetry run event.
+ * Same algorithm family as audit idempotency in `evlog/audit`.
+ */
+export function computeRunIdempotencyKey(payload: {
+  command: string
+  tool: { name: string, version: string }
+  timestamp: string
+  machineId?: string
+}): string {
+  const seconds = payload.timestamp.slice(0, 19)
+  const canonical = stableStringify({
+    command: payload.command,
+    tool: payload.tool,
+    timestamp: seconds,
+    machineId: payload.machineId,
+  })
+  const a = fnv1a32(canonical, 0x811c9dc5).toString(16).padStart(8, '0')
+  const b = fnv1a32(canonical, 0xdeadbeef).toString(16).padStart(8, '0')
+  const c = fnv1a32(canonical, 0x1f83d9ab).toString(16).padStart(8, '0')
+  const d = fnv1a32(canonical, 0x5be0cd19).toString(16).padStart(8, '0')
+  return a + b + c + d
+}

--- a/packages/telemetry/src/idempotency.ts
+++ b/packages/telemetry/src/idempotency.ts
@@ -19,8 +19,9 @@ function stableStringify(value: unknown, ancestors = new WeakSet<object>()): str
 
 function fnv1a32(input: string, seed: number): number {
   let h = seed >>> 0
-  for (let i = 0; i < input.length; i++) {
-    h ^= input.charCodeAt(i) & 0xff
+  const bytes = new TextEncoder().encode(input)
+  for (const byte of bytes) {
+    h ^= byte
     h = Math.imul(h, 0x01000193) >>> 0
   }
   return h >>> 0

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -9,6 +9,7 @@ export { withTelemetry } from './citty'
 export { defineTelemetryCommands } from './commands'
 export { createGitHubActionsTelemetry, type GitHubActionsTelemetryOptions } from './github-actions'
 export { generateDisclosure, exampleRunEvent, type DisclosureDocument } from './disclosure'
+export { parseIngestBody, IngestValidationError, type IngestValidatorOptions } from './ingest'
 
 export type {
   RunEvent,

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  createTelemetry,
+  telemetry,
+  disableTelemetry,
+  enableTelemetry,
+} from './create'
+
+export { withTelemetry } from './citty'
+export { defineTelemetryCommands } from './commands'
+export { createGitHubActionsTelemetry, type GitHubActionsTelemetryOptions } from './github-actions'
+export { generateDisclosure, exampleRunEvent, type DisclosureDocument } from './disclosure'
+
+export type {
+  RunEvent,
+  RunOutcome,
+  ToolInfo,
+  EnvInfo,
+  CollectConfig,
+  CollectFlags,
+  CollectFields,
+  CustomFields,
+  TelemetryOptions,
+  TelemetryHandle,
+  TelemetryCliError,
+} from './types'

--- a/packages/telemetry/src/ingest.ts
+++ b/packages/telemetry/src/ingest.ts
@@ -1,0 +1,203 @@
+import type { RunEvent, RunOutcome } from './types'
+
+export type { RunEvent, RunOutcome } from './types'
+
+const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024
+const DEFAULT_MAX_BATCH_SIZE = 50
+const DEFAULT_MAX_COMMAND_LENGTH = 256
+const DEFAULT_MAX_DURATION_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Server-side options for validating telemetry ingest POST bodies.
+ * Mirror the CLI's `name` and declared `collect` allowlists on your API.
+ */
+export interface IngestValidatorOptions {
+  /** Published tool names your endpoint accepts (e.g. `['my-tool']`). */
+  allowedTools: readonly string[]
+  /**
+   * Custom keys allowed per tool — should match `collect.fields` plus any
+   * `telemetry.set()` keys you document for that tool.
+   */
+  allowedCustomKeys?: Record<string, readonly string[]>
+  /** Max UTF-8 body size in bytes. Default: 64 KiB. */
+  maxBodyBytes?: number
+  /** Max events per batch. Default: 50. */
+  maxBatchSize?: number
+  /** Max `command` string length. Default: 256. */
+  maxCommandLength?: number
+  /** Max plausible `durationMs` per run. Default: 24 hours. */
+  maxDurationMs?: number
+}
+
+/** Thrown when an ingest body fails validation. */
+export class IngestValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IngestValidationError'
+  }
+}
+
+/**
+ * Parse and validate a telemetry ingest POST body (`{ events: RunEvent[] }`).
+ * Use in your API route before storing or forwarding events.
+ *
+ * @throws {@link IngestValidationError} when the payload is invalid or untrusted.
+ */
+export function parseIngestBody(raw: string, options: IngestValidatorOptions): RunEvent[] {
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES
+  const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE
+
+  if (new TextEncoder().encode(raw).byteLength > maxBodyBytes) {
+    throw new IngestValidationError('payload too large')
+  }
+
+  let body: unknown
+  try {
+    body = JSON.parse(raw)
+  } catch {
+    throw new IngestValidationError('invalid json')
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    throw new IngestValidationError('invalid body')
+  }
+
+  const { events } = body as { events?: unknown }
+  if (!Array.isArray(events) || events.length === 0 || events.length > maxBatchSize) {
+    throw new IngestValidationError('invalid batch')
+  }
+
+  return events.map(event => validateRunEvent(event, options))
+}
+
+function validateRunEvent(input: unknown, options: IngestValidatorOptions): RunEvent {
+  if (typeof input !== 'object' || input === null) {
+    throw new IngestValidationError('invalid event')
+  }
+
+  const e = input as RunEvent
+
+  if (e.event !== 'run') throw new IngestValidationError('invalid event type')
+
+  const toolName = e.tool?.name
+  if (typeof toolName !== 'string' || !options.allowedTools.includes(toolName)) {
+    throw new IngestValidationError('unknown tool')
+  }
+
+  if (typeof e.tool.version !== 'string' || !e.tool.version.trim()) {
+    throw new IngestValidationError('invalid tool version')
+  }
+
+  const maxCommandLength = options.maxCommandLength ?? DEFAULT_MAX_COMMAND_LENGTH
+  if (typeof e.command !== 'string' || !e.command.trim() || e.command.length > maxCommandLength) {
+    throw new IngestValidationError('invalid command')
+  }
+
+  const maxDurationMs = options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS
+  if (typeof e.durationMs !== 'number' || !Number.isFinite(e.durationMs) || e.durationMs < 0 || e.durationMs > maxDurationMs) {
+    throw new IngestValidationError('invalid duration')
+  }
+
+  if (!isRunOutcome(e.outcome)) throw new IngestValidationError('invalid outcome')
+
+  if (typeof e.idempotencyKey !== 'string' || !e.idempotencyKey.trim()) {
+    throw new IngestValidationError('missing idempotency key')
+  }
+
+  if (typeof e.timestamp !== 'string' || !isValidIsoTimestamp(e.timestamp)) {
+    throw new IngestValidationError('invalid timestamp')
+  }
+
+  if (e.errorCode !== undefined && (typeof e.errorCode !== 'string' || !e.errorCode.trim())) {
+    throw new IngestValidationError('invalid error code')
+  }
+
+  const flags = sanitizeRecord(e.flags, 'flags')
+  const env = validateEnv(e.env)
+  const custom = filterCustom(e.custom, toolName, options.allowedCustomKeys)
+
+  return {
+    event: 'run',
+    command: e.command,
+    durationMs: e.durationMs,
+    outcome: e.outcome,
+    errorCode: e.errorCode,
+    flags,
+    tool: { name: toolName, version: e.tool.version },
+    env,
+    machineId: typeof e.machineId === 'string' && e.machineId.trim() ? e.machineId : undefined,
+    custom,
+    idempotencyKey: e.idempotencyKey,
+    timestamp: e.timestamp,
+  }
+}
+
+function isRunOutcome(value: unknown): value is RunOutcome {
+  return value === 'success' || value === 'error'
+}
+
+function isValidIsoTimestamp(value: string): boolean {
+  if (!ISO_8601_REGEX.test(value)) return false
+  return !Number.isNaN(new Date(value).getTime())
+}
+
+function sanitizeRecord(
+  input: unknown,
+  label: string,
+): Record<string, boolean | number | string> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new IngestValidationError(`invalid ${label}`)
+  }
+
+  const out: Record<string, boolean | number | string> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string') {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+function validateEnv(input: unknown): RunEvent['env'] {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new IngestValidationError('invalid env')
+  }
+
+  const env = input as RunEvent['env']
+  if (typeof env.node !== 'string' || !env.node.trim()) {
+    throw new IngestValidationError('invalid env.node')
+  }
+  if (typeof env.ci !== 'boolean') throw new IngestValidationError('invalid env.ci')
+  if (env.provider !== null && typeof env.provider !== 'string') {
+    throw new IngestValidationError('invalid env.provider')
+  }
+  if (typeof env.tty !== 'boolean') throw new IngestValidationError('invalid env.tty')
+  if (env.agent !== null && typeof env.agent !== 'string') {
+    throw new IngestValidationError('invalid env.agent')
+  }
+
+  return {
+    node: env.node,
+    ci: env.ci,
+    provider: env.provider,
+    tty: env.tty,
+    agent: env.agent,
+  }
+}
+
+function filterCustom(
+  input: unknown,
+  toolName: string,
+  allowedCustomKeys?: Record<string, readonly string[]>,
+): Record<string, boolean | number | string> {
+  const allowed = new Set(allowedCustomKeys?.[toolName] ?? [])
+  const raw = sanitizeRecord(input ?? {}, 'custom')
+  if (allowed.size === 0) return {}
+
+  const out: Record<string, boolean | number | string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (allowed.has(key)) out[key] = value
+  }
+  return out
+}

--- a/packages/telemetry/src/notice.ts
+++ b/packages/telemetry/src/notice.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { getTelemetryDir } from './paths'
 
-const DOCS_URL = 'https://evlog.dev/use-cases/telemetry/overview'
+const DOCS_URL = 'https://evlog.dev/use-cases/telemetry'
 const DOCS_LABEL = 'evlog.dev › telemetry'
 
 const c = {

--- a/packages/telemetry/src/notice.ts
+++ b/packages/telemetry/src/notice.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { getTelemetryDir } from './paths'
+
+const DOCS_URL = 'https://evlog.dev/use-cases/telemetry/overview'
+const DOCS_LABEL = 'evlog.dev › telemetry'
+
+const c = {
+  reset: '\x1B[0m',
+  bold: '\x1B[1m',
+  dim: '\x1B[2m',
+  yellow: '\x1B[33m',
+  cyan: '\x1B[36m',
+  underline: '\x1B[4m',
+} as const
+
+const LABEL_WIDTH = 8
+
+function useColors(): boolean {
+  if (process.env.NO_COLOR !== undefined) return false
+  if (process.env.FORCE_COLOR === '1' || process.env.FORCE_COLOR === '2' || process.env.FORCE_COLOR === '3') {
+    return true
+  }
+  return isInteractiveTerminal()
+}
+
+/** True when stderr or stdout is a TTY (pnpm scripts often keep one of them). */
+export function isInteractiveTerminal(): boolean {
+  return process.stderr.isTTY === true || process.stdout.isTTY === true
+}
+
+function paint(code: string, text: string, enabled: boolean): string {
+  return enabled ? `${code}${text}${c.reset}` : text
+}
+
+/** OSC 8 terminal hyperlink when colors are enabled. */
+function terminalLink(url: string, label: string, color: boolean): string {
+  if (!color) return `${label} (${url})`
+  return `\x1B]8;;${url}\x07${paint(c.cyan + c.underline, label, true)}\x1B]8;;\x07`
+}
+
+function actionRow(label: string, body: string, color: boolean): string {
+  const bar = paint(c.dim, '│ ', color)
+  const name = paint(c.dim, label.padEnd(LABEL_WIDTH), color)
+  return `  ${bar}${name}${body}`
+}
+
+/**
+ * First-run disclosure notice for interactive terminals.
+ * Respects `NO_COLOR`; plain text when colors are disabled.
+ */
+export function formatTelemetryNotice(toolName: string): string {
+  const color = useColors()
+  const statusCmd = `${toolName} telemetry status`
+  const disableCmd = `${toolName} telemetry disable`
+
+  const brand = `${paint(c.dim, 'evlog', color)} ${paint(c.yellow + c.bold, 'telemetry', color)}`
+  const headline = `${brand}${paint(c.dim, ' — anonymous usage enabled', color)}`
+
+  const rows = [
+    `  ${headline}`,
+    actionRow('status', paint(c.cyan, statusCmd, color), color),
+    actionRow('opt-out', paint(c.cyan, disableCmd, color), color),
+    actionRow('docs', terminalLink(DOCS_URL, DOCS_LABEL, color), color),
+  ]
+
+  return `\n${rows.join('\n')}\n\n`
+}
+
+/** Whether the first-run notice was already shown for this tool. */
+export function wasNoticeShown(toolName: string): boolean {
+  try {
+    readFileSync(join(getTelemetryDir(toolName), 'notice-shown'), 'utf-8')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/telemetry/src/outbox.ts
+++ b/packages/telemetry/src/outbox.ts
@@ -1,0 +1,175 @@
+import { appendFile, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { RunEvent } from './types'
+import { getTelemetryDir } from './paths'
+
+export interface OutboxOptions {
+  toolName: string
+  maxBufferBytes?: number
+  maxEventAgeMs?: number
+}
+
+interface StoredEvent {
+  event: RunEvent
+  storedAt: number
+}
+
+const DEFAULT_MAX_BYTES = 1024 * 1024
+const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+/** Disk-buffered NDJSON outbox — append-only writes, lockfile on compaction. */
+export class TelemetryOutbox {
+  private readonly dir: string
+  private readonly outboxPath: string
+  private readonly lockPath: string
+  private readonly maxBytes: number
+  private readonly maxAgeMs: number
+
+  constructor(opts: OutboxOptions) {
+    this.dir = getTelemetryDir(opts.toolName)
+    this.outboxPath = join(this.dir, 'outbox.ndjson')
+    this.lockPath = join(this.dir, 'outbox.lock')
+    this.maxBytes = opts.maxBufferBytes ?? DEFAULT_MAX_BYTES
+    this.maxAgeMs = opts.maxEventAgeMs ?? DEFAULT_MAX_AGE_MS
+  }
+
+  /** Append one event before any network attempt. Never throws. */
+  async append(event: RunEvent): Promise<void> {
+    try {
+      await mkdir(this.dir, { recursive: true })
+      const line = `${JSON.stringify({ event, storedAt: Date.now() } satisfies StoredEvent) }\n`
+      await appendFile(this.outboxPath, line, 'utf-8')
+      await this.enforceBounds()
+    } catch {
+      // never harm the host
+    }
+  }
+
+  /** Read all valid events in order. Corrupt lines skipped. */
+  async readAll(): Promise<RunEvent[]> {
+    let raw: string
+    try {
+      raw = await readFile(this.outboxPath, 'utf-8')
+    } catch {
+      return []
+    }
+
+    const events: RunEvent[] = []
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const stored = JSON.parse(line) as StoredEvent
+        if (stored?.event?.event === 'run') events.push(stored.event)
+      } catch {
+        // skip corrupt
+      }
+    }
+    return events
+  }
+
+  /** Remove delivered events by rewriting the outbox. */
+  async removeDelivered(keys: Set<string>): Promise<void> {
+    if (keys.size === 0) return
+    try {
+      await this.withLock(async () => {
+        const remaining: StoredEvent[] = []
+        let raw: string
+        try {
+          raw = await readFile(this.outboxPath, 'utf-8')
+        } catch {
+          return
+        }
+
+        const now = Date.now()
+        for (const line of raw.split('\n')) {
+          if (!line.trim()) continue
+          try {
+            const stored = JSON.parse(line) as StoredEvent
+            if (!stored?.event?.idempotencyKey) continue
+            if (keys.has(stored.event.idempotencyKey)) continue
+            if (now - stored.storedAt > this.maxAgeMs) continue
+            remaining.push(stored)
+          } catch {
+            // skip
+          }
+        }
+
+        const tmp = `${this.outboxPath}.tmp`
+        const body = remaining.map(s => `${JSON.stringify(s) }\n`).join('')
+        await writeFile(tmp, body, 'utf-8')
+        await rename(tmp, this.outboxPath)
+      })
+    } catch {
+      // silent
+    }
+  }
+
+  /** Delete the outbox file entirely. */
+  async purge(): Promise<void> {
+    try {
+      await unlink(this.outboxPath)
+    } catch {
+      // absent is fine
+    }
+  }
+
+  private async enforceBounds(): Promise<void> {
+    try {
+      const fileStat = await stat(this.outboxPath)
+      if (fileStat.size <= this.maxBytes) return
+      await this.compactByAge()
+    } catch {
+      // silent
+    }
+  }
+
+  private async compactByAge(): Promise<void> {
+    await this.withLock(async () => {
+      const now = Date.now()
+      let raw: string
+      try {
+        raw = await readFile(this.outboxPath, 'utf-8')
+      } catch {
+        return
+      }
+
+      const kept: StoredEvent[] = []
+      for (const line of raw.split('\n')) {
+        if (!line.trim()) continue
+        try {
+          const stored = JSON.parse(line) as StoredEvent
+          if (now - stored.storedAt <= this.maxAgeMs) kept.push(stored)
+        } catch {
+          // skip
+        }
+      }
+
+      // oldest-first drop when still over budget
+      while (kept.length > 0) {
+        const body = kept.map(s => `${JSON.stringify(s) }\n`).join('')
+        if (Buffer.byteLength(body, 'utf-8') <= this.maxBytes) break
+        kept.shift()
+      }
+
+      const tmp = `${this.outboxPath}.tmp`
+      await writeFile(tmp, kept.map(s => `${JSON.stringify(s) }\n`).join(''), 'utf-8')
+      await rename(tmp, this.outboxPath)
+    })
+  }
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    await mkdir(this.dir, { recursive: true })
+    let handle
+    let acquired = false
+    try {
+      handle = await open(this.lockPath, 'wx')
+      acquired = true
+      return await fn()
+    } finally {
+      if (acquired) {
+        await handle?.close().catch(() => {})
+        await unlink(this.lockPath).catch(() => {})
+      }
+    }
+  }
+}

--- a/packages/telemetry/src/outbox.ts
+++ b/packages/telemetry/src/outbox.ts
@@ -186,15 +186,20 @@ export class TelemetryOutbox {
       }
     }
 
-    // oldest-first drop when still over budget
-    while (kept.length > 0) {
-      const body = kept.map(s => `${JSON.stringify(s) }\n`).join('')
-      if (Buffer.byteLength(body, 'utf-8') <= this.maxBytes) break
-      kept.shift()
+    const serialized = kept.map(s => `${JSON.stringify(s)}\n`)
+    let totalBytes = serialized.reduce(
+      (sum, line) => sum + Buffer.byteLength(line, 'utf-8'),
+      0,
+    )
+
+    let dropFrom = 0
+    while (dropFrom < serialized.length && totalBytes > this.maxBytes) {
+      totalBytes -= Buffer.byteLength(serialized[dropFrom]!, 'utf-8')
+      dropFrom++
     }
 
     const tmp = `${this.outboxPath}.tmp`
-    await writeFile(tmp, kept.map(s => `${JSON.stringify(s) }\n`).join(''), 'utf-8')
+    await writeFile(tmp, serialized.slice(dropFrom).join(''), 'utf-8')
     await rename(tmp, this.outboxPath)
   }
 

--- a/packages/telemetry/src/outbox.ts
+++ b/packages/telemetry/src/outbox.ts
@@ -4,9 +4,14 @@ import type { RunEvent } from './types'
 import { getTelemetryDir } from './paths'
 
 export interface OutboxOptions {
+  /** Tool name used to resolve the config directory. */
   toolName: string
+  /** Max outbox file size in bytes before oldest events are dropped. Default: 1 MiB. */
   maxBufferBytes?: number
+  /** Max age in milliseconds for buffered events. Default: 30 days. */
   maxEventAgeMs?: number
+  /** Max age of `outbox.lock` before it is treated as stale. Default: 30s. */
+  lockStaleMs?: number
 }
 
 interface StoredEvent {
@@ -14,16 +19,46 @@ interface StoredEvent {
   storedAt: number
 }
 
+interface LockMetadata {
+  pid: number
+  acquiredAt: number
+}
+
 const DEFAULT_MAX_BYTES = 1024 * 1024
 const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+const DEFAULT_LOCK_STALE_MS = 30_000
+const LOCK_RETRIES = 5
+const LOCK_RETRY_DELAY_MS = 25
 
-/** Disk-buffered NDJSON outbox — append-only writes, lockfile on compaction. */
+function isEexist(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as NodeJS.ErrnoException).code === 'EEXIST'
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    const t = setTimeout(resolve, ms)
+    ;(t as { unref?: () => void }).unref?.()
+  })
+}
+
+/** Disk-buffered NDJSON outbox — lockfile serialises all mutating operations. */
 export class TelemetryOutbox {
   private readonly dir: string
   private readonly outboxPath: string
   private readonly lockPath: string
   private readonly maxBytes: number
   private readonly maxAgeMs: number
+  private readonly lockStaleMs: number
+  private lockChain: Promise<void> = Promise.resolve()
 
   constructor(opts: OutboxOptions) {
     this.dir = getTelemetryDir(opts.toolName)
@@ -31,15 +66,18 @@ export class TelemetryOutbox {
     this.lockPath = join(this.dir, 'outbox.lock')
     this.maxBytes = opts.maxBufferBytes ?? DEFAULT_MAX_BYTES
     this.maxAgeMs = opts.maxEventAgeMs ?? DEFAULT_MAX_AGE_MS
+    this.lockStaleMs = opts.lockStaleMs ?? DEFAULT_LOCK_STALE_MS
   }
 
   /** Append one event before any network attempt. Never throws. */
   async append(event: RunEvent): Promise<void> {
     try {
-      await mkdir(this.dir, { recursive: true })
-      const line = `${JSON.stringify({ event, storedAt: Date.now() } satisfies StoredEvent) }\n`
-      await appendFile(this.outboxPath, line, 'utf-8')
-      await this.enforceBounds()
+      await this.withLock(async () => {
+        await mkdir(this.dir, { recursive: true })
+        const line = `${JSON.stringify({ event, storedAt: Date.now() } satisfies StoredEvent) }\n`
+        await appendFile(this.outboxPath, line, 'utf-8')
+        await this.enforceBoundsInLock()
+      })
     } catch {
       // never harm the host
     }
@@ -55,11 +93,14 @@ export class TelemetryOutbox {
     }
 
     const events: RunEvent[] = []
+    const now = Date.now()
     for (const line of raw.split('\n')) {
       if (!line.trim()) continue
       try {
         const stored = JSON.parse(line) as StoredEvent
-        if (stored?.event?.event === 'run') events.push(stored.event)
+        if (stored?.event?.event !== 'run') continue
+        if (now - stored.storedAt > this.maxAgeMs) continue
+        events.push(stored.event)
       } catch {
         // skip corrupt
       }
@@ -107,69 +148,122 @@ export class TelemetryOutbox {
   /** Delete the outbox file entirely. */
   async purge(): Promise<void> {
     try {
-      await unlink(this.outboxPath)
+      await this.withLock(async () => {
+        await unlink(this.outboxPath).catch(() => {})
+      })
     } catch {
       // absent is fine
     }
   }
 
-  private async enforceBounds(): Promise<void> {
+  private async enforceBoundsInLock(): Promise<void> {
     try {
       const fileStat = await stat(this.outboxPath)
       if (fileStat.size <= this.maxBytes) return
-      await this.compactByAge()
+      await this.compactByAgeInLock()
     } catch {
       // silent
     }
   }
 
-  private async compactByAge(): Promise<void> {
-    await this.withLock(async () => {
-      const now = Date.now()
-      let raw: string
-      try {
-        raw = await readFile(this.outboxPath, 'utf-8')
-      } catch {
-        return
-      }
-
-      const kept: StoredEvent[] = []
-      for (const line of raw.split('\n')) {
-        if (!line.trim()) continue
-        try {
-          const stored = JSON.parse(line) as StoredEvent
-          if (now - stored.storedAt <= this.maxAgeMs) kept.push(stored)
-        } catch {
-          // skip
-        }
-      }
-
-      // oldest-first drop when still over budget
-      while (kept.length > 0) {
-        const body = kept.map(s => `${JSON.stringify(s) }\n`).join('')
-        if (Buffer.byteLength(body, 'utf-8') <= this.maxBytes) break
-        kept.shift()
-      }
-
-      const tmp = `${this.outboxPath}.tmp`
-      await writeFile(tmp, kept.map(s => `${JSON.stringify(s) }\n`).join(''), 'utf-8')
-      await rename(tmp, this.outboxPath)
-    })
-  }
-
-  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
-    await mkdir(this.dir, { recursive: true })
-    let handle
-    let acquired = false
+  private async compactByAgeInLock(): Promise<void> {
+    const now = Date.now()
+    let raw: string
     try {
-      handle = await open(this.lockPath, 'wx')
-      acquired = true
-      return await fn()
-    } finally {
-      if (acquired) {
-        await handle?.close().catch(() => {})
-        await unlink(this.lockPath).catch(() => {})
+      raw = await readFile(this.outboxPath, 'utf-8')
+    } catch {
+      return
+    }
+
+    const kept: StoredEvent[] = []
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const stored = JSON.parse(line) as StoredEvent
+        if (now - stored.storedAt <= this.maxAgeMs) kept.push(stored)
+      } catch {
+        // skip
       }
     }
+
+    // oldest-first drop when still over budget
+    while (kept.length > 0) {
+      const body = kept.map(s => `${JSON.stringify(s) }\n`).join('')
+      if (Buffer.byteLength(body, 'utf-8') <= this.maxBytes) break
+      kept.shift()
+    }
+
+    const tmp = `${this.outboxPath}.tmp`
+    await writeFile(tmp, kept.map(s => `${JSON.stringify(s) }\n`).join(''), 'utf-8')
+    await rename(tmp, this.outboxPath)
+  }
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
+    let release!: () => void
+    const previous = this.lockChain
+    this.lockChain = new Promise<void>(resolve => {
+      release = resolve
+    })
+    await previous
+
+    try {
+      return await this.withFileLock(fn)
+    } finally {
+      release()
+    }
+  }
+
+  private async withFileLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
+    await mkdir(this.dir, { recursive: true })
+
+    for (let attempt = 0; attempt < LOCK_RETRIES; attempt++) {
+      let handle
+      let acquired = false
+      try {
+        handle = await open(this.lockPath, 'wx')
+        acquired = true
+        const meta: LockMetadata = { pid: process.pid, acquiredAt: Date.now() }
+        await handle.writeFile(JSON.stringify(meta), 'utf-8')
+        return await fn()
+      } catch (err) {
+        if (isEexist(err)) {
+          if (await this.tryRecoverStaleLock()) continue
+          await sleep(LOCK_RETRY_DELAY_MS)
+          continue
+        }
+        throw err
+      } finally {
+        if (acquired) {
+          await handle?.close().catch(() => {})
+          await unlink(this.lockPath).catch(() => {})
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  private async tryRecoverStaleLock(): Promise<boolean> {
+    try {
+      const raw = await readFile(this.lockPath, 'utf-8')
+      const meta = JSON.parse(raw) as LockMetadata
+      const staleByAge = Date.now() - meta.acquiredAt > this.lockStaleMs
+      const staleByPid = !Number.isFinite(meta.pid) || !isProcessAlive(meta.pid)
+      if (staleByAge || staleByPid) {
+        await unlink(this.lockPath).catch(() => {})
+        return true
+      }
+    } catch {
+      try {
+        const lockStat = await stat(this.lockPath)
+        if (Date.now() - lockStat.mtimeMs > this.lockStaleMs) {
+          await unlink(this.lockPath).catch(() => {})
+          return true
+        }
+      } catch {
+        // absent or unreadable
+      }
+    }
+    return false
   }
 }

--- a/packages/telemetry/src/paths.ts
+++ b/packages/telemetry/src/paths.ts
@@ -1,0 +1,8 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Per-tool telemetry config directory under XDG or `~/.config`. */
+export function getTelemetryDir(toolName: string): string {
+  const base = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config')
+  return join(base, toolName, 'telemetry')
+}

--- a/packages/telemetry/src/paths.ts
+++ b/packages/telemetry/src/paths.ts
@@ -3,6 +3,6 @@ import { join } from 'node:path'
 
 /** Per-tool telemetry config directory under XDG or `~/.config`. */
 export function getTelemetryDir(toolName: string): string {
-  const base = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config')
+  const base = process.env.XDG_CONFIG_HOME || join(homedir(), '.config')
   return join(base, toolName, 'telemetry')
 }

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -1,0 +1,72 @@
+import type { CollectConfig } from './types'
+
+/**
+ * Sanitize citty-parsed flags by shape — never reads raw argv.
+ * Booleans and numbers: value captured.
+ * Strings: presence-only unless allowlisted in `collect.flags`.
+ */
+export function sanitizeFlags(
+  raw: Record<string, unknown> | undefined,
+  collect?: CollectConfig,
+): Record<string, boolean | number | string> {
+  if (!raw) return {}
+
+  const out: Record<string, boolean | number | string> = {}
+  const allowlists = collect?.flags ?? {}
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (value === undefined || value === null) continue
+
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      out[key] = value
+      continue
+    }
+
+    if (typeof value === 'string') {
+      const allowed = allowlists[key]
+      if (allowed && allowed.includes(value)) {
+        out[key] = value
+      } else {
+        out[key] = true
+      }
+      continue
+    }
+
+    // Arrays / objects (positional): presence only
+    out[key] = true
+  }
+
+  return out
+}
+
+/**
+ * Validate and merge custom fields from {@link telemetry.set}.
+ * Undeclared strings are dropped (never thrown).
+ */
+export function sanitizeCustom(
+  input: Record<string, unknown>,
+  existing: Record<string, boolean | number | string>,
+  collect?: CollectConfig,
+): Record<string, boolean | number | string> {
+  const out = { ...existing }
+  const fieldAllowlists = collect?.fields ?? {}
+
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue
+
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      out[key] = value
+      continue
+    }
+
+    if (typeof value === 'string') {
+      const allowed = fieldAllowlists[key]
+      if (allowed && (allowed as readonly string[]).includes(value)) {
+        out[key] = value
+      }
+      // undeclared strings: dropped silently
+    }
+  }
+
+  return out
+}

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -1,4 +1,25 @@
-import type { CollectConfig } from './types'
+/** Allowlisted system-injected custom keys (e.g. GitHub Actions metadata). */
+const SYSTEM_CUSTOM_KEYS = new Set(['ghaAction', 'ghaEvent'])
+const MAX_SYSTEM_STRING_LEN = 128
+
+/**
+ * Sanitize framework-injected custom fields before they enter the event envelope.
+ * Only allowlisted keys pass through; values are truncated to a bounded length.
+ */
+export function sanitizeSystemCustom(
+  input: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!input) return {}
+
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (!SYSTEM_CUSTOM_KEYS.has(key) || typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed) continue
+    out[key] = trimmed.slice(0, MAX_SYSTEM_STRING_LEN)
+  }
+  return out
+}
 
 /**
  * Sanitize citty-parsed flags by shape — never reads raw argv.

--- a/packages/telemetry/src/storage.ts
+++ b/packages/telemetry/src/storage.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { RunContext } from './types'
+
+const storage = new AsyncLocalStorage<RunContext>()
+
+/** @internal Enter a telemetry run scope (sync or async). */
+export function runWithContext<T>(ctx: RunContext, fn: () => T): T {
+  return storage.run(ctx, fn)
+}
+
+/** @internal Read the active run context, if any. */
+export function getRunContext(): RunContext | undefined {
+  return storage.getStore()
+}

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -87,11 +87,18 @@ export interface TelemetryOptions<
   sampling?: number
 }
 
+type CustomFieldValue<T extends readonly string[] | undefined> =
+  T extends readonly (infer S extends string)[] ? boolean | number | S : boolean | number
+
 /**
  * Custom fields accepted by {@link telemetry.set} — numbers and booleans always;
  * strings only when declared in `collect.fields` (enforced at runtime).
  */
-export type CustomFields<TFields extends CollectFields = {}> = Record<string, boolean | number | undefined>
+export type CustomFields<TFields extends CollectFields = {}> = {
+  [K in string]: K extends keyof TFields
+    ? CustomFieldValue<TFields[K]>
+    : boolean | number | undefined
+}
 
 /** Error shape recognised for automatic `errorCode` capture. */
 export interface TelemetryCliError {
@@ -102,7 +109,10 @@ export interface TelemetryCliError {
 /**
  * Handle returned by {@link createTelemetry}.
  */
-export interface TelemetryHandle {
+export interface TelemetryHandle<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+> {
   /** Run an async unit of work as a single telemetry event. */
   run: <T>(
     command: string,
@@ -113,6 +123,11 @@ export interface TelemetryHandle {
   flush: () => Promise<void>
   /** Whether telemetry is active (consent granted). */
   enabled: boolean
+  /**
+   * Set custom fields for the active run.
+   * Prefer this over the ambient {@link telemetry.set} for allowlisted string autocomplete.
+   */
+  set: (fields: CustomFields<TFields>) => void
 }
 
 /** @internal Mutable run context stored in ALS during `run()`. */

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -88,17 +88,19 @@ export interface TelemetryOptions<
 }
 
 type CustomFieldValue<T extends readonly string[] | undefined> =
-  T extends readonly (infer S extends string)[] ? boolean | number | S : boolean | number
+  T extends readonly string[] ? boolean | number | T[number] : boolean | number
 
 /**
  * Custom fields accepted by {@link telemetry.set} — numbers and booleans always;
  * strings only when declared in `collect.fields` (enforced at runtime).
+ *
+ * When `collect.fields` is non-empty, only declared keys accept allowlisted strings.
+ * Add undeclared counters with a second `set()` call or the ambient {@link telemetry.set}.
  */
-export type CustomFields<TFields extends CollectFields = {}> = {
-  [K in string]: K extends keyof TFields
-    ? CustomFieldValue<TFields[K]>
-    : boolean | number | undefined
-}
+export type CustomFields<TFields extends CollectFields = {}> =
+  keyof TFields extends never
+    ? Record<string, boolean | number | undefined>
+    : { [K in keyof TFields]?: CustomFieldValue<TFields[K]> }
 
 /** Error shape recognised for automatic `errorCode` capture. */
 export interface TelemetryCliError {

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Outcome of a single tool run captured by {@link createTelemetry}.
+ */
+export type RunOutcome = 'success' | 'error'
+
+/**
+ * Tool identity attached to every telemetry run event.
+ */
+export interface ToolInfo {
+  name: string
+  version: string
+}
+
+/**
+ * Environment snapshot enriched via `std-env`.
+ */
+export interface EnvInfo {
+  node: string
+  ci: boolean
+  provider: string | null
+  tty: boolean
+  agent: string | null
+}
+
+/**
+ * Standard wide-event envelope for one CLI/tool run.
+ * Defined by @evlog/telemetry — consumers only extend `custom` via {@link telemetry.set}.
+ */
+export interface RunEvent {
+  event: 'run'
+  command: string
+  durationMs: number
+  outcome: RunOutcome
+  errorCode?: string
+  flags: Record<string, boolean | number | string>
+  tool: ToolInfo
+  env: EnvInfo
+  machineId?: string
+  custom: Record<string, boolean | number | string>
+  idempotencyKey: string
+  timestamp: string
+}
+
+/** Allowlisted string flag values declared via `collect.flags`. */
+export type CollectFlags = Record<string, readonly string[]>
+
+/** Allowlisted string custom fields declared via `collect.fields`. */
+export type CollectFields = Record<string, readonly string[]>
+
+/**
+ * Optional collection declaration — inline, no separate config file.
+ * Closed sets only; undeclared string values become presence-only at runtime.
+ */
+export interface CollectConfig<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+> {
+  flags?: TFlags
+  fields?: TFields
+}
+
+/**
+ * Options passed to {@link createTelemetry} and {@link withTelemetry}.
+ */
+export interface TelemetryOptions<
+  TFlags extends CollectFlags = {},
+  TFields extends CollectFields = {},
+> {
+  /** Telemetry tool name, e.g. `evlog-cli`. Used for config dir and disclosure. */
+  name: string
+  /** Tool version string. */
+  version: string
+  /** Default ingestion endpoint baked in by the author. Overridable via `EVLOG_TELEMETRY_ENDPOINT`. */
+  endpoint?: string
+  /** Optional allowlists for string flags and custom fields. */
+  collect?: CollectConfig<TFlags, TFields>
+  /** Hard cap (ms) for {@link TelemetryHandle.flush}. Default: 500. */
+  flushTimeoutMs?: number
+  /** Max outbox file size in bytes before oldest events are dropped. Default: 1 MiB. */
+  maxBufferBytes?: number
+  /** Max age (ms) for buffered events. Default: 30 days. */
+  maxEventAgeMs?: number
+  /**
+   * Sampling rate 0–1. Declared for future use — v1 always records.
+   * @internal Not implemented in v1.
+   */
+  sampling?: number
+}
+
+/**
+ * Custom fields accepted by {@link telemetry.set} — numbers and booleans always;
+ * strings only when declared in `collect.fields` (enforced at runtime).
+ */
+export type CustomFields<TFields extends CollectFields = {}> = Record<string, boolean | number | undefined>
+
+/** Error shape recognised for automatic `errorCode` capture. */
+export interface TelemetryCliError {
+  code: string
+  message?: string
+}
+
+/**
+ * Handle returned by {@link createTelemetry}.
+ */
+export interface TelemetryHandle {
+  /** Run an async unit of work as a single telemetry event. */
+  run: <T>(
+    command: string,
+    fn: () => T | Promise<T>,
+    opts?: { flags?: Record<string, unknown>, systemCustom?: Record<string, string> },
+  ) => Promise<T>
+  /** Flush buffered events within the hard cap. Never throws. */
+  flush: () => Promise<void>
+  /** Whether telemetry is active (consent granted). */
+  enabled: boolean
+}
+
+/** @internal Mutable run context stored in ALS during `run()`. */
+export interface RunContext {
+  custom: Record<string, boolean | number | string>
+  collect?: CollectConfig
+}

--- a/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
+++ b/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
@@ -1,0 +1,210 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`telemetry disclosure > matches snapshot for default envelope 1`] = `
+"# Telemetry disclosure — evlog-cli
+
+## Standard envelope (always collected)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| \`event\` | string | Always \`run\`. |
+| \`command\` | string | Command name, auto-captured from citty. |
+| \`durationMs\` | number | Run duration in milliseconds. |
+| \`outcome\` | string | \`success\` or \`error\`. |
+| \`errorCode\` | string | From typed CLI errors when present. |
+| \`flags\` | object | Parsed flags — booleans/numbers as values, strings as presence unless allowlisted. |
+| \`tool.name\` | string | Tool name declared at setup. |
+| \`tool.version\` | string | Tool version declared at setup. |
+| \`env.node\` | string | Node.js version. |
+| \`env.ci\` | boolean | Whether running in CI. |
+| \`env.provider\` | string | null | CI provider when detected. |
+| \`env.tty\` | boolean | Whether stdout is a TTY. |
+| \`env.agent\` | string | null | AI coding agent when detected (claude, cursor, codex, …). |
+| \`machineId\` | string | Hashed anonymous machine id; omitted in ephemeral CI. |
+| \`custom\` | object | Consumer-provided fields via telemetry.set() — numbers/booleans by default. |
+
+## Opt out
+
+- \`DO_NOT_TRACK=1\`
+- \`EVLOG_TELEMETRY=0\`
+- \`evlog telemetry disable\` (persisted preference)
+
+## Debug
+
+Set \`EVLOG_TELEMETRY_DEBUG=1\` to print would-be payloads to stderr."
+`;
+
+exports[`telemetry disclosure > matches snapshot with collect extensions 1`] = `
+{
+  "extensions": {
+    "fields": {
+      "framework": [
+        "nuxt",
+        "next",
+      ],
+    },
+    "flags": {
+      "format": [
+        "json",
+        "csv",
+      ],
+    },
+  },
+  "markdown": "# Telemetry disclosure — evlog-cli
+
+## Standard envelope (always collected)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| \`event\` | string | Always \`run\`. |
+| \`command\` | string | Command name, auto-captured from citty. |
+| \`durationMs\` | number | Run duration in milliseconds. |
+| \`outcome\` | string | \`success\` or \`error\`. |
+| \`errorCode\` | string | From typed CLI errors when present. |
+| \`flags\` | object | Parsed flags — booleans/numbers as values, strings as presence unless allowlisted. |
+| \`tool.name\` | string | Tool name declared at setup. |
+| \`tool.version\` | string | Tool version declared at setup. |
+| \`env.node\` | string | Node.js version. |
+| \`env.ci\` | boolean | Whether running in CI. |
+| \`env.provider\` | string | null | CI provider when detected. |
+| \`env.tty\` | boolean | Whether stdout is a TTY. |
+| \`env.agent\` | string | null | AI coding agent when detected (claude, cursor, codex, …). |
+| \`machineId\` | string | Hashed anonymous machine id; omitted in ephemeral CI. |
+| \`custom\` | object | Consumer-provided fields via telemetry.set() — numbers/booleans by default. |
+
+## Allowlisted flag values
+
+- \`--format\`: \`json\`, \`csv\`
+
+## Allowlisted custom fields
+
+- \`framework\`: \`nuxt\`, \`next\`
+
+## Opt out
+
+- \`DO_NOT_TRACK=1\`
+- \`EVLOG_TELEMETRY=0\`
+- \`evlog telemetry disable\` (persisted preference)
+
+## Debug
+
+Set \`EVLOG_TELEMETRY_DEBUG=1\` to print would-be payloads to stderr.",
+  "standard": [
+    {
+      "description": "Always \`run\`.",
+      "field": "event",
+      "type": "string",
+    },
+    {
+      "description": "Command name, auto-captured from citty.",
+      "field": "command",
+      "type": "string",
+    },
+    {
+      "description": "Run duration in milliseconds.",
+      "field": "durationMs",
+      "type": "number",
+    },
+    {
+      "description": "\`success\` or \`error\`.",
+      "field": "outcome",
+      "type": "string",
+    },
+    {
+      "description": "From typed CLI errors when present.",
+      "field": "errorCode",
+      "type": "string",
+    },
+    {
+      "description": "Parsed flags — booleans/numbers as values, strings as presence unless allowlisted.",
+      "field": "flags",
+      "type": "object",
+    },
+    {
+      "description": "Tool name declared at setup.",
+      "field": "tool.name",
+      "type": "string",
+    },
+    {
+      "description": "Tool version declared at setup.",
+      "field": "tool.version",
+      "type": "string",
+    },
+    {
+      "description": "Node.js version.",
+      "field": "env.node",
+      "type": "string",
+    },
+    {
+      "description": "Whether running in CI.",
+      "field": "env.ci",
+      "type": "boolean",
+    },
+    {
+      "description": "CI provider when detected.",
+      "field": "env.provider",
+      "type": "string | null",
+    },
+    {
+      "description": "Whether stdout is a TTY.",
+      "field": "env.tty",
+      "type": "boolean",
+    },
+    {
+      "description": "AI coding agent when detected (claude, cursor, codex, …).",
+      "field": "env.agent",
+      "type": "string | null",
+    },
+    {
+      "description": "Hashed anonymous machine id; omitted in ephemeral CI.",
+      "field": "machineId",
+      "type": "string",
+    },
+    {
+      "description": "Consumer-provided fields via telemetry.set() — numbers/booleans by default.",
+      "field": "custom",
+      "type": "object",
+    },
+  ],
+  "version": 1,
+}
+`;
+
+exports[`telemetry notice > matches snapshot without ANSI colors 1`] = `
+"
+  evlog telemetry — anonymous usage enabled
+  │ status  my-tool telemetry status
+  │ opt-out my-tool telemetry disable
+  │ docs    evlog.dev › telemetry (https://evlog.dev/use-cases/telemetry/overview)
+
+"
+`;
+
+exports[`telemetry payload snapshot > matches enriched run event shape 1`] = `
+{
+  "command": "doctor",
+  "custom": {
+    "checksFailed": 0,
+  },
+  "durationMs": 42,
+  "env": {
+    "agent": null,
+    "ci": false,
+    "node": "20.11",
+    "provider": null,
+    "tty": true,
+  },
+  "event": "run",
+  "flags": {
+    "json": true,
+  },
+  "idempotencyKey": "d83e92e8aa2186d25a139b8ea34b02cc",
+  "machineId": "ab3f0123456789ab",
+  "outcome": "success",
+  "timestamp": "2026-07-14T12:00:00.000Z",
+  "tool": {
+    "name": "evlog-cli",
+    "version": "0.1.0",
+  },
+}
+`;

--- a/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
+++ b/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
@@ -175,7 +175,7 @@ exports[`telemetry notice > matches snapshot without ANSI colors 1`] = `
   evlog telemetry — anonymous usage enabled
   │ status  my-tool telemetry status
   │ opt-out my-tool telemetry disable
-  │ docs    evlog.dev › telemetry (https://evlog.dev/use-cases/telemetry/overview)
+  │ docs    evlog.dev › telemetry (https://evlog.dev/use-cases/telemetry)
 
 "
 `;

--- a/packages/telemetry/test/ingest.test.ts
+++ b/packages/telemetry/test/ingest.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { exampleRunEvent } from '../src/disclosure'
+import { IngestValidationError, parseIngestBody } from '../src/ingest'
+
+const OPTIONS = {
+  allowedTools: ['my-tool'],
+  allowedCustomKeys: {
+    'my-tool': ['checksFailed', 'itemsSynced'],
+  },
+} as const
+
+function body(events: unknown[]): string {
+  return JSON.stringify({ events })
+}
+
+describe('parseIngestBody', () => {
+  it('accepts a valid batch', () => {
+    const event = exampleRunEvent({
+      tool: { name: 'my-tool', version: '1.0.0' },
+      custom: { checksFailed: 2, itemsSynced: 10, secret: 'nope' },
+    })
+    const parsed = parseIngestBody(body([event]), OPTIONS)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0]?.custom).toEqual({ checksFailed: 2, itemsSynced: 10 })
+    expect(parsed[0]?.tool.name).toBe('my-tool')
+  })
+
+  it('rejects unknown tools', () => {
+    const event = exampleRunEvent({ tool: { name: 'other-tool', version: '1.0.0' } })
+    expect(() => parseIngestBody(body([event]), OPTIONS)).toThrow(IngestValidationError)
+  })
+
+  it('rejects oversized bodies', () => {
+    expect(() => parseIngestBody('x'.repeat(100_000), OPTIONS)).toThrow(/payload too large/)
+  })
+
+  it('rejects empty batches', () => {
+    expect(() => parseIngestBody(body([]), OPTIONS)).toThrow(/invalid batch/)
+  })
+
+  it('rejects invalid json', () => {
+    expect(() => parseIngestBody('{bad', OPTIONS)).toThrow(/invalid json/)
+  })
+
+  it('rejects missing idempotency key', () => {
+    const event = {
+      ...exampleRunEvent({ tool: { name: 'my-tool', version: '1.0.0' } }),
+      idempotencyKey: '',
+    }
+    expect(() => parseIngestBody(body([event]), OPTIONS)).toThrow(/idempotency/)
+  })
+})

--- a/packages/telemetry/test/telemetry-typing.test.ts
+++ b/packages/telemetry/test/telemetry-typing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { telemetry } from '../src/create'
+import { createTelemetry, telemetry } from '../src/create'
+import type { CustomFields } from '../src/types'
 
 describe('telemetry.set typing', () => {
   it('accepts numbers and booleans without collect', () => {
@@ -9,5 +10,27 @@ describe('telemetry.set typing', () => {
   it('rejects undeclared string fields at compile time', () => {
     // @ts-expect-error framework requires collect.fields declaration
     expectTypeOf(telemetry.set).toBeCallableWith({ framework: 'nuxt' })
+  })
+
+  it('accepts allowlisted strings in CustomFields', () => {
+    type Fields = { framework: readonly ['nuxt', 'next'] }
+    expectTypeOf<CustomFields<Fields>>().toMatchTypeOf<{ framework: 'nuxt' }>()
+  })
+})
+
+describe('TelemetryHandle.set typing', () => {
+  it('accepts allowlisted strings from collect.fields', () => {
+    const handle = createTelemetry({
+      name: 'test',
+      version: '1.0.0',
+      collect: { fields: { framework: ['nuxt', 'next'] as const } },
+    })
+    expectTypeOf(handle.set).toBeCallableWith({ framework: 'nuxt', ok: true })
+  })
+
+  it('rejects undeclared string fields on the handle', () => {
+    const handle = createTelemetry({ name: 'test', version: '1.0.0' })
+    // @ts-expect-error framework requires collect.fields declaration
+    expectTypeOf(handle.set).toBeCallableWith({ framework: 'nuxt' })
   })
 })

--- a/packages/telemetry/test/telemetry-typing.test.ts
+++ b/packages/telemetry/test/telemetry-typing.test.ts
@@ -1,0 +1,13 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { telemetry } from '../src/create'
+
+describe('telemetry.set typing', () => {
+  it('accepts numbers and booleans without collect', () => {
+    expectTypeOf(telemetry.set).toBeCallableWith({ checksFailed: 2, ok: true })
+  })
+
+  it('rejects undeclared string fields at compile time', () => {
+    // @ts-expect-error framework requires collect.fields declaration
+    expectTypeOf(telemetry.set).toBeCallableWith({ framework: 'nuxt' })
+  })
+})

--- a/packages/telemetry/test/telemetry-typing.test.ts
+++ b/packages/telemetry/test/telemetry-typing.test.ts
@@ -12,9 +12,9 @@ describe('telemetry.set typing', () => {
     expectTypeOf(telemetry.set).toBeCallableWith({ framework: 'nuxt' })
   })
 
-  it('accepts allowlisted strings in CustomFields', () => {
+  it('types allowlisted string values on declared keys', () => {
     type Fields = { framework: readonly ['nuxt', 'next'] }
-    expectTypeOf<CustomFields<Fields>>().toMatchTypeOf<{ framework: 'nuxt' }>()
+    expectTypeOf<'nuxt'>().toMatchTypeOf<NonNullable<CustomFields<Fields>['framework']>>()
   })
 })
 
@@ -25,7 +25,7 @@ describe('TelemetryHandle.set typing', () => {
       version: '1.0.0',
       collect: { fields: { framework: ['nuxt', 'next'] as const } },
     })
-    expectTypeOf(handle.set).toBeCallableWith({ framework: 'nuxt', ok: true })
+    expectTypeOf(handle.set).toBeCallableWith({ framework: 'nuxt' })
   })
 
   it('rejects undeclared string fields on the handle', () => {

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -3,12 +3,18 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resolveConsent, purgeOutbox } from '../src/consent'
-import { sanitizeFlags, sanitizeCustom } from '../src/sanitize'
+import { sanitizeFlags, sanitizeCustom, sanitizeSystemCustom } from '../src/sanitize'
 import { computeRunIdempotencyKey } from '../src/idempotency'
 import { generateDisclosure, exampleRunEvent } from '../src/disclosure'
 import { TelemetryOutbox } from '../src/outbox'
 import { formatTelemetryNotice } from '../src/notice'
-import { createTelemetry, telemetry, _resetActiveTelemetryForTests } from '../src/create'
+import {
+  createTelemetry,
+  telemetry,
+  disableTelemetry,
+  enableTelemetry,
+  _resetActiveTelemetryForTests,
+} from '../src/create'
 
 const TOOL = 'evlog-test'
 
@@ -16,7 +22,8 @@ describe('telemetry consent', () => {
   const { env } = process
 
   beforeEach(() => {
-    process.env = { ...env, XDG_CONFIG_HOME: undefined }
+    process.env = { ...env }
+    delete process.env.XDG_CONFIG_HOME
     delete process.env.DO_NOT_TRACK
     delete process.env.EVLOG_TELEMETRY
   })
@@ -72,6 +79,19 @@ describe('telemetry sanitize', () => {
     )
     expect(out).toEqual({ framework: 'nuxt' })
   })
+
+  it('allowlists system-injected custom keys only', () => {
+    expect(sanitizeSystemCustom({
+      ghaAction: 'checkout',
+      ghaEvent: 'push',
+      secret: 'nope',
+    })).toEqual({ ghaAction: 'checkout', ghaEvent: 'push' })
+  })
+
+  it('truncates long system custom strings', () => {
+    const long = 'x'.repeat(200)
+    expect(sanitizeSystemCustom({ ghaAction: long }).ghaAction).toHaveLength(128)
+  })
 })
 
 describe('telemetry outbox', () => {
@@ -111,6 +131,57 @@ describe('telemetry outbox', () => {
     await purgeOutbox(TOOL)
     expect(await outbox.readAll()).toHaveLength(0)
   })
+
+  it('excludes expired events on read', async () => {
+    const dir = join(base, TOOL, 'telemetry')
+    await mkdir(dir, { recursive: true })
+    const stale = { event: exampleRunEvent({ idempotencyKey: 'stale' }), storedAt: Date.now() - 60_000 }
+    const fresh = { event: exampleRunEvent({ idempotencyKey: 'fresh' }), storedAt: Date.now() }
+    await writeFile(
+      join(dir, 'outbox.ndjson'),
+      `${JSON.stringify(stale) }\n${JSON.stringify(fresh) }\n`,
+    )
+    const outbox = new TelemetryOutbox({ toolName: TOOL, maxEventAgeMs: 30_000 })
+    const read = await outbox.readAll()
+    expect(read).toHaveLength(1)
+    expect(read[0]?.idempotencyKey).toBe('fresh')
+  })
+
+  it('serializes concurrent appends without corrupting the outbox', async () => {
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        outbox.append(exampleRunEvent({ idempotencyKey: `key-${i}` })),
+      ),
+    )
+    const read = await outbox.readAll()
+    expect(read).toHaveLength(20)
+    expect(new Set(read.map(e => e.idempotencyKey)).size).toBe(20)
+  })
+
+  it('recovers a stale lock from a dead pid', async () => {
+    const dir = join(base, TOOL, 'telemetry')
+    await mkdir(dir, { recursive: true })
+    await writeFile(
+      join(dir, 'outbox.lock'),
+      JSON.stringify({ pid: 99_999_999, acquiredAt: Date.now() }),
+    )
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    await outbox.append(exampleRunEvent({ idempotencyKey: 'recovered' }))
+    expect(await outbox.readAll()).toHaveLength(1)
+  })
+
+  it('recovers a stale lock by age', async () => {
+    const dir = join(base, TOOL, 'telemetry')
+    await mkdir(dir, { recursive: true })
+    await writeFile(
+      join(dir, 'outbox.lock'),
+      JSON.stringify({ pid: process.pid, acquiredAt: Date.now() - 60_000 }),
+    )
+    const outbox = new TelemetryOutbox({ toolName: TOOL, lockStaleMs: 30_000 })
+    await outbox.append(exampleRunEvent({ idempotencyKey: 'aged-out' }))
+    expect(await outbox.readAll()).toHaveLength(1)
+  })
 })
 
 describe('telemetry flush', () => {
@@ -149,6 +220,28 @@ describe('telemetry flush', () => {
     const outbox = new TelemetryOutbox({ toolName: TOOL })
     const events = await outbox.readAll()
     expect(events[0]?.custom).toEqual({ checksFailed: 2, ok: true })
+  })
+
+  it('stops recording after disableTelemetry on the active instance', async () => {
+    const instance = createTelemetry({ name: TOOL, version: '0.0.0' })
+    await instance.run('before', () => undefined)
+    await disableTelemetry(TOOL)
+    expect(instance.enabled).toBe(false)
+    await instance.run('after', () => undefined)
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    expect(await outbox.readAll()).toHaveLength(0)
+  })
+
+  it('resumes recording after enableTelemetry on the active instance', async () => {
+    const instance = createTelemetry({ name: TOOL, version: '0.0.0' })
+    await disableTelemetry(TOOL)
+    await enableTelemetry(TOOL)
+    expect(instance.enabled).toBe(true)
+    await instance.run('again', () => undefined)
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    const events = await outbox.readAll()
+    expect(events).toHaveLength(1)
+    expect(events[0]?.command).toBe('again')
   })
 })
 

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -1,0 +1,197 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveConsent, purgeOutbox } from '../src/consent'
+import { sanitizeFlags, sanitizeCustom } from '../src/sanitize'
+import { computeRunIdempotencyKey } from '../src/idempotency'
+import { generateDisclosure, exampleRunEvent } from '../src/disclosure'
+import { TelemetryOutbox } from '../src/outbox'
+import { formatTelemetryNotice } from '../src/notice'
+import { createTelemetry, telemetry, _resetActiveTelemetryForTests } from '../src/create'
+
+const TOOL = 'evlog-test'
+
+describe('telemetry consent', () => {
+  const { env } = process
+
+  beforeEach(() => {
+    process.env = { ...env, XDG_CONFIG_HOME: undefined }
+    delete process.env.DO_NOT_TRACK
+    delete process.env.EVLOG_TELEMETRY
+  })
+
+  afterEach(() => {
+    process.env = env
+  })
+
+  it('honours DO_NOT_TRACK first', () => {
+    process.env.DO_NOT_TRACK = '1'
+    process.env.EVLOG_TELEMETRY = '1'
+    expect(resolveConsent(TOOL)).toBe(false)
+  })
+
+  it('honours EVLOG_TELEMETRY=0 over default', () => {
+    process.env.EVLOG_TELEMETRY = '0'
+    expect(resolveConsent(TOOL)).toBe(false)
+  })
+
+  it('honours EVLOG_TELEMETRY=1', () => {
+    process.env.EVLOG_TELEMETRY = '1'
+    expect(resolveConsent(TOOL)).toBe(true)
+  })
+})
+
+describe('telemetry sanitize', () => {
+  it('captures boolean and number flag values', () => {
+    expect(sanitizeFlags({ json: true, limit: 50 })).toEqual({ json: true, limit: 50 })
+  })
+
+  it('records string flags as presence-only by default', () => {
+    expect(sanitizeFlags({ output: '/secret/path' })).toEqual({ output: true })
+  })
+
+  it('allowlists declared string flag values', () => {
+    const flags = sanitizeFlags(
+      { format: 'json' },
+      { flags: { format: ['json', 'csv'] } },
+    )
+    expect(flags).toEqual({ format: 'json' })
+  })
+
+  it('drops undeclared string custom fields', () => {
+    const out = sanitizeCustom({ secret: 'nope' }, {}, undefined)
+    expect(out).toEqual({})
+  })
+
+  it('accepts declared string custom fields', () => {
+    const out = sanitizeCustom(
+      { framework: 'nuxt' },
+      {},
+      { fields: { framework: ['nitro', 'nuxt', 'next'] } },
+    )
+    expect(out).toEqual({ framework: 'nuxt' })
+  })
+})
+
+describe('telemetry outbox', () => {
+  let base: string
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'evlog-telemetry-'))
+    process.env.XDG_CONFIG_HOME = base
+  })
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true })
+    delete process.env.XDG_CONFIG_HOME
+    _resetActiveTelemetryForTests()
+  })
+
+  it('round-trips events offline then drains on next run', async () => {
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    const event = exampleRunEvent({ idempotencyKey: 'abc' })
+    await outbox.append(event)
+    const read = await outbox.readAll()
+    expect(read).toHaveLength(1)
+    expect(read[0]?.idempotencyKey).toBe('abc')
+  })
+
+  it('skips corrupt lines', async () => {
+    const dir = join(base, TOOL, 'telemetry')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'outbox.ndjson'), `{bad\n${ JSON.stringify({ event: exampleRunEvent(), storedAt: Date.now() }) }\n`)
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    expect(await outbox.readAll()).toHaveLength(1)
+  })
+
+  it('purges on opt-out', async () => {
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    await outbox.append(exampleRunEvent())
+    await purgeOutbox(TOOL)
+    expect(await outbox.readAll()).toHaveLength(0)
+  })
+})
+
+describe('telemetry flush', () => {
+  let base: string
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'evlog-telemetry-'))
+    process.env.XDG_CONFIG_HOME = base
+    process.env.EVLOG_TELEMETRY = '1'
+    _resetActiveTelemetryForTests()
+  })
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true })
+    delete process.env.XDG_CONFIG_HOME
+    delete process.env.EVLOG_TELEMETRY
+    _resetActiveTelemetryForTests()
+  })
+
+  it('never throws when drain always fails', async () => {
+    const instance = createTelemetry({
+      name: TOOL,
+      version: '0.0.0',
+      endpoint: 'http://127.0.0.1:1', // unreachable
+      flushTimeoutMs: 100,
+    })
+    await expect(instance.run('test', () => 'ok')).resolves.toBe('ok')
+    await expect(instance.flush()).resolves.toBeUndefined()
+  })
+
+  it('collects custom fields via telemetry.set()', async () => {
+    const instance = createTelemetry({ name: TOOL, version: '0.0.0' })
+    await instance.run('doctor', () => {
+      telemetry.set({ checksFailed: 2, ok: true })
+    })
+    const outbox = new TelemetryOutbox({ toolName: TOOL })
+    const events = await outbox.readAll()
+    expect(events[0]?.custom).toEqual({ checksFailed: 2, ok: true })
+  })
+})
+
+describe('telemetry notice', () => {
+  const { env } = process
+
+  beforeEach(() => {
+    process.env = { ...env }
+    process.env.NO_COLOR = '1'
+  })
+
+  afterEach(() => {
+    process.env = env
+    delete process.env.NO_COLOR
+  })
+
+  it('matches snapshot without ANSI colors', () => {
+    expect(formatTelemetryNotice('my-tool')).toMatchSnapshot()
+  })
+})
+
+describe('telemetry disclosure', () => {
+  it('matches snapshot for default envelope', () => {
+    expect(generateDisclosure('evlog-cli').markdown).toMatchSnapshot()
+  })
+
+  it('matches snapshot with collect extensions', () => {
+    const doc = generateDisclosure('evlog-cli', {
+      flags: { format: ['json', 'csv'] },
+      fields: { framework: ['nuxt', 'next'] },
+    })
+    expect(doc).toMatchSnapshot()
+  })
+})
+
+describe('telemetry payload snapshot', () => {
+  it('matches enriched run event shape', () => {
+    const key = computeRunIdempotencyKey({
+      command: 'doctor',
+      tool: { name: 'evlog-cli', version: '0.1.0' },
+      timestamp: '2026-07-14T12:00:00.000Z',
+      machineId: 'ab3f0123456789ab',
+    })
+    expect(exampleRunEvent({ idempotencyKey: key })).toMatchSnapshot()
+  })
+})

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ESNext"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/telemetry/tsdown.config.ts
+++ b/packages/telemetry/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: 'esm',
+  dts: true,
+  clean: true,
+  fixedExtension: true,
+})

--- a/packages/telemetry/tsdown.config.ts
+++ b/packages/telemetry/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    ingest: 'src/ingest.ts',
   },
   format: 'esm',
   dts: true,

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
     dependencies:
       '@databuddy/nuxt':
         specifier: ^2.4.20
-        version: 2.4.20(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.20(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/fonts':
         specifier: 0.14.0
         version: 0.14.0(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -75,22 +75,22 @@ importers:
         version: 2.6.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       docus:
         specifier: ^5.10.1
-        version: 5.10.1(4bb03f336682a9f31a3a83b41ca71fcc)
+        version: 5.10.1(19bf385c2a350654bfe793b6ed7f1036)
       motion-v:
         specifier: ^2.2.1
         version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(9759e11547571991a351c21f7950ae84)
+        version: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       nuxt-studio:
         specifier: ^1.6.1
         version: 1.7.0(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
@@ -109,7 +109,7 @@ importers:
     dependencies:
       '@comark/nuxt':
         specifier: ^0.3.1
-        version: 0.3.1(katex@0.16.47)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
+        version: 0.3.1(katex@0.16.47)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/content':
         specifier: ^3.13.0
         version: 3.13.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.3))
@@ -118,16 +118,16 @@ importers:
         version: 4.7.1(198690880b5ae677e908fab613f69444)
       '@nuxtjs/sitemap':
         specifier: ^8.0.14
-        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
+        version: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
       shiki:
         specifier: 4.0.2
         version: 4.0.2
@@ -181,7 +181,7 @@ importers:
         version: 3.0.260610-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       rolldown:
         specifier: latest
-        version: 1.1.4
+        version: 1.1.5
 
   apps/nitro-v2-playground:
     dependencies:
@@ -194,7 +194,7 @@ importers:
         version: 1.15.11
       nitropack:
         specifier: ^2.13.3
-        version: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4)
+        version: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)
 
   apps/nuxthub-playground:
     dependencies:
@@ -239,7 +239,7 @@ importers:
         version: 4.7.1(65e37946ecaaadf70b7f13c25f86be87)
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(a57889fcd46a40869578f7a6a38b8a84)
+        version: 1.6.9(26b9a8bdbd2bb4345925af1d00faa4d9)
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -248,7 +248,7 @@ importers:
         version: link:../../packages/evlog
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
+        version: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -361,7 +361,7 @@ importers:
         version: 4.3.0
       '@vercel/connect':
         specifier: 0.2.2
-        version: 0.2.2(@ai-sdk/mcp@1.0.39(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.9(79340e0b111d34b3e177fe53f6c14509))(eve@0.12.3(10aaaec19871a4666c04855ff5015fb6))
+        version: 0.2.2(@ai-sdk/mcp@1.0.39(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.9(b19dc0cf074181bab87470771343aa58))(eve@0.12.3(510ea272993aea4194cf71a70b0e7064))
       ai:
         specifier: ^7.0.0
         version: 7.0.15(zod@4.4.3)
@@ -376,7 +376,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       eve:
         specifier: ^0.12.3
-        version: 0.12.3(10aaaec19871a4666c04855ff5015fb6)
+        version: 0.12.3(510ea272993aea4194cf71a70b0e7064)
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -521,10 +521,10 @@ importers:
     dependencies:
       '@orpc/openapi':
         specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.6(srvx@0.11.16))(fastify@5.8.5)(ws@8.20.0)
+        version: 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.10(srvx@0.11.22))(fastify@5.8.5)(ws@8.20.0)
       '@orpc/server':
         specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.6(srvx@0.11.16))(fastify@5.8.5)(ws@8.20.0)
+        version: 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.10(srvx@0.11.22))(fastify@5.8.5)(ws@8.20.0)
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -593,7 +593,7 @@ importers:
         version: 0.15.4(solid-js@1.9.12)
       '@solidjs/start':
         specifier: ^1.2.1
-        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -646,7 +646,7 @@ importers:
         version: 1.166.12(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.169.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.167.61(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -658,7 +658,7 @@ importers:
         version: 0.545.0(react@19.2.5)
       nitro:
         specifier: npm:nitro-nightly@latest
-        version: nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: nitro-nightly@3.0.1-20260712-095235-05bf1c38(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -693,6 +693,19 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
+  examples/telemetry-playground:
+    dependencies:
+      '@evlog/telemetry':
+        specifier: workspace:*
+        version: link:../../packages/telemetry
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+    devDependencies:
+      tsx:
+        specifier: ^4.20.7
+        version: 4.21.0
 
   examples/vite:
     dependencies:
@@ -889,6 +902,31 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/telemetry:
+    dependencies:
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      std-env:
+        specifier: ^4.1.0
+        version: 4.1.0
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsdown:
+        specifier: ^0.21.10
+        version: 0.21.10(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
+      tsx:
+        specifier: ^4.20.7
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
 packages:
 
@@ -1538,11 +1576,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3':
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -3071,12 +3109,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -4074,11 +4106,11 @@ packages:
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
-  '@oxc-project/types@0.137.0':
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
-
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@oxc-transform/binding-android-arm-eabi@0.112.0':
     resolution: {integrity: sha512-r4LuBaPnOAi0eUOBNi880Fm2tO2omH7N1FRrL6+nyz/AjQ+QPPLtoyZJva0O+sKi1buyN/7IzM5p9m+5ANSDbg==}
@@ -5470,14 +5502,14 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.1.2':
-    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.1.4':
-    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -5494,14 +5526,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
-    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
-    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -5518,14 +5550,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.2':
-    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.4':
-    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -5542,14 +5574,14 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
-    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
-    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -5566,14 +5598,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
-    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
-    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -5592,15 +5624,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
-    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
-    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5620,15 +5652,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
-    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
-    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5641,15 +5673,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
-    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
-    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -5662,15 +5694,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
-    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
-    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -5690,15 +5722,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
-    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
-    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5718,15 +5750,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
-    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
-    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5744,14 +5776,14 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
-    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
-    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -5766,13 +5798,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
-    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
@@ -5788,14 +5820,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
-    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5812,14 +5844,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
-    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
-    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -7230,9 +7262,6 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -8862,6 +8891,14 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
+  crossws@0.4.10:
+    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
   crossws@0.4.5:
     resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
     peerDependencies:
@@ -9627,6 +9664,24 @@ packages:
       wrangler:
         optional: true
 
+  env-runner@0.1.16:
+    resolution: {integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4.1.23
+      '@vercel/queue': '>=0.2.0'
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      '@vercel/queue':
+        optional: true
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
+
   env-runner@0.1.7:
     resolution: {integrity: sha512-i7h96jxETJYhXy5grgHNJ9xNzCzWIn9Ck/VkkYgOlE4gOqknsLX3CmlVb5LmwNex8sOoLFVZLz+TIw/+b5rktA==}
     hasBin: true
@@ -9991,6 +10046,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -10400,20 +10458,20 @@ packages:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  h3-rules@0.1.0:
+    resolution: {integrity: sha512-MrUUH1E/yoM7hvpKVbLs/CFeindwiTn7Fcfo+zXDpfuRYbcpJDPkYGGttCSiHNJmjUQNYQ5yn9veUIqFonYXuw==}
+    peerDependencies:
+      h3: ^2.0.1-rc.25
+      ocache: '>=0.2.0'
+    peerDependenciesMeta:
+      ocache:
+        optional: true
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   h3@1.15.3:
     resolution: {integrity: sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==}
-
-  h3@2.0.1-rc.2:
-    resolution: {integrity: sha512-2vS7OETzPDzGQxmmcs6ttu7p0NW25zAdkPXYOr43dn4GZf81uUljJvupa158mcpUGpsQUqIy4O4THWUQT1yVeA==}
-    engines: {node: '>=20.11.1'}
-    peerDependencies:
-      crossws: ^0.4.1
-    peerDependenciesMeta:
-      crossws:
-        optional: true
 
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
@@ -10441,6 +10499,16 @@ packages:
     hasBin: true
     peerDependencies:
       crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  h3@2.0.1-rc.25:
+    resolution: {integrity: sha512-uIK++Up28xDt4n0+bSWfVssRivNXpUmMmA6CCiK6j9+utLcBMcFK97Gn9PlSZwAPW9oLy3CjGJ4ag40CY9YYtQ==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.9
     peerDependenciesMeta:
       crossws:
         optional: true
@@ -10610,6 +10678,9 @@ packages:
 
   httpxy@0.5.3:
     resolution: {integrity: sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -11820,29 +11891,44 @@ packages:
       sass:
         optional: true
 
-  nf3@0.1.12:
-    resolution: {integrity: sha512-qbMXT7RTGh74MYWPeqTIED8nDW70NXOULVHpdWcdZ7IVHVnAsMV9fNugSNnvooipDc1FMOzpis7T9nXJEbJhvQ==}
-
   nf3@0.3.16:
     resolution: {integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==}
 
   nf3@0.3.17:
     resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
 
-  nitro-nightly@4.0.0-20251010-091516-7cafddba:
-    resolution: {integrity: sha512-biADkmoR/Nb9OmUURTfDI2BpGo2IMEt2RbsiMhjqdwz2w3tEm+tx0Hd28LXjBCwid+l8jpqyfmpwc8jzwdng3w==}
+  nf3@0.3.22:
+    resolution: {integrity: sha512-NOcqlHu22X1rUakd0SrqllP8kb3LWFmSAi1svTxaKxz+yB604xlaOmUfI3oO+RkODvaocKDDy8bgthnZL8hrkw==}
+
+  nitro-nightly@3.0.1-20260712-095235-05bf1c38:
+    resolution: {integrity: sha512-aOE3Pc2BNMorvXCMlBdBRAkWY+brTFEbg1EKbiouYdhbTcdjpfzwhlvk8duirKiIA+c2B06MlnrNHXUMLkI/mQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      rolldown: '*'
-      vite: ^7
+      '@vercel/queue': ^0.4.0
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.7.0
+      rollup: ^4.62.0
+      vite: ^7 || ^8
       xml2js: ^0.6.2
+      zephyr-agent: ^1.1.2
     peerDependenciesMeta:
-      rolldown:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
         optional: true
       vite:
         optional: true
       xml2js:
+        optional: true
+      zephyr-agent:
         optional: true
 
   nitro@3.0.260311-beta:
@@ -12081,6 +12167,9 @@ packages:
 
   ocache@0.1.5:
     resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
+
+  ocache@0.2.0:
+    resolution: {integrity: sha512-QE+SxXf/A8yR01rEOg2X5KwUe+mARHo1xQXl+iwLMzLIH06S5lBOZhhHQWp7T5etfFa8nOnRhvjGuo9YBCWwig==}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -12976,10 +13065,6 @@ packages:
   remend@1.3.0:
     resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
-  rendu@0.0.6:
-    resolution: {integrity: sha512-nZ512Dw0MxKiIYfCVv8DPe6ig4m0Qt3FOYBJEXrammjIYBBPuHaudc0AGfYx+iyOw2q0itAtPywiVZXtTFCsig==}
-    hasBin: true
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -13073,13 +13158,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.1.2:
-    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.1.4:
-    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -13126,6 +13211,9 @@ packages:
 
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
+  rou3@0.9.1:
+    resolution: {integrity: sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==}
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -13474,8 +13562,8 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
-  srvx@0.8.16:
-    resolution: {integrity: sha512-hmcGW4CgroeSmzgF1Ihwgl+Ths0JqAJ7HwjP2X7e3JzY7u4IydLMcdnlqGQiQGUswz+PO9oh/KtCpOISIvs9QQ==}
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -14014,9 +14102,6 @@ packages:
   unenv@2.0.0-rc.14:
     resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
 
-  unenv@2.0.0-rc.21:
-    resolution: {integrity: sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==}
-
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -14202,80 +14287,6 @@ packages:
       idb-keyval:
         optional: true
       ioredis:
-        optional: true
-      uploadthing:
-        optional: true
-
-  unstorage@2.0.0-alpha.3:
-    resolution: {integrity: sha512-BeoqISVh8jxqnPseHH7/92twe2VkQztrudXg8RFZVbXb4ckkFdpLk1LnNvsUndDltyodBMVxgI6V7JcbJYt2VQ==}
-    peerDependencies:
-      '@azure/app-configuration': ^1.8.0
-      '@azure/cosmos': ^4.2.0
-      '@azure/data-tables': ^13.3.0
-      '@azure/identity': ^4.6.0
-      '@azure/keyvault-secrets': ^4.9.0
-      '@azure/storage-blob': ^12.26.0
-      '@capacitor/preferences': ^6.0.3 || ^7.0.0
-      '@deno/kv': '>=0.9.0'
-      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
-      '@planetscale/database': ^1.19.0
-      '@upstash/redis': ^1.34.3
-      '@vercel/blob': '>=0.27.1'
-      '@vercel/functions': ^2.2.12 || ^3.0.0
-      '@vercel/kv': ^1.0.1
-      aws4fetch: ^1.0.20
-      chokidar: ^4.0.3
-      db0: '>=0.2.1'
-      idb-keyval: ^6.2.1
-      ioredis: ^5.4.2
-      lru-cache: ^11.2.2
-      mongodb: ^6.20.0
-      ofetch: ^1.4.1
-      uploadthing: ^7.4.4
-    peerDependenciesMeta:
-      '@azure/app-configuration':
-        optional: true
-      '@azure/cosmos':
-        optional: true
-      '@azure/data-tables':
-        optional: true
-      '@azure/identity':
-        optional: true
-      '@azure/keyvault-secrets':
-        optional: true
-      '@azure/storage-blob':
-        optional: true
-      '@capacitor/preferences':
-        optional: true
-      '@deno/kv':
-        optional: true
-      '@netlify/blobs':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@vercel/blob':
-        optional: true
-      '@vercel/functions':
-        optional: true
-      '@vercel/kv':
-        optional: true
-      aws4fetch:
-        optional: true
-      chokidar:
-        optional: true
-      db0:
-        optional: true
-      idb-keyval:
-        optional: true
-      ioredis:
-        optional: true
-      lru-cache:
-        optional: true
-      mongodb:
-        optional: true
-      ofetch:
         optional: true
       uploadthing:
         optional: true
@@ -15809,12 +15820,12 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@comark/nuxt@0.3.1(katex@0.16.47)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))':
+  '@comark/nuxt@0.3.1(katex@0.16.47)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@comark/vue': 0.3.1(katex@0.16.47)(shiki@4.0.2)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       comark: 0.3.2(katex@0.16.47)(shiki@4.0.2)
-      nuxt: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
+      nuxt: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
     transitivePeerDependencies:
       - beautiful-mermaid
       - katex
@@ -15840,12 +15851,12 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@databuddy/nuxt@2.4.20(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))':
+  '@databuddy/nuxt@2.4.20(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@databuddy/sdk': 2.4.20(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@nuxt/schema': 4.4.6
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
     optionalDependencies:
       vue: 3.5.33(typescript@6.0.3)
     transitivePeerDependencies:
@@ -16661,7 +16672,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -17077,7 +17088,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -17085,13 +17096,6 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -17890,7 +17894,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(7bd188e1e04a5a825a38611cf5569dda))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(8d86e90b37330199037fcfad0b7ac55e))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -17908,8 +17912,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4)
-      nuxt: 4.4.4(7bd188e1e04a5a825a38611cf5569dda)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)
+      nuxt: 4.4.4(8d86e90b37330199037fcfad0b7ac55e)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -17962,7 +17966,7 @@ snapshots:
       - xml2js
     optional: true
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@6.0.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -17980,8 +17984,79 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4)
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)
+      nuxt: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
+      vue: 3.5.33(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@6.0.3)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.11
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -18053,77 +18128,6 @@ snapshots:
       mocked-exports: 0.1.1
       nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)
       nuxt: 4.4.4(d1aca583cca69d3e2fbcf4879061daac)
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.8.1
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unctx: 2.5.0
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
-      vue: 3.5.33(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@6.0.3)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.11
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4)
-      nuxt: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -18772,7 +18776,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(7bd188e1e04a5a825a38611cf5569dda))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(8d86e90b37330199037fcfad0b7ac55e))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -18790,7 +18794,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(7bd188e1e04a5a825a38611cf5569dda)
+      nuxt: 4.4.4(8d86e90b37330199037fcfad0b7ac55e)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -18807,8 +18811,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.2)
+      rolldown: 1.1.5
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -18835,7 +18839,7 @@ snapshots:
       - yaml
     optional: true
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -18853,7 +18857,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -18870,8 +18874,70 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.2)
+      rolldown: 1.1.5
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.13)
+      consola: 3.4.2
+      cssnano: 7.1.8(postcss@8.5.13)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.6.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.13
+      seroval: 1.5.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite-plugin-checker: 0.13.0(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue-tsc@3.2.7(typescript@6.0.3))
+      vue: 3.5.33(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      rolldown: 1.1.5
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -18934,68 +19000,6 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       rolldown: 1.0.0-rc.17
       rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.2)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
-    dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.13)
-      consola: 3.4.2
-      cssnano: 7.1.8(postcss@8.5.13)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.6.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.13
-      seroval: 1.5.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vite-plugin-checker: 0.13.0(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue-tsc@3.2.7(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -19355,15 +19359,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)':
+  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -19376,14 +19380,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
+  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.7.2
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -19451,13 +19455,13 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/openapi@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.6(srvx@0.11.16))(fastify@5.8.5)(ws@8.20.0)':
+  '@orpc/openapi@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.10(srvx@0.11.22))(fastify@5.8.5)(ws@8.20.0)':
     dependencies:
       '@orpc/client': 1.14.2(@opentelemetry/api@1.9.1)
       '@orpc/contract': 1.14.2(@opentelemetry/api@1.9.1)
       '@orpc/interop': 1.14.2
       '@orpc/openapi-client': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/server': 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.6(srvx@0.11.16))(fastify@5.8.5)(ws@8.20.0)
+      '@orpc/server': 1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.10(srvx@0.11.22))(fastify@5.8.5)(ws@8.20.0)
       '@orpc/shared': 1.14.2(@opentelemetry/api@1.9.1)
       '@orpc/standard-server': 1.14.2(@opentelemetry/api@1.9.1)
       json-schema-typed: 8.0.2
@@ -19467,6 +19471,26 @@ snapshots:
       - crossws
       - fastify
       - ws
+
+  '@orpc/server@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.10(srvx@0.11.22))(fastify@5.8.5)(ws@8.20.0)':
+    dependencies:
+      '@orpc/client': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/interop': 1.14.2
+      '@orpc/shared': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-aws-lambda': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fastify': 1.14.2(@opentelemetry/api@1.9.1)(fastify@5.8.5)
+      '@orpc/standard-server-fetch': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-node': 1.14.2(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-peer': 1.14.2(@opentelemetry/api@1.9.1)
+      cookie: 1.1.1
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - fastify
 
   '@orpc/server@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.5(srvx@0.11.15))(fastify@5.8.5)(ws@8.20.0)':
     dependencies:
@@ -19483,26 +19507,6 @@ snapshots:
       cookie: 1.1.1
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - fastify
-
-  '@orpc/server@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.6(srvx@0.11.16))(fastify@5.8.5)(ws@8.20.0)':
-    dependencies:
-      '@orpc/client': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/contract': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/interop': 1.14.2
-      '@orpc/shared': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-aws-lambda': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fastify': 1.14.2(@opentelemetry/api@1.9.1)(fastify@5.8.5)
-      '@orpc/standard-server-fetch': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-node': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-peer': 1.14.2(@opentelemetry/api@1.9.1)
-      cookie: 1.1.1
-    optionalDependencies:
-      crossws: 0.4.6(srvx@0.11.16)
       ws: 8.20.0
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -19724,7 +19728,7 @@ snapshots:
 
   '@oxc-parser/binding-wasm32-wasi@0.112.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -19763,9 +19767,9 @@ snapshots:
 
   '@oxc-project/types@0.128.0': {}
 
-  '@oxc-project/types@0.137.0': {}
-
   '@oxc-project/types@0.138.0': {}
+
+  '@oxc-project/types@0.139.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.112.0':
     optional: true
@@ -19865,7 +19869,7 @@ snapshots:
 
   '@oxc-transform/binding-wasm32-wasi@0.112.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -21024,10 +21028,10 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.1.2':
+  '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.1.4':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
@@ -21036,10 +21040,10 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
+  '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.57':
@@ -21048,10 +21052,10 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.2':
+  '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.4':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
@@ -21060,10 +21064,10 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
+  '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
@@ -21072,10 +21076,10 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
@@ -21084,10 +21088,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
@@ -21096,28 +21100,28 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
@@ -21126,10 +21130,10 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
@@ -21138,10 +21142,10 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
+  '@rolldown/binding-linux-x64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
@@ -21150,15 +21154,15 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
+  '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -21171,14 +21175,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
+  '@rolldown/binding-wasm32-wasi@1.1.4':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
@@ -21191,10 +21195,10 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
@@ -21203,10 +21207,10 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.40': {}
@@ -21600,11 +21604,11 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
@@ -21616,7 +21620,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.12)
       tinyglobby: 0.2.16
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -22346,62 +22350,16 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optional: true
 
-  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-core': 1.169.1
-      '@tanstack/router-utils': 1.161.7
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
-      '@tanstack/start-storage-context': 1.166.34
-      pathe: 2.0.3
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - crossws
-      - supports-color
-      - vite
-      - vite-plugin-solid
-      - webpack
-    optional: true
-
-  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-core': 1.169.1
-      '@tanstack/router-utils': 1.161.7
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
-      '@tanstack/start-storage-context': 1.166.34
-      pathe: 2.0.3
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - crossws
-      - supports-color
-      - vite
-      - vite-plugin-solid
-      - webpack
-    optional: true
-
-  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.169.1
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.6(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.8.16))
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       '@tanstack/start-storage-context': 1.166.34
       pathe: 2.0.3
       react: 19.2.5
@@ -22414,41 +22372,110 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-server@1.166.50(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
+      '@tanstack/start-storage-context': 1.166.34
+      pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+    optional: true
+
+  '@tanstack/react-start-rsc@0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
+      '@tanstack/start-storage-context': 1.166.34
+      pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+    optional: true
+
+  '@tanstack/react-start-server@1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/react-start-server@1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/history': 1.161.6
       '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.169.1
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - crossws
     optional: true
 
-  '@tanstack/react-start-server@1.166.50(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-start@1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@tanstack/history': 1.161.6
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.169.1
+      '@tanstack/react-start-client': 1.166.47(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.8.16))
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
+      pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
+      - '@rspack/core'
       - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
 
-  '@tanstack/react-start@1.167.61(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/react-start@1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.166.47(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -22463,16 +22490,16 @@ snapshots:
       - webpack
     optional: true
 
-  '@tanstack/react-start@1.167.61(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/react-start@1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.166.47(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start-server': 1.166.50(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
+      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -22486,29 +22513,6 @@ snapshots:
       - vite-plugin-solid
       - webpack
     optional: true
-
-  '@tanstack/react-start@1.167.61(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-client': 1.166.47(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.0.40(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start-server': 1.166.50(crossws@0.4.6(srvx@0.8.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-utils': 1.161.7
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-plugin-core': 1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.6(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.8.16))
-      pathe: 2.0.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - crossws
-      - react-server-dom-rspack
-      - supports-color
-      - vite-plugin-solid
-      - webpack
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -22665,7 +22669,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.6(srvx@0.8.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -22676,7 +22680,7 @@ snapshots:
       '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.8.16))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       cheerio: 1.2.0
       exsolve: 1.0.8
       lightningcss: 1.32.0
@@ -22684,7 +22688,7 @@ snapshots:
       picomatch: 4.0.4
       seroval: 1.5.2
       source-map: 0.7.6
-      srvx: 0.11.15
+      srvx: 0.11.16
       tinyglobby: 0.2.16
       ufo: 1.6.4
       vitefu: 1.1.3(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -22699,7 +22703,7 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -22710,7 +22714,7 @@ snapshots:
       '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       cheerio: 1.2.0
       exsolve: 1.0.8
       lightningcss: 1.32.0
@@ -22718,7 +22722,7 @@ snapshots:
       picomatch: 4.0.4
       seroval: 1.5.2
       source-map: 0.7.6
-      srvx: 0.11.15
+      srvx: 0.11.16
       tinyglobby: 0.2.16
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -22734,7 +22738,7 @@ snapshots:
       - webpack
     optional: true
 
-  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.6(srvx@0.11.16))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tanstack/start-plugin-core@1.169.16(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.10(srvx@0.11.22))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -22745,7 +22749,7 @@ snapshots:
       '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tanstack/router-utils': 1.161.7
       '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-server-core': 1.167.28(crossws@0.4.6(srvx@0.11.16))
+      '@tanstack/start-server-core': 1.167.28(crossws@0.4.10(srvx@0.11.22))
       cheerio: 1.2.0
       exsolve: 1.0.8
       lightningcss: 1.32.0
@@ -22753,7 +22757,7 @@ snapshots:
       picomatch: 4.0.4
       seroval: 1.5.2
       source-map: 0.7.6
-      srvx: 0.11.15
+      srvx: 0.11.16
       tinyglobby: 0.2.16
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -22769,27 +22773,14 @@ snapshots:
       - webpack
     optional: true
 
-  '@tanstack/start-server-core@1.167.28(crossws@0.4.6(srvx@0.11.16))':
+  '@tanstack/start-server-core@1.167.28(crossws@0.4.10(srvx@0.11.22))':
     dependencies:
       '@tanstack/history': 1.161.6
       '@tanstack/router-core': 1.169.1
       '@tanstack/start-client-core': 1.168.1
       '@tanstack/start-storage-context': 1.166.34
       fetchdts: 0.1.7
-      h3-v2: h3@2.0.1-rc.20(crossws@0.4.6(srvx@0.11.16))
-      seroval: 1.5.2
-    transitivePeerDependencies:
-      - crossws
-    optional: true
-
-  '@tanstack/start-server-core@1.167.28(crossws@0.4.6(srvx@0.8.16))':
-    dependencies:
-      '@tanstack/history': 1.161.6
-      '@tanstack/router-core': 1.169.1
-      '@tanstack/start-client-core': 1.168.1
-      '@tanstack/start-storage-context': 1.166.34
-      fetchdts: 0.1.7
-      h3-v2: h3@2.0.1-rc.20(crossws@0.4.6(srvx@0.8.16))
+      h3-v2: h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.11.22))
       seroval: 1.5.2
     transitivePeerDependencies:
       - crossws
@@ -23076,11 +23067,6 @@ snapshots:
     optional: true
 
   '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -23562,20 +23548,20 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
+      nuxt: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -23589,14 +23575,14 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.2.2(@ai-sdk/mcp@1.0.39(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.9(79340e0b111d34b3e177fe53f6c14509))(eve@0.12.3(10aaaec19871a4666c04855ff5015fb6))':
+  '@vercel/connect@0.2.2(@ai-sdk/mcp@1.0.39(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.9(b19dc0cf074181bab87470771343aa58))(eve@0.12.3(510ea272993aea4194cf71a70b0e7064))':
     dependencies:
       '@vercel/oidc': 3.6.1
     optionalDependencies:
       '@ai-sdk/mcp': 1.0.39(zod@4.4.3)
       ai: 7.0.15(zod@4.4.3)
-      better-auth: 1.6.9(79340e0b111d34b3e177fe53f6c14509)
-      eve: 0.12.3(10aaaec19871a4666c04855ff5015fb6)
+      better-auth: 1.6.9(b19dc0cf074181bab87470771343aa58)
+      eve: 0.12.3(510ea272993aea4194cf71a70b0e7064)
 
   '@vercel/nft@1.5.0(rollup@4.60.2)':
     dependencies:
@@ -23625,11 +23611,11 @@ snapshots:
       '@vercel/cli-exec': 0.1.1
       jose: 5.10.0
 
-  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -23654,7 +23640,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.3
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/parser': 7.29.3
       acorn: 8.16.0
@@ -23665,18 +23651,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vinxi: 0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -24369,44 +24355,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  better-auth@1.6.9(79340e0b111d34b3e177fe53f6c14509):
-    dependencies:
-      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
-      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.4.2)
-      defu: 6.1.7
-      jose: 6.2.3
-      kysely: 0.28.17
-      nanostores: 1.3.0
-      zod: 4.4.2
-    optionalDependencies:
-      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start': 1.167.61(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      better-sqlite3: 12.9.0
-      drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      solid-js: 1.9.12
-      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      vue: 3.5.33(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-    optional: true
-
-  better-auth@1.6.9(a57889fcd46a40869578f7a6a38b8a84):
+  better-auth@1.6.9(26b9a8bdbd2bb4345925af1d00faa4d9):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
@@ -24427,7 +24376,7 @@ snapshots:
       zod: 4.4.2
     optionalDependencies:
       '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@tanstack/react-start': 1.167.61(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start': 1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       better-sqlite3: 12.9.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)
@@ -24441,6 +24390,43 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
+
+  better-auth@1.6.9(b19dc0cf074181bab87470771343aa58):
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
+      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260503.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.2))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.5(zod@4.4.2)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.28.17
+      nanostores: 1.3.0
+      zod: 4.4.2
+    optionalDependencies:
+      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@tanstack/react-start': 1.167.61(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      better-sqlite3: 12.9.0
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      solid-js: 1.9.12
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      vue: 3.5.33(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+    optional: true
 
   better-call@1.3.5(zod@4.4.2):
     dependencies:
@@ -24958,6 +24944,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  crossws@0.4.10(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
+
   crossws@0.4.5(srvx@0.11.15):
     optionalDependencies:
       srvx: 0.11.15
@@ -24969,10 +24959,6 @@ snapshots:
   crossws@0.4.6(srvx@0.11.16):
     optionalDependencies:
       srvx: 0.11.16
-
-  crossws@0.4.6(srvx@0.8.16):
-    optionalDependencies:
-      srvx: 0.8.16
 
   css-background-parser@0.1.0: {}
 
@@ -25377,7 +25363,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docus@5.10.1(4bb03f336682a9f31a3a83b41ca71fcc):
+  docus@5.10.1(19bf385c2a350654bfe793b6ed7f1036):
     dependencies:
       '@ai-sdk/gateway': 3.0.109(zod@4.4.2)
       '@ai-sdk/mcp': 1.0.39(zod@4.4.2)
@@ -25392,7 +25378,7 @@ snapshots:
       '@nuxtjs/i18n': 10.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vue/compiler-dom@3.5.33)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
       '@nuxtjs/mcp-toolkit': 0.16.1(@vue/compiler-sfc@3.5.33)(h3@1.15.11)(magicast@0.5.2)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.2)
-      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -25405,9 +25391,9 @@ snapshots:
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.4.10(05dbe4e2df162f5b505ff2aff828fd35)
+      nuxt-og-image: 6.4.10(e778a93ae2d3ed44ff9a6c71ee83f56e)
       pkg-types: 2.3.1
       scule: 1.3.0
       shiki-stream: 0.1.4(react@19.2.6)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))
@@ -25712,6 +25698,13 @@ snapshots:
       exsolve: 1.0.8
       httpxy: 0.5.3
       srvx: 0.11.16
+
+  env-runner@0.1.16:
+    dependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.0
+      httpxy: 0.5.5
+      srvx: 0.11.22
 
   env-runner@0.1.7:
     dependencies:
@@ -26160,19 +26153,19 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.12.3(10aaaec19871a4666c04855ff5015fb6):
+  eve@0.12.3(275d4dbcfdadf3fc6e9b5e677feb198e):
     dependencies:
       ai: 7.0.15(zod@4.4.3)
-      nitro: 3.0.260610-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(rollup@4.60.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      nitro: 3.0.260610-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.4(7bd188e1e04a5a825a38611cf5569dda)
-      react: 19.2.6
+      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.5))(react@19.2.5)
+      nuxt: 4.4.4(d1aca583cca69d3e2fbcf4879061daac)
+      react: 19.2.5
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
-      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vue: 3.5.33(typescript@5.9.3)
+      vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vue: 3.5.33(typescript@6.0.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -26212,19 +26205,19 @@ snapshots:
       - xml2js
       - zephyr-agent
 
-  eve@0.12.3(275d4dbcfdadf3fc6e9b5e677feb198e):
+  eve@0.12.3(510ea272993aea4194cf71a70b0e7064):
     dependencies:
       ai: 7.0.15(zod@4.4.3)
-      nitro: 3.0.260610-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      nitro: 3.0.260610-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(rollup@4.60.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.5))(react@19.2.5)
-      nuxt: 4.4.4(d1aca583cca69d3e2fbcf4879061daac)
-      react: 19.2.5
+      '@sveltejs/kit': 2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      nuxt: 4.4.4(8d86e90b37330199037fcfad0b7ac55e)
+      react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
-      vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vue: 3.5.33(typescript@6.0.3)
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vue: 3.5.33(typescript@5.9.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -26404,6 +26397,8 @@ snapshots:
       - supports-color
 
   exsolve@1.0.8: {}
+
+  exsolve@1.1.0: {}
 
   extend@3.0.2: {}
 
@@ -26906,6 +26901,14 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  h3-rules@0.1.0(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(ocache@0.2.0):
+    dependencies:
+      h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      rou3: 0.9.1
+      ufo: 1.6.4
+    optionalDependencies:
+      ocache: 0.2.0
+
   h3@1.15.11:
     dependencies:
       cookie-es: 1.2.3
@@ -26930,36 +26933,19 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.2(crossws@0.4.6(srvx@0.8.16)):
+  h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
-      cookie-es: 2.0.1
-      fetchdts: 0.1.7
-      rou3: 0.7.12
-      srvx: 0.8.16
+      rou3: 0.8.1
+      srvx: 0.11.22
     optionalDependencies:
-      crossws: 0.4.6(srvx@0.8.16)
+      crossws: 0.4.10(srvx@0.11.22)
 
   h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.16
+      srvx: 0.11.22
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
-
-  h3@2.0.1-rc.20(crossws@0.4.6(srvx@0.11.16)):
-    dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.16
-    optionalDependencies:
-      crossws: 0.4.6(srvx@0.11.16)
-    optional: true
-
-  h3@2.0.1-rc.20(crossws@0.4.6(srvx@0.8.16)):
-    dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.16
-    optionalDependencies:
-      crossws: 0.4.6(srvx@0.8.16)
 
   h3@2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
@@ -26974,6 +26960,13 @@ snapshots:
       srvx: 0.11.15
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.16)
+
+  h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)):
+    dependencies:
+      rou3: 0.9.1
+      srvx: 0.11.22
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.11.22)
 
   hachure-fill@0.5.2: {}
 
@@ -27263,6 +27256,8 @@ snapshots:
   httpxy@0.5.1: {}
 
   httpxy@0.5.3: {}
+
+  httpxy@0.5.5: {}
 
   human-id@4.1.3: {}
 
@@ -28495,7 +28490,7 @@ snapshots:
       pkg-types: 2.3.1
       postcss: 8.5.13
       postcss-nested: 7.0.2(postcss@8.5.13)
-      semver: 7.7.4
+      semver: 7.8.1
       tinyglobby: 0.2.16
     optionalDependencies:
       typescript: 6.0.3
@@ -28693,33 +28688,34 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nf3@0.1.12: {}
-
   nf3@0.3.16: {}
 
   nf3@0.3.17: {}
 
-  nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
+  nf3@0.3.22: {}
+
+  nitro-nightly@3.0.1-20260712-095235-05bf1c38(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
-      cookie-es: 2.0.1
-      crossws: 0.4.6(srvx@0.8.16)
+      crossws: 0.4.10(srvx@0.11.22)
       db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
-      esbuild: 0.25.12
-      fetchdts: 0.1.7
-      h3: 2.0.1-rc.2(crossws@0.4.6(srvx@0.8.16))
-      jiti: 2.7.0
-      nf3: 0.1.12
-      ofetch: 1.5.1
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      h3-rules: 0.1.0(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(ocache@0.2.0)
+      hookable: 6.1.1
+      nf3: 0.3.22
+      ocache: 0.2.0
+      ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rendu: 0.0.6
-      rollup: 4.60.2
-      srvx: 0.8.16
-      undici: 7.25.0
-      unenv: 2.0.0-rc.21
-      unstorage: 2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
+      rolldown: 1.1.5
+      rou3: 0.9.1
+      srvx: 0.11.22
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
-      rolldown: 1.1.4
+      dotenv: 17.4.2
+      giget: 3.2.0
+      jiti: 2.7.0
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -28733,6 +28729,7 @@ snapshots:
       - '@electric-sql/pglite'
       - '@libsql/client'
       - '@netlify/blobs'
+      - '@netlify/runtime'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/blob'
@@ -28745,10 +28742,12 @@ snapshots:
       - idb-keyval
       - ioredis
       - lru-cache
+      - miniflare
       - mongodb
       - mysql2
       - sqlite3
       - uploadthing
+      - wrangler
 
   nitro@3.0.260311-beta(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
@@ -28762,7 +28761,7 @@ snapshots:
       ocache: 0.1.4
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.2
+      rolldown: 1.1.4
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
@@ -28815,7 +28814,7 @@ snapshots:
       ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.2
+      rolldown: 1.1.4
       srvx: 0.11.16
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
@@ -28869,7 +28868,7 @@ snapshots:
       ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.2
+      rolldown: 1.1.4
       srvx: 0.11.16
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(ofetch@2.0.0-alpha.3)
@@ -29119,7 +29118,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4):
+  nitropack@2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -29172,7 +29171,7 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
       scule: 1.3.0
       semver: 7.7.4
       serve-placeholder: 2.0.2
@@ -29294,7 +29293,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.4.10(05dbe4e2df162f5b505ff2aff828fd35):
+  nuxt-og-image@6.4.10(e778a93ae2d3ed44ff9a6c71ee83f56e):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
@@ -29310,8 +29309,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -29354,12 +29353,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
@@ -29372,12 +29371,12 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
@@ -29434,16 +29433,16 @@ snapshots:
       - uploadthing
       - vue
 
-  nuxt@4.4.4(7bd188e1e04a5a825a38611cf5569dda):
+  nuxt@4.4.4(8d86e90b37330199037fcfad0b7ac55e):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@5.9.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(7bd188e1e04a5a825a38611cf5569dda))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(8d86e90b37330199037fcfad0b7ac55e))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@5.9.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(7bd188e1e04a5a825a38611cf5569dda))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.4)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(8d86e90b37330199037fcfad0b7ac55e))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@5.9.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -29564,16 +29563,145 @@ snapshots:
       - yaml
     optional: true
 
-  nuxt@4.4.4(9759e11547571991a351c21f7950ae84):
+  nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
+      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
+      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@6.0.3)
+      '@nuxt/schema': 4.4.4
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.128.0
+      oxc-parser: 0.128.0
+      oxc-transform: 0.128.0
+      oxc-walker: 0.7.0(oxc-parser@0.128.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.2.0(oxc-parser@0.128.0)
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.33(typescript@6.0.3)
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(oxc-parser@0.128.0)(rolldown@1.1.5)(typescript@6.0.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -29822,135 +29950,6 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8):
-    dependencies:
-      '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(oxc-parser@0.128.0)(rolldown@1.1.4)(typescript@6.0.3)
-      '@nuxt/schema': 4.4.4
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.7
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.1
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.6
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.128.0
-      oxc-parser: 0.128.0
-      oxc-transform: 0.128.0
-      oxc-walker: 0.7.0(oxc-parser@0.128.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.2.0(oxc-parser@0.128.0)
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.33(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.9.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
   nuxt@4.4.4(f0eebb652e8b2bed4092e4ed7fc178f5):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
@@ -30080,32 +30079,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
-    dependencies:
-      '@clack/prompts': 1.3.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/schema': 4.4.6
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.4.4(9759e11547571991a351c21f7950ae84)
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      vue: 3.5.33(typescript@6.0.3)
-    optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(9759e11547571991a351c21f7950ae84))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
-      zod: 4.4.2
-    transitivePeerDependencies:
-      - magicast
-      - vite
-
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -30114,7 +30088,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8)
+      nuxt: 4.4.4(a0fc27f665c4fbb98b45fc8a504138e6)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -30124,8 +30098,33 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(e0c99ca1427cd6c4f091feb75ecb41f8))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a0fc27f665c4fbb98b45fc8a504138e6))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       zod: 3.25.76
+    transitivePeerDependencies:
+      - magicast
+      - vite
+
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2):
+    dependencies:
+      '@clack/prompts': 1.3.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/schema': 4.4.6
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.4.4(a99c048242c96bba4f9abafbe1bc32b5)
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      vue: 3.5.33(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.4(a99c048242c96bba4f9abafbe1bc32b5))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.33(typescript@6.0.3))(zod@4.4.2)
+      zod: 4.4.2
     transitivePeerDependencies:
       - magicast
       - vite
@@ -30147,6 +30146,10 @@ snapshots:
       ohash: 2.0.11
 
   ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ocache@0.2.0:
     dependencies:
       ohash: 2.0.11
 
@@ -31332,11 +31335,6 @@ snapshots:
 
   remend@1.3.0: {}
 
-  rendu@0.0.6:
-    dependencies:
-      cookie-es: 2.0.1
-      srvx: 0.8.16
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -31462,27 +31460,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rolldown@1.1.2:
-    dependencies:
-      '@oxc-project/types': 0.137.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.2
-      '@rolldown/binding-darwin-arm64': 1.1.2
-      '@rolldown/binding-darwin-x64': 1.1.2
-      '@rolldown/binding-freebsd-x64': 1.1.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
-      '@rolldown/binding-linux-arm64-gnu': 1.1.2
-      '@rolldown/binding-linux-arm64-musl': 1.1.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
-      '@rolldown/binding-linux-s390x-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-musl': 1.1.2
-      '@rolldown/binding-openharmony-arm64': 1.1.2
-      '@rolldown/binding-wasm32-wasi': 1.1.2
-      '@rolldown/binding-win32-arm64-msvc': 1.1.2
-      '@rolldown/binding-win32-x64-msvc': 1.1.2
-
   rolldown@1.1.4:
     dependencies:
       '@oxc-project/types': 0.138.0
@@ -31503,6 +31480,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.4
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rollup-plugin-dts@6.4.1(rollup@4.60.2)(typescript@6.0.3):
     dependencies:
@@ -31545,14 +31543,14 @@ snapshots:
       rolldown: 1.0.0-rc.17
       rollup: 4.60.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.2):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.1.4
+      rolldown: 1.1.5
       rollup: 4.60.2
 
   rollup-pluginutils@2.8.2:
@@ -31595,6 +31593,8 @@ snapshots:
   rou3@0.7.12: {}
 
   rou3@0.8.1: {}
+
+  rou3@0.9.1: {}
 
   roughjs@4.6.6:
     dependencies:
@@ -32061,7 +32061,7 @@ snapshots:
 
   srvx@0.11.16: {}
 
-  srvx@0.8.16: {}
+  srvx@0.11.22: {}
 
   stable-hash-x@0.2.0: {}
 
@@ -32697,14 +32697,6 @@ snapshots:
       pathe: 2.0.3
       ufo: 1.6.4
 
-  unenv@2.0.0-rc.21:
-    dependencies:
-      defu: 6.1.7
-      exsolve: 1.0.8
-      ohash: 2.0.11
-      pathe: 2.0.3
-      ufo: 1.6.4
-
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -32918,14 +32910,6 @@ snapshots:
       db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
       ioredis: 5.10.1
 
-  unstorage@2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1):
-    optionalDependencies:
-      chokidar: 4.0.3
-      db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))
-      ioredis: 5.10.1
-      lru-cache: 11.3.5
-      ofetch: 1.5.1
-
   unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1):
     optionalDependencies:
       chokidar: 5.0.0
@@ -33052,7 +33036,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.4)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
+  vinxi@0.5.11(@libsql/client@0.17.3)(@types/node@25.9.1)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -33073,7 +33057,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.4)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `@evlog/telemetry` package for privacy-conscious CLI/automation telemetry, including event wrapping, local buffering, generated disclosures, and a non-blocking flush with debug mode.
  * Added telemetry lifecycle commands (`status`, `enable`, `disable`) and server ingestion validation with an `ingest` export.
  * Added GitHub Actions telemetry support and an example playground CLI.

* **Documentation**
  * Added “Tool telemetry” docs and initial package documentation for `@evlog/telemetry`.

* **Tests**
  * Added end-to-end telemetry/outbox/drain tests, ingestion validation tests, and TypeScript typing coverage.

* **Chores**
  * Updated publish workflow, PR scope validation, and versioning via a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->