### PR TITLE
feat: introduce `@evlog/cli`

### DIFF
--- a/.changeset/cli-skeleton-doctor.md
+++ b/.changeset/cli-skeleton-doctor.md
@@ -1,5 +1,0 @@
----
-"@evlog/cli": minor
----
-
-Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. One anonymous wide event per command via `@evlog/telemetry`; opt out with `evlog telemetry disable` or `DO_NOT_TRACK=1`.

--- a/.changeset/cli-skeleton-doctor.md
+++ b/.changeset/cli-skeleton-doctor.md
@@ -1,0 +1,5 @@
+---
+"@evlog/cli": minor
+---
+
+Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. One anonymous wide event per command via `@evlog/telemetry`; opt out with `evlog telemetry disable` or `DO_NOT_TRACK=1`.

--- a/.changeset/cli.md
+++ b/.changeset/cli.md
@@ -3,7 +3,7 @@
 "@evlog/telemetry": patch
 ---
 
-Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. Opt into debug with `--debug` / `EVLOG_CLI_DEBUG=1`. Commands use `defineEvlogCommand` → `{ cli, log, ui }`: `log.step` / `log.finding(cliErrors.X)` for diagnostics, `ui.done` for human/json/exit. Compact case-file on stderr; raw event with `--json --debug`.
+Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. Opt into debug with `--debug` / `EVLOG_CLI_DEBUG=1`. Commands use `defineEvlogCommand` → `{ cli, log, ui }`: `log.step` / `log.finding(cliErrors.X)` for diagnostics, `ui.done` for human/json/exit. Compact case-file on stderr; raw event with `--json --debug`. Workspace detection covers pnpm, bun (`bun.lock` / `bun.lockb`), npm, and yarn.
 
 `--json`, `--debug`, and telemetry all include an `environment` stage (`development` | `preview` | `production`). Packaged installs (`npx` / `node_modules`) report `production`; workspace builds report `development`. Override with `EVLOG_CLI_ENV` / `EVLOG_TELEMETRY_ENV`, or inherit `VERCEL_ENV`.
 

--- a/.changeset/cli.md
+++ b/.changeset/cli.md
@@ -5,4 +5,6 @@
 
 Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. Opt into debug with `--debug` / `EVLOG_CLI_DEBUG=1`. Commands use `defineEvlogCommand` → `{ cli, log, ui }`: `log.step` / `log.finding(cliErrors.X)` for diagnostics, `ui.done` for human/json/exit. Compact case-file on stderr; raw event with `--json --debug`.
 
-`withTelemetry()` is now generic over citty `ArgsDef`, so root commands with typed flags (e.g. `--debug`) type-check cleanly. `evlog telemetry status` (and any tool using `defineTelemetryCommands`) prints the local data directory path.
+`--json`, `--debug`, and telemetry all include an `environment` stage (`development` | `preview` | `production`). Packaged installs (`npx` / `node_modules`) report `production`; workspace builds report `development`. Override with `EVLOG_CLI_ENV` / `EVLOG_TELEMETRY_ENV`, or inherit `VERCEL_ENV`.
+
+`withTelemetry()` is now generic over citty `ArgsDef`, so root commands with typed flags (e.g. `--debug`) type-check cleanly. `evlog telemetry status` (and any tool using `defineTelemetryCommands`) prints the local data directory path. Telemetry `env.environment` is part of the standard envelope; authors may pass `environment` in `TelemetryOptions`.

--- a/.changeset/cli.md
+++ b/.changeset/cli.md
@@ -1,0 +1,8 @@
+---
+"@evlog/cli": minor
+"@evlog/telemetry": patch
+---
+
+Introduce the evlog CLI (`@evlog/cli`, binary `evlog`). First release ships `evlog doctor` — diagnoses your setup (Node version, evlog install, local `.evlog/logs` sink) with a branded terminal report or `--json` output — plus `evlog telemetry status|enable|disable`. Opt into debug with `--debug` / `EVLOG_CLI_DEBUG=1`. Commands use `defineEvlogCommand` → `{ cli, log, ui }`: `log.step` / `log.finding(cliErrors.X)` for diagnostics, `ui.done` for human/json/exit. Compact case-file on stderr; raw event with `--json --debug`.
+
+`withTelemetry()` is now generic over citty `ArgsDef`, so root commands with typed flags (e.g. `--debug`) type-check cleanly. `evlog telemetry status` (and any tool using `defineTelemetryCommands`) prints the local data directory path.

--- a/.changeset/evlog-package-json-export.md
+++ b/.changeset/evlog-package-json-export.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Export `evlog/package.json` so tooling (e.g. `evlog doctor`) can resolve the installed version via `require.resolve('evlog/package.json')` under Node's `exports` map.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ scope.
 - bench (benchmarks)
 - better-auth (Better Auth integration)
 - better-stack (Better Stack drain adapter)
+- cli (`@evlog/cli` package)
 - core (logger, pipeline, error, redact, catalog internals)
 - datadog (Datadog drain adapter)
 - deps (the dependencies)

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -27,6 +27,7 @@ jobs:
             bench
             better-auth
             better-stack
+            cli
             core
             datadog
             deps

--- a/packages/cli/DEBUG-DX.md
+++ b/packages/cli/DEBUG-DX.md
@@ -1,0 +1,66 @@
+# CLI debug DX — frictions & wishlist
+
+Notes from wiring `--debug` on `@evlog/cli` (dogfooding `evlog` + the error catalog). Keep this file for maintainers; not user-facing docs.
+
+## Command author contract
+
+`defineEvlogCommand` injects **`{ args, cli, log, ui }`** plus shared flags (`json`, `debug`, `noHeader`).
+
+| Object | Role | API |
+| --- | --- | --- |
+| `cli` | Inputs (cwd, env, color, …) | read-only context |
+| `log` | Debug / diagnostics | `step`, `finding`, `set`, `raw` |
+| `ui` | Terminal output + exit | `human`, `json`, `exit`, `done` |
+
+```ts
+export default defineEvlogCommand('audit', {
+  meta: { description: '…' },
+  args: { since: { type: 'string' } },
+  async run({ args, cli, log, ui }) {
+    const data = await log.step('load', () => load(cli.cwd))
+    if (!data) {
+      log.finding(cliErrors.LOGS_SINK_MISSING, { id: 'logs' })
+      ui.done({ human: 'No sink.', summary: { ok: 0, warn: 1, fail: 0 } })
+      return
+    }
+    // unexpected throw inside step → steps trail + cli.COMMAND_FAILED when --debug
+    ui.done({
+      jsonMode: args.json,
+      json: { data },
+      human: format(data),
+      summary: { ok: 1, warn: 0, fail: 0 },
+    })
+  },
+})
+```
+
+Rules:
+
+1. **Filet** (header, debug event, catch throw) = zero lines in the command  
+2. **Récit** = `log.step` / `log.finding(cliErrors.X)` only where useful  
+3. **Pixels / JSON / exit** = `ui.*` only — never touch `process.stdout` / `exitCode` in commands  
+
+## Target flow
+
+```bash
+evlog <cmd> --debug                 # compact case-file report on stderr
+evlog <cmd> --json --debug 2>e.json # stdout = contract, stderr = raw wide event
+```
+
+## What works today
+
+- `defineEvlogCommand` → `{ cli, log, ui }` + `COMMON_ARGS`
+- `log.step('name', fn)` / `log.finding(cliErrors.X, { id, status })`
+- `ui.done({ human, json, summary, jsonMode })`
+- Human `--debug` → `formatDebugReport`; `--json --debug` → raw event on stderr
+
+## Friction / wishlist
+
+- Soft findings still mapped in doctor via `findingsForChecks` — ideal: checks carry a catalog ref
+- `DefinedError.toFinding()` on evlog catalog would remove `toCliFinding` glue
+- Pretty → stderr / isolated logger still useful upstream in `evlog`
+- Live breadcrumbs (`--debug -v`) for long commands later
+
+## Publish note — `workspace:*` deps
+
+`package.json` keeps `"evlog": "workspace:*"` and `"@evlog/telemetry": "workspace:*"` for local linking. **pnpm / `changeset publish` rewrite `workspace:` to real semver** on the tarball.

--- a/packages/cli/DEBUG-DX.md
+++ b/packages/cli/DEBUG-DX.md
@@ -65,3 +65,5 @@ evlog <cmd> --json --debug 2>e.json # stdout = contract, stderr = raw wide event
 ## Publish note — `workspace:*` deps
 
 `package.json` keeps `"evlog": "workspace:*"` and `"@evlog/telemetry": "workspace:*"` for local linking. **pnpm / `changeset publish` rewrite `workspace:` to real semver** on the tarball.
+
+Doctor resolves the install via `require.resolve('evlog/package.json')` — that subpath is exported on `evlog` (`"./package.json": "./package.json"`).

--- a/packages/cli/DEBUG-DX.md
+++ b/packages/cli/DEBUG-DX.md
@@ -53,6 +53,7 @@ evlog <cmd> --json --debug 2>e.json # stdout = contract, stderr = raw wide event
 - `log.step('name', fn)` / `log.finding(cliErrors.X, { id, status })`
 - `ui.done({ human, json, summary, jsonMode })`
 - Human `--debug` → `formatDebugReport`; `--json --debug` → raw event on stderr
+- `environment` on `--json` / debug / telemetry: packaged install → `production`, workspace → `development` (`EVLOG_CLI_ENV` / `VERCEL_ENV` override)
 
 ## Friction / wishlist
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,7 @@ npx @evlog/cli doctor --cwd apps/web
 | --- | --- |
 | `evlog doctor` | Monorepo-aware diagnosis: Node, project/workspace, stack, evlog install, `.evlog/logs` |
 | `evlog doctor --cwd <dir>` | Run against another directory |
+| `evlog doctor --debug` | Same, plus a debug wide event (see Debug) |
 | `evlog telemetry status` | Show telemetry status and disclosure |
 | `evlog telemetry enable` / `disable` | Change telemetry preference (disable purges buffered data) |
 
@@ -77,9 +78,20 @@ Full policy: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/ove
 
 Commands print a short branded header by default. Skip it with `--no-header`, `EVLOG_CLI_NO_HEADER=1`, or `--json`.
 
+## Debug
+
+Emit one debug case file per command with `--debug` or `EVLOG_CLI_DEBUG=1` (dogfoods `evlog`). Human mode prints a compact summary on stderr (`steps`, `findings`, resolve probes). With `--json`, the raw wide event goes to stderr so stdout stays a clean JSON contract. Separate from product telemetry (`@evlog/telemetry`).
+
+```bash
+evlog doctor --debug
+evlog doctor --json --debug   # JSON result on stdout, full debug event on stderr
+```
+
+Maintainer notes on frictions / wishlist: [`DEBUG-DX.md`](./DEBUG-DX.md).
+
 ## Adding a command
 
-1. Create `src/commands/<name>.ts` exporting a **default** citty command via `defineEvlogCommand('name', …)` from `lib/command` — branded header is automatic (skipped for `--json` / `--no-header`). Pure logic in the same file (or under `lib/`); render via `core/output.ts`.
+1. Create `src/commands/<name>.ts` with `defineEvlogCommand('name', { run({ args, cli, log, ui }) { … } })` — header, `--json` / `--debug` / `--no-header`, and debug filet are automatic. Use `log.step` / `log.finding` for diagnostics; `ui.done` / `ui.human` / `ui.json` for output.
 2. Register it with one import + one line in [`src/commands/index.ts`](src/commands/index.ts).
 
 `src/index.ts` stays a thin shell (meta + `withTelemetry`). Do not embed command bodies there.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,9 +13,9 @@
 
 **Digging through logs is not observability. It's hope.**
 
