### PR TITLE
fix: pretty printer shows `[object Object]` for array field values

### DIFF
--- a/.changeset/fifty-olives-reply.md
+++ b/.changeset/fifty-olives-reply.md
@@ -1,0 +1,5 @@
+---
+'evlog': patch
+---
+
+fix: pretty printer shows `[object Object]` for array field values

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -360,6 +360,9 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return String(value)
   }
+  if (Array.isArray(value)) {
+    return JSON.stringify(value)
+  }
   if (isPlainObject(value)) {
     const pairs: string[] = []
     for (const [k, v] of Object.entries(value)) {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -1226,3 +1226,34 @@ describe('pretty-print tool input serialization', () => {
     expect(() => logger.emit()).not.toThrow()
   })
 })
+
+describe('pretty-print array field values', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    initLogger({ pretty: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('serializes top-level array of objects as JSON instead of [object Object]', () => {
+    log.info({ action: 'demo', issues: [{ code: 'invalid_union', path: [], message: 'Invalid input' }] })
+
+    const logSpy = vi.mocked(console.log)
+    const output = logSpy.mock.calls.map(call => String(call[0])).join('\n')
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('[{"code":"invalid_union","path":[],"message":"Invalid input"}]')
+  })
+
+  it('serializes array of strings', () => {
+    log.info({ action: 'test', tags: ['a', 'b', 'c'] })
+
+    const logSpy = vi.mocked(console.log)
+    const output = logSpy.mock.calls.map(call => String(call[0])).join('\n')
+
+    expect(output).not.toContain('[object Object]')
+    expect(output).toContain('["a","b","c"]')
+  })
+})


### PR DESCRIPTION
## Description

Fixes #414 — when a wide event contains an array field (e.g. `issues: [{ code: 'invalid_union' }]`), the pretty printer renders it as `[object Object]` instead of the actual JSON.

## Root cause

`formatValue()` in `packages/evlog/src/logger.ts` had no handling for arrays. `Array.isArray()` was never checked, so arrays fell through to `String(value)`, which produces `[object Object]`.

## Fix

Added an `Array.isArray(value)` branch that returns `JSON.stringify(value)`, placed **before** the `isPlainObject` check to ensure arrays are handled before objects.

## Tests

- ✅ `serializes top-level array of objects as JSON instead of [object Object]`
- ✅ `serializes array of strings`

Both tests assert output does NOT contain `[object Object]` and DOES contain the correctly serialized JSON.

## Verification

- `pnpm run test` — 82 passed (including 2 new tests)
- `pnpm run lint` — 0 errors (2 pre-existing warnings unrelated)
- `pnpm run typecheck` — all 13 packages passed
- `pnpm run build` — successful

## Changeset

✅ Added as `patch` for `evlog`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pretty-printed logs displaying array values as `[object Object]`.
  * Arrays of objects and strings are now rendered as readable JSON in pretty mode.

* **Tests**
  * Added coverage for pretty-printing array field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->