### PR TITLE
feat(core): add waitUntil to toolkit middleware APIs

### DIFF
--- a/.changeset/toolkit-waituntil-serverless.md
+++ b/.changeset/toolkit-waituntil-serverless.md
@@ -1,0 +1,5 @@
+---
+'evlog': minor
+---
+
+Add `waitUntil` support to `createMiddlewareLogger` and `defineFrameworkIntegration` so custom framework integrations can defer async drains on Cloudflare Workers and Vercel Edge without blocking the response. Pass `waitUntil` per request (e.g. `ctx.waitUntil.bind(ctx)`) or declare `extractWaitUntil` on the integration manifest.

--- a/apps/docs/content/5.extend/10.custom-framework.md
+++ b/apps/docs/content/5.extend/10.custom-framework.md
@@ -50,6 +50,7 @@ Wire evlog into an HTTP framework (or non-HTTP runtime) that doesn't have a buil
 - Run downstream handlers inside `runWith(() => next())` so `AsyncLocalStorage` and `log.fork()` work
 - On success: `await finish({ status })`; on error: `await finish({ error })` then re-throw
 - Expose `drain`, `enrich`, `keep`, `include`, `exclude`, `routes`, and `plugins` options
+- On Cloudflare Workers / Vercel Edge, pass `waitUntil` (or `extractWaitUntil` on the manifest) so async drains complete after the response
 - For non-HTTP runtimes (queue workers, CLI, cron), use `createRequestLogger` from `evlog/toolkit` directly — wrap each unit of work in a logger lifecycle
 
 Docs: https://www.evlog.dev/extend/custom-framework
@@ -79,6 +80,7 @@ npm install evlog
 |--------|---------|
 | `defineFrameworkIntegration(spec)` | Manifest factory — extract request, create logger, attach, run with ALS |
 | `createMiddlewareLogger(opts)` | Lower-level lifecycle (custom mode) |
