### PR TITLE
fix(next): thread redact through createInstrumentation().register()

### DIFF
--- a/.changeset/fix-next-instrumentation-redact.md
+++ b/.changeset/fix-next-instrumentation-redact.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+fix(next): thread `redact` through `createInstrumentation().register()` — it previously re-initialised the logger without redaction and locked it, silently disabling `redact` configured for the Next.js instrumentation path

--- a/packages/evlog/src/next/instrumentation-create.ts
+++ b/packages/evlog/src/next/instrumentation-create.ts
@@ -1,5 +1,5 @@
 import { registerDiskPrettyErrorSnippetReader } from '../shared/register-disk-snippet'
-import type { DrainContext, EnvironmentContext, LogLevel, Log, SamplingConfig } from '../types'
+import type { DrainContext, EnvironmentContext, LogLevel, Log, RedactConfig, SamplingConfig } from '../types'
 import type {
   NextInstrumentationErrorContext,
   NextInstrumentationRequest,
@@ -58,6 +58,8 @@ export interface InstrumentationOptions {
   stringify?: boolean
   /** Drain callback called with every emitted event. */
   drain?: (ctx: DrainContext) => void | Promise<void>
+  /** Auto-redaction configuration for PII protection. @default true in production */
+  redact?: boolean | RedactConfig
   /** Capture stdout/stderr as structured log events (Node.js only). */
   captureOutput?: boolean | CaptureOutputOptions
 }
@@ -204,6 +206,7 @@ export function createInstrumentation(options: InstrumentationOptions = {}): Ins
         minLevel: options.minLevel,
         stringify: options.stringify,
         drain: options.drain,
+        redact: options.redact,
       })
       lockLogger()
       if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/packages/evlog/test/next/instrumentation.test.ts
+++ b/packages/evlog/test/next/instrumentation.test.ts
@@ -81,6 +81,7 @@ describe('createInstrumentation', () => {
       drain: drainMock,
       sampling: { rates: { info: 50 } },
       stringify: false,
+      redact: { paths: ['error.message', 'error.cause'] },
     })
 
     await runRegister(register)
@@ -93,6 +94,7 @@ describe('createInstrumentation', () => {
     expect(config.drain).toBe(drainMock)
     expect(config.sampling).toEqual({ rates: { info: 50 } })
     expect(config.stringify).toBe(false)
+    expect(config.redact).toEqual({ paths: ['error.message', 'error.cause'] })
   })
 
   it('register() with captureOutput patches stdout and stderr', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #441

### 📚 Description

`register()` in `next/instrumentation-create.ts` re-initialises the global logger without threading `options.redact` and then calls `lockLogger()` — so with the documented Next.js setup (`createEvlog({ redact })` + the instrumentation module loading at boot), redaction configured at import is silently wiped once `register()` runs, and errors reach drains unredacted.

Next-only: the handler path threads `redact` since #409, and both nitro plugins pass it — this was the last init path missing it.

Changes:
- `redact` added to `InstrumentationOptions` (same `boolean | RedactConfig` shape as `NextEvlogOptions`; raw pass-through like the handler path — the logger resolves it internally).
- Threaded in `register()`'s `initLogger` call.
- Regression test on the existing `initLogger` spy (fails on `main`).
- Changeset (patch).

`vitest run test/next/instrumentation.test.ts` → 24/24; `pnpm --filter evlog run build` clean.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. <!-- no docs change needed: docs already describe redact as working for the Next.js setup; this makes the instrumentation path match them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring automatic PII redaction in Next.js instrumentation via a new `redact` option (boolean or custom config).

- **Bug Fixes**
  - Fixed an issue where the configured `redact` settings were not honored during instrumentation registration, resulting in redaction being silently ignored.

- **Tests**
  - Added a regression test to confirm custom redaction paths are correctly applied when instrumentation is registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->