### PR TITLE
fix(nitro): preserve h3 HTTPError message in JSON responses

### DIFF
--- a/.changeset/fix-nitro-httperror-message.md
+++ b/.changeset/fix-nitro-httperror-message.md
@@ -1,0 +1,7 @@
+---
+'evlog': patch
+---
+
+fix(nitro): preserve h3 HTTPError `message` in JSON error responses instead of overwriting it with `statusText`
+
+---

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -240,19 +240,20 @@ export function buildPlainNitroErrorBody(
   isDev = process.env.NODE_ENV === 'development',
 ): Record<string, unknown> {
   const status = extractErrorStatus(error)
-  const rawMessage = ((error as { statusText?: string }).statusText
+  const shortStatus = (error as { statusText?: string }).statusText
     ?? (error as { statusMessage?: string }).statusMessage
-    ?? error.message) || 'Internal Server Error'
-  const message = isDev
-    ? rawMessage
-    : (status >= 500 ? 'Internal Server Error' : rawMessage)
+  const rawMessage = error.message || shortStatus || 'Internal Server Error'
+  const sanitize = (text: string) =>
+    isDev ? text : (status >= 500 ? 'Internal Server Error' : text)
+  const message = sanitize(rawMessage)
+  const statusMessage = sanitize(shortStatus ?? rawMessage)
 
   return {
     url,
     status,
     statusCode: status,
-    statusText: message,
-    statusMessage: message,
+    statusText: statusMessage,
+    statusMessage,
     message,
     error: true,
   }

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -252,7 +252,7 @@ export function buildPlainNitroErrorBody(
     url,
     status,
     statusCode: status,
-    statusText: statusMessage,
+    statusText: message,
     statusMessage,
     message,
     error: true,


### PR DESCRIPTION
Closes #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nitro JSON error responses now preserve an HTTP error’s original message instead of overwriting it with status text.
  * In development, extracted status text is retained for clearer error reporting.
  * In non-development environments, server errors (500+) are consistently shown as “Internal Server Error” by normalizing both status text and status message.
  * Non-server errors keep their original status text and status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->