+| `waitUntil` on middleware options | Defer drain on Cloudflare Workers / Vercel Edge (see [Serverless](#serverless-workers-edge)) |
 | `createRequestLogger(opts)` | Wrap a non-HTTP unit of work in a logger lifecycle |
 | `BaseEvlogOptions` | Base user-facing options — `drain`, `enrich`, `keep`, `include`, `exclude`, `routes`, `plugins` |
 | `MiddlewareLoggerResult` | Return type: `{ logger, finish, skipped }` |
@@ -179,6 +181,48 @@ const { logger, finish, skipped } = createMiddlewareLogger({
 ```
 
 You'll be responsible for ALS wrapping (`storage.run`), `log.fork()` attachment (via `attachForkToLogger`), and finishing the lifecycle — but you keep the full pipeline (route filtering, sampling, emit, enrich, drain, plugins) for free.
+
+## Serverless (Workers / Edge)
+
+On Cloudflare Workers and Vercel Edge, the runtime can terminate as soon as the response is returned. If your drain sends HTTP to an observability backend, pass `waitUntil` so enrich still runs inline but drain work survives after the response — the same behavior as [`evlog/workers`](/integrate/frameworks/cloudflare-workers) and the Nitro plugin.
+
+**Custom mode** — pass `waitUntil` per request:
+
+```typescript
+import { waitUntil } from '@vercel/functions'
+// import { waitUntil } from 'cloudflare:workers' // Vercel-style global on some runtimes
+
+const { logger, finish, skipped } = createMiddlewareLogger({
+  method,
+  path,
+  requestId,
+  headers: extractSafeNodeHeaders(rawHeaders),
+  waitUntil, // or ctx.waitUntil.bind(ctx) on Cloudflare
+  ...options,
+})
+```
+
+**Manifest mode** — either pass `waitUntil` in `integration.start(ctx, options)` or declare `extractWaitUntil` on the manifest when the hook lives on the framework context:
+
+```typescript
+const integration = defineFrameworkIntegration<WorkerContext>({
+  name: 'my-framework',
+  extractRequest: (ctx) => ({ /* … */ }),
+  attachLogger: (ctx, logger) => { /* … */ },
+  extractWaitUntil: ctx => ctx.executionCtx.waitUntil.bind(ctx.executionCtx),
+})
+
+export function evlog(options: BaseEvlogOptions = {}) {
+  return async (ctx, next) => {
+    const { skipped, finish, runWith } = integration.start(ctx, options)
+    // Per-request override still works:
+    // integration.start(ctx, { ...options, waitUntil: ctx.executionCtx.waitUntil.bind(ctx.executionCtx) })
+    // …
+  }
+}
+```
+
+Per-request `options.waitUntil` takes precedence over `extractWaitUntil`. Without either, drains are awaited (correct for traditional Node.js servers).
 
 ## Non-HTTP runtimes
 

--- a/packages/evlog/src/nitro/deferred-drain.ts
+++ b/packages/evlog/src/nitro/deferred-drain.ts
@@ -1,12 +1,1 @@
-/** @internal Extend drain lifetime on Cloudflare without blocking Nitro Node responses. */
-export function extendDeferredDrain(
-  drainPromise: Promise<unknown>,
-  waitUntil?: (promise: Promise<unknown>) => void,
-): void {
-  void drainPromise.catch((err) => {
-    console.error('[evlog] background drain failed:', err)
-  })
-  if (typeof waitUntil === 'function') {
-    waitUntil(drainPromise)
-  }
-}
+export { extendDeferredDrain } from '../shared/deferred-drain'

--- a/packages/evlog/src/shared/deferred-drain.ts
+++ b/packages/evlog/src/shared/deferred-drain.ts
@@ -1,0 +1,15 @@
+/**
+ * Extend drain lifetime on serverless runtimes without blocking the HTTP response.
+ * When `waitUntil` is omitted, callers should await `drainPromise` themselves.
+ */
+export function extendDeferredDrain(
+  drainPromise: Promise<unknown>,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): void {
+  void drainPromise.catch((err) => {
+    console.error('[evlog] background drain failed:', err)
+  })
+  if (typeof waitUntil === 'function') {
+    waitUntil(drainPromise)
+  }
+}

--- a/packages/evlog/src/shared/integration.ts
+++ b/packages/evlog/src/shared/integration.ts
@@ -34,6 +34,12 @@ export interface FrameworkIntegrationSpec<TCtx> {
   storage?: AsyncLocalStorage<RequestLogger>
   /** Fork lifecycle hooks (only used when `storage` is set). */
   forkLifecycle?: import('./fork').ForkLifecycle
+  /**
+   * Extract platform `waitUntil` from the framework context (Cloudflare Workers
+   * `ExecutionContext`, Vercel Edge, …). Applied on each `start()` call;
+   * per-request `options.waitUntil` takes precedence.
+   */
+  extractWaitUntil?: (ctx: TCtx) => ((promise: Promise<unknown>) => void) | undefined
 }
 
 /** Result returned by {@link FrameworkIntegrationHelpers.start}. */
@@ -101,12 +107,14 @@ export function defineFrameworkIntegration<TCtx>(
     start(ctx, options = {}) {
       const extracted = spec.extractRequest(ctx)
       const headers = normalizeHeaders(extracted.headers)
+      const waitUntil = options.waitUntil ?? spec.extractWaitUntil?.(ctx)
       const middlewareOptions: MiddlewareLoggerOptions = {
         method: extracted.method,
         path: extracted.path,
         requestId: extracted.requestId || crypto.randomUUID(),
         headers,
         ...options,
+        waitUntil,
       }
       const result = createMiddlewareLogger(middlewareOptions)
 

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -6,6 +6,7 @@ import { extractErrorStatus } from './errors'
 import type { EvlogPlugin, PluginRunner } from './plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './plugin'
 import { shouldLog, getServiceForPath } from './routes'
+import { extendDeferredDrain } from './deferred-drain'
 import { bindStreamingResponseLifecycle, shouldDeferEmitForResponse } from './streamResponse'
 
 /**
@@ -32,6 +33,15 @@ export interface BaseEvlogOptions {
   redact?: boolean | RedactConfig
   /** Plugins for this middleware, merged with globally-registered ones. */
   plugins?: EvlogPlugin[]
+  /**
+   * Serverless runtime hook (Cloudflare Workers `ExecutionContext#waitUntil`,
+   * Vercel Edge `@vercel/functions`, …). When set, enrich still runs before the
+   * response returns but drain work is registered with `waitUntil` instead of
+   * being awaited — same behavior as `evlog/workers` and the Nitro plugin.
+   *
+   * Pass a bound method per request, e.g. `ctx.waitUntil.bind(ctx)`.
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 
 /** Internal options accepted by `createMiddlewareLogger`. */
@@ -173,7 +183,12 @@ export async function runEnrichAndDrain(
     if (hasPluginDrain) {
       tasks.push(runner.runDrain(drainCtx))
     }
-    await Promise.all(tasks)
+    const drainPromise = Promise.all(tasks)
+    if (options.waitUntil) {
+      extendDeferredDrain(drainPromise, options.waitUntil)
+      return
+    }
+    await drainPromise
   }
 }
 

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -433,6 +433,99 @@ describe('createMiddlewareLogger', () => {
     })
   })
 
