### PR TITLE
fix(nitro): stop wrapping streaming responses in the Nitro v3 response hook

### DIFF
--- a/.changeset/nitro-v3-streaming-responses.md
+++ b/.changeset/nitro-v3-streaming-responses.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix the Nitro v3 response hook breaking every streaming response (SSE, NDJSON, and `transfer-encoding: chunked` — which includes all tRPC v11 `httpBatchStreamLink` traffic). The hook locked the original response body via `getReader()` and assigned the wrapped response to `event.res`, which is a getter-only accessor on h3 v2, producing `Attempted to assign to readonly property` followed by `ReadableStream is locked` and a 500 for the client. Streaming responses now pass through untouched and the wide event is emitted at header time; stream-lifetime metrics are not observable from h3 v2's `onResponse` hook, which cannot replace the outgoing response.

--- a/packages/evlog/src/nitro-v3/plugin.ts
+++ b/packages/evlog/src/nitro-v3/plugin.ts
@@ -10,7 +10,6 @@ import { shouldLog, getServiceForPath, extractErrorStatus } from '../nitro'
 import { extendDeferredDrain } from '../nitro/deferred-drain'
 import { normalizeRedactConfig } from '../redact'
 import { resolveEvlogConfigForNitroPlugin, setActiveNitroRuntime } from '../shared/nitroConfigBridge'
-import { bindStreamingResponseLifecycle, shouldDeferEmitForResponse } from '../shared/streamResponse'
 import type { EnrichContext, RequestLogger, TailSamplingContext, WideEvent } from '../types'
 import { filterSafeHeaders } from '../utils'
 
@@ -269,19 +268,12 @@ export default definePlugin(async (nitroApp) => {
       await callEnrichAndDrain(hooks, emittedEvent, event, res)
     }
 
-    if (shouldDeferEmitForResponse(res)) {
-      const wrapped = bindStreamingResponseLifecycle(res, async (meta) => {
-        if (meta.error) {
-          log.error(meta.error)
-        }
-        await emitSuccessResponse(meta.status ?? res.status)
-      })
-      if (wrapped !== res && 'res' in event) {
-        (event as { res: Response }).res = wrapped
-      }
-      return
-    }
-
+    // Streaming responses (SSE, NDJSON, chunked) emit at header time: h3 v2's
+    // `onResponse` hook cannot swap the outgoing response (`H3Event.res` is a
+    // getter-only accessor, and `toResponse` sends the original response no
+    // matter what the hook does), so wrapping the body here would only lock the
+    // original stream and break the response. Stream-lifetime metrics are not
+    // observable from this hook.
     await emitSuccessResponse(res.status)
   })
 

--- a/packages/evlog/test/nitro-v3/fixture/routes/stream.ts
+++ b/packages/evlog/test/nitro-v3/fixture/routes/stream.ts
@@ -1,0 +1,21 @@
+import { defineHandler } from 'nitro/h3'
+import { useLogger } from 'evlog'
+
+export default defineHandler((event) => {
+  const log = useLogger(event)
+
+  log.set({ stream: { kind: 'sse' } })
+
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('data: one\n\n'))
+      controller.enqueue(encoder.encode('data: two\n\n'))
+      controller.close()
+    },
+  })
+
+  return new Response(body, {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+})

--- a/packages/evlog/test/nitro-v3/nitro-v3.test.ts
+++ b/packages/evlog/test/nitro-v3/nitro-v3.test.ts
@@ -90,6 +90,39 @@ describe.sequential('Nitro v3 Server with evlog', () => {
     }
   })
 
