### PR TITLE
fix(telemetry): drop permanently-rejected outbox batches instead of retrying forever

### DIFF
--- a/.changeset/drop-poisoned-telemetry-batches.md
+++ b/.changeset/drop-poisoned-telemetry-batches.md
@@ -1,0 +1,5 @@
+---
+"@evlog/telemetry": patch
+---
+
+Fix the outbox getting permanently stuck when the ingest endpoint rejects a batch with a 4xx response (oversized batch, unknown tool, schema drift on older buffered events, etc.). Previously, any non-2xx response kept the batch buffered forever, and since the whole outbox is resent together on every run, one bad batch silently blocked all future telemetry for the tool. Batches rejected with 400/401/403/404 (anything but 429, which is treated as transient) are now dropped instead of retried indefinitely.

--- a/packages/telemetry/src/drain.ts
+++ b/packages/telemetry/src/drain.ts
@@ -2,7 +2,10 @@ import type { RunEvent } from './types'
 
 /**
  * Drain function that attempts delivery for buffered run events.
- * @returns `true` when at least one downstream sink reports successful delivery.
+ * @returns `true` when the batch should be removed from the outbox — either
+ * because it was delivered, or because the server permanently rejected it
+ * and retrying would never succeed. `false` keeps the batch buffered for a
+ * later, transient-failure retry (network error, timeout, 5xx, 429).
  */
 export type TelemetryDrain = (events: RunEvent[]) => Promise<boolean>
 
@@ -27,7 +30,7 @@ export function createDebugDrain(): TelemetryDrain {
   }
 }
 
-/** HTTP ingestion drain with timeout. Returns true when delivery succeeds. */
+/** HTTP ingestion drain with timeout. Returns true when the outbox should drop the batch. */
 export function createHttpDrain(endpoint: string, timeoutMs = 400): TelemetryDrain {
   return async (events) => {
     if (events.length === 0) return true
@@ -40,7 +43,16 @@ export function createHttpDrain(endpoint: string, timeoutMs = 400): TelemetryDra
         body: JSON.stringify({ events }),
         signal: controller.signal,
       })
-      return res.ok
+      if (res.ok) return true
+      // A 4xx (excluding 429, which is transient rate limiting) means the
+      // server permanently rejected this exact payload — an oversized batch,
+      // a schema it doesn't recognise, etc. Retrying identical bytes will
+      // never succeed, and leaving them in the outbox would silently poison
+      // it forever: every future run re-sends the same broken batch first,
+      // blocking all telemetry for this tool indefinitely. Drop it instead —
+      // losing one batch beats losing all of them.
+      if (res.status >= 400 && res.status < 500 && res.status !== 429) return true
+      return false
     } catch {
       return false
     } finally {

--- a/packages/telemetry/test/drain.test.ts
+++ b/packages/telemetry/test/drain.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createHttpDrain } from '../src/drain'
+import { exampleRunEvent } from '../src/disclosure'
+
+function mockFetch(status: number): void {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status })))
+}
+
+describe('createHttpDrain', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports delivered (drop from outbox) on a 2xx response', async () => {
+    mockFetch(204)
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([exampleRunEvent()])).resolves.toBe(true)
+  })
+
+  it('drops permanently-rejected batches on 400 instead of retrying forever', async () => {
+    // The exact failure mode this guards: a stale/oversized outbox batch
+    // that will never become valid by resending the same bytes — without
+    // this, it would block all future telemetry for the tool indefinitely.
+    mockFetch(400)
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([exampleRunEvent()])).resolves.toBe(true)
+  })
+
+  it('keeps retrying on 429 (rate limited)', async () => {
+    mockFetch(429)
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([exampleRunEvent()])).resolves.toBe(false)
+  })
+
+  it('keeps retrying on a 5xx server error', async () => {
+    mockFetch(500)
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([exampleRunEvent()])).resolves.toBe(false)
+  })
+
+  it('keeps retrying on a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([exampleRunEvent()])).resolves.toBe(false)
+  })
+
+  it('short-circuits on an empty batch without calling fetch', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const drain = createHttpDrain('http://example.test/ingest')
+    await expect(drain([])).resolves.toBe(true)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

The CLI telemetry outbox buffers events on disk and resends the *entire* pending batch together on every run. If the ingest endpoint rejects that batch with a non-2xx response for any reason, the old drain treated it as "keep retrying" — with no way to ever recover if the rejection was permanent (oversized batch, schema drift on old buffered events, unknown tool, etc.). That poisoned batch would then be resent first on every future run, blocking all telemetry for the tool indefinitely.

This was caught live: a local `evlog-cli` outbox had accumulated 89 events since testing began (including some missing a field added later), which combined to trip both `maxBatchSize` and payload validation on the deployed ingest endpoint — every subsequent command kept re-sending the same broken batch and getting a 400.

## Fix

`createHttpDrain` now distinguishes permanent rejection from transient failure:
- 2xx → delivered, drop from outbox (unchanged)
- 4xx except 429 → permanently rejected, drop from outbox (**new** — was previously kept forever)
- 429 / 5xx / network error / timeout → transient, keep for retry (unchanged)

## Testing

- `packages/telemetry/test/drain.test.ts` (new) — covers 2xx/400/429/5xx/network-error/empty-batch
- `pnpm turbo run lint typecheck test --filter=@evlog/telemetry --filter=evlog-telemetry` — all green
- Changeset included (patch, `@evlog/telemetry`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented permanently rejected telemetry batches from blocking future telemetry.
  * Batches receiving non-retryable 4xx responses are now discarded, while rate limits, server errors, and network failures remain eligible for retry.

* **Tests**
  * Added coverage for successful delivery, permanent rejections, transient failures, network errors, and empty batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->