+  describe('waitUntil', () => {
+    it('registers drain with waitUntil without awaiting drain completion', async () => {
+      let drainSettled = false
+      const drain = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        drainSettled = true
+      })
+      const waitUntil = vi.fn()
+
+      const { finish } = createMiddlewareLogger({
+        method: 'GET',
+        path: '/api/test',
+        drain,
+        waitUntil,
+      })
+
+      await finish({ status: 200 })
+
+      expect(waitUntil).toHaveBeenCalledOnce()
+      expect(drainSettled).toBe(false)
+
+      const [[scheduled]] = waitUntil.mock.calls
+      await scheduled
+      expect(drain).toHaveBeenCalledOnce()
+      expect(drainSettled).toBe(true)
+    })
+
+    it('still awaits enrich before registering waitUntil drain', async () => {
+      let enrichDone = false
+      const enrich = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 5))
+        enrichDone = true
+      })
+      const drain = vi.fn()
+      const waitUntil = vi.fn()
+
+      const { finish } = createMiddlewareLogger({
+        method: 'GET',
+        path: '/api/test',
+        enrich,
+        drain,
+        waitUntil,
+      })
+
+      await finish({ status: 200 })
+
+      expect(enrichDone).toBe(true)
+      expect(waitUntil).toHaveBeenCalledOnce()
+      const [[scheduled]] = waitUntil.mock.calls
+      await scheduled
+      expect(drain).toHaveBeenCalledOnce()
+    })
+
+    it('awaits drain when waitUntil is not provided', async () => {
+      let drainSettled = false
+      const drain = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 5))
+        drainSettled = true
+      })
+
+      const { finish } = createMiddlewareLogger({
+        method: 'GET',
+        path: '/api/test',
+        drain,
+      })
+
+      await finish({ status: 200 })
+
+      expect(drainSettled).toBe(true)
+      expect(drain).toHaveBeenCalledOnce()
+    })
+
+    it('preserves this binding when calling waitUntil', async () => {
+      const host = {
+        waitUntil(promise: Promise<unknown>) {
+          void promise
+        },
+      }
+      const waitUntilSpy = vi.spyOn(host, 'waitUntil')
+      const drain = vi.fn()
+
+      const { finish } = createMiddlewareLogger({
+        method: 'GET',
+        path: '/api/test',
+        drain,
+        waitUntil: host.waitUntil.bind(host),
+      })
+
+      await expect(finish({ status: 200 })).resolves.not.toThrow()
+      expect(waitUntilSpy).toHaveBeenCalledOnce()
+    })
+  })
+
   describe('redact', () => {
     it('skips middleware redaction when initLogger already redacted the event', async () => {
       const { drain } = createPipelineSpies()

--- a/packages/evlog/test/toolkit/toolkit.test.ts
+++ b/packages/evlog/test/toolkit/toolkit.test.ts
@@ -609,4 +609,39 @@ describe('defineFrameworkIntegration', () => {
     expect(observed).toBe(logger)
     await finish({ status: 204 })
   })
+
+  it('wires extractWaitUntil into middleware options', async () => {
+    const waitUntil = vi.fn()
+    const integration = defineFrameworkIntegration<{ waitUntil: typeof waitUntil }>({
+      name: 'serverless-test',
+      extractRequest: () => ({ method: 'GET', path: '/api' }),
+      attachLogger: () => {},
+      extractWaitUntil: ctx => ctx.waitUntil,
+    })
+
+    const drain = vi.fn()
+    const { finish } = integration.start({ waitUntil }, { drain, waitUntil: undefined })
+    await finish({ status: 200 })
+    expect(waitUntil).toHaveBeenCalledOnce()
+  })
+
+  it('prefers options.waitUntil over extractWaitUntil', async () => {
+    const ctxWaitUntil = vi.fn()
+    const optionsWaitUntil = vi.fn()
+    const integration = defineFrameworkIntegration<{ waitUntil: typeof ctxWaitUntil }>({
+      name: 'serverless-priority',
+      extractRequest: () => ({ method: 'GET', path: '/api' }),
+      attachLogger: () => {},
+      extractWaitUntil: ctx => ctx.waitUntil,
+    })
+
+    const drain = vi.fn()
+    const { finish } = integration.start(
+      { waitUntil: ctxWaitUntil },
+      { drain, waitUntil: optionsWaitUntil },
+    )
+    await finish({ status: 200 })
+    expect(optionsWaitUntil).toHaveBeenCalledOnce()
+    expect(ctxWaitUntil).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

- Add optional `waitUntil` to `BaseEvlogOptions` / `createMiddlewareLogger` so custom integrations can defer async drains on Cloudflare Workers and Vercel Edge without blocking the response
- Add `extractWaitUntil` on `defineFrameworkIntegration` manifests for per-context wiring
- Move `extendDeferredDrain` to `shared/` (re-exported from Nitro) and document serverless usage on the custom framework page

Closes #416

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] New middleware + toolkit tests for `waitUntil` and `extractWaitUntil` precedence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added serverless runtime support for deferring asynchronous log processing with `waitUntil`.
  * Supports per-request configuration and framework integration settings.
  * Per-request `waitUntil` configuration takes precedence when both options are available.

* **Documentation**
  * Added guidance and examples for Cloudflare Workers, Vercel Edge, and other serverless environments.
  * Documented fallback behavior for standard Node.js runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->