+  it.sequential('should pass streaming responses through and emit at header time', async () => {
+    const logs: any[] = []
+    const mockFn = vi.fn((context) => {
+      logs.push(String(context))
+    })
+
+    consola.mockTypes((typeName, type) => mockFn)
+    consola.wrapAll()
+
+    try {
+      const res = await server.fetch(new Request(new URL('/stream', server.url)))
+
+      expect(res.status).toBe(200)
+
+      // The plugin must not lock, wrap, or replace the streaming body
+      const text = await res.text()
+      expect(text).toContain('data: one')
+      expect(text).toContain('data: two')
+
+      // Wait for async logs to be written
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      expect(mockFn).toHaveBeenCalled()
+      const logOutput = logs.join('\n')
+
+      expect(logOutput).toMatch(/INFO.*GET \/stream.*200/)
+      expect(logOutput).toContain('stream:')
+      expect(logOutput).toContain('kind=sse')
+    } finally {
+      consola.restoreAll()
+    }
+  })
+
   it.sequential('should handle structured errors correctly', async () => {
     const logs: any[] = []
     const mockFn = vi.fn((context) => {

--- a/packages/evlog/test/nitro-v3/nitro-v3.test.ts
+++ b/packages/evlog/test/nitro-v3/nitro-v3.test.ts
@@ -109,13 +109,13 @@ describe.sequential('Nitro v3 Server with evlog', () => {
       expect(text).toContain('data: one')
       expect(text).toContain('data: two')
 
-      // Wait for async logs to be written
-      await new Promise(resolve => setTimeout(resolve, 100))
+      // Wait for the async log write deterministically instead of sleeping
+      await vi.waitFor(
+        () => expect(logs.join('\n')).toMatch(/INFO.*GET \/stream.*200/),
+        { timeout: 1000, interval: 5 },
+      )
 
-      expect(mockFn).toHaveBeenCalled()
       const logOutput = logs.join('\n')
-
-      expect(logOutput).toMatch(/INFO.*GET \/stream.*200/)
       expect(logOutput).toContain('stream:')
       expect(logOutput).toContain('kind=sse')
     } finally {


### PR DESCRIPTION
Fixes #432

The Nitro v3 response hook breaks every streaming response (SSE, NDJSON, `transfer-encoding: chunked` — including all tRPC v11 `httpBatchStreamLink` traffic). Full root-cause analysis in the issue; short version: `bindStreamingResponseLifecycle` locks the original body via `getReader()`, the `event.res = wrapped` assignment throws because h3 v2's `H3Event.res` is getter-only, and even a successful assignment would be discarded since h3 v2's `toResponse` sends the original response regardless of the `onResponse` hook. The client gets a 500 (`Attempted to assign to readonly property`, then `ReadableStream is locked`).

### Changes

- `src/nitro-v3/plugin.ts`: remove the wrap-and-observe branch, always emit at header time, never touch the body. `bindStreamingResponseLifecycle` itself is untouched — other integrations use it where they legitimately own the Response.
- `test/nitro-v3/fixture/routes/stream.ts` + regression test: an SSE route must return 200 with a readable body and emit the wide event. Fails on `main` (500), passes with this change.
- Changeset (patch).

### Tradeoffs

- Wide events for streaming responses record time-to-headers, not stream lifetime; mid-stream errors/cancellations are not captured in the request event. Nothing working regresses — the current behavior is a 500.
- `log.set()` calls made while the body streams (tRPC operation results, AI SDK usage at stream end) now land after emission and are dropped with the existing late-set warning. You may want to dedupe that warning or document the limitation for streaming routes.
- Proper stream-end observation on Nitro v3 likely needs a layer that owns the Response (srvx middleware / fetch wrapper) rather than the h3 `onResponse` hook — happy to discuss as a follow-up.

### Verification

- New regression test fails on `main`, passes here; full `packages/evlog` suite: 1570 passed, the one failure (`test/nuxt/auto-import-types.test.ts`) fails identically on pristine `main`.
- `pnpm --filter evlog run build` passes; eslint on changed files: 0 errors.
- Verified in a real app (nitro `3.0.260610-beta`, h3 `2.0.1-rc.22`, bun 1.3.14, tRPC `httpBatchStreamLink`): the equivalent dist patch takes every tRPC request from 500 to 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Nitro v3 response-hook handling for streaming responses, including SSE, NDJSON, `transfer-encoding: chunked`, and compatible tRPC streaming.
  * Streaming responses now pass through without server errors or locked streams.
  * Request logging is emitted when streaming headers are sent (at header time).

* **Tests**
  * Added a Nitro v3 test covering SSE streaming delivery and verifying the expected logging metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->