-The **evlog command line** — operate your [evlog](https://evlog.dev) wide events from the terminal. Binary: `evlog`.
+The official command line for [evlog](https://evlog.dev).
 
-Today it diagnoses your setup (`evlog doctor`); the same skeleton will grow the full surface — exploring logs, auditing, mapping your event catalog, and more.
+Diagnose your install. Inspect wide events. Audit and map what your app emits.
 
 ## Usage
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,105 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/HugoRCD/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
+</p>
+
+# @evlog/cli
+
+[![npm version](https://img.shields.io/npm/v/@evlog/cli?color=black)](https://npmjs.com/package/@evlog/cli)
+[![npm downloads](https://img.shields.io/npm/dm/@evlog/cli?color=black)](https://npm.chart.dev/@evlog/cli)
+[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev)
+[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+
+**Digging through logs is not observability. It's hope.**
+
+The **evlog command line** — operate your [evlog](https://evlog.dev) wide events from the terminal. Binary: `evlog`.
+
+Today it diagnoses your setup (`evlog doctor`); the same skeleton will grow the full surface — exploring logs, auditing, mapping your event catalog, and more.
+
+## Usage
+
+```bash
+npx @evlog/cli doctor              # diagnose the current project
+npx @evlog/cli doctor --json       # machine-readable output on stdout
+npx @evlog/cli doctor --no-header  # skip the branded title + gradient
+```
+
+Or install it as a devDependency:
+
+```bash
+pnpm add -D @evlog/cli
+pnpm evlog doctor
+```
+
+## Header
+
+Every command prints a short branded header (`evlog <command>` + gradient). Disable it when you want quieter output:
+
+| Mechanism | Example |
+| --- | --- |
+| Flag (any command) | `evlog doctor --no-header` |
+| Env (persistent) | `EVLOG_CLI_NO_HEADER=1` or `EVLOG_CLI_HEADER=0` |
+| JSON mode | `evlog doctor --json` (header never printed) |
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `evlog doctor` | Monorepo-aware diagnosis: Node, project/workspace, stack, evlog install, `.evlog/logs` |
+| `evlog doctor --cwd <dir>` | Run against another directory |
+| `evlog telemetry status` | Show telemetry status and disclosure |
+| `evlog telemetry enable` / `disable` | Change telemetry preference (disable purges buffered data) |
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All checks passed (warnings allowed) |
+| `1` | At least one check failed |
+| `2` | Usage error (unknown command or flags) |
+
+## `--json` output
+
+With `--json`, the payload is the **only** thing written to stdout — everything human goes to stderr. The shape is a contract:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "checks": [{ "id": "node", "status": "ok", "message": "Node v22.1.0" }],
+  "summary": { "ok": 4, "warn": 0, "fail": 0 }
+}
+```
+
+Breaking this shape requires a `schemaVersion` bump.
+
+## Adding a command
+
+1. Create `src/commands/<name>.ts` exporting a **default** citty command via `defineEvlogCommand('name', …)` from `lib/command` — that prints the branded header (`evlog <name>` + gradient) automatically. Pure logic in the same file (or under `lib/`); render via `core/output.ts`. Skip the header yourself only for `--json`.
+2. Register it with one import + one line in [`src/commands/index.ts`](src/commands/index.ts).
+
+`src/index.ts` stays a thin shell (meta + `withTelemetry`). Do not embed command bodies there.
+
+```
+src/
+  cli.ts              # bin entry (runMain)
+  index.ts            # main command tree
+  commands/           # one file per command + registry
+  core/               # context, output, brand, usage
+  lib/                # shared constants / helpers
+```
+
+
+## Telemetry
+
+The CLI records **one anonymous wide event per command** via [`@evlog/telemetry`](https://npmjs.com/package/@evlog/telemetry) (tool name `evlog-cli`): command name, duration, outcome, sanitized flags. No arguments, paths, or file contents. Opt out anytime:
+
+```bash
+evlog telemetry disable   # or DO_NOT_TRACK=1 / EVLOG_TELEMETRY=0
+```
+
+Full policy: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/overview)
+
+## Docs
+
+Full guide: [evlog.dev](https://evlog.dev)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,27 +20,17 @@ Diagnose your install. Inspect wide events. Audit and map what your app emits.
 ## Usage
 
 ```bash
-npx @evlog/cli doctor              # diagnose the current project
-npx @evlog/cli doctor --json       # machine-readable output on stdout
-npx @evlog/cli doctor --no-header  # skip the branded title + gradient
-```
-
-Or install it as a devDependency:
-
-```bash
 pnpm add -D @evlog/cli
 pnpm evlog doctor
 ```
 
-## Header
+Or without installing:
 
-Every command prints a short branded header (`evlog <command>` + gradient). Disable it when you want quieter output:
-
-| Mechanism | Example |
-| --- | --- |
-| Flag (any command) | `evlog doctor --no-header` |
-| Env (persistent) | `EVLOG_CLI_NO_HEADER=1` or `EVLOG_CLI_HEADER=0` |
-| JSON mode | `evlog doctor --json` (header never printed) |
+```bash
+npx @evlog/cli doctor
+npx @evlog/cli doctor --json
+npx @evlog/cli doctor --cwd apps/web
+```
 
 ## Commands
 
@@ -73,9 +63,23 @@ With `--json`, the payload is the **only** thing written to stdout — everythin
 
 Breaking this shape requires a `schemaVersion` bump.
 
+## Telemetry
+
+The CLI records **one anonymous wide event per command** via [`@evlog/telemetry`](https://npmjs.com/package/@evlog/telemetry) (tool name `evlog-cli`): command name, duration, outcome, sanitized flags. No arguments, paths, or file contents. Opt out anytime:
+
+```bash
+evlog telemetry disable   # or DO_NOT_TRACK=1 / EVLOG_TELEMETRY=0
+```
+
+Full policy: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/overview)
+
+## Quieter output
+
+Commands print a short branded header by default. Skip it with `--no-header`, `EVLOG_CLI_NO_HEADER=1`, or `--json`.
+
 ## Adding a command
 
-1. Create `src/commands/<name>.ts` exporting a **default** citty command via `defineEvlogCommand('name', …)` from `lib/command` — that prints the branded header (`evlog <name>` + gradient) automatically. Pure logic in the same file (or under `lib/`); render via `core/output.ts`. Skip the header yourself only for `--json`.
+1. Create `src/commands/<name>.ts` exporting a **default** citty command via `defineEvlogCommand('name', …)` from `lib/command` — branded header is automatic (skipped for `--json` / `--no-header`). Pure logic in the same file (or under `lib/`); render via `core/output.ts`.
 2. Register it with one import + one line in [`src/commands/index.ts`](src/commands/index.ts).
 
 `src/index.ts` stays a thin shell (meta + `withTelemetry`). Do not embed command bodies there.
@@ -88,17 +92,6 @@ src/
   core/               # context, output, brand, usage
   lib/                # shared constants / helpers
 ```
-
-
-## Telemetry
-
-The CLI records **one anonymous wide event per command** via [`@evlog/telemetry`](https://npmjs.com/package/@evlog/telemetry) (tool name `evlog-cli`): command name, duration, outcome, sanitized flags. No arguments, paths, or file contents. Opt out anytime:
-
-```bash
-evlog telemetry disable   # or DO_NOT_TRACK=1 / EVLOG_TELEMETRY=0
-```
-
-Full policy: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/overview)
 
 ## Docs
 

--- a/packages/cli/bin/evlog.mjs
+++ b/packages/cli/bin/evlog.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/cli.mjs'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@evlog/cli",
+  "version": "0.0.0",
+  "description": "The evlog command line — operate your wide events from the terminal: diagnose your setup today, explore, audit, and map your logs next",
+  "author": "HugoRCD <contact@hrcd.fr>",
+  "homepage": "https://evlog.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/HugoRCD/evlog/issues"
+  },
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "bin": {
+    "evlog": "./bin/evlog.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "bin",
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "evlog",
+    "cli",
+    "wide-events",
+    "doctor",
+    "citty",
+    "structured-logging",
+    "telemetry"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "dev:prepare": "tsdown",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "echo 'Typecheck handled by build'"
+  },
+  "dependencies": {
+    "@evlog/telemetry": "workspace:*",
+    "citty": "^0.2.2",
+    "evlog": "workspace:*"
+  },
+  "devDependencies": {
+    "tsdown": "^0.22.8",
+    "tsx": "^4.23.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evlog/cli",
   "version": "0.0.0",
-  "description": "The evlog command line — operate your wide events from the terminal: diagnose your setup today, explore, audit, and map your logs next",
+  "description": "The official command line for evlog",
   "author": "HugoRCD <contact@hrcd.fr>",
   "homepage": "https://evlog.dev",
   "repository": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,5 @@
+import { runMain } from 'citty'
+import { showUsage } from './core/usage'
+import { main } from './index'
+
+runMain(main, { showUsage })

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,276 @@
+import { defineCommand } from 'citty'
+import { telemetry } from '@evlog/telemetry'
+import { OUTPUT_PAD, formatCommandHeader, wantsHeader } from '../core/brand'
+import { createContext } from '../core/context'
+import type { CliContext } from '../core/context'
+import {
+  createStyle,
+  exitCodeFor,
+  summarize,
+  writeHuman,
+  writeJson,
+} from '../core/output'
+import type { Check, CheckSummary } from '../core/output'
+import {
+  detectStack,
+  findLogsSink,
+  prettyPath,
+  resolveEvlog,
+  resolveProject,
+} from '../lib/project'
+import type { ProjectInfo } from '../lib/project'
+
+/** Typed result of `evlog doctor` — rendered by {@link formatDoctorReport}. */
+export interface DoctorResult {
+  project: {
+    cwd: string
+    root: string
+    packageDir: string
+    kind: string
+    name: string | null
+    stack: string[]
+  }
+  checks: Check[]
+  sections: { title: string, checks: Check[] }[]
+  summary: CheckSummary
+}
+
+const MIN_NODE_MAJOR = 20
+
+function checkNode(ctx: CliContext): Check {
+  const major = Number.parseInt(ctx.nodeVersion.replace(/^v/, ''), 10)
+  if (Number.isNaN(major)) {
+    return { id: 'node', status: 'warn', message: `unrecognized Node version ${ctx.nodeVersion}` }
+  }
+  if (major < MIN_NODE_MAJOR) {
+    return {
+      id: 'node',
+      status: 'fail',
+      message: `Node ${ctx.nodeVersion} is too old`,
+      hint: `evlog CLI requires Node >= ${MIN_NODE_MAJOR}`,
+    }
+  }
+  return { id: 'node', status: 'ok', message: ctx.nodeVersion }
+}
+
+function checkProject(project: ProjectInfo): Check {
+  if (!project.packageJson) {
+    return {
+      id: 'project',
+      status: 'warn',
+      message: 'no package.json found',
+      hint: 'run from your app or package directory',
+    }
+  }
+
+  const name = project.packageName ?? prettyPath(project.root, project.packageDir)
+  if (project.kind === 'single') {
+    return { id: 'project', status: 'ok', message: name }
+  }
+
+  const where = prettyPath(project.root, project.packageDir)
+  const scope = where === '.' ? 'workspace root' : where
+  return {
+    id: 'project',
+    status: 'ok',
+    message: `${name} · ${project.kind} · ${scope}`,
+  }
+}
+
+function checkEvlog(
+  project: ProjectInfo,
+  resolved: Awaited<ReturnType<typeof resolveEvlog>>,
+): Check {
+  const { install, declared } = resolved
+
+  if (install) {
+    const loc = prettyPath(project.root, install.path)
+    const range = install.declaredRange ? ` (${install.declaredRange})` : ''
+    return {
+      id: 'evlog',
+      status: 'ok',
+      message: `v${install.version}${range}`,
+      hint: loc !== '.' ? `resolved from ${loc}` : undefined,
+    }
+  }
+
+  if (declared) {
+    return {
+      id: 'evlog',
+      status: 'warn',
+      message: `declared ${declared.range} but not installed`,
+      hint: 'run your package manager install step',
+    }
+  }
+
+  return {
+    id: 'evlog',
+    status: 'warn',
+    message: 'not found in this project',
+    hint: 'pnpm add evlog — https://evlog.dev/getting-started/installation',
+  }
+}
+
+function checkStack(stack: string[], hasEvlog: boolean): Check | null {
+  if (stack.length === 0) return null
+  const labels = stack.join(', ')
+  if (hasEvlog) {
+    return { id: 'stack', status: 'ok', message: labels }
+  }
+  return {
+    id: 'stack',
+    status: 'warn',
+    message: labels,
+    hint: 'framework detected — add evlog and wire the matching integration',
+  }
+}
+
+async function checkLogs(project: ProjectInfo): Promise<Check> {
+  const sink = await findLogsSink(project)
+  if (!sink) {
+    return {
+      id: 'logs',
+      status: 'warn',
+      message: 'no local sink yet',
+      hint: 'created on first write by the fs drain (evlog/fs) → .evlog/logs',
+    }
+  }
+  const loc = prettyPath(project.cwd, sink.dir)
+  if (sink.files === 0) {
+    return { id: 'logs', status: 'ok', message: `empty sink · ${loc}` }
+  }
+  return {
+    id: 'logs',
+    status: 'ok',
+    message: `${sink.files} file${sink.files === 1 ? '' : 's'} · ${loc}`,
+  }
+}
+
+/**
+ * Diagnose the evlog setup for `ctx.cwd` (monorepo-aware).
+ * Pure with respect to the context: no printing, no `process.*` access.
+ */
+export async function runDoctor(ctx: CliContext): Promise<DoctorResult> {
+  const project = await resolveProject(ctx.cwd)
+  const resolved = await resolveEvlog(project)
+  const stack = detectStack(project.packageJson)
+
+  const environment: Check[] = [
+    checkNode(ctx),
+    checkProject(project),
+  ]
+  const stackCheck = checkStack(stack, !!resolved.install)
+  if (stackCheck) environment.push(stackCheck)
+
+  const evlog: Check[] = [
+    checkEvlog(project, resolved),
+    await checkLogs(project),
+  ]
+
+  const sections = [
+    { title: 'ENVIRONMENT', checks: environment },
+    { title: 'EVLOG', checks: evlog },
+  ]
+  const checks = sections.flatMap(s => s.checks)
+
+  return {
+    project: {
+      cwd: project.cwd,
+      root: project.root,
+      packageDir: project.packageDir,
+      kind: project.kind,
+      name: project.packageName,
+      stack,
+    },
+    checks,
+    sections,
+    summary: summarize(checks),
+  }
+}
+
+const SYMBOLS = {
+  ok: { glyph: '✓', color: 'green' as const },
+  warn: { glyph: '⚠', color: 'yellow' as const },
+  fail: { glyph: '✗', color: 'red' as const },
+}
+
+/**
+ * On-brand doctor report: shared command header (unless disabled), sectioned checks, summary.
+ */
+export function formatDoctorReport(ctx: CliContext, result: DoctorResult): string {
+  const { paint, link } = createStyle(ctx)
+  const pad = OUTPUT_PAD
+  const lines: string[] = []
+
+  if (wantsHeader(ctx)) {
+    lines.push(formatCommandHeader(ctx, { command: 'doctor' }).trimEnd(), '')
+  }
+
+  const where = result.project.kind === 'single'
+    ? paint('dim', result.project.name ?? result.project.cwd)
+    : paint('dim', `${result.project.kind} workspace`)
+  lines.push(`${pad}${where}`)
+  lines.push('')
+
+  for (const section of result.sections) {
+    lines.push(`${pad}${paint('dim', section.title)}`)
+    const idWidth = Math.max(...section.checks.map(c => c.id.length))
+    for (const check of section.checks) {
+      const { glyph, color } = SYMBOLS[check.status]
+      const symbol = paint(color, glyph)
+      const id = paint(['cyan'], check.id.padEnd(idWidth))
+      lines.push(`${pad}${paint('blue', '│')} ${symbol} ${id}  ${check.message}`)
+      if (check.hint) {
+        lines.push(`${pad}${paint('blue', '│')}   ${paint('dim', `└ ${check.hint}`)}`)
+      }
+    }
+    lines.push('')
+  }
+
+  const { summary } = result
+  const parts = [
+    paint(summary.ok > 0 ? 'green' : 'dim', `${summary.ok} ok`),
+    paint(summary.warn > 0 ? 'yellow' : 'dim', `${summary.warn} warn`),
+    paint(summary.fail > 0 ? 'red' : 'dim', `${summary.fail} fail`),
+  ]
+  lines.push(`${pad}${parts.join(paint('dim', ' · '))}`)
+  lines.push(`${pad}${paint('dim', 'docs')} ${link('https://evlog.dev', 'evlog.dev')}`)
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+/**
+ * `evlog doctor` — diagnose the local evlog setup.
+ * Logic lives in {@link runDoctor}; this file owns the citty surface.
+ */
+export default defineCommand({
+  meta: { name: 'doctor', description: 'Diagnose your evlog setup' },
+  args: {
+    cwd: { type: 'string', description: 'Project directory (default: current)' },
+    json: { type: 'boolean', description: 'Machine-readable JSON on stdout' },
+  },
+  async run({ args }) {
+    const cwd = typeof args.cwd === 'string' && args.cwd.length > 0 ? args.cwd : undefined
+    const ctx = createContext(cwd ? { cwd } : {})
+    const result = await runDoctor(ctx)
+
+    telemetry.set({
+      checksFailed: result.summary.fail,
+      checksWarned: result.summary.warn,
+      workspace: result.project.kind !== 'single',
+    })
+
+    if (args.json) {
+      writeJson({
+        project: result.project,
+        checks: result.checks,
+        summary: result.summary,
+      })
+    } else {
+      writeHuman(formatDoctorReport(ctx, result))
+    }
+
+    process.exitCode = exitCodeFor(result.summary)
+  },
+})

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,16 +1,18 @@
-import { defineCommand } from 'citty'
 import { telemetry } from '@evlog/telemetry'
-import { OUTPUT_PAD, formatCommandHeader, wantsHeader } from '../core/brand'
-import { createContext } from '../core/context'
 import type { CliContext } from '../core/context'
 import {
+  DOCS_LABEL,
+  DOCS_URL,
   createStyle,
-  exitCodeFor,
+  formatChecks,
+  formatSummary,
   summarize,
-  writeHuman,
-  writeJson,
 } from '../core/output'
 import type { Check, CheckSummary } from '../core/output'
+import { defineEvlogCommand } from '../lib/command'
+import type { CatalogFindingSource, CliDebug } from '../lib/debug'
+import { createNoopCliDebug } from '../lib/debug'
+import { cliErrors } from '../lib/errors'
 import {
   detectStack,
   findLogsSink,
@@ -146,32 +148,120 @@ async function checkLogs(project: ProjectInfo): Promise<Check> {
   }
 }
 
+function findingsForChecks(
+  checks: Check[],
+  resolved: Awaited<ReturnType<typeof resolveEvlog>>,
+): Array<{ source: CatalogFindingSource, id: string, status: Check['status'] }> {
+  const findings: Array<{ source: CatalogFindingSource, id: string, status: Check['status'] }> = []
+
+  for (const check of checks) {
+    if (check.status === 'ok') continue
+
+    if (check.id === 'node' && check.status === 'fail') {
+      findings.push({ source: cliErrors.NODE_TOO_OLD, id: check.id, status: check.status })
+      continue
+    }
+
+    if (check.id === 'project') {
+      findings.push({ source: cliErrors.PROJECT_NO_PACKAGE, id: check.id, status: check.status })
+      continue
+    }
+
+    if (check.id === 'evlog') {
+      findings.push({
+        source: resolved.declared
+          ? cliErrors.EVLOG_DECLARED_NOT_INSTALLED
+          : cliErrors.EVLOG_NOT_FOUND,
+        id: check.id,
+        status: check.status,
+      })
+      continue
+    }
+
+    if (check.id === 'logs') {
+      findings.push({ source: cliErrors.LOGS_SINK_MISSING, id: check.id, status: check.status })
+    }
+  }
+
+  return findings
+}
+
 /**
  * Diagnose the evlog setup for `ctx.cwd` (monorepo-aware).
  * Pure with respect to the context: no printing, no `process.*` access.
  */
-export async function runDoctor(ctx: CliContext): Promise<DoctorResult> {
-  const project = await resolveProject(ctx.cwd)
-  const resolved = await resolveEvlog(project)
-  const stack = detectStack(project.packageJson)
+export async function runDoctor(
+  ctx: CliContext,
+  log: CliDebug = createNoopCliDebug(),
+): Promise<DoctorResult> {
+  const project = await log.step(
+    'resolveProject',
+    () => resolveProject(ctx.cwd),
+    p => ({
+      cwd: ctx.cwd,
+      project: {
+        kind: p.kind,
+        root: p.root,
+        packageDir: p.packageDir,
+        name: p.packageName,
+      },
+    }),
+  )
 
-  const environment: Check[] = [
-    checkNode(ctx),
-    checkProject(project),
-  ]
-  const stackCheck = checkStack(stack, !!resolved.install)
-  if (stackCheck) environment.push(stackCheck)
+  const resolved = await log.step(
+    'resolveEvlog',
+    () => resolveEvlog(project),
+    r => ({
+      evlog: r.install
+        ? { version: r.install.version, path: r.install.path }
+        : { missing: true, declared: r.declared },
+      resolveTried: r.tried,
+    }),
+  )
 
-  const evlog: Check[] = [
-    checkEvlog(project, resolved),
-    await checkLogs(project),
-  ]
+  const stack = await log.step(
+    'detectStack',
+    () => detectStack(project.packageJson),
+    s => ({ stack: s }),
+  )
+
+  const checks = await log.step('checks', async () => {
+    const environment: Check[] = [
+      checkNode(ctx),
+      checkProject(project),
+    ]
+    const stackCheck = checkStack(stack, !!resolved.install)
+    if (stackCheck) environment.push(stackCheck)
+
+    return [
+      ...environment,
+      checkEvlog(project, resolved),
+      await checkLogs(project),
+    ]
+  })
 
   const sections = [
-    { title: 'ENVIRONMENT', checks: environment },
-    { title: 'EVLOG', checks: evlog },
+    {
+      title: 'ENVIRONMENT',
+      checks: checks.filter(c => c.id === 'node' || c.id === 'project' || c.id === 'stack'),
+    },
+    {
+      title: 'EVLOG',
+      checks: checks.filter(c => c.id === 'evlog' || c.id === 'logs'),
+    },
   ]
-  const checks = sections.flatMap(s => s.checks)
+
+  const summary = summarize(checks)
+
+  for (const { source, id, status } of findingsForChecks(checks, resolved)) {
+    log.finding(source, { id, status })
+  }
+
+  log.set({
+    steps: ['done'],
+    summary,
+    checks: checks.map(c => ({ id: c.id, status: c.status })),
+  })
 
   return {
     project: {
@@ -184,57 +274,30 @@ export async function runDoctor(ctx: CliContext): Promise<DoctorResult> {
     },
     checks,
     sections,
-    summary: summarize(checks),
+    summary,
   }
-}
-
-const SYMBOLS = {
-  ok: { glyph: '✓', color: 'green' as const },
-  warn: { glyph: '⚠', color: 'yellow' as const },
-  fail: { glyph: '✗', color: 'red' as const },
 }
 
 /**
- * On-brand doctor report: shared command header (unless disabled), sectioned checks, summary.
+ * On-brand doctor report: sectioned checks + summary.
+ * Command header is owned by {@link defineEvlogCommand}.
  */
 export function formatDoctorReport(ctx: CliContext, result: DoctorResult): string {
   const { paint, link } = createStyle(ctx)
-  const pad = OUTPUT_PAD
   const lines: string[] = []
-
-  if (wantsHeader(ctx)) {
-    lines.push(formatCommandHeader(ctx, { command: 'doctor' }).trimEnd(), '')
-  }
 
   const where = result.project.kind === 'single'
     ? paint('dim', result.project.name ?? result.project.cwd)
     : paint('dim', `${result.project.kind} workspace`)
-  lines.push(`${pad}${where}`)
-  lines.push('')
+  lines.push(where, '')
 
   for (const section of result.sections) {
-    lines.push(`${pad}${paint('dim', section.title)}`)
-    const idWidth = Math.max(...section.checks.map(c => c.id.length))
-    for (const check of section.checks) {
-      const { glyph, color } = SYMBOLS[check.status]
-      const symbol = paint(color, glyph)
-      const id = paint(['cyan'], check.id.padEnd(idWidth))
-      lines.push(`${pad}${paint('blue', '│')} ${symbol} ${id}  ${check.message}`)
-      if (check.hint) {
-        lines.push(`${pad}${paint('blue', '│')}   ${paint('dim', `└ ${check.hint}`)}`)
-      }
-    }
-    lines.push('')
+    lines.push(paint('dim', section.title))
+    lines.push(formatChecks(ctx, section.checks), '')
   }
 
-  const { summary } = result
-  const parts = [
-    paint(summary.ok > 0 ? 'green' : 'dim', `${summary.ok} ok`),
-    paint(summary.warn > 0 ? 'yellow' : 'dim', `${summary.warn} warn`),
-    paint(summary.fail > 0 ? 'red' : 'dim', `${summary.fail} fail`),
-  ]
-  lines.push(`${pad}${parts.join(paint('dim', ' · '))}`)
-  lines.push(`${pad}${paint('dim', 'docs')} ${link('https://evlog.dev', 'evlog.dev')}`)
+  lines.push(formatSummary(ctx, result.summary))
+  lines.push(`${paint('dim', 'docs')} ${link(DOCS_URL, DOCS_LABEL)}`)
   lines.push('')
 
   return lines.join('\n')
@@ -244,16 +307,15 @@ export function formatDoctorReport(ctx: CliContext, result: DoctorResult): strin
  * `evlog doctor` — diagnose the local evlog setup.
  * Logic lives in {@link runDoctor}; this file owns the citty surface.
  */
-export default defineCommand({
+export default defineEvlogCommand('doctor', {
   meta: { name: 'doctor', description: 'Diagnose your evlog setup' },
   args: {
     cwd: { type: 'string', description: 'Project directory (default: current)' },
-    json: { type: 'boolean', description: 'Machine-readable JSON on stdout' },
   },
-  async run({ args }) {
+  async run({ args, cli, log, ui }) {
     const cwd = typeof args.cwd === 'string' && args.cwd.length > 0 ? args.cwd : undefined
-    const ctx = createContext(cwd ? { cwd } : {})
-    const result = await runDoctor(ctx)
+    const ctx = cwd ? { ...cli, cwd } : cli
+    const result = await runDoctor(ctx, log)
 
     telemetry.set({
       checksFailed: result.summary.fail,
@@ -261,16 +323,15 @@ export default defineCommand({
       workspace: result.project.kind !== 'single',
     })
 
-    if (args.json) {
-      writeJson({
+    ui.done({
+      jsonMode: args.json,
+      json: {
         project: result.project,
         checks: result.checks,
         summary: result.summary,
-      })
-    } else {
-      writeHuman(formatDoctorReport(ctx, result))
-    }
-
-    process.exitCode = exitCodeFor(result.summary)
+      },
+      human: formatDoctorReport(ctx, result),
+      summary: result.summary,
+    })
   },
 })

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,18 @@
+import doctor from './doctor'
+import telemetry from './telemetry'
+
+/**
+ * Root subcommand registry.
+ *
+ * Adding a command:
+ * 1. Create `src/commands/<name>.ts` exporting a default citty `defineCommand`
+ *    (prefer `defineEvlogCommand` from `lib/command` so the branded header is automatic)
+ * 2. Import it here and add one line to {@link subCommands}
+ *
+ * Keep `index.ts` free of command bodies — this file is the only place that
+ * grows when the surface expands (audit, map, push, …).
+ */
+export const subCommands = {
+  doctor,
+  telemetry,
+}

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,13 @@
+import { defineTelemetryCommands } from '@evlog/telemetry'
+import type { CommandDef } from 'citty'
+import { TOOL_NAME } from '../lib/constants'
+import { withCommandHeaders } from '../lib/command'
+
+/**
+ * `evlog telemetry *` — `@evlog/telemetry` consent commands, wrapped with
+ * the branded command header on every leaf.
+ */
+export default withCommandHeaders(
+  defineTelemetryCommands({ name: TOOL_NAME }) as CommandDef,
+  ['telemetry'],
+)

--- a/packages/cli/src/core/brand.ts
+++ b/packages/cli/src/core/brand.ts
@@ -1,0 +1,151 @@
+import { version as VERSION } from '../../package.json'
+import type { CliContext } from './context'
+import { DOCS_LABEL, DOCS_URL, createStyle } from './output'
+
+/** Brand tagline — the evlog slogan. */
+export const TAGLINE = 'DIGGING THROUGH LOGS IS NOT OBSERVABILITY. IT\'S HOPE'
+
+/**
+ * `evlog` wordmark — figlet "slant" font (UnJS-family aesthetic).
+ * Trailing spaces stripped; every line padded to the same width.
+ */
+export const WORDMARK = [
+  '             __           ',
+  '  ___ _   __/ /___  ____ _',
+  ' / _ \\ | / / / __ \\/ __ `/',
+  '/  __/ |/ / / /_/ / /_/ / ',
+  '\\___/|___/_/\\____/\\__, /  ',
+  '                 /____/   ',
+] as const
+
+const WORDMARK_WIDTH = WORDMARK[0].length
+const MIN_COLUMNS = WORDMARK_WIDTH + 8
+
+/**
+ * Vertical scanline glow across the wordmark rows — bright core, dim edges.
+ * Six rows: dim → mid → bold → bold → mid → dim.
+ */
+const SCANLINES = [
+  ['dim', 'white'],
+  ['white'],
+  ['bold', 'white'],
+  ['bold', 'white'],
+  ['white'],
+  ['dim', 'white'],
+] as const
+
+/** Gradient stops: brand blue → near-black (site accent bar, L→R fade). */
+const GRADIENT_FROM = [43, 90, 255] as const
+const GRADIENT_TO = [8, 10, 40] as const
+
+/**
+ * Where the accent bar sits inside its terminal row — the only sub-cell
+ * ("pixel") control terminals give us:
+ *
+ * | Glyph | Position in cell      | Air above text |
+ * | ----- | --------------------- | -------------- |
+ * | `▀`   | top half              | none (glued)   |
+ * | `━`   | optical middle        | some           |
+ * | `▄`   | lower half (default)  | half cell      |
+ * | `▂`   | lower quarter         | more           |
+ * | `▁`   | baseline              | most           |
+ */
+export const GRADIENT_GLYPH = '▄'
+
+/** Shared left padding for command headers and reports (flush left). */
+export const OUTPUT_PAD = ''
+
+
+/** Accent bar width under command titles. */
+export const HEADER_GRADIENT_WIDTH = 28
+
+/**
+ * Horizontal rule fading blue → dark, like the site's accent bar.
+ * Truecolor per-cell; plain dashes when colors are off.
+ *
+ * @param glyph - Override {@link GRADIENT_GLYPH} to tune vertical air above the bar.
+ */
+export function gradientRule(
+  ctx: Pick<CliContext, 'color'>,
+  width: number,
+  glyph: string = GRADIENT_GLYPH,
+): string {
+  if (!ctx.color) return '─'.repeat(width)
+  let out = ''
+  for (let i = 0; i < width; i++) {
+    const t = width === 1 ? 1 : i / (width - 1)
+    const r = Math.round(GRADIENT_FROM[0] + (GRADIENT_TO[0] - GRADIENT_FROM[0]) * t)
+    const g = Math.round(GRADIENT_FROM[1] + (GRADIENT_TO[1] - GRADIENT_FROM[1]) * t)
+    const b = Math.round(GRADIENT_FROM[2] + (GRADIENT_TO[2] - GRADIENT_FROM[2]) * t)
+    out += `\x1B[38;2;${r};${g};${b}m${glyph}`
+  }
+  return `${out}\x1B[0m`
+}
+
+/**
+ * Whether the branded command header should print.
+ *
+ * Disabled when:
+ * - `--json` (machine output)
+ * - `--no-header` (flag on the command or anywhere on argv)
+ * - `EVLOG_CLI_NO_HEADER=1` or `EVLOG_CLI_HEADER=0`
+ */
+export function wantsHeader(
+  ctx: Pick<CliContext, 'env'>,
+  args?: { json?: boolean, noHeader?: boolean },
+  argv: readonly string[] = process.argv,
+): boolean {
+  if (args?.json) return false
+  if (args?.noHeader) return false
+  if (ctx.env.EVLOG_CLI_NO_HEADER === '1') return false
+  if (ctx.env.EVLOG_CLI_HEADER === '0') return false
+  if (argv.includes('--no-header')) return false
+  return true
+}
+
+/**
+ * Branded command header used by every leaf command:
+ *
+ * ```
+ *     evlog doctor v0.0.0
+ *     ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+ * ```
+ *
+ * Vertical air between title and bar is controlled by {@link GRADIENT_GLYPH}
+ * (sub-cell), not by blank rows. Skip via {@link wantsHeader}.
+ */
+export function formatCommandHeader(
+  ctx: CliContext,
+  options: { command: string, version?: string },
+): string {
+  const { paint } = createStyle(ctx)
+  const version = options.version ?? VERSION
+  return [
+    '',
+    `${OUTPUT_PAD}${paint('bold', 'evlog')} ${paint(['cyan', 'bold'], options.command)} ${paint('dim', `v${version}`)}`,
+    `${OUTPUT_PAD}${gradientRule(ctx, HEADER_GRADIENT_WIDTH)}`,
+    '',
+  ].join('\n')
+}
+
+/**
+ * Full branded banner: figlet wordmark with scanline glow, gradient accent
+ * rule, and a single dim meta line (tagline · version · docs link).
+ *
+ * Falls back to a compact one-liner when colors are off or the terminal is
+ * too narrow for the art.
+ */
+export function formatBanner(ctx: CliContext, version: string): string {
+  const { paint, link } = createStyle(ctx)
+
+  if (!ctx.color || ctx.columns < MIN_COLUMNS) {
+    return `  ${paint('bold', 'evlog')} ${paint('dim', `v${version} — digging through logs is not observability ·`)} ${link(DOCS_URL, DOCS_LABEL)}\n`
+  }
+
+  const art = WORDMARK.map((row, i) => `  ${paint([...SCANLINES[i]!], row)}`)
+  const rule = `  ${gradientRule(ctx, WORDMARK_WIDTH)}`
+  const slogan = `  ${paint('dim', TAGLINE)}`
+  const meta = `  ${paint('dim', `v${version} · `)}${link(DOCS_URL, DOCS_LABEL)}`
+
+  return `${art.join('\n')}\n\n${rule}\n\n${slogan}\n${meta}\n`
+}

--- a/packages/cli/src/core/brand.ts
+++ b/packages/cli/src/core/brand.ts
@@ -52,10 +52,6 @@ const GRADIENT_TO = [8, 10, 40] as const
  */
 export const GRADIENT_GLYPH = '▄'
 
-/** Shared left padding for command headers and reports (flush left). */
-export const OUTPUT_PAD = ''
-
-
 /** Accent bar width under command titles. */
 export const HEADER_GRADIENT_WIDTH = 28
 
@@ -122,8 +118,8 @@ export function formatCommandHeader(
   const version = options.version ?? VERSION
   return [
     '',
-    `${OUTPUT_PAD}${paint('bold', 'evlog')} ${paint(['cyan', 'bold'], options.command)} ${paint('dim', `v${version}`)}`,
-    `${OUTPUT_PAD}${gradientRule(ctx, HEADER_GRADIENT_WIDTH)}`,
+    `${paint('bold', 'evlog')} ${paint(['cyan', 'bold'], options.command)} ${paint('dim', `v${version}`)}`,
+    `${gradientRule(ctx, HEADER_GRADIENT_WIDTH)}`,
     '',
   ].join('\n')
 }

--- a/packages/cli/src/core/context.ts
+++ b/packages/cli/src/core/context.ts
@@ -1,6 +1,9 @@
 /**
  * Execution context passed to every command.
  * The only place allowed to read `process.*` — commands stay pure and testable.
+ *
+ * Debug instrumentation uses {@link import('../lib/debug').CliDebug} from
+ * {@link import('../lib/command').defineEvlogCommand}, not this object.
  */
 export interface CliContext {
   /** Working directory used to resolve the host project. */

--- a/packages/cli/src/core/context.ts
+++ b/packages/cli/src/core/context.ts
@@ -1,0 +1,45 @@
+/**
+ * Execution context passed to every command.
+ * The only place allowed to read `process.*` — commands stay pure and testable.
+ */
+export interface CliContext {
+  /** Working directory used to resolve the host project. */
+  cwd: string
+  /** Environment snapshot — commands never touch `process.env` directly. */
+  env: Record<string, string | undefined>
+  /** Running Node.js version, e.g. `v22.1.0`. */
+  nodeVersion: string
+  /** Whether the terminal is interactive (stdout or stderr is a TTY). */
+  tty: boolean
+  /** Whether ANSI styling should be emitted. */
+  color: boolean
+  /** Terminal width in columns (80 when unknown). */
+  columns: number
+}
+
+function isInteractive(): boolean {
+  return process.stdout.isTTY === true || process.stderr.isTTY === true
+}
+
+function useColors(env: Record<string, string | undefined>, tty: boolean): boolean {
+  if (env.NO_COLOR !== undefined) return false
+  if (env.FORCE_COLOR === '1' || env.FORCE_COLOR === '2' || env.FORCE_COLOR === '3') return true
+  return tty
+}
+
+/**
+ * Build the {@link CliContext} for the current process.
+ * Pass `overrides` in tests to fake cwd, env, or terminal capabilities.
+ */
+export function createContext(overrides: Partial<CliContext> = {}): CliContext {
+  const env = overrides.env ?? { ...process.env }
+  const tty = overrides.tty ?? isInteractive()
+  return {
+    cwd: overrides.cwd ?? process.cwd(),
+    env,
+    nodeVersion: overrides.nodeVersion ?? process.version,
+    tty,
+    color: overrides.color ?? useColors(env, tty),
+    columns: overrides.columns ?? process.stdout.columns ?? process.stderr.columns ?? 80,
+  }
+}

--- a/packages/cli/src/core/output.ts
+++ b/packages/cli/src/core/output.ts
@@ -1,0 +1,147 @@
+import type { CliContext } from './context'
+
+export const DOCS_URL = 'https://evlog.dev'
+export const DOCS_LABEL = 'evlog.dev'
+
+/** Current CLI result schema. Bump when a `--json` payload shape changes. */
+export const SCHEMA_VERSION = 1
+
+/** Documented exit codes: 0 ok (warns allowed), 1 any fail, 2 usage error. */
+export const EXIT_OK = 0
+export const EXIT_FAIL = 1
+export const EXIT_USAGE = 2
+
+const codes = {
+  reset: '\x1B[0m',
+  bold: '\x1B[1m',
+  dim: '\x1B[2m',
+  underline: '\x1B[4m',
+  red: '\x1B[31m',
+  green: '\x1B[32m',
+  yellow: '\x1B[33m',
+  blue: '\x1B[34m',
+  cyan: '\x1B[36m',
+  white: '\x1B[37m',
+} as const
+
+type StyleCode = keyof typeof codes
+
+/**
+ * Minimal ANSI kit bound to a {@link CliContext} — hand-rolled like
+ * evlog's pretty printer and the telemetry notice, no color dependency.
+ */
+export interface Style {
+  paint: (code: StyleCode | StyleCode[], text: string) => string
+  link: (url: string, label: string) => string
+}
+
+/** Create the styling helpers for a context (honors `NO_COLOR` / non-TTY). */
+export function createStyle(ctx: Pick<CliContext, 'color'>): Style {
+  const paint = (code: StyleCode | StyleCode[], text: string): string => {
+    if (!ctx.color) return text
+    const seq = (Array.isArray(code) ? code : [code]).map(k => codes[k]).join('')
+    return `${seq}${text}${codes.reset}`
+  }
+  const link = (url: string, label: string): string => {
+    if (!ctx.color) return `${label} (${url})`
+    return `\x1B]8;;${url}\x07${paint(['cyan', 'underline'], label)}\x1B]8;;\x07`
+  }
+  return { paint, link }
+}
+
+/** Status of a single diagnostic check. */
+export type CheckStatus = 'ok' | 'warn' | 'fail'
+
+/** One diagnostic check result — commands return these, never print. */
+export interface Check {
+  id: string
+  status: CheckStatus
+  message: string
+  hint?: string
+}
+
+/** Aggregate counts over a list of checks. */
+export interface CheckSummary {
+  ok: number
+  warn: number
+  fail: number
+}
+
+/** Count check statuses. */
+export function summarize(checks: Check[]): CheckSummary {
+  const summary: CheckSummary = { ok: 0, warn: 0, fail: 0 }
+  for (const check of checks) summary[check.status]++
+  return summary
+}
+
+/** Exit code for a set of checks: 1 when any check failed, 0 otherwise. */
+export function exitCodeFor(summary: CheckSummary): number {
+  return summary.fail > 0 ? EXIT_FAIL : EXIT_OK
+}
+
+const SYMBOLS: Record<CheckStatus, { glyph: string, color: StyleCode }> = {
+  ok: { glyph: '✓', color: 'green' },
+  warn: { glyph: '⚠', color: 'yellow' },
+  fail: { glyph: '✗', color: 'red' },
+}
+
+/**
+ * Compact brand header for command output: blue accent bar, bold `evlog`
+ * wordmark, cyan command, dim version and docs link. The full ASCII banner
+ * belongs to the help — command output stays tight.
+ */
+export function formatHeader(ctx: CliContext, options: { command?: string, version: string }): string {
+  const { paint, link } = createStyle(ctx)
+  const accent = paint('blue', '▍')
+  const wordmark = paint('bold', 'evlog')
+  const command = options.command ? ` ${paint(['cyan', 'bold'], options.command)}` : ''
+  const version = paint('dim', `· v${options.version} ·`)
+  return `\n  ${accent} ${wordmark}${command} ${version} ${link(DOCS_URL, DOCS_LABEL)}\n`
+}
+
+/**
+ * Render checks as a blue-railed, aligned list with ✓ / ⚠ / ✗ and dim hints —
+ * same left-rail language as the telemetry notice and the wide-event tree.
+ */
+export function formatChecks(ctx: CliContext, checks: Check[]): string {
+  const { paint } = createStyle(ctx)
+  const width = Math.max(...checks.map(c => c.id.length))
+  const rail = paint('blue', '│')
+  const lines: string[] = []
+
+  for (const check of checks) {
+    const { glyph, color } = SYMBOLS[check.status]
+    const symbol = paint(color, glyph)
+    const id = paint('dim', check.id.padEnd(width))
+    lines.push(`  ${rail} ${symbol} ${id}  ${check.message}`)
+    if (check.hint && check.status !== 'ok') {
+      lines.push(`  ${rail}   ${paint('dim', `└─ ${check.hint}`)}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/** One-line footer: `3 ok · 1 warn · 0 fail` with blue accent and status colors. */
+export function formatSummary(ctx: CliContext, summary: CheckSummary): string {
+  const { paint } = createStyle(ctx)
+  const parts = [
+    paint(summary.ok > 0 ? 'green' : 'dim', `${summary.ok} ok`),
+    paint(summary.warn > 0 ? 'yellow' : 'dim', `${summary.warn} warn`),
+    paint(summary.fail > 0 ? 'red' : 'dim', `${summary.fail} fail`),
+  ]
+  return `\n  ${paint('blue', '▍')} ${parts.join(paint('dim', ' · '))}\n`
+}
+
+/**
+ * Write a `--json` payload — the only thing allowed on stdout in JSON mode.
+ * Always includes `schemaVersion`; breaking the shape requires a bump.
+ */
+export function writeJson(payload: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify({ schemaVersion: SCHEMA_VERSION, ...payload })}\n`)
+}
+
+/** Write human-readable output to stderr (stdout is reserved for `--json`). */
+export function writeHuman(text: string): void {
+  process.stderr.write(`${text}\n`)
+}

--- a/packages/cli/src/core/output.ts
+++ b/packages/cli/src/core/output.ts
@@ -1,10 +1,11 @@
+import { resolveCliEnvironment } from '../lib/environment'
 import type { CliContext } from './context'
 
 export const DOCS_URL = 'https://evlog.dev'
 export const DOCS_LABEL = 'evlog.dev'
 
 /** Current CLI result schema. Bump when a `--json` payload shape changes. */
-export const SCHEMA_VERSION = 1
+export const SCHEMA_VERSION = 2
 
 /** Documented exit codes: 0 ok (warns allowed), 1 any fail, 2 usage error. */
 export const EXIT_OK = 0
@@ -122,10 +123,14 @@ export function formatSummary(ctx: Pick<CliContext, 'color'>, summary: CheckSumm
 
 /**
  * Write a `--json` payload — the only thing allowed on stdout in JSON mode.
- * Always includes `schemaVersion`; breaking the shape requires a bump.
+ * Always includes `schemaVersion` and `environment`; breaking the shape requires a bump.
  */
 export function writeJson(payload: Record<string, unknown>): void {
-  process.stdout.write(`${JSON.stringify({ schemaVersion: SCHEMA_VERSION, ...payload })}\n`)
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: SCHEMA_VERSION,
+    environment: resolveCliEnvironment(),
+    ...payload,
+  })}\n`)
 }
 
 /** Write human-readable output to stderr (stdout is reserved for `--json`). */

--- a/packages/cli/src/core/output.ts
+++ b/packages/cli/src/core/output.ts
@@ -52,6 +52,13 @@ export function createStyle(ctx: Pick<CliContext, 'color'>): Style {
 /** Status of a single diagnostic check. */
 export type CheckStatus = 'ok' | 'warn' | 'fail'
 
+/** Shared glyphs for check / finding status (doctor report + debug case file). */
+export const CHECK_STATUS: Record<CheckStatus, { glyph: string, color: StyleCode }> = {
+  ok: { glyph: '✓', color: 'green' },
+  warn: { glyph: '⚠', color: 'yellow' },
+  fail: { glyph: '✗', color: 'red' },
+}
+
 /** One diagnostic check result — commands return these, never print. */
 export interface Check {
   id: string
@@ -79,58 +86,38 @@ export function exitCodeFor(summary: CheckSummary): number {
   return summary.fail > 0 ? EXIT_FAIL : EXIT_OK
 }
 
-const SYMBOLS: Record<CheckStatus, { glyph: string, color: StyleCode }> = {
-  ok: { glyph: '✓', color: 'green' },
-  warn: { glyph: '⚠', color: 'yellow' },
-  fail: { glyph: '✗', color: 'red' },
-}
-
 /**
- * Compact brand header for command output: blue accent bar, bold `evlog`
- * wordmark, cyan command, dim version and docs link. The full ASCII banner
- * belongs to the help — command output stays tight.
+ * Render checks as a blue-railed list with ✓ / ⚠ / ✗, cyan ids, and dim hints.
  */
-export function formatHeader(ctx: CliContext, options: { command?: string, version: string }): string {
-  const { paint, link } = createStyle(ctx)
-  const accent = paint('blue', '▍')
-  const wordmark = paint('bold', 'evlog')
-  const command = options.command ? ` ${paint(['cyan', 'bold'], options.command)}` : ''
-  const version = paint('dim', `· v${options.version} ·`)
-  return `\n  ${accent} ${wordmark}${command} ${version} ${link(DOCS_URL, DOCS_LABEL)}\n`
-}
-
-/**
- * Render checks as a blue-railed, aligned list with ✓ / ⚠ / ✗ and dim hints —
- * same left-rail language as the telemetry notice and the wide-event tree.
- */
-export function formatChecks(ctx: CliContext, checks: Check[]): string {
+export function formatChecks(ctx: Pick<CliContext, 'color'>, checks: Check[]): string {
+  if (checks.length === 0) return ''
   const { paint } = createStyle(ctx)
   const width = Math.max(...checks.map(c => c.id.length))
   const rail = paint('blue', '│')
   const lines: string[] = []
 
   for (const check of checks) {
-    const { glyph, color } = SYMBOLS[check.status]
+    const { glyph, color } = CHECK_STATUS[check.status]
     const symbol = paint(color, glyph)
-    const id = paint('dim', check.id.padEnd(width))
-    lines.push(`  ${rail} ${symbol} ${id}  ${check.message}`)
+    const id = paint('cyan', check.id.padEnd(width))
+    lines.push(`${rail} ${symbol} ${id}  ${check.message}`)
     if (check.hint && check.status !== 'ok') {
-      lines.push(`  ${rail}   ${paint('dim', `└─ ${check.hint}`)}`)
+      lines.push(`${rail}   ${paint('dim', `└ ${check.hint}`)}`)
     }
   }
 
   return lines.join('\n')
 }
 
-/** One-line footer: `3 ok · 1 warn · 0 fail` with blue accent and status colors. */
-export function formatSummary(ctx: CliContext, summary: CheckSummary): string {
+/** One-line footer: `3 ok · 1 warn · 0 fail`. */
+export function formatSummary(ctx: Pick<CliContext, 'color'>, summary: CheckSummary): string {
   const { paint } = createStyle(ctx)
   const parts = [
     paint(summary.ok > 0 ? 'green' : 'dim', `${summary.ok} ok`),
     paint(summary.warn > 0 ? 'yellow' : 'dim', `${summary.warn} warn`),
     paint(summary.fail > 0 ? 'red' : 'dim', `${summary.fail} fail`),
   ]
-  return `\n  ${paint('blue', '▍')} ${parts.join(paint('dim', ' · '))}\n`
+  return parts.join(paint('dim', ' · '))
 }
 
 /**

--- a/packages/cli/src/core/usage.ts
+++ b/packages/cli/src/core/usage.ts
@@ -1,0 +1,71 @@
+import type { ArgsDef, CommandDef } from 'citty'
+import { formatBanner } from './brand'
+import { createContext } from './context'
+import { createStyle, writeHuman } from './output'
+
+async function resolve<T>(value: T | (() => T | Promise<T>) | Promise<T> | undefined): Promise<T | undefined> {
+  if (typeof value === 'function') return await (value as () => T | Promise<T>)()
+  return await value
+}
+
+interface Row {
+  name: string
+  description: string
+}
+
+function formatSection(title: string, rows: Row[], paint: ReturnType<typeof createStyle>['paint']): string {
+  const width = Math.max(...rows.map(r => r.name.length))
+  const lines = rows.map(row => `  ${paint('blue', '│')} ${paint(['cyan', 'bold'], row.name.padEnd(width))}  ${row.description}`)
+  return `  ${paint('dim', title)}\n\n${lines.join('\n')}`
+}
+
+/**
+ * Branded replacement for citty's default usage renderer — banner on top,
+ * blue-railed command and option lists, no repeated boilerplate: the docs
+ * link lives in the banner meta line only.
+ */
+export async function showUsage(cmd: CommandDef<any>, parent?: CommandDef<any>): Promise<void> {
+  const ctx = createContext()
+  const { paint } = createStyle(ctx)
+
+  const meta = await resolve(cmd.meta)
+  const parentMeta = await resolve(parent?.meta)
+  const commandName = [parentMeta?.name, meta?.name].filter(Boolean).join(' ') || 'evlog'
+  const version = meta?.version ?? parentMeta?.version ?? ''
+
+  const subCommands = await resolve(cmd.subCommands)
+  const args = await resolve(cmd.args as ArgsDef | undefined)
+  const hasCommands = !!subCommands && Object.keys(subCommands).length > 0
+  const hasArgs = !!args && Object.keys(args).length > 0
+
+  const sections: string[] = [formatBanner(ctx, version).trimEnd()]
+
+  const usageParts = [commandName]
+  if (hasCommands) usageParts.push('<command>')
+  if (hasArgs) usageParts.push('[options]')
+  sections.push(`  ${paint('dim', 'USAGE')}  ${paint('bold', usageParts.join(' '))}`)
+
+  if (hasCommands) {
+    const rows: Row[] = []
+    for (const [name, sub] of Object.entries(subCommands)) {
+      const subMeta = await resolve((sub as CommandDef).meta)
+      rows.push({ name, description: subMeta?.description ?? '' })
+    }
+    sections.push(formatSection('COMMANDS', rows, paint))
+  }
+
+  if (hasArgs) {
+    const rows: Row[] = Object.entries(args).map(([name, def]) => ({
+      name: `--${name}`,
+      description: (def as { description?: string }).description ?? '',
+    }))
+    sections.push(formatSection('OPTIONS', rows, paint))
+  }
+
+  if (hasCommands) {
+    sections.push(`  ${paint('dim', `Use ${commandName} <command> --help for details`)}`)
+  }
+
+  // One blank line between major sections; no leading spacer above the banner
+  writeHuman(`${sections.join('\n\n')}\n`)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,22 @@
+import { defineCommand } from 'citty'
+import { withTelemetry } from '@evlog/telemetry'
+import { subCommands } from './commands'
+import { TOOL_NAME, VERSION } from './lib/constants'
+
+/**
+ * The evlog CLI command tree, telemetry-wrapped and ready for `runMain()`.
+ * Command bodies live under `commands/` — see `commands/index.ts` to register one.
+ */
+export const main = withTelemetry(
+  defineCommand({
+    meta: {
+      name: 'evlog',
+      description: 'evlog — digging through logs is not observability. it\'s hope · https://evlog.dev',
+      version: VERSION,
+    },
+    subCommands,
+  }),
+  { name: TOOL_NAME, version: VERSION },
+)
+
+export { TOOL_NAME, VERSION as version }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { withTelemetry } from '@evlog/telemetry'
 import { subCommands } from './commands'
 import { COMMON_ARGS } from './lib/command'
 import { TOOL_NAME, VERSION } from './lib/constants'
+import { resolveCliEnvironment } from './lib/environment'
 
 /**
  * The evlog CLI command tree, telemetry-wrapped and ready for `runMain()`.
@@ -20,7 +21,12 @@ export const main = withTelemetry(
     },
     subCommands,
   }),
-  { name: TOOL_NAME, version: VERSION },
+  {
+    name: TOOL_NAME,
+    version: VERSION,
+    // Packaged installs report `production`; workspace builds report `development`.
+    environment: resolveCliEnvironment(),
+  },
 )
 
 export { TOOL_NAME, VERSION as version }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty'
 import { withTelemetry } from '@evlog/telemetry'
 import { subCommands } from './commands'
+import { COMMON_ARGS } from './lib/command'
 import { TOOL_NAME, VERSION } from './lib/constants'
 
 /**
@@ -13,6 +14,9 @@ export const main = withTelemetry(
       name: 'evlog',
       description: 'evlog — digging through logs is not observability. it\'s hope · https://evlog.dev',
       version: VERSION,
+    },
+    args: {
+      debug: COMMON_ARGS.debug,
     },
     subCommands,
   }),

--- a/packages/cli/src/lib/command.ts
+++ b/packages/cli/src/lib/command.ts
@@ -1,46 +1,116 @@
-import type { ArgsDef, CommandDef, CommandContext } from 'citty'
+import type { ArgsDef, CommandDef, CommandContext, CommandMeta } from 'citty'
 import { defineCommand } from 'citty'
 import { createContext } from '../core/context'
+import type { CliContext } from '../core/context'
 import { formatCommandHeader, wantsHeader } from '../core/brand'
 import { writeHuman } from '../core/output'
+import { withCliDebug } from './debug'
+import type { CliDebug, DebugArgs } from './debug'
+import { createUi } from './ui'
+import type { CliUi } from './ui'
 
 type AnyCommand = CommandDef<ArgsDef>
 
-function headerArgs(args: unknown): { json?: boolean, noHeader?: boolean } {
-  const a = args as { json?: boolean, noHeader?: boolean }
-  return { json: a?.json, noHeader: a?.noHeader }
+/**
+ * Args injected on every {@link defineEvlogCommand} leaf.
+ * Commands may still declare their own; these are merged in (command wins on clash).
+ */
+export const COMMON_ARGS = {
+  json: { type: 'boolean', description: 'Machine-readable JSON on stdout' },
+  debug: { type: 'boolean', description: 'Emit a debug case file via evlog' },
+  noHeader: { type: 'boolean', description: 'Skip the branded command header' },
+} as const satisfies ArgsDef
+
+/** Citty context plus CLI helpers injected by {@link defineEvlogCommand}. */
+export type EvlogRunContext<T extends ArgsDef = ArgsDef> = CommandContext<T> & {
+  /** Process / terminal context (cwd, env, color, …). */
+  cli: CliContext
+  /**
+   * Debug handle — always present. No-ops when `--debug` is off;
+   * `log.step` still executes the work.
+   */
+  log: CliDebug
+  /**
+   * Terminal output — `human` (stderr), `json` (stdout), `exit`, `done`.
+   * Prefer this over touching `process.stdout` / `exitCode` in commands.
+   */
+  ui: CliUi
+}
+
+export type EvlogCommandDef<T extends ArgsDef = ArgsDef> = Omit<CommandDef<T>, 'run' | 'args'> & {
+  args?: T
+  run?: (ctx: EvlogRunContext<T & typeof COMMON_ARGS>) => ReturnType<NonNullable<CommandDef<T>['run']>>
+}
+
+function runArgs(args: unknown): DebugArgs & { noHeader?: boolean } {
+  const a = args as DebugArgs & { noHeader?: boolean }
+  return { json: a?.json, noHeader: a?.noHeader, debug: a?.debug }
+}
+
+function syncMeta(meta: CommandDef['meta']): CommandMeta {
+  if (meta && typeof meta === 'object' && !('then' in meta)) {
+    return meta
+  }
+  return {}
 }
 
 /**
- * Define a citty command that prints the branded header
- * (`evlog <command> vX` + gradient) before running — unless disabled
- * (`--json`, `--no-header`, or `EVLOG_CLI_NO_HEADER=1`).
+ * Define a citty command with branded header, shared flags, debug filet, and `ui`.
  *
- * Use for every leaf command so the CLI surface stays consistent as it grows.
+ * `run` receives `{ …citty, cli, log, ui }`.
+ *
+ * @example
+ * ```ts
+ * export default defineEvlogCommand('audit', {
+ *   meta: { description: '…' },
+ *   args: { since: { type: 'string' } },
+ *   async run({ args, cli, log, ui }) {
+ *     const data = await log.step('load', () => load(cli.cwd))
+ *     ui.done({
+ *       jsonMode: args.json,
+ *       json: { data },
+ *       human: format(data),
+ *       summary: { ok: 1, warn: 0, fail: 0 },
+ *     })
+ *   },
+ * })
+ * ```
  */
 export function defineEvlogCommand<T extends ArgsDef = ArgsDef>(
   command: string,
-  def: CommandDef<T>,
-): CommandDef<T> {
+  def: EvlogCommandDef<T>,
+): CommandDef<T & typeof COMMON_ARGS> {
+  const baseMeta = syncMeta(def.meta)
+  const args = {
+    ...COMMON_ARGS,
+    ...def.args,
+  } as T & typeof COMMON_ARGS
+
   return defineCommand({
     ...def,
+    args,
     meta: {
-      ...def.meta,
-      name: def.meta?.name ?? command.split(' ').at(-1),
+      ...baseMeta,
+      name: baseMeta.name ?? command.split(' ').at(-1),
     },
-    async run(ctx: CommandContext<T>) {
+    async run(ctx: CommandContext<T & typeof COMMON_ARGS>) {
+      const flags = runArgs(ctx.args)
       const cli = createContext()
-      if (wantsHeader(cli, headerArgs(ctx.args))) {
+      if (wantsHeader(cli, flags)) {
         writeHuman(formatCommandHeader(cli, { command }))
       }
-      return await def.run?.(ctx)
+      const ui = createUi({ json: flags.json })
+      return await withCliDebug(cli, { command, ...flags }, async (log) => {
+        return await def.run?.({ ...ctx, cli, log, ui })
+      })
     },
-  })
+  } as CommandDef<T & typeof COMMON_ARGS>)
 }
 
 /**
  * Recursively wrap every leaf `run` handler in a command tree with the
- * branded header. Useful for third-party trees (e.g. `@evlog/telemetry`).
+ * branded header (and optional debug wide event). Useful for third-party
+ * trees (e.g. `@evlog/telemetry`).
  *
  * @param path - Command path segments already walked, e.g. `['telemetry']`.
  */
@@ -65,11 +135,12 @@ export function withCommandHeaders(cmd: AnyCommand, path: string[] = []): AnyCom
     ...cmd,
     subCommands: wrappedSubs,
     async run(ctx) {
+      const flags = runArgs(ctx.args)
       const cli = createContext()
-      if (wantsHeader(cli, headerArgs(ctx.args))) {
+      if (wantsHeader(cli, flags)) {
         writeHuman(formatCommandHeader(cli, { command: label }))
       }
-      return await originalRun(ctx)
+      return await withCliDebug(cli, { command: label, ...flags }, () => originalRun(ctx))
     },
   }
 }

--- a/packages/cli/src/lib/command.ts
+++ b/packages/cli/src/lib/command.ts
@@ -1,0 +1,75 @@
+import type { ArgsDef, CommandDef, CommandContext } from 'citty'
+import { defineCommand } from 'citty'
+import { createContext } from '../core/context'
+import { formatCommandHeader, wantsHeader } from '../core/brand'
+import { writeHuman } from '../core/output'
+
+type AnyCommand = CommandDef<ArgsDef>
+
+function headerArgs(args: unknown): { json?: boolean, noHeader?: boolean } {
+  const a = args as { json?: boolean, noHeader?: boolean }
+  return { json: a?.json, noHeader: a?.noHeader }
+}
+
+/**
+ * Define a citty command that prints the branded header
+ * (`evlog <command> vX` + gradient) before running — unless disabled
+ * (`--json`, `--no-header`, or `EVLOG_CLI_NO_HEADER=1`).
+ *
+ * Use for every leaf command so the CLI surface stays consistent as it grows.
+ */
+export function defineEvlogCommand<T extends ArgsDef = ArgsDef>(
+  command: string,
+  def: CommandDef<T>,
+): CommandDef<T> {
+  return defineCommand({
+    ...def,
+    meta: {
+      ...def.meta,
+      name: def.meta?.name ?? command.split(' ').at(-1),
+    },
+    async run(ctx: CommandContext<T>) {
+      const cli = createContext()
+      if (wantsHeader(cli, headerArgs(ctx.args))) {
+        writeHuman(formatCommandHeader(cli, { command }))
+      }
+      return await def.run?.(ctx)
+    },
+  })
+}
+
+/**
+ * Recursively wrap every leaf `run` handler in a command tree with the
+ * branded header. Useful for third-party trees (e.g. `@evlog/telemetry`).
+ *
+ * @param path - Command path segments already walked, e.g. `['telemetry']`.
+ */
+export function withCommandHeaders(cmd: AnyCommand, path: string[] = []): AnyCommand {
+  const wrappedSubs = cmd.subCommands
+    ? Object.fromEntries(
+      Object.entries(cmd.subCommands).map(([key, sub]) => [
+        key,
+        withCommandHeaders(sub as AnyCommand, [...path, key]),
+      ]),
+    )
+    : undefined
+
+  if (!cmd.run) {
+    return { ...cmd, subCommands: wrappedSubs }
+  }
+
+  const label = path.join(' ') || 'evlog'
+  const originalRun = cmd.run
+
+  return {
+    ...cmd,
+    subCommands: wrappedSubs,
+    async run(ctx) {
+      const cli = createContext()
+      if (wantsHeader(cli, headerArgs(ctx.args))) {
+        writeHuman(formatCommandHeader(cli, { command: label }))
+      }
+      return await originalRun(ctx)
+    },
+  }
+}

--- a/packages/cli/src/lib/constants.ts
+++ b/packages/cli/src/lib/constants.ts
@@ -1,0 +1,7 @@
+import { version as pkgVersion } from '../../package.json'
+
+/** Telemetry tool name — user-facing in disclosure and consent strings. */
+export const TOOL_NAME = 'evlog-cli'
+
+/** Package version — shared by the main meta and command headers. */
+export const VERSION = pkgVersion

--- a/packages/cli/src/lib/debug-report.ts
+++ b/packages/cli/src/lib/debug-report.ts
@@ -43,9 +43,13 @@ export function formatDebugReport(
 
   const command = typeof event.command === 'string' ? event.command : undefined
   const cwd = typeof event.cwd === 'string' ? event.cwd : undefined
+  const environment = typeof event.environment === 'string' ? event.environment : undefined
 
   if (command) {
     lines.push(`${paint('dim', 'command')}  ${paint('cyan', command)}`)
+  }
+  if (environment) {
+    lines.push(`${paint('dim', 'env')}      ${paint('cyan', environment)}`)
   }
   if (cwd) {
     lines.push(`${paint('dim', 'cwd')}      ${cwd}`)

--- a/packages/cli/src/lib/debug-report.ts
+++ b/packages/cli/src/lib/debug-report.ts
@@ -1,0 +1,118 @@
+import type { CliContext } from '../core/context'
+import { CHECK_STATUS, createStyle } from '../core/output'
+import type { CheckStatus } from '../core/output'
+
+type FindingLike = {
+  id?: unknown
+  status?: unknown
+  code?: unknown
+  why?: unknown
+  fix?: unknown
+  link?: unknown
+}
+
+type AttemptLike = {
+  base?: unknown
+  method?: unknown
+  ok?: unknown
+  error?: unknown
+}
+
+function asStatus(value: unknown): CheckStatus {
+  if (value === 'ok' || value === 'warn' || value === 'fail') return value
+  return 'warn'
+}
+
+function shortPath(path: string, max = 64): string {
+  if (path.length <= max) return path
+  return `…${path.slice(-(max - 1))}`
+}
+
+/**
+ * Human-readable debug case file for a CLI wide event.
+ * Keeps the terminal scannable; full dump stays on `--json --debug` (stderr).
+ */
+export function formatDebugReport(
+  event: Record<string, unknown>,
+  ctx: Pick<CliContext, 'color'>,
+): string {
+  const { paint } = createStyle(ctx)
+  const lines: string[] = ['']
+
+  lines.push(paint('dim', '── debug ────────────────────────────────'))
+
+  const command = typeof event.command === 'string' ? event.command : undefined
+  const cwd = typeof event.cwd === 'string' ? event.cwd : undefined
+
+  if (command) {
+    lines.push(`${paint('dim', 'command')}  ${paint('cyan', command)}`)
+  }
+  if (cwd) {
+    lines.push(`${paint('dim', 'cwd')}      ${cwd}`)
+  }
+
+  const steps = Array.isArray(event.steps) ? event.steps.map(String) : []
+  if (steps.length > 0) {
+    lines.push(
+      `${paint('dim', 'steps')}    ${steps.map(s => paint('cyan', s)).join(paint('dim', ' → '))}`,
+    )
+  }
+
+  const { error } = event
+  if (error && typeof error === 'object') {
+    const err = error as Record<string, unknown>
+    lines.push('')
+    lines.push(paint('dim', 'error'))
+    const code = typeof err.code === 'string' ? err.code : undefined
+    const message = typeof err.message === 'string' ? err.message : undefined
+    if (code) lines.push(`  ${paint('red', '✗')} ${paint('cyan', code)}`)
+    if (message) lines.push(`    ${message}`)
+    if (typeof err.why === 'string') lines.push(`    ${paint('dim', 'why')}  ${err.why}`)
+    if (typeof err.fix === 'string') lines.push(`    ${paint('dim', 'fix')}  ${err.fix}`)
+  }
+
+  const findings = Array.isArray(event.findings) ? event.findings as FindingLike[] : []
+  if (findings.length > 0) {
+    lines.push('')
+    lines.push(paint('dim', 'findings'))
+    for (const finding of findings) {
+      const status = asStatus(finding.status)
+      const { glyph, color } = CHECK_STATUS[status]
+      const code = typeof finding.code === 'string' ? finding.code : String(finding.id ?? 'unknown')
+      lines.push(`  ${paint(color, glyph)} ${paint('cyan', code)}`)
+      if (typeof finding.why === 'string') {
+        lines.push(`    ${paint('dim', 'why')}  ${finding.why}`)
+      }
+      if (typeof finding.fix === 'string') {
+        lines.push(`    ${paint('dim', 'fix')}  ${finding.fix}`)
+      }
+      if (typeof finding.link === 'string') {
+        lines.push(`    ${paint('dim', 'link')} ${finding.link}`)
+      }
+    }
+  }
+
+  const tried = Array.isArray(event.resolveTried) ? event.resolveTried as AttemptLike[] : []
+  if (tried.length > 0) {
+    const okCount = tried.filter(t => t.ok === true).length
+    lines.push('')
+    lines.push(`${paint('dim', 'resolve')}  ${okCount}/${tried.length} probes ok`)
+
+    const failed = tried.filter(t => t.ok !== true)
+    const show = failed.slice(0, 4)
+    for (const attempt of show) {
+      const method = typeof attempt.method === 'string' ? attempt.method : '?'
+      const base = typeof attempt.base === 'string' ? shortPath(attempt.base) : '?'
+      const err = typeof attempt.error === 'string' ? paint('dim', ` · ${attempt.error}`) : ''
+      lines.push(`  ${paint('dim', '·')} ${method} ${base}${err}`)
+    }
+    if (failed.length > show.length) {
+      lines.push(paint('dim', `  · … ${failed.length - show.length} more`))
+    }
+  }
+
+  lines.push(paint('dim', '──────────────────────────────────────────'))
+  lines.push(paint('dim', 'full event → --json --debug  (stderr)'))
+  lines.push('')
+  return lines.join('\n')
+}

--- a/packages/cli/src/lib/debug.ts
+++ b/packages/cli/src/lib/debug.ts
@@ -1,0 +1,240 @@
+import { createLogger, EvlogError, initLogger } from 'evlog'
+import type { RequestLogger } from 'evlog'
+import type { CliContext } from '../core/context'
+import type { CheckStatus } from '../core/output'
+import { VERSION } from './constants'
+import { formatDebugReport } from './debug-report'
+import { cliErrors } from './errors'
+
+export type DebugArgs = { debug?: boolean, json?: boolean }
+
+/** Soft finding attached to the debug wide event (catalog-backed). */
+export interface CliFinding {
+  code: string
+  status?: CheckStatus
+  id?: string
+  why?: string
+  fix?: string
+  link?: string
+}
+
+/**
+ * Catalog factory shape (`cliErrors.X`) — static `code` / `why` / `fix` / `link`
+ * from {@link import('evlog').defineError}.
+ */
+export type CatalogFindingSource = {
+  code: string
+  why?: unknown
+  fix?: unknown
+  link?: unknown
+}
+
+type StepFields<T>
+  = Record<string, unknown>
+    | ((result: T) => Record<string, unknown> | undefined)
+
+/**
+ * Debug handle for one CLI command invocation.
+ *
+ * Always available from {@link import('./command').defineEvlogCommand}:
+ * when `--debug` is off, `step` still runs the work and `finding` / `set` no-op.
+ */
+export interface CliDebug {
+  /** Underlying request logger when debug is on. */
+  readonly raw: RequestLogger | undefined
+
+  /**
+   * Run work as a named checkpoint. Appends to `steps` when debug is on.
+   * On throw, still records the step as failed, then rethrows.
+   */
+  step: <T>(
+    name: string,
+    fn: () => T | Promise<T>,
+    fields?: StepFields<T>,
+  ) => Promise<T>
+
+  /**
+   * Append a catalog-backed finding.
+   *
+   * @example
+   * ```ts
+   * log.finding(cliErrors.EVLOG_NOT_FOUND, { id: 'evlog', status: 'warn' })
+   * ```
+   */
+  finding: (
+    source: CliFinding | CatalogFindingSource,
+    extras?: Pick<CliFinding, 'status' | 'id'>,
+  ) => void
+
+  /** Merge arbitrary fields into the wide event when debug is on. */
+  set: (fields: Record<string, unknown>) => void
+}
+
+let loggerReady = false
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function toCliFinding(
+  source: CliFinding | CatalogFindingSource,
+  extras?: Pick<CliFinding, 'status' | 'id'>,
+): CliFinding {
+  const s = source as CliFinding
+  const status = extras?.status
+    ?? (s.status === 'ok' || s.status === 'warn' || s.status === 'fail' ? s.status : undefined)
+    ?? 'warn'
+
+  return {
+    code: source.code,
+    why: asOptionalString(source.why),
+    fix: asOptionalString(source.fix),
+    link: asOptionalString(source.link),
+    id: extras?.id ?? (typeof s.id === 'string' ? s.id : undefined),
+    status,
+  }
+}
+
+function resolveFields<T>(
+  fields: StepFields<T> | undefined,
+  result: T,
+): Record<string, unknown> | undefined {
+  if (!fields) return undefined
+  if (typeof fields === 'function') return fields(result) ?? undefined
+  return fields
+}
+
+/** Live debug handle backed by a request logger. */
+export function createCliDebug(log: RequestLogger): CliDebug {
+  return {
+    raw: log,
+    async step(name, fn, fields) {
+      try {
+        const result = await fn()
+        const extra = resolveFields(fields, result)
+        log.set({ steps: [name], ...extra })
+        return result
+      } catch (error) {
+        log.set({ steps: [name], stepFailed: name })
+        throw error
+      }
+    },
+    finding(source, extras) {
+      log.set({ findings: [toCliFinding(source, extras)] })
+    },
+    set(fields) {
+      log.set(fields)
+    },
+  }
+}
+
+/** No-op debug handle — `step` still executes `fn`. */
+export function createNoopCliDebug(): CliDebug {
+  return {
+    raw: undefined,
+    async step(_name, fn) {
+      return await fn()
+    },
+    finding() {},
+    set() {},
+  }
+}
+
+/**
+ * Whether CLI debug wide events should run.
+ *
+ * Enabled when:
+ * - `--debug` (flag on the command or anywhere on argv)
+ * - `EVLOG_CLI_DEBUG=1`
+ *
+ * Independent of `@evlog/telemetry` / `EVLOG_TELEMETRY_DEBUG`.
+ */
+export function wantsDebug(
+  ctx: Pick<CliContext, 'env'>,
+  args?: DebugArgs,
+  argv: readonly string[] = process.argv,
+): boolean {
+  if (args?.debug) return true
+  if (ctx.env.EVLOG_CLI_DEBUG === '1') return true
+  if (argv.includes('--debug')) return true
+  return false
+}
+
+/**
+ * One-time `initLogger` for CLI debug.
+ *
+ * - Human (`--debug`): compact case-file report on stderr
+ * - JSON (`--json --debug`): raw wide event JSON on stderr
+ */
+export function ensureCliDebugLogger(options: { json?: boolean, color?: boolean } = {}): void {
+  if (loggerReady) return
+  loggerReady = true
+
+  const json = options.json === true
+  const color = options.color === true
+
+  initLogger({
+    env: { service: 'evlog-cli', version: VERSION },
+    pretty: false,
+    silent: true,
+    minLevel: 'debug',
+    _suppressDrainWarning: true,
+    drain: ({ event }) => {
+      if (json) {
+        process.stderr.write(`${JSON.stringify(event)}\n`)
+        return
+      }
+      process.stderr.write(formatDebugReport(event as Record<string, unknown>, { color }))
+    },
+  })
+}
+
+/** Create a request logger for one CLI command invocation. */
+export function createCliLogger(seed: Record<string, unknown> = {}): RequestLogger {
+  return createLogger(seed)
+}
+
+/**
+ * Run `fn` with a {@link CliDebug} handle. Always passes a handle:
+ * live when debug is on, no-op (but `step` still runs work) when off.
+ *
+ * Emits once in `finally` when debug is on. Unexpected throws become
+ * {@link cliErrors.COMMAND_FAILED} when not already an {@link EvlogError}.
+ */
+export async function withCliDebug<T>(
+  ctx: CliContext,
+  options: { command: string } & DebugArgs,
+  fn: (log: CliDebug) => Promise<T> | T,
+): Promise<T> {
+  if (!wantsDebug(ctx, options)) {
+    return await fn(createNoopCliDebug())
+  }
+
+  ensureCliDebugLogger({ json: options.json, color: ctx.color })
+  const raw = createCliLogger({
+    command: options.command,
+    cliVersion: VERSION,
+  })
+  const log = createCliDebug(raw)
+
+  try {
+    return await fn(log)
+  } catch (error) {
+    if (error instanceof EvlogError) {
+      raw.error(error)
+    } else {
+      raw.error(cliErrors.COMMAND_FAILED({
+        cause: error instanceof Error ? error : undefined,
+        message: error instanceof Error ? error.message : String(error),
+      }))
+    }
+    throw error
+  } finally {
+    raw.emit()
+  }
+}
+
+/** Reset module state — tests only. */
+export function resetCliDebugLoggerForTests(): void {
+  loggerReady = false
+}

--- a/packages/cli/src/lib/debug.ts
+++ b/packages/cli/src/lib/debug.ts
@@ -4,6 +4,7 @@ import type { CliContext } from '../core/context'
 import type { CheckStatus } from '../core/output'
 import { VERSION } from './constants'
 import { formatDebugReport } from './debug-report'
+import { resolveCliEnvironment } from './environment'
 import { cliErrors } from './errors'
 
 export type DebugArgs = { debug?: boolean, json?: boolean }
@@ -174,7 +175,11 @@ export function ensureCliDebugLogger(options: { json?: boolean, color?: boolean 
   const color = options.color === true
 
   initLogger({
-    env: { service: 'evlog-cli', version: VERSION },
+    env: {
+      service: 'evlog-cli',
+      version: VERSION,
+      environment: resolveCliEnvironment(),
+    },
     pretty: false,
     silent: true,
     minLevel: 'debug',
@@ -214,6 +219,7 @@ export async function withCliDebug<T>(
   const raw = createCliLogger({
     command: options.command,
     cliVersion: VERSION,
+    environment: resolveCliEnvironment(),
   })
   const log = createCliDebug(raw)
 

--- a/packages/cli/src/lib/environment.ts
+++ b/packages/cli/src/lib/environment.ts
@@ -1,0 +1,55 @@
+/**
+ * Deploy / runtime stage for the CLI itself.
+ *
+ * Not the user's app env — whether *this* `evlog` binary is a local workspace
+ * build or a packaged install (`npx`, dependency, global).
+ */
+export type CliEnvironment = 'development' | 'preview' | 'production' | string
+
+export type ResolveCliEnvironmentOptions = {
+  /** Process env (defaults to `process.env`). */
+  env?: NodeJS.Dict<string>
+  /**
+   * Module URL used to detect packaged vs workspace installs.
+   * Defaults to this file's `import.meta.url`.
+   */
+  moduleUrl?: string
+}
+
+/**
+ * True when the CLI is running from a published / installed package
+ * (`node_modules/.../@evlog/cli`), not from the monorepo `packages/cli` tree.
+ */
+export function isPackagedCli(moduleUrl: string = import.meta.url): boolean {
+  const normalized = moduleUrl.replace(/\\/g, '/')
+  if (normalized.includes('/node_modules/')) return true
+  if (normalized.includes('/packages/cli/')) return false
+  // Unknown install path (custom global, bundled) → treat as packaged.
+  return true
+}
+
+/**
+ * Resolve the CLI's own environment for `--json`, `--debug`, and telemetry.
+ *
+ * Priority:
+ * 1. `EVLOG_CLI_ENV` (explicit override)
+ * 2. `VERCEL_ENV` (when the CLI runs on Vercel: production | preview | development)
+ * 3. Packaged install → `production` (users running published `evlog`)
+ * 4. Workspace / local → `NODE_ENV` or `development`
+ */
+export function resolveCliEnvironment(
+  options: ResolveCliEnvironmentOptions = {},
+): CliEnvironment {
+  const env = options.env ?? process.env
+  const moduleUrl = options.moduleUrl ?? import.meta.url
+
+  const explicit = env.EVLOG_CLI_ENV?.trim()
+  if (explicit) return explicit
+
+  const vercel = env.VERCEL_ENV?.trim()
+  if (vercel) return vercel
+
+  if (isPackagedCli(moduleUrl)) return 'production'
+
+  return env.NODE_ENV?.trim() || 'development'
+}

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,0 +1,63 @@
+import { defineErrorCatalog } from 'evlog'
+
+/**
+ * Typed error catalog for `@evlog/cli`.
+ *
+ * Wire codes are `cli.<KEY>` (e.g. `cli.EVLOG_NOT_FOUND`). Used when a
+ * command aborts, and attached as `findings[].code` on `--debug` wide events
+ * so a failed doctor check carries why / fix / link without throwing.
+ */
+export const cliErrors = defineErrorCatalog('cli', {
+  NODE_TOO_OLD: {
+    status: 400,
+    message: ({ version, min }: { version: string, min: number }) =>
+      `Node ${version} is too old (need >= ${min})`,
+    why: 'The evlog CLI requires a modern Node runtime',
+    fix: 'Upgrade Node to the latest LTS',
+    link: 'https://nodejs.org/',
+    tags: ['doctor', 'environment'],
+  },
+  PROJECT_NO_PACKAGE: {
+    status: 404,
+    message: 'No package.json found',
+    why: 'Doctor needs a package root to diagnose the project',
+    fix: 'Run from your app directory or pass --cwd',
+    tags: ['doctor', 'project'],
+  },
+  EVLOG_NOT_FOUND: {
+    status: 404,
+    message: 'evlog is not installed in this project',
+    why: 'No resolvable evlog package in node_modules and no declaration in package.json',
+    fix: 'pnpm add evlog — see installation docs',
+    link: 'https://evlog.dev/getting-started/installation',
+    tags: ['doctor', 'evlog'],
+  },
+  EVLOG_DECLARED_NOT_INSTALLED: {
+    status: 404,
+    message: ({ range }: { range: string }) =>
+      `evlog is declared (${range}) but not installed`,
+    why: 'package.json lists evlog but node_modules resolve failed',
+    fix: 'Run your package manager install step',
+    tags: ['doctor', 'evlog'],
+  },
+  LOGS_SINK_MISSING: {
+    status: 404,
+    message: 'No local .evlog/logs sink yet',
+    why: 'The fs drain has not written any local logs yet',
+    fix: 'Enable the fs drain (evlog/fs); the sink is created on first write',
+    tags: ['doctor', 'logs'],
+  },
+  COMMAND_FAILED: {
+    status: 500,
+    message: 'CLI command failed',
+    why: 'An unexpected error aborted the command',
+    fix: 'Re-run with --debug and share the wide event',
+    tags: ['cli'],
+  },
+})
+
+declare module 'evlog' {
+  interface RegisteredErrorCatalogs {
+    cli: typeof cliErrors
+  }
+}

--- a/packages/cli/src/lib/project.ts
+++ b/packages/cli/src/lib/project.ts
@@ -1,0 +1,230 @@
+import { access, readFile, readdir, stat } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+
+export interface PackageJson {
+  name?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  workspaces?: string[] | { packages?: string[] }
+}
+
+export type WorkspaceKind = 'single' | 'pnpm' | 'npm' | 'yarn'
+
+export interface ProjectInfo {
+  /** Directory the user ran from (or `--cwd`). */
+  cwd: string
+  /** Nearest package.json directory (may equal cwd). */
+  packageDir: string
+  /** Workspace / project root (pnpm-workspace, workspaces field, or packageDir). */
+  root: string
+  kind: WorkspaceKind
+  packageName: string | null
+  packageJson: PackageJson | null
+}
+
+export interface EvlogInstall {
+  version: string
+  /** Absolute path to the resolved `evlog` package root. */
+  path: string
+  /** Where it was declared, if found (`dependencies` / `devDependencies`). */
+  declaredIn: string | null
+  declaredRange: string | null
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Read and parse a JSON file; `null` on missing / invalid. */
+export async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as T
+  } catch {
+    return null
+  }
+}
+
+async function detectWorkspaceKind(dir: string, pkg: PackageJson | null): Promise<WorkspaceKind | null> {
+  if (await exists(join(dir, 'pnpm-workspace.yaml'))) return 'pnpm'
+  if (await exists(join(dir, 'yarn.lock')) && pkg?.workspaces) return 'yarn'
+  if (pkg?.workspaces) return 'npm'
+  return null
+}
+
+/**
+ * Walk up from `start` to locate the nearest package and the workspace root.
+ * Handles pnpm / npm / yarn workspaces and plain single packages.
+ */
+export async function resolveProject(start: string): Promise<ProjectInfo> {
+  const cwd = resolve(start)
+  let packageDir: string | null = null
+  let packageJson: PackageJson | null = null
+  let root = cwd
+  let kind: WorkspaceKind = 'single'
+
+  let dir = cwd
+  for (;;) {
+    const pkgPath = join(dir, 'package.json')
+    if (await exists(pkgPath)) {
+      const pkg = await readJson<PackageJson>(pkgPath)
+      if (!packageDir) {
+        packageDir = dir
+        packageJson = pkg
+      }
+      const detected = await detectWorkspaceKind(dir, pkg)
+      if (detected) {
+        root = dir
+        kind = detected
+        break
+      }
+      // Keep walking — a parent may be the workspace root.
+      root = dir
+    }
+
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  if (!packageDir) {
+    return {
+      cwd,
+      packageDir: cwd,
+      root: cwd,
+      kind: 'single',
+      packageName: null,
+      packageJson: null,
+    }
+  }
+
+  return {
+    cwd,
+    packageDir,
+    root,
+    kind,
+    packageName: packageJson?.name ?? null,
+    packageJson,
+  }
+}
+
+function declaredEvlog(pkg: PackageJson | null): { range: string, field: string } | null {
+  if (!pkg) return null
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+    const range = pkg[field]?.evlog
+    if (range) return { range, field }
+  }
+  return null
+}
+
+/**
+ * Resolve an installed `evlog` package by walking `node_modules` (hoist-aware)
+ * via `createRequire`, then fall back to declared ranges in the local package.json.
+ */
+export async function resolveEvlog(project: ProjectInfo): Promise<{
+  install: EvlogInstall | null
+  declared: { range: string, field: string } | null
+}> {
+  const declared = declaredEvlog(project.packageJson)
+
+  const candidates = [project.packageDir, project.root, project.cwd]
+  for (const base of candidates) {
+    const pkgJsonPath = join(base, 'package.json')
+    if (!(await exists(pkgJsonPath))) continue
+    try {
+      const require = createRequire(pkgJsonPath)
+      const resolved = require.resolve('evlog/package.json')
+      const meta = await readJson<{ version?: string }>(resolved)
+      if (meta?.version) {
+        return {
+          install: {
+            version: meta.version,
+            path: dirname(resolved),
+            declaredIn: declared ? project.packageDir : null,
+            declaredRange: declared?.range ?? null,
+          },
+          declared,
+        }
+      }
+    } catch {
+      // not resolvable from this base
+    }
+  }
+
+  // Direct filesystem probe (no package.json at base, or createRequire failed)
+  for (const base of candidates) {
+    const direct = join(base, 'node_modules', 'evlog', 'package.json')
+    const meta = await readJson<{ version?: string }>(direct)
+    if (meta?.version) {
+      return {
+        install: {
+          version: meta.version,
+          path: dirname(direct),
+          declaredIn: declared ? project.packageDir : null,
+          declaredRange: declared?.range ?? null,
+        },
+        declared,
+      }
+    }
+  }
+
+  return { install: null, declared }
+}
+
+/** Relative path for display; `.` when identical. */
+export function prettyPath(from: string, to: string): string {
+  const rel = relative(from, to)
+  if (!rel) return '.'
+  return rel.split(sep).join('/')
+}
+
+/**
+ * Locate a readable `.evlog/logs` sink — prefers cwd, then package dir, then root.
+ */
+export async function findLogsSink(project: ProjectInfo): Promise<{
+  dir: string
+  files: number
+} | null> {
+  for (const base of [project.cwd, project.packageDir, project.root]) {
+    const dir = join(base, '.evlog', 'logs')
+    try {
+      await stat(dir)
+      const entries = await readdir(dir)
+      return { dir, files: entries.filter(f => f.endsWith('.jsonl')).length }
+    } catch {
+      // try next
+    }
+  }
+  return null
+}
+
+/** Framework / integration hints based on package.json dependencies. */
+export function detectStack(pkg: PackageJson | null): string[] {
+  if (!pkg) return []
+  const all = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  }
+  const hits: string[] = []
+  const probes: [string, string][] = [
+    ['nuxt', 'nuxt'],
+    ['next', 'next'],
+    ['nitro', 'nitropack'],
+    ['hono', 'hono'],
+    ['express', 'express'],
+    ['fastify', 'fastify'],
+    ['@sveltejs/kit', 'sveltekit'],
+    ['@evlog/nuxthub', 'nuxthub'],
+    ['@evlog/telemetry', 'telemetry'],
+  ]
+  for (const [dep, label] of probes) {
+    if (all[dep]) hits.push(label)
+  }
+  return hits
+}

--- a/packages/cli/src/lib/project.ts
+++ b/packages/cli/src/lib/project.ts
@@ -33,6 +33,15 @@ export interface EvlogInstall {
   declaredRange: string | null
 }
 
+/** One probe while resolving `evlog` from the filesystem / require graph. */
+export interface ResolveAttempt {
+  base: string
+  method: 'require' | 'fs'
+  ok: boolean
+  path?: string
+  error?: string
+}
+
 async function exists(path: string): Promise<boolean> {
   try {
     await access(path)
@@ -40,6 +49,11 @@ async function exists(path: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+/** Deduplicate path list while preserving order. */
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths)]
 }
 
 /** Read and parse a JSON file; `null` on missing / invalid. */
@@ -126,34 +140,51 @@ function declaredEvlog(pkg: PackageJson | null): { range: string, field: string 
 /**
  * Resolve an installed `evlog` package by walking `node_modules` (hoist-aware)
  * via `createRequire`, then fall back to declared ranges in the local package.json.
+ *
+ * `tried` lists every probe (for `--debug` decision trails).
  */
 export async function resolveEvlog(project: ProjectInfo): Promise<{
   install: EvlogInstall | null
   declared: { range: string, field: string } | null
+  tried: ResolveAttempt[]
 }> {
   const declared = declaredEvlog(project.packageJson)
+  const tried: ResolveAttempt[] = []
 
-  const candidates = [project.packageDir, project.root, project.cwd]
+  // packageDir / root / cwd often collapse to the same path (e.g. bare /tmp)
+  const candidates = uniquePaths([project.packageDir, project.root, project.cwd])
   for (const base of candidates) {
     const pkgJsonPath = join(base, 'package.json')
-    if (!(await exists(pkgJsonPath))) continue
+    if (!(await exists(pkgJsonPath))) {
+      tried.push({ base, method: 'require', ok: false, error: 'no package.json' })
+      continue
+    }
     try {
       const require = createRequire(pkgJsonPath)
       const resolved = require.resolve('evlog/package.json')
       const meta = await readJson<{ version?: string }>(resolved)
       if (meta?.version) {
+        const path = dirname(resolved)
+        tried.push({ base, method: 'require', ok: true, path })
         return {
           install: {
             version: meta.version,
-            path: dirname(resolved),
+            path,
             declaredIn: declared ? project.packageDir : null,
             declaredRange: declared?.range ?? null,
           },
           declared,
+          tried,
         }
       }
-    } catch {
-      // not resolvable from this base
+      tried.push({ base, method: 'require', ok: false, error: 'package.json missing version' })
+    } catch (error) {
+      tried.push({
+        base,
+        method: 'require',
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
   }
 
@@ -162,19 +193,23 @@ export async function resolveEvlog(project: ProjectInfo): Promise<{
     const direct = join(base, 'node_modules', 'evlog', 'package.json')
     const meta = await readJson<{ version?: string }>(direct)
     if (meta?.version) {
+      const path = dirname(direct)
+      tried.push({ base, method: 'fs', ok: true, path })
       return {
         install: {
           version: meta.version,
-          path: dirname(direct),
+          path,
           declaredIn: declared ? project.packageDir : null,
           declaredRange: declared?.range ?? null,
         },
         declared,
+        tried,
       }
     }
+    tried.push({ base, method: 'fs', ok: false, error: 'not found' })
   }
 
-  return { install: null, declared }
+  return { install: null, declared, tried }
 }
 
 /** Relative path for display; `.` when identical. */
@@ -191,7 +226,7 @@ export async function findLogsSink(project: ProjectInfo): Promise<{
   dir: string
   files: number
 } | null> {
-  for (const base of [project.cwd, project.packageDir, project.root]) {
+  for (const base of uniquePaths([project.cwd, project.packageDir, project.root])) {
     const dir = join(base, '.evlog', 'logs')
     try {
       await stat(dir)

--- a/packages/cli/src/lib/project.ts
+++ b/packages/cli/src/lib/project.ts
@@ -2,6 +2,7 @@ import { access, readFile, readdir, stat } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 
+/** Minimal `package.json` fields used for project / workspace discovery. */
 export interface PackageJson {
   name?: string
   dependencies?: Record<string, string>
@@ -10,8 +11,10 @@ export interface PackageJson {
   workspaces?: string[] | { packages?: string[] }
 }
 
-export type WorkspaceKind = 'single' | 'pnpm' | 'npm' | 'yarn'
+/** How the project is laid out — plain package or a detected workspace tool. */
+export type WorkspaceKind = 'single' | 'pnpm' | 'npm' | 'yarn' | 'bun'
 
+/** Resolved project layout for the directory the user ran from. */
 export interface ProjectInfo {
   /** Directory the user ran from (or `--cwd`). */
   cwd: string
@@ -24,6 +27,7 @@ export interface ProjectInfo {
   packageJson: PackageJson | null
 }
 
+/** Resolved `evlog` install discovered under the project (version + paths). */
 export interface EvlogInstall {
   version: string
   /** Absolute path to the resolved `evlog` package root. */
@@ -67,14 +71,16 @@ export async function readJson<T>(path: string): Promise<T | null> {
 
 async function detectWorkspaceKind(dir: string, pkg: PackageJson | null): Promise<WorkspaceKind | null> {
   if (await exists(join(dir, 'pnpm-workspace.yaml'))) return 'pnpm'
-  if (await exists(join(dir, 'yarn.lock')) && pkg?.workspaces) return 'yarn'
-  if (pkg?.workspaces) return 'npm'
-  return null
+  if (!pkg?.workspaces) return null
+  // Bun uses the npm `workspaces` field; distinguish via lockfile.
+  if (await exists(join(dir, 'bun.lock')) || await exists(join(dir, 'bun.lockb'))) return 'bun'
+  if (await exists(join(dir, 'yarn.lock'))) return 'yarn'
+  return 'npm'
 }
 
 /**
  * Walk up from `start` to locate the nearest package and the workspace root.
- * Handles pnpm / npm / yarn workspaces and plain single packages.
+ * Handles pnpm / bun / npm / yarn workspaces and plain single packages.
  */
 export async function resolveProject(start: string): Promise<ProjectInfo> {
   const cwd = resolve(start)
@@ -91,6 +97,8 @@ export async function resolveProject(start: string): Promise<ProjectInfo> {
       if (!packageDir) {
         packageDir = dir
         packageJson = pkg
+        // Single-package default: root is the nearest package, not a parent.
+        root = dir
       }
       const detected = await detectWorkspaceKind(dir, pkg)
       if (detected) {
@@ -98,8 +106,7 @@ export async function resolveProject(start: string): Promise<ProjectInfo> {
         kind = detected
         break
       }
-      // Keep walking — a parent may be the workspace root.
-      root = dir
+      // Keep walking — a parent may still be a workspace root.
     }
 
     const parent = dirname(dir)

--- a/packages/cli/src/lib/ui.ts
+++ b/packages/cli/src/lib/ui.ts
@@ -1,0 +1,53 @@
+import type { CheckSummary } from '../core/output'
+import { exitCodeFor, writeHuman, writeJson } from '../core/output'
+
+/**
+ * Output helpers for a command run — the only place commands should write
+ * to the terminal or set an exit code.
+ *
+ * - {@link CliUi.human} → stderr
+ * - {@link CliUi.json} → stdout (+ `schemaVersion`)
+ * - {@link CliUi.exit} → `process.exitCode` from a check summary (or raw code)
+ * - {@link CliUi.done} → human **or** json + exit in one call
+ */
+export interface CliUi {
+  /** Human report on stderr. */
+  human: (text: string) => void
+  /** Machine payload on stdout (adds `schemaVersion`). */
+  json: (payload: Record<string, unknown>) => void
+  /** Set exit code from a check summary (`fail > 0` → 1) or a raw code. */
+  exit: (summaryOrCode: CheckSummary | number) => void
+  /**
+   * Emit the command result: JSON when `jsonMode` (or constructor `json`) is
+   * on, otherwise the human string; then set the exit code from `summary`.
+   */
+  done: (options: {
+    human?: string
+    json?: Record<string, unknown>
+    summary?: CheckSummary
+    jsonMode?: boolean
+  }) => void
+}
+
+/** Build a {@link CliUi} bound to the current process streams. */
+export function createUi(options: { json?: boolean } = {}): CliUi {
+  const ui: CliUi = {
+    human: writeHuman,
+    json: writeJson,
+    exit(summaryOrCode) {
+      process.exitCode = typeof summaryOrCode === 'number'
+        ? summaryOrCode
+        : exitCodeFor(summaryOrCode)
+    },
+    done({ human, json, summary, jsonMode }) {
+      const useJson = jsonMode ?? options.json === true
+      if (useJson) {
+        if (json) writeJson(json)
+      } else if (human !== undefined) {
+        writeHuman(human)
+      }
+      if (summary) ui.exit(summary)
+    },
+  }
+  return ui
+}

--- a/packages/cli/test/brand.test.ts
+++ b/packages/cli/test/brand.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { TAGLINE, WORDMARK, formatBanner, wantsHeader } from '../src/core/brand'
+import { createContext } from '../src/core/context'
+
+const base = { cwd: '/tmp', env: {}, nodeVersion: 'v22.0.0', tty: true }
+
+describe('wantsHeader', () => {
+  const ctx = createContext({ ...base, color: false, columns: 80 })
+
+  it('is on by default', () => {
+    expect(wantsHeader(ctx, {}, [])).toBe(true)
+  })
+
+  it('respects --json, --no-header, and env opt-outs', () => {
+    expect(wantsHeader(ctx, { json: true }, [])).toBe(false)
+    expect(wantsHeader(ctx, { noHeader: true }, [])).toBe(false)
+    expect(wantsHeader(ctx, {}, ['node', 'evlog', 'doctor', '--no-header'])).toBe(false)
+    expect(wantsHeader(createContext({ ...base, env: { EVLOG_CLI_NO_HEADER: '1' } }), {}, [])).toBe(false)
+    expect(wantsHeader(createContext({ ...base, env: { EVLOG_CLI_HEADER: '0' } }), {}, [])).toBe(false)
+  })
+})
+
+describe('formatBanner', () => {
+  it('renders the ASCII wordmark, tagline, and docs link with colors', () => {
+    const banner = formatBanner(createContext({ ...base, color: true, columns: 100 }), '0.0.0')
+    for (const row of WORDMARK) expect(banner).toContain(row)
+    expect(banner).toContain(TAGLINE)
+    expect(banner).toContain('v0.0.0')
+    expect(banner).toContain('\x1B]8;;https://evlog.dev')
+  })
+
+  it('keeps all wordmark rows the same width', () => {
+    const widths = new Set(WORDMARK.map(row => row.length))
+    expect(widths.size).toBe(1)
+  })
+
+  it('falls back to a compact one-liner without colors, with no ANSI leaked', () => {
+    const banner = formatBanner(createContext({ ...base, color: false, columns: 100 }), '0.0.0')
+    expect(banner).not.toContain(WORDMARK[0])
+    expect(banner).not.toContain('\x1B')
+    expect(banner).toContain('evlog v0.0.0 — digging through logs is not observability')
+  })
+
+  it('falls back to the one-liner on narrow terminals even with colors', () => {
+    const banner = formatBanner(createContext({ ...base, color: true, columns: 30 }), '0.0.0')
+    expect(banner).not.toContain(WORDMARK[0])
+  })
+
+  it('renders a truecolor gradient rule that fades blue to dark', () => {
+    const banner = formatBanner(createContext({ ...base, color: true, columns: 100 }), '0.0.0')
+    expect(banner).toContain('\x1B[38;2;43;90;255m') // brand blue start
+    expect(banner).toContain('\x1B[38;2;8;10;40m') // near-black end
+  })
+})

--- a/packages/cli/test/debug-report.test.ts
+++ b/packages/cli/test/debug-report.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { formatDebugReport } from '../src/lib/debug-report'
+
+describe('formatDebugReport', () => {
+  const ctx = { color: false }
+
+  it('renders a scannable case file for soft findings', () => {
+    const out = formatDebugReport({
+      command: 'doctor',
+      cwd: '/tmp',
+      steps: ['resolveProject', 'resolveEvlog', 'done'],
+      findings: [
+        {
+          id: 'project',
+          status: 'warn',
+          code: 'cli.PROJECT_NO_PACKAGE',
+          why: 'Doctor needs a package root',
+          fix: 'Pass --cwd',
+        },
+      ],
+      resolveTried: [
+        { base: '/tmp', method: 'require', ok: false, error: 'no package.json' },
+        { base: '/tmp', method: 'fs', ok: false, error: 'not found' },
+      ],
+    }, ctx)
+
+    expect(out).toContain('── debug')
+    expect(out).toContain('command  doctor')
+    expect(out).toContain('cwd      /tmp')
+    expect(out).toContain('resolveProject → resolveEvlog → done')
+    expect(out).toContain('cli.PROJECT_NO_PACKAGE')
+    expect(out).toContain('why  Doctor needs a package root')
+    expect(out).toContain('fix  Pass --cwd')
+    expect(out).toContain('resolve  0/2 probes ok')
+    expect(out).toContain('--json --debug')
+    expect(out).not.toContain('"resolveTried"')
+  })
+
+  it('renders error catalog fields when present', () => {
+    const out = formatDebugReport({
+      command: 'doctor',
+      steps: ['resolveProject'],
+      error: {
+        code: 'cli.COMMAND_FAILED',
+        message: 'boom',
+        why: 'unexpected',
+        fix: 're-run with --debug',
+      },
+    }, ctx)
+
+    expect(out).toContain('cli.COMMAND_FAILED')
+    expect(out).toContain('boom')
+    expect(out).toContain('why  unexpected')
+  })
+})

--- a/packages/cli/test/debug.test.ts
+++ b/packages/cli/test/debug.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createContext } from '../src/core/context'
+import {
+  createCliDebug,
+  createCliLogger,
+  ensureCliDebugLogger,
+  resetCliDebugLoggerForTests,
+  wantsDebug,
+  withCliDebug,
+} from '../src/lib/debug'
+
+const base = {
+  cwd: '/tmp',
+  env: {} as Record<string, string | undefined>,
+  nodeVersion: 'v22.0.0',
+  tty: false,
+  color: false,
+  columns: 80,
+}
+
+afterEach(() => {
+  resetCliDebugLoggerForTests()
+  vi.restoreAllMocks()
+})
+
+describe('wantsDebug', () => {
+  it('is off by default', () => {
+    const ctx = createContext({ ...base, env: {} })
+    expect(wantsDebug(ctx, {}, [])).toBe(false)
+  })
+
+  it('respects --debug, args.debug, and EVLOG_CLI_DEBUG', () => {
+    const ctx = createContext({ ...base, env: {} })
+    expect(wantsDebug(ctx, { debug: true }, [])).toBe(true)
+    expect(wantsDebug(ctx, {}, ['node', 'evlog', 'doctor', '--debug'])).toBe(true)
+    expect(wantsDebug(createContext({ ...base, env: { EVLOG_CLI_DEBUG: '1' } }), {}, [])).toBe(true)
+  })
+})
+
+describe('withCliDebug', () => {
+  it('passes a noop log when debug is off (step still runs)', async () => {
+    const ctx = createContext({ ...base, env: {} })
+    let ran = false
+    const log = await withCliDebug(ctx, { command: 'doctor' }, async (l) => {
+      await l.step('work', () => {
+        ran = true
+      })
+      return l
+    })
+    expect(ran).toBe(true)
+    expect(log.raw).toBeUndefined()
+  })
+
+  it('emits a wide event to stderr when --json and debug are on', async () => {
+    const writes: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stderr.write)
+
+    const ctx = createContext({ ...base, env: { EVLOG_CLI_DEBUG: '1' } })
+    await withCliDebug(ctx, { command: 'doctor', json: true, debug: true }, async (log) => {
+      expect(log.raw).toBeDefined()
+      await log.step('a', () => undefined)
+      await log.step('b', () => undefined)
+    })
+
+    const line = writes.find(w => w.includes('"command":"doctor"'))
+    expect(line).toBeDefined()
+    const event = JSON.parse(line!.trim())
+    expect(event.command).toBe('doctor')
+    expect(event.steps).toEqual(['a', 'b'])
+    expect(event.service).toBe('evlog-cli')
+  })
+
+  it('records the failed step then wraps unexpected throws', async () => {
+    const writes: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stderr.write)
+
+    const ctx = createContext({ ...base, env: {} })
+    await expect(withCliDebug(ctx, { command: 'doctor', json: true, debug: true }, async (log) => {
+      await log.step('before', () => 'ok')
+      await log.step('boom', () => {
+        throw new Error('boom')
+      })
+    })).rejects.toThrow('boom')
+
+    const line = writes.find(w => w.includes('"command":"doctor"'))
+    expect(line).toBeDefined()
+    const event = JSON.parse(line!.trim())
+    expect(event.steps).toEqual(['before', 'boom'])
+    expect(event.stepFailed).toBe('boom')
+    expect(event.error?.code).toBe('cli.COMMAND_FAILED')
+  })
+
+  it('log.step merges fields from the result callback', async () => {
+    ensureCliDebugLogger({ json: true })
+    const raw = createCliLogger({ command: 'x' })
+    const log = createCliDebug(raw)
+    await log.step('one', () => ({ n: 1 }), r => ({ cwd: '/tmp', n: r.n }))
+    expect(raw.getContext().steps).toEqual(['one'])
+    expect(raw.getContext().cwd).toBe('/tmp')
+    expect(raw.getContext().n).toBe(1)
+  })
+
+  it('log.finding accepts a catalog factory', async () => {
+    const { cliErrors } = await import('../src/lib/errors')
+    ensureCliDebugLogger({ json: true })
+    const raw = createCliLogger({ command: 'x' })
+    const log = createCliDebug(raw)
+    log.finding(cliErrors.EVLOG_NOT_FOUND, { id: 'evlog', status: 'warn' })
+    const findings = raw.getContext().findings as Array<Record<string, unknown>>
+    expect(findings).toEqual([
+      expect.objectContaining({
+        code: 'cli.EVLOG_NOT_FOUND',
+        id: 'evlog',
+        status: 'warn',
+        why: expect.any(String),
+        fix: expect.any(String),
+      }),
+    ])
+  })
+})

--- a/packages/cli/test/debug.test.ts
+++ b/packages/cli/test/debug.test.ts
@@ -71,6 +71,7 @@ describe('withCliDebug', () => {
     expect(event.command).toBe('doctor')
     expect(event.steps).toEqual(['a', 'b'])
     expect(event.service).toBe('evlog-cli')
+    expect(typeof event.environment).toBe('string')
   })
 
   it('records the failed step then wraps unexpected throws', async () => {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,11 +1,12 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { formatDoctorReport, runDoctor } from '../src/commands/doctor'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import doctor, { formatDoctorReport, runDoctor } from '../src/commands/doctor'
 import { createContext } from '../src/core/context'
 import type { CliContext } from '../src/core/context'
 import { SCHEMA_VERSION } from '../src/core/output'
+import { resolveCliEnvironment } from '../src/lib/environment'
 
 const tempDirs: string[] = []
 
@@ -33,6 +34,8 @@ function fakeContext(cwd: string, overrides: Partial<CliContext> = {}): CliConte
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks()
+  process.exitCode = undefined
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -132,57 +135,69 @@ describe('runDoctor', () => {
       '.evlog/logs/2026-07-17.jsonl': '{"event":"request"}\n',
     })
 
-    const result = await runDoctor(fakeContext(cwd))
-    const payload = {
-      schemaVersion: SCHEMA_VERSION,
-      environment: 'development',
+    const out: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      out.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stdout.write)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const run = typeof doctor.run === 'function' ? doctor.run : await doctor.run
+    await run!({
+      args: { json: true, noHeader: true, cwd, debug: false },
+      rawArgs: [],
+      cmd: doctor,
+      data: {},
+    })
+
+    const raw = JSON.parse(out.join('').trim()) as {
+      schemaVersion: number
+      environment: string
       project: {
-        kind: result.project.kind,
-        name: result.project.name,
-        stack: result.project.stack,
-      },
-      checks: result.checks.map(({ id, status, message }) => ({ id, status, message })),
-      summary: result.summary,
+        kind: string
+        name: string | null
+        stack: string[]
+        cwd: string
+        root: string
+        packageDir: string
+      }
+      checks: Array<{ id: string, status: string, message: string, hint?: string }>
+      summary: { ok: number, warn: number, fail: number }
     }
 
-    expect(payload).toMatchInlineSnapshot(`
-      {
-        "checks": [
-          {
-            "id": "node",
-            "message": "v22.0.0",
-            "status": "ok",
-          },
-          {
-            "id": "project",
-            "message": "app",
-            "status": "ok",
-          },
-          {
-            "id": "evlog",
-            "message": "v2.22.0 (^2.0.0)",
-            "status": "ok",
-          },
-          {
-            "id": "logs",
-            "message": "1 file · .evlog/logs",
-            "status": "ok",
-          },
-        ],
-        "environment": "development",
-        "project": {
-          "kind": "single",
-          "name": "app",
-          "stack": [],
-        },
-        "schemaVersion": 2,
-        "summary": {
-          "fail": 0,
-          "ok": 4,
-          "warn": 0,
-        },
-      }
-    `)
+    expect(raw.schemaVersion).toBe(SCHEMA_VERSION)
+    expect(raw.environment).toBe(resolveCliEnvironment())
+    expect(raw.project.cwd).toBe(cwd)
+    expect(raw.project.root).toBe(cwd)
+    expect(raw.project.packageDir).toBe(cwd)
+
+    // Stable contract fields (paths asserted above; node message follows the host).
+    expect({
+      schemaVersion: raw.schemaVersion,
+      environment: raw.environment,
+      project: {
+        kind: raw.project.kind,
+        name: raw.project.name,
+        stack: raw.project.stack,
+      },
+      checks: raw.checks.map(({ id, status, message }) => ({ id, status, message })),
+      summary: raw.summary,
+    }).toEqual({
+      schemaVersion: SCHEMA_VERSION,
+      environment: resolveCliEnvironment(),
+      project: {
+        kind: 'single',
+        name: 'app',
+        stack: [],
+      },
+      checks: [
+        { id: 'node', message: process.version, status: 'ok' },
+        { id: 'project', message: 'app', status: 'ok' },
+        { id: 'evlog', message: 'v2.22.0 (^2.0.0)', status: 'ok' },
+        { id: 'logs', message: '1 file · .evlog/logs', status: 'ok' },
+      ],
+      summary: { fail: 0, ok: 4, warn: 0 },
+    })
   })
 })
 

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,0 +1,193 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { formatDoctorReport, runDoctor } from '../src/commands/doctor'
+import { createContext } from '../src/core/context'
+import type { CliContext } from '../src/core/context'
+import { SCHEMA_VERSION } from '../src/core/output'
+
+const tempDirs: string[] = []
+
+async function makeProject(files: Record<string, string> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'evlog-cli-doctor-'))
+  tempDirs.push(dir)
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(dir, path)
+    await mkdir(join(full, '..'), { recursive: true })
+    await writeFile(full, contents, 'utf-8')
+  }
+  return dir
+}
+
+function fakeContext(cwd: string, overrides: Partial<CliContext> = {}): CliContext {
+  return createContext({
+    cwd,
+    env: {},
+    nodeVersion: 'v22.0.0',
+    tty: false,
+    color: false,
+    columns: 80,
+    ...overrides,
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('runDoctor', () => {
+  it('reports a healthy single-package project', async () => {
+    const cwd = await makeProject({
+      'package.json': JSON.stringify({ name: 'app', dependencies: { evlog: '^2.0.0' } }),
+      'node_modules/evlog/package.json': JSON.stringify({ name: 'evlog', version: '2.22.0' }),
+      '.evlog/logs/2026-07-17.jsonl': '{"event":"request"}\n',
+    })
+
+    const result = await runDoctor(fakeContext(cwd))
+
+    expect(result.summary.fail).toBe(0)
+    expect(result.checks.find(c => c.id === 'evlog')?.status).toBe('ok')
+    expect(result.checks.find(c => c.id === 'evlog')?.message).toContain('2.22.0')
+    expect(result.checks.find(c => c.id === 'logs')?.status).toBe('ok')
+    expect(result.project.kind).toBe('single')
+  })
+
+  it('resolves evlog from a pnpm workspace root when run in a child package', async () => {
+    const root = await makeProject({
+      'pnpm-workspace.yaml': 'packages:\n  - apps/*\n',
+      'package.json': JSON.stringify({ name: 'monorepo', private: true }),
+      'apps/web/package.json': JSON.stringify({
+        name: 'web',
+        dependencies: { nuxt: '^3.0.0', evlog: 'workspace:*' },
+      }),
+      'node_modules/evlog/package.json': JSON.stringify({ name: 'evlog', version: '2.22.0' }),
+    })
+    const cwd = join(root, 'apps/web')
+
+    const result = await runDoctor(fakeContext(cwd))
+
+    expect(result.project.kind).toBe('pnpm')
+    expect(result.project.name).toBe('web')
+    expect(result.checks.find(c => c.id === 'evlog')?.status).toBe('ok')
+    expect(result.checks.find(c => c.id === 'stack')?.message).toContain('nuxt')
+  })
+
+  it('finds .evlog/logs at the workspace root from a child cwd', async () => {
+    const root = await makeProject({
+      'pnpm-workspace.yaml': 'packages:\n  - packages/*\n',
+      'package.json': JSON.stringify({ name: 'mono', private: true }),
+      'packages/app/package.json': JSON.stringify({ name: 'app', dependencies: { evlog: '^2.0.0' } }),
+      'node_modules/evlog/package.json': JSON.stringify({ name: 'evlog', version: '2.22.0' }),
+      '.evlog/logs/2026-07-17.jsonl': '{"event":"request"}\n',
+    })
+
+    const result = await runDoctor(fakeContext(join(root, 'packages/app')))
+    const logs = result.checks.find(c => c.id === 'logs')
+    expect(logs?.status).toBe('ok')
+    expect(logs?.message).toContain('1 file')
+  })
+
+  it('fails on unsupported Node versions', async () => {
+    const cwd = await makeProject({ 'package.json': '{}' })
+    const result = await runDoctor(fakeContext(cwd, { nodeVersion: 'v18.19.0' }))
+
+    const node = result.checks.find(c => c.id === 'node')
+    expect(node?.status).toBe('fail')
+    expect(result.summary.fail).toBeGreaterThan(0)
+  })
+
+  it('warns when evlog is declared but not installed', async () => {
+    const cwd = await makeProject({
+      'package.json': JSON.stringify({ name: 'app', devDependencies: { evlog: '^2.0.0' } }),
+    })
+
+    const result = await runDoctor(fakeContext(cwd))
+    const evlog = result.checks.find(c => c.id === 'evlog')
+    expect(evlog?.status).toBe('warn')
+    expect(evlog?.message).toContain('not installed')
+  })
+
+  it('warns outside a Node project', async () => {
+    const cwd = await makeProject()
+    const result = await runDoctor(fakeContext(cwd))
+    expect(result.checks.find(c => c.id === 'project')?.status).toBe('warn')
+    expect(result.summary.fail).toBe(0)
+  })
+
+  it('keeps the --json schema contract', async () => {
+    const cwd = await makeProject({
+      'package.json': JSON.stringify({ name: 'app', dependencies: { evlog: '^2.0.0' } }),
+      'node_modules/evlog/package.json': JSON.stringify({ name: 'evlog', version: '2.22.0' }),
+      '.evlog/logs/2026-07-17.jsonl': '{"event":"request"}\n',
+    })
+
+    const result = await runDoctor(fakeContext(cwd))
+    const payload = {
+      schemaVersion: SCHEMA_VERSION,
+      project: {
+        kind: result.project.kind,
+        name: result.project.name,
+        stack: result.project.stack,
+      },
+      checks: result.checks.map(({ id, status, message }) => ({ id, status, message })),
+      summary: result.summary,
+    }
+
+    expect(payload).toMatchInlineSnapshot(`
+      {
+        "checks": [
+          {
+            "id": "node",
+            "message": "v22.0.0",
+            "status": "ok",
+          },
+          {
+            "id": "project",
+            "message": "app",
+            "status": "ok",
+          },
+          {
+            "id": "evlog",
+            "message": "v2.22.0 (^2.0.0)",
+            "status": "ok",
+          },
+          {
+            "id": "logs",
+            "message": "1 file · .evlog/logs",
+            "status": "ok",
+          },
+        ],
+        "project": {
+          "kind": "single",
+          "name": "app",
+          "stack": [],
+        },
+        "schemaVersion": 1,
+        "summary": {
+          "fail": 0,
+          "ok": 4,
+          "warn": 0,
+        },
+      }
+    `)
+  })
+})
+
+describe('formatDoctorReport', () => {
+  it('renders sections without ANSI in plain mode', async () => {
+    const cwd = await makeProject({
+      'package.json': JSON.stringify({ name: 'app', dependencies: { evlog: '^2.0.0' } }),
+      'node_modules/evlog/package.json': JSON.stringify({ name: 'evlog', version: '2.22.0' }),
+    })
+    const ctx = fakeContext(cwd)
+    const result = await runDoctor(ctx)
+    const out = formatDoctorReport(ctx, result)
+
+    expect(out).not.toContain('\x1B')
+    expect(out).toContain('evlog doctor')
+    expect(out).toContain('ENVIRONMENT')
+    expect(out).toContain('EVLOG')
+    expect(out).toContain('docs')
+  })
+})

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -142,8 +142,7 @@ describe('runDoctor', () => {
     }) as typeof process.stdout.write)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
-    const run = typeof doctor.run === 'function' ? doctor.run : await doctor.run
-    await run!({
+    await doctor.run!({
       args: { json: true, noHeader: true, cwd, debug: false },
       rawArgs: [],
       cmd: doctor,

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -135,6 +135,7 @@ describe('runDoctor', () => {
     const result = await runDoctor(fakeContext(cwd))
     const payload = {
       schemaVersion: SCHEMA_VERSION,
+      environment: 'development',
       project: {
         kind: result.project.kind,
         name: result.project.name,
@@ -168,12 +169,13 @@ describe('runDoctor', () => {
             "status": "ok",
           },
         ],
+        "environment": "development",
         "project": {
           "kind": "single",
           "name": "app",
           "stack": [],
         },
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "summary": {
           "fail": 0,
           "ok": 4,

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -97,15 +97,25 @@ describe('runDoctor', () => {
     expect(result.summary.fail).toBeGreaterThan(0)
   })
 
-  it('warns when evlog is declared but not installed', async () => {
+  it('records steps + catalog findings on the debug logger', async () => {
     const cwd = await makeProject({
       'package.json': JSON.stringify({ name: 'app', devDependencies: { evlog: '^2.0.0' } }),
     })
+    const { createCliDebug, createCliLogger, ensureCliDebugLogger } = await import('../src/lib/debug')
+    ensureCliDebugLogger({ json: true })
+    const raw = createCliLogger({ command: 'doctor' })
+    const log = createCliDebug(raw)
 
-    const result = await runDoctor(fakeContext(cwd))
-    const evlog = result.checks.find(c => c.id === 'evlog')
-    expect(evlog?.status).toBe('warn')
-    expect(evlog?.message).toContain('not installed')
+    const result = await runDoctor(fakeContext(cwd), log)
+    expect(result.checks.find(c => c.id === 'evlog')?.status).toBe('warn')
+
+    const ctx = raw.getContext()
+    expect(ctx.steps).toEqual(['resolveProject', 'resolveEvlog', 'detectStack', 'checks', 'done'])
+    expect(Array.isArray(ctx.resolveTried)).toBe(true)
+
+    const findings = ctx.findings as Array<{ code: string }> | undefined
+    expect(findings?.some(f => f.code === 'cli.EVLOG_DECLARED_NOT_INSTALLED')).toBe(true)
+    expect(findings?.some(f => f.code === 'cli.LOGS_SINK_MISSING')).toBe(true)
   })
 
   it('warns outside a Node project', async () => {
@@ -185,7 +195,6 @@ describe('formatDoctorReport', () => {
     const out = formatDoctorReport(ctx, result)
 
     expect(out).not.toContain('\x1B')
-    expect(out).toContain('evlog doctor')
     expect(out).toContain('ENVIRONMENT')
     expect(out).toContain('EVLOG')
     expect(out).toContain('docs')

--- a/packages/cli/test/environment.test.ts
+++ b/packages/cli/test/environment.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { isPackagedCli, resolveCliEnvironment } from '../src/lib/environment'
+
+describe('isPackagedCli', () => {
+  it('treats node_modules installs as packaged', () => {
+    expect(isPackagedCli('file:///tmp/node_modules/@evlog/cli/dist/index.mjs')).toBe(true)
+    expect(isPackagedCli('file:///Users/x/.pnpm/@evlog+cli@1.0.0/node_modules/@evlog/cli/dist/x.mjs')).toBe(true)
+  })
+
+  it('treats monorepo packages/cli as workspace', () => {
+    expect(isPackagedCli('file:///Users/hugorichard/Dev/evlog/packages/cli/src/lib/environment.ts')).toBe(false)
+    expect(isPackagedCli('file:///Users/hugorichard/Dev/evlog/packages/cli/dist/index.mjs')).toBe(false)
+  })
+})
+
+describe('resolveCliEnvironment', () => {
+  const workspace = 'file:///repo/packages/cli/dist/index.mjs'
+  const packaged = 'file:///repo/node_modules/@evlog/cli/dist/index.mjs'
+
+  it('honors EVLOG_CLI_ENV over everything', () => {
+    expect(resolveCliEnvironment({
+      env: { EVLOG_CLI_ENV: 'preview', VERCEL_ENV: 'production', NODE_ENV: 'development' },
+      moduleUrl: packaged,
+    })).toBe('preview')
+  })
+
+  it('honors VERCEL_ENV when set', () => {
+    expect(resolveCliEnvironment({
+      env: { VERCEL_ENV: 'preview' },
+      moduleUrl: packaged,
+    })).toBe('preview')
+  })
+
+  it('reports production for packaged installs', () => {
+    expect(resolveCliEnvironment({
+      env: {},
+      moduleUrl: packaged,
+    })).toBe('production')
+  })
+
+  it('reports development for workspace builds by default', () => {
+    expect(resolveCliEnvironment({
+      env: {},
+      moduleUrl: workspace,
+    })).toBe('development')
+  })
+
+  it('uses NODE_ENV in workspace when set', () => {
+    expect(resolveCliEnvironment({
+      env: { NODE_ENV: 'test' },
+      moduleUrl: workspace,
+    })).toBe('test')
+  })
+})

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -5,10 +5,10 @@ import {
   createStyle,
   exitCodeFor,
   formatChecks,
-  formatHeader,
   formatSummary,
   summarize,
 } from '../src/core/output'
+import { formatCommandHeader } from '../src/core/brand'
 import { createContext } from '../src/core/context'
 import type { Check } from '../src/core/output'
 
@@ -48,26 +48,27 @@ describe('summarize / exitCodeFor', () => {
 describe('rendering', () => {
   it('renders a railed plain-text check list with hints', () => {
     expect(formatChecks(plain, checks)).toMatchInlineSnapshot(`
-      "  │ ✓ node   Node v22.0.0
-        │ ⚠ evlog  evlog is not a dependency
-        │   └─ pnpm add evlog
-        │ ✗ logs   sink unreadable
-        │   └─ check permissions"
+      "│ ✓ node   Node v22.0.0
+      │ ⚠ evlog  evlog is not a dependency
+      │   └ pnpm add evlog
+      │ ✗ logs   sink unreadable
+      │   └ check permissions"
     `)
   })
 
   it('renders the summary footer', () => {
-    expect(formatSummary(plain, summarize(checks))).toBe('\n  ▍ 1 ok · 1 warn · 1 fail\n')
+    expect(formatSummary(plain, summarize(checks))).toBe('1 ok · 1 warn · 1 fail')
   })
 
-  it('renders the branded header without ANSI when colors are off', () => {
-    expect(formatHeader(plain, { command: 'doctor', version: '0.0.0' }))
-      .toBe('\n  ▍ evlog doctor · v0.0.0 · evlog.dev (https://evlog.dev)\n')
+  it('renders the command header without ANSI when colors are off', () => {
+    const out = formatCommandHeader(plain, { command: 'doctor', version: '0.0.0' })
+    expect(out).toContain('evlog doctor v0.0.0')
+    expect(out).not.toContain('\x1B')
   })
 
   it('never leaks ANSI codes in plain mode', () => {
     const output = [
-      formatHeader(plain, { version: '0.0.0' }),
+      formatCommandHeader(plain, { command: 'doctor', version: '0.0.0' }),
       formatChecks(plain, checks),
       formatSummary(plain, summarize(checks)),
     ].join('\n')

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXIT_FAIL,
+  EXIT_OK,
+  createStyle,
+  exitCodeFor,
+  formatChecks,
+  formatHeader,
+  formatSummary,
+  summarize,
+} from '../src/core/output'
+import { createContext } from '../src/core/context'
+import type { Check } from '../src/core/output'
+
+const plain = createContext({ cwd: '/tmp', env: {}, nodeVersion: 'v22.0.0', tty: false, color: false, columns: 80 })
+const colored = { ...plain, color: true }
+
+const checks: Check[] = [
+  { id: 'node', status: 'ok', message: 'Node v22.0.0' },
+  { id: 'evlog', status: 'warn', message: 'evlog is not a dependency', hint: 'pnpm add evlog' },
+  { id: 'logs', status: 'fail', message: 'sink unreadable', hint: 'check permissions' },
+]
+
+describe('createStyle', () => {
+  it('passes text through untouched without color', () => {
+    const { paint, link } = createStyle(plain)
+    expect(paint('cyan', 'hello')).toBe('hello')
+    expect(link('https://evlog.dev', 'evlog.dev')).toBe('evlog.dev (https://evlog.dev)')
+  })
+
+  it('emits ANSI sequences and OSC 8 links with color', () => {
+    const { paint, link } = createStyle(colored)
+    expect(paint('bold', 'evlog')).toBe('\x1B[1mevlog\x1B[0m')
+    expect(paint(['cyan', 'bold'], 'x')).toBe('\x1B[36m\x1B[1mx\x1B[0m')
+    expect(link('https://evlog.dev', 'evlog.dev')).toContain('\x1B]8;;https://evlog.dev\x07')
+  })
+})
+
+describe('summarize / exitCodeFor', () => {
+  it('counts statuses and maps them to exit codes', () => {
+    const summary = summarize(checks)
+    expect(summary).toEqual({ ok: 1, warn: 1, fail: 1 })
+    expect(exitCodeFor(summary)).toBe(EXIT_FAIL)
+    expect(exitCodeFor({ ok: 2, warn: 1, fail: 0 })).toBe(EXIT_OK)
+  })
+})
+
+describe('rendering', () => {
+  it('renders a railed plain-text check list with hints', () => {
+    expect(formatChecks(plain, checks)).toMatchInlineSnapshot(`
+      "  │ ✓ node   Node v22.0.0
+        │ ⚠ evlog  evlog is not a dependency
+        │   └─ pnpm add evlog
+        │ ✗ logs   sink unreadable
+        │   └─ check permissions"
+    `)
+  })
+
+  it('renders the summary footer', () => {
+    expect(formatSummary(plain, summarize(checks))).toBe('\n  ▍ 1 ok · 1 warn · 1 fail\n')
+  })
+
+  it('renders the branded header without ANSI when colors are off', () => {
+    expect(formatHeader(plain, { command: 'doctor', version: '0.0.0' }))
+      .toBe('\n  ▍ evlog doctor · v0.0.0 · evlog.dev (https://evlog.dev)\n')
+  })
+
+  it('never leaks ANSI codes in plain mode', () => {
+    const output = [
+      formatHeader(plain, { version: '0.0.0' }),
+      formatChecks(plain, checks),
+      formatSummary(plain, summarize(checks)),
+    ].join('\n')
+    expect(output).not.toContain('\x1B')
+  })
+})

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveProject } from '../src/lib/project'
+
+const tempDirs: string[] = []
+
+async function makeTree(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'evlog-cli-project-'))
+  tempDirs.push(dir)
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(dir, path)
+    await mkdir(join(full, '..'), { recursive: true })
+    await writeFile(full, contents, 'utf-8')
+  }
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(d => rm(d, { recursive: true, force: true })))
+})
+
+describe('resolveProject', () => {
+  it('does not promote an unrelated ancestor package.json to root', async () => {
+    const root = await makeTree({
+      'package.json': JSON.stringify({ name: 'unrelated-parent' }),
+      'apps/web/package.json': JSON.stringify({ name: 'web' }),
+    })
+    const cwd = join(root, 'apps/web')
+
+    const project = await resolveProject(cwd)
+
+    expect(project.kind).toBe('single')
+    expect(project.packageDir).toBe(cwd)
+    expect(project.root).toBe(cwd)
+    expect(project.packageName).toBe('web')
+  })
+
+  it('promotes root when a workspace marker is found above the package', async () => {
+    const root = await makeTree({
+      'pnpm-workspace.yaml': 'packages:\n  - apps/*\n',
+      'package.json': JSON.stringify({ name: 'monorepo', private: true }),
+      'apps/web/package.json': JSON.stringify({ name: 'web' }),
+    })
+    const cwd = join(root, 'apps/web')
+
+    const project = await resolveProject(cwd)
+
+    expect(project.kind).toBe('pnpm')
+    expect(project.packageDir).toBe(cwd)
+    expect(project.root).toBe(root)
+  })
+
+  it('detects bun workspaces via bun.lock', async () => {
+    const root = await makeTree({
+      'bun.lock': '{ "lockfileVersion": 1 }\n',
+      'package.json': JSON.stringify({
+        name: 'monorepo',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'apps/web/package.json': JSON.stringify({ name: 'web' }),
+    })
+    const cwd = join(root, 'apps/web')
+
+    const project = await resolveProject(cwd)
+
+    expect(project.kind).toBe('bun')
+    expect(project.packageDir).toBe(cwd)
+    expect(project.root).toBe(root)
+  })
+
+  it('detects bun workspaces via legacy bun.lockb', async () => {
+    const root = await makeTree({
+      'bun.lockb': 'binary-stub',
+      'package.json': JSON.stringify({
+        name: 'monorepo',
+        private: true,
+        workspaces: ['packages/*'],
+      }),
+      'packages/app/package.json': JSON.stringify({ name: 'app' }),
+    })
+
+    const project = await resolveProject(join(root, 'packages/app'))
+
+    expect(project.kind).toBe('bun')
+    expect(project.root).toBe(root)
+  })
+})

--- a/packages/cli/test/ui.test.ts
+++ b/packages/cli/test/ui.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createUi } from '../src/lib/ui'
+import { SCHEMA_VERSION } from '../src/core/output'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.exitCode = undefined
+})
+
+describe('createUi', () => {
+  it('writes human to stderr and json to stdout', () => {
+    const err: string[] = []
+    const out: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      err.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stderr.write)
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      out.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stdout.write)
+
+    const ui = createUi()
+    ui.human('hello')
+    ui.json({ ok: true })
+
+    expect(err.join('')).toContain('hello')
+    expect(JSON.parse(out.join(''))).toEqual({ schemaVersion: SCHEMA_VERSION, ok: true })
+  })
+
+  it('done picks json vs human and sets exit code', () => {
+    const err: string[] = []
+    const out: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      err.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stderr.write)
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      out.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stdout.write)
+
+    createUi().done({
+      jsonMode: false,
+      human: 'report',
+      json: { a: 1 },
+      summary: { ok: 0, warn: 0, fail: 1 },
+    })
+    expect(err.join('')).toContain('report')
+    expect(out.join('')).toBe('')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = undefined
+    err.length = 0
+    out.length = 0
+
+    createUi({ json: true }).done({
+      human: 'ignored',
+      json: { a: 1 },
+      summary: { ok: 1, warn: 0, fail: 0 },
+    })
+    expect(JSON.parse(out.join(''))).toMatchObject({ a: 1 })
+    expect(err.join('')).toBe('')
+    expect(process.exitCode).toBe(0)
+  })
+})

--- a/packages/cli/test/ui.test.ts
+++ b/packages/cli/test/ui.test.ts
@@ -25,7 +25,11 @@ describe('createUi', () => {
     ui.json({ ok: true })
 
     expect(err.join('')).toContain('hello')
-    expect(JSON.parse(out.join(''))).toEqual({ schemaVersion: SCHEMA_VERSION, ok: true })
+    expect(JSON.parse(out.join(''))).toEqual({
+      schemaVersion: SCHEMA_VERSION,
+      environment: expect.any(String),
+      ok: true,
+    })
   })
 
   it('done picks json vs human and sets exit code', () => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ESNext"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    cli: 'src/cli.ts',
+  },
+  format: 'esm',
+  dts: true,
+  clean: true,
+  fixedExtension: true,
+})

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -45,6 +45,7 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./package.json": "./package.json",
     "./nuxt": {
       "types": "./dist/nuxt/module.d.mts",
       "import": "./dist/nuxt/module.mjs",

--- a/packages/telemetry/src/citty.ts
+++ b/packages/telemetry/src/citty.ts
@@ -1,8 +1,8 @@
-import type { CommandDef } from 'citty'
+import type { ArgsDef, CommandDef } from 'citty'
 import { createTelemetry } from './create'
 import type { CollectFields, CollectFlags, TelemetryOptions } from './types'
 
-type AnyCommand = CommandDef & {
+type AnyCommand = CommandDef<ArgsDef> & {
   subCommands?: Record<string, AnyCommand>
 }
 
@@ -47,12 +47,13 @@ function wrapCommand(
  * Returns the wrapped command for `runMain()`.
  */
 export function withTelemetry<
+  const TArgs extends ArgsDef = ArgsDef,
   TFlags extends CollectFlags = {},
   TFields extends CollectFields = {},
 >(
-  command: CommandDef,
+  command: CommandDef<TArgs>,
   options: TelemetryOptions<TFlags, TFields>,
-): CommandDef {
+): CommandDef<TArgs> {
   const instance = createTelemetry(options)
-  return wrapCommand(command as AnyCommand, instance, [], true)
+  return wrapCommand(command as AnyCommand, instance, [], true) as CommandDef<TArgs>
 }

--- a/packages/telemetry/src/commands.ts
+++ b/packages/telemetry/src/commands.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 import { disableTelemetry, enableTelemetry } from './create'
 import { generateDisclosure } from './disclosure'
 import { readPreferenceSync, resolveConsent } from './consent'
+import { getTelemetryDir } from './paths'
 import type { TelemetryOptions } from './types'
 
 /**
@@ -21,7 +22,9 @@ export function defineTelemetryCommands(options: Pick<TelemetryOptions, 'name' |
         run() {
           const enabled = resolveConsent(options.name)
           const pref = readPreferenceSync(options.name)
+          const dir = getTelemetryDir(options.name)
           process.stderr.write(`Telemetry: ${enabled ? 'enabled' : 'disabled'} (preference: ${pref})\n`)
+          process.stderr.write(`Data directory: ${dir}\n`)
           process.stderr.write('\n')
           process.stderr.write(disclosure.markdown)
           process.stderr.write('\n')

--- a/packages/telemetry/src/create.ts
+++ b/packages/telemetry/src/create.ts
@@ -172,7 +172,7 @@ class InternalTelemetry<
       errorCode: parts.errorCode,
       flags: parts.flags,
       tool,
-      env: buildEnvInfo(),
+      env: buildEnvInfo({ environment: this.options.environment }),
       machineId: this.machineId,
       custom: parts.custom,
       idempotencyKey,

--- a/packages/telemetry/src/disclosure.ts
+++ b/packages/telemetry/src/disclosure.ts
@@ -14,6 +14,7 @@ const STANDARD_FIELDS: Array<{ field: string, type: string, description: string 
   { field: 'env.provider', type: 'string | null', description: 'CI provider when detected.' },
   { field: 'env.tty', type: 'boolean', description: 'Whether stdout is a TTY.' },
   { field: 'env.agent', type: 'string | null', description: 'AI coding agent when detected (claude, cursor, codex, …).' },
+  { field: 'env.environment', type: 'string', description: 'Deploy stage (`development` | `preview` | `production`).' },
   { field: 'machineId', type: 'string', description: 'Hashed anonymous machine id; omitted in ephemeral CI.' },
   { field: 'custom', type: 'object', description: 'Consumer-provided fields via telemetry.set() — numbers/booleans by default.' },
 ]
@@ -105,7 +106,14 @@ export function exampleRunEvent(overrides?: Partial<RunEvent>): RunEvent {
     outcome: 'success',
     flags: { json: true },
     tool: { name: 'evlog-cli', version: '0.1.0' },
-    env: { node: '20.11', ci: false, provider: null, tty: true, agent: null },
+    env: {
+      node: '20.11',
+      ci: false,
+      provider: null,
+      tty: true,
+      agent: null,
+      environment: 'development',
+    },
     machineId: 'ab3f0123456789ab',
     custom: { checksFailed: 0 },
     idempotencyKey: '00000000000000000000000000000000',

--- a/packages/telemetry/src/enrich.ts
+++ b/packages/telemetry/src/enrich.ts
@@ -5,14 +5,39 @@ import { agent, hasTTY, isCI, nodeVersion, provider } from 'std-env'
 import type { EnvInfo } from './types'
 import { getTelemetryDir } from './paths'
 
-/** Build the standard `env` block from std-env. */
-export function buildEnvInfo(): EnvInfo {
+export type ResolveEnvironmentOptions = {
+  /** Process env (defaults to `process.env`). */
+  env?: NodeJS.Dict<string>
+  /** Author override (e.g. packaged CLI → `production`). */
+  override?: string
+}
+
+/**
+ * Deploy / runtime stage for a telemetry run.
+ *
+ * Priority: `EVLOG_TELEMETRY_ENV` → `VERCEL_ENV` → tool `override` → `NODE_ENV` → `development`.
+ */
+export function resolveEnvironment(options: ResolveEnvironmentOptions = {}): string {
+  const env = options.env ?? process.env
+  const explicit = env.EVLOG_TELEMETRY_ENV?.trim()
+  if (explicit) return explicit
+  const vercel = env.VERCEL_ENV?.trim()
+  if (vercel) return vercel
+  if (options.override?.trim()) return options.override.trim()
+  const nodeEnv = env.NODE_ENV?.trim()
+  if (nodeEnv) return nodeEnv
+  return 'development'
+}
+
+/** Build the standard `env` block from std-env (+ deploy stage). */
+export function buildEnvInfo(options: { environment?: string } = {}): EnvInfo {
   return {
     node: nodeVersion ?? process.version.replace(/^v/, ''),
     ci: isCI,
     provider: provider ?? null,
     tty: hasTTY,
     agent: agent ?? null,
+    environment: resolveEnvironment({ override: options.environment }),
   }
 }
 

--- a/packages/telemetry/src/ingest.ts
+++ b/packages/telemetry/src/ingest.ts
@@ -176,6 +176,9 @@ function validateEnv(input: unknown): RunEvent['env'] {
   if (env.agent !== null && typeof env.agent !== 'string') {
     throw new IngestValidationError('invalid env.agent')
   }
+  if (typeof env.environment !== 'string' || !env.environment.trim()) {
+    throw new IngestValidationError('invalid env.environment')
+  }
 
   return {
     node: env.node,
@@ -183,6 +186,7 @@ function validateEnv(input: unknown): RunEvent['env'] {
     provider: env.provider,
     tty: env.tty,
     agent: env.agent,
+    environment: env.environment.trim(),
   }
 }
 

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -12,7 +12,7 @@ export interface ToolInfo {
 }
 
 /**
- * Environment snapshot enriched via `std-env`.
+ * Environment snapshot enriched via `std-env` (+ deploy stage).
  */
 export interface EnvInfo {
   node: string
@@ -20,6 +20,11 @@ export interface EnvInfo {
   provider: string | null
   tty: boolean
   agent: string | null
+  /**
+   * Deploy / runtime stage: `development` | `preview` | `production` (or custom).
+   * From `EVLOG_TELEMETRY_ENV` → `VERCEL_ENV` → {@link TelemetryOptions.environment} → `NODE_ENV` → `development`.
+   */
+  environment: string
 }
 
 /**
@@ -70,6 +75,11 @@ export interface TelemetryOptions<
   name: string
   /** Tool version string. */
   version: string
+  /**
+   * Override `env.environment` on every run event.
+   * Useful when the tool knows its own stage (e.g. packaged CLI → `production`).
+   */
+  environment?: string
   /** Default ingestion endpoint baked in by the author. Overridable via `EVLOG_TELEMETRY_ENDPOINT`. */
   endpoint?: string
   /** Optional allowlists for string flags and custom fields. */

--- a/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
+++ b/packages/telemetry/test/__snapshots__/telemetry.test.ts.snap
@@ -20,6 +20,7 @@ exports[`telemetry disclosure > matches snapshot for default envelope 1`] = `
 | \`env.provider\` | string | null | CI provider when detected. |
 | \`env.tty\` | boolean | Whether stdout is a TTY. |
 | \`env.agent\` | string | null | AI coding agent when detected (claude, cursor, codex, …). |
+| \`env.environment\` | string | Deploy stage (\`development\` | \`preview\` | \`production\`). |
 | \`machineId\` | string | Hashed anonymous machine id; omitted in ephemeral CI. |
 | \`custom\` | object | Consumer-provided fields via telemetry.set() — numbers/booleans by default. |
 
@@ -69,6 +70,7 @@ exports[`telemetry disclosure > matches snapshot with collect extensions 1`] = `
 | \`env.provider\` | string | null | CI provider when detected. |
 | \`env.tty\` | boolean | Whether stdout is a TTY. |
 | \`env.agent\` | string | null | AI coding agent when detected (claude, cursor, codex, …). |
+| \`env.environment\` | string | Deploy stage (\`development\` | \`preview\` | \`production\`). |
 | \`machineId\` | string | Hashed anonymous machine id; omitted in ephemeral CI. |
 | \`custom\` | object | Consumer-provided fields via telemetry.set() — numbers/booleans by default. |
 
@@ -156,6 +158,11 @@ Set \`EVLOG_TELEMETRY_DEBUG=1\` to print would-be payloads to stderr.",
       "type": "string | null",
     },
     {
+      "description": "Deploy stage (\`development\` | \`preview\` | \`production\`).",
+      "field": "env.environment",
+      "type": "string",
+    },
+    {
       "description": "Hashed anonymous machine id; omitted in ephemeral CI.",
       "field": "machineId",
       "type": "string",
@@ -190,6 +197,7 @@ exports[`telemetry payload snapshot > matches enriched run event shape 1`] = `
   "env": {
     "agent": null,
     "ci": false,
+    "environment": "development",
     "node": "20.11",
     "provider": null,
     "tty": true,

--- a/packages/telemetry/test/enrich.test.ts
+++ b/packages/telemetry/test/enrich.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildEnvInfo, resolveEnvironment } from '../src/enrich'
+
+describe('resolveEnvironment', () => {
+  afterEach(() => {
+    delete process.env.EVLOG_TELEMETRY_ENV
+    delete process.env.VERCEL_ENV
+  })
+
+  it('honors EVLOG_TELEMETRY_ENV then VERCEL_ENV then override then NODE_ENV', () => {
+    expect(resolveEnvironment({
+      env: { EVLOG_TELEMETRY_ENV: 'staging', VERCEL_ENV: 'preview', NODE_ENV: 'production' },
+      override: 'development',
+    })).toBe('staging')
+
+    expect(resolveEnvironment({
+      env: { VERCEL_ENV: 'preview', NODE_ENV: 'production' },
+      override: 'development',
+    })).toBe('preview')
+
+    expect(resolveEnvironment({
+      env: { NODE_ENV: 'test' },
+      override: 'production',
+    })).toBe('production')
+
+    expect(resolveEnvironment({
+      env: { NODE_ENV: 'test' },
+    })).toBe('test')
+  })
+
+  it('defaults to development', () => {
+    expect(resolveEnvironment({ env: {} })).toBe('development')
+  })
+})
+
+describe('buildEnvInfo', () => {
+  it('includes environment', () => {
+    const info = buildEnvInfo({ environment: 'production' })
+    expect(info.environment).toBe('production')
+    expect(typeof info.node).toBe('string')
+    expect(typeof info.ci).toBe('boolean')
+  })
+})

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -288,3 +288,34 @@ describe('telemetry payload snapshot', () => {
     expect(exampleRunEvent({ idempotencyKey: key })).toMatchSnapshot()
   })
 })
+
+describe('telemetry status command', () => {
+  it('prints the local data directory', async () => {
+    const { defineTelemetryCommands } = await import('../src/commands')
+    const { getTelemetryDir } = await import('../src/paths')
+    const writes: string[] = []
+    const original = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+      return true
+    }) as typeof process.stderr.write
+
+    try {
+      const tree = defineTelemetryCommands({ name: TOOL })
+      const status = tree.subCommands?.status
+      expect(status).toBeDefined()
+      const cmd = typeof status === 'function' ? await status() : await status
+      await cmd!.run?.({
+        args: {},
+        rawArgs: [],
+        data: undefined,
+        cmd: cmd!,
+      })
+      const out = writes.join('')
+      expect(out).toContain(`Data directory: ${getTelemetryDir(TOOL)}`)
+      expect(out).toMatch(/Telemetry: (enabled|disabled)/)
+    } finally {
+      process.stderr.write = original
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,34 +63,34 @@ importers:
     dependencies:
       '@databuddy/nuxt':
         specifier: ^2.4.20
-        version: 2.4.20(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.20(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/fonts':
         specifier: 0.14.0
         version: 0.14.0(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/ui':
         specifier: ^4.10.0
-        version: 4.10.0(cd65fc90423797eec0febd015f329066)
+        version: 4.10.0(1a7122ab616755b849382195a594c78d)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.0(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
       docus:
         specifier: ^5.12.3
-        version: 5.12.3(712d4b5d4bd0715e41025aa5916be48e)
+        version: 5.12.3(9ae62989b0983a6059a9112b4875a8d1)
       motion-v:
         specifier: ^2.3.0
         version: 2.3.0(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.33(typescript@6.0.3))
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+        version: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nuxt-studio:
         specifier: ^1.7.0
         version: 1.7.0(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(srvx@0.11.22)(vue@3.5.33(typescript@6.0.3))
@@ -109,25 +109,25 @@ importers:
     dependencies:
       '@comark/nuxt':
         specifier: ^0.5.1
-        version: 0.5.1(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(shiki@4.3.1)(vue@3.5.33(typescript@6.0.3))
+        version: 0.5.1(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(shiki@4.3.1)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/content':
         specifier: ^3.15.0
-        version: 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+        version: 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/ui':
         specifier: ^4.9.0
-        version: 4.10.0(a4387387d6f44014df13b0d5fe910422)
+        version: 4.10.0(010fcab92c54da5022a839b9ba5934f8)
       '@nuxtjs/sitemap':
         specifier: ^8.2.2
-        version: 8.2.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+        version: 8.2.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(08f8f26771505e5846e0a46912d513e5)
+        version: 4.4.4(335d0e596a2dfa339194289c407e4463)
       shiki:
         specifier: 4.3.1
         version: 4.3.1
@@ -181,7 +181,7 @@ importers:
         version: 3.0.260610-beta(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       rolldown:
         specifier: latest
-        version: 1.1.5
+        version: 1.2.0
 
   apps/nitro-v2-playground:
     dependencies:
@@ -194,7 +194,7 @@ importers:
         version: 1.15.11
       nitropack:
         specifier: ^2.13.4
-        version: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/nuxthub-playground:
     dependencies:
@@ -209,7 +209,7 @@ importers:
         version: 0.17.4
       '@nuxthub/core':
         specifier: ^0.10.8
-        version: 0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+        version: 0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
       ai:
         specifier: ^7.0.28
         version: 7.0.29(zod@4.4.3)
@@ -227,7 +227,7 @@ importers:
         version: 1.0.0(@types/markdown-it@14.1.2)(react@19.2.6)(solid-js@1.9.12)(vue@3.5.33(typescript@5.9.3))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(ec65edef976a632117fd4193e516298c)
+        version: 4.4.4(e403bae20d047df41dab5a20e9a2f8eb)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -236,7 +236,7 @@ importers:
     dependencies:
       '@nuxt/ui':
         specifier: ^4.9.0
-        version: 4.10.0(70e7bbac9ee8eef3f591b9d14fccbb48)
+        version: 4.10.0(014eb712ce4482f931c4cab5ec81bc5a)
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(553cd30787483f6c2c8dbb1803b3c154)
@@ -248,7 +248,7 @@ importers:
         version: link:../../packages/evlog
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(f1fffd6ba4797b39e7156a553959e323)
+        version: 4.4.4(512e987a24fc82a9489273c38391af0e)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -361,7 +361,7 @@ importers:
         version: 4.3.0
       '@vercel/connect':
         specifier: 0.2.2
-        version: 0.2.2(@ai-sdk/mcp@1.0.62(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.23(2920a4d4c7ac0a3829fa8cc6bb9c6d37))(eve@0.12.3(4debaf7e0b4c4c3fc4147c98427f633a))
+        version: 0.2.2(@ai-sdk/mcp@1.0.62(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.23(2920a4d4c7ac0a3829fa8cc6bb9c6d37))(eve@0.12.3(a476a191091068fb5f2b9f2404ce5bbd))
       ai:
         specifier: ^7.0.0
         version: 7.0.15(zod@4.4.3)
@@ -376,7 +376,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       eve:
         specifier: ^0.12.3
-        version: 0.12.3(4debaf7e0b4c4c3fc4147c98427f633a)
+        version: 0.12.3(a476a191091068fb5f2b9f2404ce5bbd)
       evlog:
         specifier: workspace:*
         version: link:../../packages/evlog
@@ -658,7 +658,7 @@ importers:
         version: 0.545.0(react@19.2.5)
       nitro:
         specifier: npm:nitro-nightly@latest
-        version: nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.1.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.2.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -735,6 +735,31 @@ importers:
       wrangler:
         specifier: ^3.101.0
         version: 3.114.17(@cloudflare/workers-types@4.20260503.1)
+
+  packages/cli:
+    dependencies:
+      '@evlog/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      evlog:
+        specifier: workspace:*
+        version: link:../evlog
+    devDependencies:
+      tsdown:
+        specifier: ^0.22.8
+        version: 0.22.8(tsx@4.23.1)(typescript@6.0.3)(unrun@0.2.37)(vue-tsc@3.3.7(typescript@6.0.3))
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/evlog:
     dependencies:
@@ -846,10 +871,10 @@ importers:
         version: 3.0.260311-beta(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       nitropack:
         specifier: ^2.13.4
-        version: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.1.5)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.2.0)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.4(024eba7bfbd65691ad53cfb6faad2378)
+        version: 4.4.4(5ad9f9faf84cf7851733c29a2cc90662)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -888,7 +913,7 @@ importers:
     dependencies:
       '@nuxthub/core':
         specifier: ^0.10.8
-        version: 0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
+        version: 0.10.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
       drizzle-orm:
         specifier: '>=0.45.2'
         version: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)
@@ -1620,11 +1645,17 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -3184,12 +3215,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -4324,11 +4349,11 @@ packages:
   '@oxc-project/types@0.135.0':
     resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
-  '@oxc-project/types@0.138.0':
-    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
-
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
 
   '@oxc-transform/binding-android-arm-eabi@0.128.0':
     resolution: {integrity: sha512-qVO4izEs88ZSo7KOK4P+O5nAXXJmkSadInvFjGkhVnm2R2Wr8trU/GLhjAK0S0u8Qv9bkXspNhgpECk+CTQ/ew==}
@@ -5593,14 +5618,14 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.1.4':
-    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -5617,14 +5642,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
-    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -5641,14 +5666,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.4':
-    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -5665,14 +5690,14 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
-    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -5689,14 +5714,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
-    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -5715,15 +5740,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
-    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5743,15 +5768,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
-    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5764,15 +5789,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
-    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -5785,15 +5810,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
-    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -5813,15 +5838,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
-    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5841,15 +5866,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
-    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5867,14 +5892,14 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
-    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -5889,13 +5914,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
-    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
@@ -5911,14 +5936,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
-    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5935,14 +5960,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
-    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -5958,9 +5983,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
-
-  '@rolldown/pluginutils@1.0.0-rc.18':
-    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -7523,9 +7545,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -8603,9 +8622,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  alien-signals@3.1.2:
-    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
-
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
@@ -8635,10 +8651,6 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-
-  ansis@4.2.0:
-    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
-    engines: {node: '>=14'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -10140,10 +10152,6 @@ packages:
 
   emoticon@4.1.0:
     resolution: {integrity: sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==}
-
-  empathic@2.0.0:
-    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
-    engines: {node: '>=14'}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -13808,13 +13816,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.1.4:
-    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -16156,12 +16164,12 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
 
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -16171,13 +16179,13 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -16190,10 +16198,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -16205,8 +16213,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -16222,7 +16230,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -16250,18 +16258,18 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16269,14 +16277,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -16292,7 +16300,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16313,7 +16321,7 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -16412,17 +16420,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -16767,12 +16775,12 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@comark/nuxt@0.5.1(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(shiki@4.3.1)(vue@3.5.33(typescript@6.0.3))':
+  '@comark/nuxt@0.5.1(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(shiki@4.3.1)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@comark/vue': 0.5.1(shiki@4.3.1)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       comark: 0.5.1(shiki@4.3.1)
-      nuxt: 4.4.4(08f8f26771505e5846e0a46912d513e5)
+      nuxt: 4.4.4(335d0e596a2dfa339194289c407e4463)
     transitivePeerDependencies:
       - beautiful-mermaid
       - katex
@@ -16805,12 +16813,12 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@databuddy/nuxt@2.4.20(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))':
+  '@databuddy/nuxt@2.4.20(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@databuddy/sdk': 2.4.20(react@19.2.6)(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@nuxt/schema': 4.4.6
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
     optionalDependencies:
       vue: 3.5.33(typescript@6.0.3)
     transitivePeerDependencies:
@@ -16869,12 +16877,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -17965,7 +17984,7 @@ snapshots:
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
       '@types/ws': 8.18.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -18016,7 +18035,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.13
     transitivePeerDependencies:
       - encoding
@@ -18063,13 +18082,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -18081,6 +18093,20 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -18271,7 +18297,7 @@ snapshots:
   '@nuxt/cli@3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.2)
-      '@clack/prompts': 1.3.0
+      '@clack/prompts': 1.7.0
       c12: 3.3.4(magicast@0.5.3)
       citty: 0.2.2
       confbox: 0.2.4
@@ -18284,18 +18310,18 @@ snapshots:
       giget: 3.2.0
       jiti: 2.7.0
       listhen: 1.10.0(srvx@0.11.22)
-      nypm: 0.6.6
+      nypm: 0.6.8
       ofetch: 1.5.1
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       srvx: 0.11.22
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyclip: 0.1.12
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -18309,7 +18335,7 @@ snapshots:
   '@nuxt/cli@3.35.1(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.2)
-      '@clack/prompts': 1.3.0
+      '@clack/prompts': 1.7.0
       c12: 3.3.4(magicast@0.5.3)
       citty: 0.2.2
       confbox: 0.2.4
@@ -18322,18 +18348,18 @@ snapshots:
       giget: 3.2.0
       jiti: 2.7.0
       listhen: 1.10.0(srvx@0.11.22)
-      nypm: 0.6.6
+      nypm: 0.6.8
       ofetch: 1.5.1
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       srvx: 0.11.22
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyclip: 0.1.12
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -18344,7 +18370,7 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/content@3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@nuxt/content@3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxtjs/mdc': 0.22.1(magicast@0.5.3)
@@ -18384,14 +18410,14 @@ snapshots:
       shiki: 4.3.1
       slugify: 1.6.9
       socket.io-client: 4.8.3
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
       unified: 11.0.5
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
@@ -18453,7 +18479,7 @@ snapshots:
   '@nuxt/devtools-kit@4.0.0-alpha.3(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       vite: 8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
@@ -18467,7 +18493,7 @@ snapshots:
       magicast: 0.5.2
       pathe: 2.0.3
       pkg-types: 2.3.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@nuxt/devtools@3.2.4(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
@@ -18718,7 +18744,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -18818,7 +18844,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -18843,7 +18869,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -18874,7 +18900,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(024eba7bfbd65691ad53cfb6faad2378))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.15)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -18889,11 +18915,11 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(024eba7bfbd65691ad53cfb6faad2378)
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(335d0e596a2dfa339194289c407e4463)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -18954,7 +18980,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -18969,11 +18995,11 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(08f8f26771505e5846e0a46912d513e5)
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -19034,7 +19060,167 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(512e987a24fc82a9489273c38391af0e))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      h3: 1.15.11
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(512e987a24fc82a9489273c38391af0e)
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
+      vue: 3.5.33(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(5ad9f9faf84cf7851733c29a2cc90662))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.15)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      h3: 1.15.11
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(5ad9f9faf84cf7851733c29a2cc90662)
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
+      vue: 3.5.33(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -19049,11 +19235,11 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3)
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -19115,87 +19301,7 @@ snapshots:
       - xml2js
     optional: true
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.8.1
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unctx: 2.5.0
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
-      vue: 3.5.33(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - sqlite3
-      - srvx
-      - supports-color
-      - typescript
-      - unloader
-      - uploadthing
-      - vite
-      - webpack
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(ec65edef976a632117fd4193e516298c))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(e403bae20d047df41dab5a20e9a2f8eb))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -19210,11 +19316,11 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(ec65edef976a632117fd4193e516298c)
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nuxt: 4.4.4(e403bae20d047df41dab5a20e9a2f8eb)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -19224,86 +19330,6 @@ snapshots:
       unctx: 2.5.0
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       vue: 3.5.33(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - sqlite3
-      - srvx
-      - supports-color
-      - typescript
-      - unloader
-      - uploadthing
-      - vite
-      - webpack
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(f1fffd6ba4797b39e7156a553959e323))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nuxt: 4.4.4(f1fffd6ba4797b39e7156a553959e323)
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.8.1
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unctx: 2.5.0
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
-      vue: 3.5.33(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     optionalDependencies:
@@ -19377,7 +19403,7 @@ snapshots:
       defu: 6.1.7
       pathe: 2.0.3
       pkg-types: 2.3.1
-      std-env: 4.1.0
+      std-env: 4.2.0
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))':
     dependencies:
@@ -19428,7 +19454,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.10.0(70e7bbac9ee8eef3f591b9d14fccbb48)':
+  '@nuxt/ui@4.10.0(010fcab92c54da5022a839b9ba5934f8)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
@@ -19489,136 +19515,15 @@ snapshots:
       tinyglobby: 0.2.17
       typescript: 6.0.3
       ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
       vaul-vue: 0.4.1(reka-ui@2.10.1(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
       vue-component-type-helpers: 3.3.7
     optionalDependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      ai: 7.0.29(zod@4.4.3)
-      valibot: 1.3.1(typescript@6.0.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emotion/is-prop-valid'
-      - '@farmfe/core'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
-      - aws4fetch
-      - axios
-      - bun-types-no-globals
-      - change-case
-      - db0
-      - drauu
-      - embla-carousel
-      - esbuild
-      - focus-trap
-      - idb-keyval
-      - ioredis
-      - jwt-decode
-      - magicast
-      - nprogress
-      - qrcode
-      - react
-      - react-dom
-      - rolldown
-      - rollup
-      - sortablejs
-      - universal-cookie
-      - unloader
-      - uploadthing
-      - vite
-      - vue
-      - webpack
-
-  '@nuxt/ui@4.10.0(a4387387d6f44014df13b0d5fe910422)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/fonts': 0.14.0(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      '@nuxt/icon': 2.3.1(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/schema': 4.4.8
-      '@nuxtjs/color-mode': 4.0.1(magicast@0.5.3)
-      '@standard-schema/spec': 1.1.0
-      '@tailwindcss/postcss': 4.3.2
-      '@tailwindcss/vite': 4.3.2(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.33(typescript@6.0.3))
-      '@tanstack/vue-virtual': 3.13.32(vue@3.5.33(typescript@6.0.3))
-      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
-      '@tiptap/extension-bubble-menu': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/extension-code': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
-      '@tiptap/extension-collaboration': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
-      '@tiptap/extension-drag-handle': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
-      '@tiptap/extension-drag-handle-vue-3': 3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
-      '@tiptap/extension-floating-menu': 3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/extension-horizontal-rule': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/extension-image': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
-      '@tiptap/extension-mention': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
-      '@tiptap/extension-node-range': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/extension-placeholder': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
-      '@tiptap/markdown': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/pm': 3.22.5
-      '@tiptap/starter-kit': 3.22.5
-      '@tiptap/suggestion': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3))
-      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(axios@1.16.0)(fuse.js@7.5.0)(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      colortranslator: 5.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.33(typescript@6.0.3))
-      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
-      fuse.js: 7.5.0
-      hookable: 6.1.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.33(typescript@6.0.3))
-      ohash: 2.0.11
-      pathe: 2.0.3
-      reka-ui: 2.10.1(vue@3.5.33(typescript@6.0.3))
-      scule: 1.3.0
-      tailwind-merge: 3.6.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
-      tailwindcss: 4.3.2
-      tinyglobby: 0.2.17
-      typescript: 6.0.3
-      ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      vaul-vue: 0.4.1(reka-ui@2.10.1(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
-      vue-component-type-helpers: 3.3.7
-    optionalDependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.6
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       ai: 7.0.29(zod@3.25.76)
       valibot: 1.3.1(typescript@6.0.3)
       zod: 3.25.76
@@ -19669,7 +19574,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/ui@4.10.0(cd65fc90423797eec0febd015f329066)':
+  '@nuxt/ui@4.10.0(014eb712ce4482f931c4cab5ec81bc5a)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
@@ -19730,15 +19635,136 @@ snapshots:
       tinyglobby: 0.2.17
       typescript: 6.0.3
       ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
       vaul-vue: 0.4.1(reka-ui@2.10.1(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
       vue-component-type-helpers: 3.3.7
     optionalDependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      ai: 7.0.29(zod@4.4.3)
+      valibot: 1.3.1(typescript@6.0.3)
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@emotion/is-prop-valid'
+      - '@farmfe/core'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/composition-api'
+      - async-validator
+      - aws4fetch
+      - axios
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - jwt-decode
+      - magicast
+      - nprogress
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - vite
+      - vue
+      - webpack
+
+  '@nuxt/ui@4.10.0(1a7122ab616755b849382195a594c78d)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/icon': 2.3.1(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/schema': 4.4.8
+      '@nuxtjs/color-mode': 4.0.1(magicast@0.5.3)
+      '@standard-schema/spec': 1.1.0
+      '@tailwindcss/postcss': 4.3.2
+      '@tailwindcss/vite': 4.3.2(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.33(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.32(vue@3.5.33(typescript@6.0.3))
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/extension-bubble-menu': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-code': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-collaboration': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
+      '@tiptap/extension-drag-handle': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
+      '@tiptap/extension-drag-handle-vue-3': 3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      '@tiptap/extension-floating-menu': 3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-horizontal-rule': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-image': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-mention': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-node-range': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-placeholder': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/markdown': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+      '@tiptap/starter-kit': 3.22.5
+      '@tiptap/suggestion': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3))
+      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(axios@1.16.0)(fuse.js@7.5.0)(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      colortranslator: 5.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-vue: 8.6.0(vue@3.5.33(typescript@6.0.3))
+      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
+      fuse.js: 7.5.0
+      hookable: 6.1.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.33(typescript@6.0.3))
+      ohash: 2.0.11
+      pathe: 2.0.3
+      reka-ui: 2.10.1(vue@3.5.33(typescript@6.0.3))
+      scule: 1.3.0
+      tailwind-merge: 3.6.0
+      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+      tailwindcss: 4.3.2
+      tinyglobby: 0.2.17
+      typescript: 6.0.3
+      ufo: 1.6.4
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      vaul-vue: 0.4.1(reka-ui@2.10.1(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      vue-component-type-helpers: 3.3.7
+    optionalDependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       ai: 6.0.209(zod@4.4.3)
       valibot: 1.3.1(typescript@6.0.3)
       zod: 4.4.3
@@ -19789,7 +19815,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.3.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.3.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -19807,7 +19833,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3)
+      nuxt: 4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -19824,8 +19850,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.5
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -19852,7 +19878,7 @@ snapshots:
       - yaml
     optional: true
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(024eba7bfbd65691ad53cfb6faad2378))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -19870,7 +19896,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(024eba7bfbd65691ad53cfb6faad2378)
+      nuxt: 4.4.4(335d0e596a2dfa339194289c407e4463)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -19887,8 +19913,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.5
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -19914,69 +19940,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
-    dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.19)
-      consola: 3.4.2
-      cssnano: 7.1.8(postcss@8.5.19)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.4(08f8f26771505e5846e0a46912d513e5)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.19
-      seroval: 1.5.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@9.39.5(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.5
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -19994,7 +19958,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -20011,8 +19975,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.5
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -20038,69 +20002,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(ec65edef976a632117fd4193e516298c))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
-    dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
-      autoprefixer: 10.5.0(postcss@8.5.19)
-      consola: 3.4.2
-      cssnano: 7.1.8(postcss@8.5.19)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.4(ec65edef976a632117fd4193e516298c)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.19
-      seroval: 1.5.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@9.39.5(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue-tsc@3.2.7(typescript@5.9.3))
-      vue: 3.5.33(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(f1fffd6ba4797b39e7156a553959e323))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(512e987a24fc82a9489273c38391af0e))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -20118,7 +20020,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(f1fffd6ba4797b39e7156a553959e323)
+      nuxt: 4.4.4(512e987a24fc82a9489273c38391af0e)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -20135,8 +20037,8 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.5
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -20162,7 +20064,131 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxthub/core@0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(5ad9f9faf84cf7851733c29a2cc90662))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.19)
+      consola: 3.4.2
+      cssnano: 7.1.8(postcss@8.5.19)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.4(5ad9f9faf84cf7851733c29a2cc90662)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.19
+      seroval: 1.5.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(eslint@9.39.5(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@6.0.3))
+      vue: 3.5.33(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      rolldown: 1.2.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(e403bae20d047df41dab5a20e9a2f8eb))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
+      autoprefixer: 10.5.0(postcss@8.5.19)
+      consola: 3.4.2
+      cssnano: 7.1.8(postcss@8.5.19)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.4(e403bae20d047df41dab5a20e9a2f8eb)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.19
+      seroval: 1.5.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(eslint@9.39.5(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue-tsc@3.2.7(typescript@5.9.3))
+      vue: 3.5.33(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxthub/core@0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))':
     dependencies:
       '@cloudflare/workers-types': 4.20260503.1
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -20184,7 +20210,7 @@ snapshots:
       scule: 1.3.0
       std-env: 3.10.0
       tinyglobby: 0.2.17
-      tsdown: 0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      tsdown: 0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
       ufo: 1.6.4
       uncrypto: 0.1.3
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
@@ -20223,7 +20249,7 @@ snapshots:
       - uploadthing
       - vue-tsc
 
-  '@nuxthub/core@0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))':
+  '@nuxthub/core@0.10.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))':
     dependencies:
       '@cloudflare/workers-types': 4.20260503.1
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -20245,7 +20271,7 @@ snapshots:
       scule: 1.3.0
       std-env: 3.10.0
       tinyglobby: 0.2.17
-      tsdown: 0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
+      tsdown: 0.18.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
       ufo: 1.6.4
       uncrypto: 0.1.3
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
@@ -20294,7 +20320,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/i18n@10.4.1(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(esbuild@0.28.0)(eslint@9.39.5(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))':
+  '@nuxtjs/i18n@10.4.1(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(esbuild@0.28.0)(eslint@9.39.5(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@intlify/core': 11.4.0
       '@intlify/h3': 0.7.4
@@ -20317,11 +20343,11 @@ snapshots:
       oxc-walker: 0.7.0(oxc-parser@0.128.0)
       pathe: 2.0.3
       ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unrouting: 0.1.7
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       vue-i18n: 11.4.0(vue@3.5.33(typescript@6.0.3))
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -20488,15 +20514,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nuxtjs/robots@6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/robots@6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -20509,14 +20535,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/sitemap@8.2.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
+  '@nuxtjs/sitemap@8.2.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.10.0
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -20851,7 +20877,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-minify/binding-win32-arm64-msvc@0.128.0':
@@ -20963,7 +20989,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.135.0':
@@ -20999,9 +21025,9 @@ snapshots:
 
   '@oxc-project/types@0.135.0': {}
 
-  '@oxc-project/types@0.138.0': {}
-
   '@oxc-project/types@0.139.0': {}
+
+  '@oxc-project/types@0.140.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.128.0':
     optional: true
@@ -21055,7 +21081,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-transform/binding-win32-arm64-msvc@0.128.0':
@@ -21111,7 +21137,7 @@ snapshots:
   '@parcel/watcher-wasm@2.5.6':
     dependencies:
       is-glob: 4.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
@@ -21127,7 +21153,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -22195,10 +22221,10 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.1.4':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
@@ -22207,10 +22233,10 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.57':
@@ -22219,10 +22245,10 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.4':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.0':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
@@ -22231,10 +22257,10 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
@@ -22243,10 +22269,10 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
@@ -22255,10 +22281,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
@@ -22267,28 +22293,28 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
@@ -22297,10 +22323,10 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
@@ -22309,10 +22335,10 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.0':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
@@ -22321,15 +22347,23 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -22342,18 +22376,18 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
+  '@rolldown/binding-wasm32-wasi@1.2.0':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57':
@@ -22362,10 +22396,10 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
@@ -22374,10 +22408,10 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.40': {}
@@ -22387,8 +22421,6 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -22407,10 +22439,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.2
 
@@ -22419,10 +22451,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.2
 
@@ -22477,7 +22509,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.2
 
@@ -22937,6 +22969,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
   '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.2)
@@ -22969,10 +23005,10 @@ snapshots:
   '@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@types/cookie': 0.6.0
-      acorn: 8.16.0
+      acorn: 8.17.0
       cookie: 0.6.0
       devalue: 5.8.1
       esm-env: 1.2.2
@@ -22991,10 +23027,10 @@ snapshots:
   '@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@types/cookie': 0.6.0
-      acorn: 8.16.0
+      acorn: 8.17.0
       cookie: 0.6.0
       devalue: 5.8.1
       esm-env: 1.2.2
@@ -23891,9 +23927,9 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-      ansis: 4.2.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      ansis: 4.3.1
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
@@ -23922,7 +23958,7 @@ snapshots:
       '@tanstack/router-core': 1.169.1
       '@tanstack/start-fn-stubs': 1.161.6
       '@tanstack/start-storage-context': 1.166.34
-      seroval: 1.5.2
+      seroval: 1.5.5
 
   '@tanstack/start-client-core@1.170.14':
     dependencies:
@@ -23939,7 +23975,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.169.1
       '@tanstack/router-generator': 1.166.39
@@ -23951,8 +23987,8 @@ snapshots:
       exsolve: 1.1.0
       lightningcss: 1.32.0
       pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.2
+      picomatch: 4.0.5
+      seroval: 1.5.5
       source-map: 0.7.6
       srvx: 0.11.22
       tinyglobby: 0.2.17
@@ -23973,7 +24009,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.169.1
       '@tanstack/router-generator': 1.166.39
@@ -23985,8 +24021,8 @@ snapshots:
       exsolve: 1.1.0
       lightningcss: 1.32.0
       pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.2
+      picomatch: 4.0.5
+      seroval: 1.5.5
       source-map: 0.7.6
       srvx: 0.11.22
       tinyglobby: 0.2.17
@@ -24008,7 +24044,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.169.1
       '@tanstack/router-generator': 1.166.39
@@ -24020,8 +24056,8 @@ snapshots:
       exsolve: 1.1.0
       lightningcss: 1.32.0
       pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.2
+      picomatch: 4.0.5
+      seroval: 1.5.5
       source-map: 0.7.6
       srvx: 0.11.22
       tinyglobby: 0.2.17
@@ -24047,7 +24083,7 @@ snapshots:
       '@tanstack/start-storage-context': 1.166.34
       fetchdts: 0.1.7
       h3-v2: h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.11.22))
-      seroval: 1.5.2
+      seroval: 1.5.5
     transitivePeerDependencies:
       - crossws
     optional: true
@@ -24060,7 +24096,7 @@ snapshots:
       '@tanstack/start-storage-context': 1.166.34
       fetchdts: 0.1.7
       h3-v2: h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.8.16))
-      seroval: 1.5.2
+      seroval: 1.5.5
     transitivePeerDependencies:
       - crossws
 
@@ -24356,11 +24392,6 @@ snapshots:
   '@turbo/windows-arm64@2.10.5':
     optional: true
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -24368,24 +24399,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -24743,7 +24774,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -24861,20 +24892,20 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      nuxt: 4.4.4(08f8f26771505e5846e0a46912d513e5)
+      nuxt: 4.4.4(335d0e596a2dfa339194289c407e4463)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -24888,28 +24919,28 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.2.2(@ai-sdk/mcp@1.0.62(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.23(2920a4d4c7ac0a3829fa8cc6bb9c6d37))(eve@0.12.3(4debaf7e0b4c4c3fc4147c98427f633a))':
+  '@vercel/connect@0.2.2(@ai-sdk/mcp@1.0.62(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(better-auth@1.6.23(2920a4d4c7ac0a3829fa8cc6bb9c6d37))(eve@0.12.3(a476a191091068fb5f2b9f2404ce5bbd))':
     dependencies:
       '@vercel/oidc': 3.6.1
     optionalDependencies:
       '@ai-sdk/mcp': 1.0.62(zod@4.4.3)
       ai: 7.0.15(zod@4.4.3)
       better-auth: 1.6.23(2920a4d4c7ac0a3829fa8cc6bb9c6d37)
-      eve: 0.12.3(4debaf7e0b4c4c3fc4147c98427f633a)
+      eve: 0.12.3(a476a191091068fb5f2b9f2404ce5bbd)
 
   '@vercel/nft@1.5.0(rollup@4.60.2)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
       glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -24924,11 +24955,11 @@ snapshots:
       '@vercel/cli-exec': 0.1.1
       jose: 5.10.0
 
-  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(react@19.2.6)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vue: 3.5.33(typescript@6.0.3)
@@ -24994,7 +25025,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.18
+      '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.33(typescript@5.9.3)
@@ -25007,7 +25038,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.18
+      '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vue: 3.5.33(typescript@6.0.3)
@@ -25019,7 +25050,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.18
+      '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.33(typescript@5.9.3)
@@ -25031,7 +25062,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.18
+      '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.33(typescript@6.0.3)
@@ -25077,9 +25108,9 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.1.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
 
@@ -25091,9 +25122,9 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.1.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.6)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
     optional: true
@@ -25211,7 +25242,7 @@ snapshots:
 
   '@vue-macros/common@3.1.2(vue@3.5.33(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.33
+      '@vue/compiler-sfc': 3.5.39
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -25221,7 +25252,7 @@ snapshots:
 
   '@vue-macros/common@3.1.2(vue@3.5.33(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.33
+      '@vue/compiler-sfc': 3.5.39
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -25286,7 +25317,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.33':
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.5.33
       '@vue/compiler-dom': 3.5.33
       '@vue/compiler-ssr': 3.5.33
@@ -25361,12 +25392,12 @@ snapshots:
   '@vue/language-core@3.2.7':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
-      alien-signals: 3.1.2
+      alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@vue/language-core@3.3.7':
     dependencies:
@@ -25543,9 +25574,9 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -25640,8 +25671,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alien-signals@3.1.2: {}
-
   alien-signals@3.2.1: {}
 
   angular-html-parser@10.4.0: {}
@@ -25661,8 +25690,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
-
-  ansis@4.2.0: {}
 
   ansis@4.3.1: {}
 
@@ -25729,7 +25756,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
 
   ast-types@0.16.1:
@@ -25749,8 +25776,8 @@ snapshots:
 
   ast-walker-scope@0.9.0:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       ast-kit: 2.2.0
 
   astring@1.9.0: {}
@@ -25831,7 +25858,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       html-entities: 2.3.3
       parse5: 7.3.0
 
@@ -26942,7 +26969,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docus@5.12.3(712d4b5d4bd0715e41025aa5916be48e):
+  docus@5.12.3(9ae62989b0983a6059a9112b4875a8d1):
     dependencies:
       '@ai-sdk/gateway': 3.0.134(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.62(zod@4.4.3)
@@ -26951,14 +26978,14 @@ snapshots:
       '@iconify-json/lucide': 1.2.117
       '@iconify-json/simple-icons': 1.2.90
       '@iconify-json/vscode-icons': 1.2.67
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(valibot@1.3.1(typescript@6.0.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/image': 2.0.0(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(magicast@0.5.3)(srvx@0.11.22)
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/ui': 4.10.0(cd65fc90423797eec0febd015f329066)
-      '@nuxtjs/i18n': 10.4.1(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(esbuild@0.28.0)(eslint@9.39.5(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rolldown@1.1.5)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/ui': 4.10.0(1a7122ab616755b849382195a594c78d)
+      '@nuxtjs/i18n': 10.4.1(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(esbuild@0.28.0)(eslint@9.39.5(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
       '@nuxtjs/mcp-toolkit': 0.18.0(@vue/compiler-sfc@3.5.33)(h3@1.15.11)(magicast@0.5.3)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       '@nuxtjs/mdc': 0.22.1(magicast@0.5.3)
-      '@nuxtjs/robots': 6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/robots': 6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       '@shikijs/core': 4.3.1
       '@shikijs/engine-javascript': 4.3.1
       '@shikijs/langs': 4.3.1
@@ -26972,9 +26999,9 @@ snapshots:
       exsolve: 1.1.0
       git-url-parse: 16.1.0
       motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.33(typescript@6.0.3))
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nuxt-llms: 0.2.0(magicast@0.5.3)
-      nuxt-og-image: 6.6.0(670840bb62f311577044e2fe83597918)
+      nuxt-og-image: 6.6.0(ce24a13652e905711afcc933b4ff6d4d)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -27266,8 +27293,6 @@ snapshots:
 
   emoticon@4.1.0: {}
 
-  empathic@2.0.0: {}
-
   empathic@2.0.1: {}
 
   enabled@2.0.0: {}
@@ -27519,7 +27544,7 @@ snapshots:
   eslint-compat-utils@0.6.5(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)
-      semver: 7.8.1
+      semver: 7.8.5
 
   eslint-config-flat-gitignore@0.3.0(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
@@ -27554,7 +27579,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
@@ -27573,7 +27598,7 @@ snapshots:
       espree: 10.4.0
       esquery: 1.7.0
       parse-imports-exports: 0.2.4
-      semver: 7.8.1
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -27587,7 +27612,7 @@ snapshots:
       eslint-fix-utils: 0.2.1(@types/estree@1.0.8)(eslint@9.39.5(jiti@2.7.0))
       jsonc-eslint-parser: 2.4.2
       package-json-validator: 0.10.2
-      semver: 7.8.1
+      semver: 7.8.5
       sort-object-keys: 1.1.3
       sort-package-json: 3.6.1
       validate-npm-package-name: 6.0.2
@@ -27612,7 +27637,7 @@ snapshots:
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
-      semver: 7.8.1
+      semver: 7.8.5
       vue-eslint-parser: 9.4.3(eslint@9.39.5(jiti@2.7.0))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
@@ -27733,7 +27758,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.12.3(4debaf7e0b4c4c3fc4147c98427f633a):
+  eve@0.12.3(a476a191091068fb5f2b9f2404ce5bbd):
     dependencies:
       ai: 7.0.15(zod@4.4.3)
       nitro: 3.0.260610-beta(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -27741,7 +27766,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@sveltejs/kit': 2.69.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3)
+      nuxt: 4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e)
       react: 19.2.6
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
       vite: 8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
@@ -28079,7 +28104,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       toad-cache: 3.7.0
 
   fastify@5.8.5:
@@ -28107,6 +28132,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fecha@4.2.3: {}
 
@@ -28877,12 +28906,12 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
-  impound@1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  impound@1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.1.0
       pathe: 2.0.3
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -28895,12 +28924,12 @@ snapshots:
       - vite
       - webpack
 
-  impound@1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  impound@1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.1.0
       pathe: 2.0.3
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -28914,12 +28943,12 @@ snapshots:
       - webpack
     optional: true
 
-  impound@1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  impound@1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.1.0
       pathe: 2.0.3
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -29236,7 +29265,7 @@ snapshots:
       acorn: 8.16.0
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -29393,7 +29422,7 @@ snapshots:
       mlly: 1.8.2
       node-forge: 1.4.0
       pathe: 2.0.3
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyclip: 0.1.12
       ufo: 1.6.4
       untun: 0.1.3
@@ -29416,7 +29445,7 @@ snapshots:
       mlly: 1.8.2
       node-forge: 1.4.0
       pathe: 2.0.3
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyclip: 0.1.12
       ufo: 1.6.4
       untun: 0.1.3
@@ -29439,7 +29468,7 @@ snapshots:
       mlly: 1.8.2
       node-forge: 1.4.0
       pathe: 2.0.3
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinyclip: 0.1.12
       ufo: 1.6.4
       untun: 0.1.3
@@ -29534,12 +29563,12 @@ snapshots:
       ufo: 1.6.4
       unplugin: 2.3.11
 
-  magic-regexp@0.11.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  magic-regexp@0.11.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       magic-string: 0.30.21
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -29577,13 +29606,13 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   markdown-exit@1.0.0-beta.9:
     dependencies:
@@ -30220,7 +30249,7 @@ snapshots:
       pkg-types: 2.3.1
       postcss: 8.5.19
       postcss-nested: 7.0.2(postcss@8.5.19)
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 6.0.3
@@ -30443,7 +30472,7 @@ snapshots:
 
   nf3@0.3.17: {}
 
-  nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.1.5)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
+  nitro-nightly@4.0.0-20251010-091516-7cafddba(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(chokidar@4.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.2.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.1
@@ -30463,7 +30492,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
     optionalDependencies:
-      rolldown: 1.1.5
+      rolldown: 1.2.0
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -30506,7 +30535,7 @@ snapshots:
       ocache: 0.1.4
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.4
+      rolldown: 1.1.5
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
@@ -30559,7 +30588,7 @@ snapshots:
       ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.4
+      rolldown: 1.2.0
       srvx: 0.11.16
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
@@ -30613,7 +30642,7 @@ snapshots:
       ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.1.4
+      rolldown: 1.2.0
       srvx: 0.11.16
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(ofetch@2.0.0-alpha.3)
@@ -30655,7 +30684,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -30667,7 +30696,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -30695,7 +30724,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -30708,19 +30737,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -30766,7 +30795,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -30778,7 +30807,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -30806,7 +30835,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0(srvx@0.11.15)
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -30819,19 +30848,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -30877,7 +30906,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -30889,7 +30918,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -30917,7 +30946,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0(srvx@0.11.22)
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -30930,19 +30959,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -30989,7 +31018,7 @@ snapshots:
       - webpack
     optional: true
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -31001,7 +31030,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -31029,7 +31058,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0(srvx@0.11.22)
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -31042,19 +31071,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -31100,7 +31129,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -31112,7 +31141,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -31140,7 +31169,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -31153,19 +31182,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -31211,7 +31240,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.1.5)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.2.0)(srvx@0.11.15)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -31223,7 +31252,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -31251,7 +31280,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0(srvx@0.11.15)
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -31264,19 +31293,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -31322,7 +31351,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  nitropack@2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.135.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -31334,7 +31363,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -31362,7 +31391,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0(srvx@0.11.22)
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -31375,19 +31404,19 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.0)(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -31445,7 +31474,7 @@ snapshots:
       '@rollup/plugin-terser': 1.0.0(rollup@4.60.2)
       '@vercel/nft': 1.5.0(rollup@4.60.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
       citty: 0.2.2
       compatx: 0.2.0
@@ -31473,7 +31502,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.10.0
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mime: 4.1.0
       mlly: 1.8.2
       node-fetch-native: 1.6.7
@@ -31488,11 +31517,11 @@ snapshots:
       rollup: 4.60.2
       rollup-plugin-visualizer: 7.0.1(rollup@4.60.2)
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
-      std-env: 4.1.0
+      std-env: 4.2.0
       ufo: 1.6.4
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
@@ -31546,7 +31575,7 @@ snapshots:
 
   node-abi@3.90.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   node-addon-api@7.1.1: {}
 
@@ -31615,7 +31644,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.6.0(670840bb62f311577044e2fe83597918):
+  nuxt-og-image@6.6.0(ce24a13652e905711afcc933b4ff6d4d):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -31633,13 +31662,13 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
       oxc-parser: 0.135.0
-      oxc-walker: 1.0.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      oxc-walker: 1.0.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       pathe: 2.0.3
       pkg-types: 2.3.1
       radix3: 1.1.2
@@ -31649,13 +31678,13 @@ snapshots:
       tinyglobby: 0.2.17
       ufo: 1.6.4
       ultrahtml: 1.6.0
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
     optionalDependencies:
       '@resvg/resvg-js': 2.6.2
       '@takumi-rs/core': 1.8.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fontless: 0.2.1(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(ioredis@5.10.1)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      nitropack: 2.13.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(oxc-parser@0.128.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       satori: 0.28.0
       sharp: 0.34.5
       tailwindcss: 4.3.2
@@ -31696,12 +31725,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.3)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
@@ -31714,13 +31743,13 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.1(magicast@0.5.3)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.1(vue@3.5.33(typescript@6.0.3))
@@ -31733,13 +31762,13 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.1(magicast@0.5.3)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.1(vue@3.5.33(typescript@6.0.3))
@@ -31797,16 +31826,16 @@ snapshots:
       - uploadthing
       - vue
 
-  nuxt@4.4.4(024eba7bfbd65691ad53cfb6faad2378):
+  nuxt@4.4.4(335d0e596a2dfa339194289c407e4463):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(024eba7bfbd65691ad53cfb6faad2378))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.15)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(024eba7bfbd65691ad53cfb6faad2378))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -31820,7 +31849,7 @@ snapshots:
       exsolve: 1.0.8
       hookable: 6.1.1
       ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       jiti: 2.6.1
       klona: 2.0.6
       knitwork: 1.3.0
@@ -31848,12 +31877,12 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.33(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.5
@@ -31933,16 +31962,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5):
+  nuxt@4.4.4(486678913684595740bdc5ec9f676aaa):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -31956,7 +31985,7 @@ snapshots:
       exsolve: 1.0.8
       hookable: 6.1.1
       ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       jiti: 2.6.1
       klona: 2.0.6
       knitwork: 1.3.0
@@ -31984,12 +32013,12 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.33(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.5
@@ -32069,16 +32098,288 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3):
+  nuxt@4.4.4(512e987a24fc82a9489273c38391af0e):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
+      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
+      '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(512e987a24fc82a9489273c38391af0e))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/schema': 4.4.4
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(512e987a24fc82a9489273c38391af0e))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.128.0
+      oxc-parser: 0.128.0
+      oxc-transform: 0.128.0
+      oxc-walker: 0.7.0(oxc-parser@0.128.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.33(typescript@6.0.3)
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.9.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.4.4(5ad9f9faf84cf7851733c29a2cc90662):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
+      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
+      '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(5ad9f9faf84cf7851733c29a2cc90662))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.15)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/schema': 4.4.4
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(5ad9f9faf84cf7851733c29a2cc90662))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
+      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
+      '@vue/shared': 3.5.33
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.128.0
+      oxc-parser: 0.128.0
+      oxc-transform: 0.128.0
+      oxc-walker: 0.7.0(oxc-parser@0.128.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.33(typescript@6.0.3)
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.9.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e))(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(12bae51b94aa2e8144c9a2d3641a7cf3))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.3.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.17)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(8adf110bee3b164e3e10fb0bf41e6e4e))(optionator@0.9.4)(rolldown@1.2.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.3.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@5.9.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -32092,7 +32393,7 @@ snapshots:
       exsolve: 1.0.8
       hookable: 6.1.1
       ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       jiti: 2.6.1
       klona: 2.0.6
       knitwork: 1.3.0
@@ -32120,12 +32421,12 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.33(typescript@5.9.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 22.19.17
@@ -32206,152 +32507,16 @@ snapshots:
       - yaml
     optional: true
 
-  nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb):
-    dependencies:
-      '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      '@nuxt/schema': 4.4.4
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.8.4)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.7
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.1
-      ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.6
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.128.0
-      oxc-parser: 0.128.0
-      oxc-transform: 0.128.0
-      oxc-walker: 0.7.0(oxc-parser@0.128.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.33(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.9.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxt@4.4.4(ec65edef976a632117fd4193e516298c):
+  nuxt@4.4.4(e403bae20d047df41dab5a20e9a2f8eb):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(ec65edef976a632117fd4193e516298c))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(e403bae20d047df41dab5a20e9a2f8eb))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(typescript@5.9.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(ec65edef976a632117fd4193e516298c))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(e403bae20d047df41dab5a20e9a2f8eb))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@5.9.3))
       '@vue/shared': 3.5.33
       chokidar: 5.0.0
@@ -32365,7 +32530,7 @@ snapshots:
       exsolve: 1.0.8
       hookable: 6.1.1
       ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       jiti: 2.6.1
       klona: 2.0.6
       knitwork: 1.3.0
@@ -32393,12 +32558,12 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.33(typescript@5.9.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.5
@@ -32478,143 +32643,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.4(f1fffd6ba4797b39e7156a553959e323):
-    dependencies:
-      '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17))(esbuild@0.28.0)(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(f1fffd6ba4797b39e7156a553959e323))(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(srvx@0.11.22)(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      '@nuxt/schema': 4.4.4
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.5)(eslint@9.39.5(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(f1fffd6ba4797b39e7156a553959e323))(optionator@0.9.4)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2))(rollup@4.60.2)(terser@5.46.2)(tsx@4.23.1)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.7
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.1
-      ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.6
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.128.0
-      oxc-parser: 0.128.0
-      oxc-transform: 0.128.0
-      oxc-walker: 0.7.0(oxc-parser@0.128.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.33(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.9.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -32623,7 +32652,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -32633,13 +32662,13 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
       - vite
 
-  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -32648,7 +32677,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nypm: 0.6.8
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -32659,13 +32688,13 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
       - vite
 
-  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
+  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76))(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -32674,7 +32703,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(08f8f26771505e5846e0a46912d513e5)
+      nuxt: 4.4.4(335d0e596a2dfa339194289c407e4463)
       nypm: 0.6.8
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -32685,13 +32714,13 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(08f8f26771505e5846e0a46912d513e5))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(335d0e596a2dfa339194289c407e4463))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - magicast
       - vite
 
-  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -32700,7 +32729,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(ec63090d65f1528e5b89c6da7032fbeb)
+      nuxt: 4.4.4(486678913684595740bdc5ec9f676aaa)
       nypm: 0.6.8
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -32711,7 +32740,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(ec63090d65f1528e5b89c6da7032fbeb))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(486678913684595740bdc5ec9f676aaa))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
@@ -32721,7 +32750,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
 
   nypm@0.6.8:
     dependencies:
@@ -32933,12 +32962,12 @@ snapshots:
       magic-regexp: 0.10.0
       oxc-parser: 0.128.0
 
-  oxc-walker@1.0.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  oxc-walker@1.0.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      magic-regexp: 0.11.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      magic-regexp: 0.11.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
       oxc-parser: 0.135.0
-      rolldown: 1.1.5
+      rolldown: 1.2.0
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -33978,7 +34007,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.3
@@ -33987,15 +34016,15 @@ snapshots:
       birpc: 4.0.0
       dts-resolver: 2.1.3
       get-tsconfig: 4.14.0
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      obug: 2.1.3
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.2.7(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3)):
+  rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.3
@@ -34004,8 +34033,8 @@ snapshots:
       birpc: 4.0.0
       dts-resolver: 2.1.3
       get-tsconfig: 4.14.0
-      obug: 2.1.1
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      obug: 2.1.3
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.2.7(typescript@6.0.3)
@@ -34027,7 +34056,7 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+  rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2):
     dependencies:
       '@oxc-project/types': 0.103.0
       '@rolldown/pluginutils': 1.0.0-beta.57
@@ -34042,7 +34071,29 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.57
       '@rolldown/binding-linux-x64-musl': 1.0.0-beta.57
       '@rolldown/binding-openharmony-arm64': 1.0.0-beta.57
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.57
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.57
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+    dependencies:
+      '@oxc-project/types': 0.103.0
+      '@rolldown/pluginutils': 1.0.0-beta.57
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.57
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.57
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.57
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.57
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.57
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.57
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.57
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.57
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.57
     transitivePeerDependencies:
@@ -34070,27 +34121,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rolldown@1.1.4:
-    dependencies:
-      '@oxc-project/types': 0.138.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.4
-      '@rolldown/binding-darwin-arm64': 1.1.4
-      '@rolldown/binding-darwin-x64': 1.1.4
-      '@rolldown/binding-freebsd-x64': 1.1.4
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
-      '@rolldown/binding-linux-arm64-gnu': 1.1.4
-      '@rolldown/binding-linux-arm64-musl': 1.1.4
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
-      '@rolldown/binding-linux-s390x-gnu': 1.1.4
-      '@rolldown/binding-linux-x64-gnu': 1.1.4
-      '@rolldown/binding-linux-x64-musl': 1.1.4
-      '@rolldown/binding-openharmony-arm64': 1.1.4
-      '@rolldown/binding-wasm32-wasi': 1.1.4
-      '@rolldown/binding-win32-arm64-msvc': 1.1.4
-      '@rolldown/binding-win32-x64-msvc': 1.1.4
-
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -34111,6 +34141,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.0:
+    dependencies:
+      '@oxc-project/types': 0.140.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
 
   rollup-plugin-dts@6.4.1(rollup@4.60.2)(typescript@6.0.3):
     dependencies:
@@ -34133,30 +34184,30 @@ snapshots:
     dependencies:
       rollup-plugin-inject: 3.0.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2):
     dependencies:
       open: 11.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       rollup: 4.60.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.60.2):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2):
     dependencies:
       open: 11.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.1.5
+      rolldown: 1.2.0
       rollup: 4.60.2
 
   rollup-plugin-visualizer@7.0.1(rollup@4.60.2):
     dependencies:
       open: 11.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
@@ -34379,7 +34430,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -34406,7 +34457,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -34602,14 +34653,14 @@ snapshots:
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.5
+      seroval-plugins: 1.5.5(seroval@1.5.5)
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       solid-js: 1.9.12
     transitivePeerDependencies:
       - supports-color
@@ -34632,7 +34683,7 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.2.1
       is-plain-obj: 4.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.17
 
@@ -34879,14 +34930,14 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
       '@types/estree': 1.0.8
       '@types/trusted-types': 2.0.7
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.8.0
+      devalue: 5.8.1
       esm-env: 1.2.2
       esrap: 2.2.5(@typescript-eslint/types@8.59.1)
       is-reference: 3.0.3
@@ -34987,7 +35038,7 @@ snapshots:
   terser@5.46.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -35079,20 +35130,20 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  tsdown@0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  tsdown@0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
     dependencies:
-      ansis: 4.2.0
+      ansis: 4.3.1
       cac: 6.7.14
       defu: 6.1.7
-      empathic: 2.0.0
+      empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.2.5
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      rolldown-plugin-dts: 0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
-      semver: 7.8.1
-      tinyexec: 1.1.2
+      obug: 2.1.3
+      picomatch: 4.0.5
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      rolldown-plugin-dts: 0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      semver: 7.8.5
+      tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -35108,20 +35159,20 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.18.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3)):
+  tsdown@0.18.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3)):
     dependencies:
-      ansis: 4.2.0
+      ansis: 4.3.1
       cac: 6.7.14
       defu: 6.1.7
-      empathic: 2.0.0
+      empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.2.5
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      rolldown-plugin-dts: 0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
-      semver: 7.8.1
-      tinyexec: 1.1.2
+      obug: 2.1.3
+      picomatch: 4.0.5
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      rolldown-plugin-dts: 0.20.0(rolldown@1.0.0-beta.57(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
+      semver: 7.8.5
+      tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -35304,7 +35355,7 @@ snapshots:
 
   unctx@2.5.0:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
@@ -35395,7 +35446,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
@@ -35403,21 +35454,21 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
-  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.2.1
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.128.0
@@ -35432,21 +35483,21 @@ snapshots:
       - vite
       - webpack
 
-  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.2.1
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.128.0
@@ -35462,21 +35513,21 @@ snapshots:
       - webpack
     optional: true
 
-  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.2.1
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.128.0
@@ -35491,21 +35542,21 @@ snapshots:
       - vite
       - webpack
 
-  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unimport@6.2.0(esbuild@0.28.0)(oxc-parser@0.135.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.2.1
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.135.0
@@ -35522,14 +35573,14 @@ snapshots:
 
   unimport@6.2.0(esbuild@0.28.0)(rollup@4.60.2)(vite@6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.2.1
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
@@ -35612,9 +35663,9 @@ snapshots:
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
+  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.1
@@ -35623,7 +35674,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
@@ -35643,7 +35694,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.17.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unplugin@3.0.0:
@@ -35652,44 +35703,44 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.0
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       rollup: 4.60.2
       vite: 8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
 
-  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.0
-      rolldown: 1.1.5
+      rolldown: 1.2.0
       rollup: 4.60.2
       vite: 8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
     optional: true
 
-  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.0
-      rolldown: 1.1.5
+      rolldown: 1.2.0
       rollup: 4.60.2
       vite: 8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
 
   unplugin@3.3.0(esbuild@0.28.0)(rollup@4.60.2)(vite@6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.0
@@ -36018,7 +36069,7 @@ snapshots:
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -36039,7 +36090,7 @@ snapshots:
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
@@ -36059,7 +36110,7 @@ snapshots:
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       vite: 7.3.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -36081,7 +36132,7 @@ snapshots:
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.17
@@ -36100,7 +36151,7 @@ snapshots:
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.17
@@ -36118,7 +36169,7 @@ snapshots:
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.17
@@ -36136,7 +36187,7 @@ snapshots:
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.17
@@ -36150,7 +36201,7 @@ snapshots:
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.4(magicast@0.5.3))(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      ansis: 4.2.0
+      ansis: 4.3.1
       debug: 4.4.3
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
@@ -36168,7 +36219,7 @@ snapshots:
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.4(magicast@0.5.3))(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      ansis: 4.2.0
+      ansis: 4.3.1
       debug: 4.4.3
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
@@ -36596,7 +36647,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.7.0
       lodash: 4.18.1
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -36608,7 +36659,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.33(typescript@6.0.3)
 
-  vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
+  vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@6.0.3))
@@ -36621,10 +36672,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@6.0.3)
       yaml: 2.8.4
@@ -36641,7 +36692,7 @@ snapshots:
       - vite
       - webpack
 
-  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3)):
+  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@5.9.3))
@@ -36654,10 +36705,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2))(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@5.9.3)
       yaml: 2.8.4
@@ -36674,7 +36725,7 @@ snapshots:
       - vite
       - webpack
 
-  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3)):
+  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@5.9.3))
@@ -36687,10 +36738,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@5.9.3)
       yaml: 2.8.4
@@ -36708,7 +36759,7 @@ snapshots:
       - webpack
     optional: true
 
-  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
+  vue-router@5.0.6(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@6.0.3))
@@ -36721,10 +36772,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@6.0.3)
       yaml: 2.8.4
@@ -36741,7 +36792,7 @@ snapshots:
       - vite
       - webpack
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.33)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@6.0.3))
@@ -36754,10 +36805,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@6.0.3)
       yaml: 2.9.0
@@ -36774,7 +36825,7 @@ snapshots:
       - unloader
       - webpack
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@6.0.3))
@@ -36787,10 +36838,10 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.1.5)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.4(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@6.0.3)
       yaml: 2.9.0
@@ -37023,7 +37074,7 @@ snapshots:
       '@oozcitak/dom': 2.0.2
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
## Summary
- Introduce `@evlog/cli` (binary `evlog`): citty command tree with registry under `commands/`, branded help + per-command header (gradient), opt-out via `--no-header` / `EVLOG_CLI_NO_HEADER`
- Ship `evlog doctor` (monorepo-aware: workspace root, hoist-aware `evlog` resolve, stack detect, `.evlog/logs`) and `evlog telemetry status|enable|disable` via `@evlog/telemetry`
- Register `cli` conventional-commit scope; include changeset for the first minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `evlog` CLI with `doctor` diagnostics and `telemetry` management.
  * Added branded help/banner and consistent headers with opt-out; supports `--debug` and `--json`.
  * Updated `doctor --json` to include environment details and JSON schema v2; improved output/exit-code behavior.
  * `telemetry status` now displays the telemetry data directory.
* **Documentation**
  * Added full CLI README and debug DX guidance.
* **Tests**
  * Added/expanded coverage for `doctor`, branding, output/UI/exit behavior, debug reporting, environment resolution, and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->