### PR TITLE
ci: run @evlog/cli tests and publish it via pkg-pr-new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,20 @@ jobs:
       - name: Test + build (apps/telemetry)
         run: pnpm exec turbo run test build --filter=evlog-telemetry
 
+  cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Test (packages/cli)
+        run: pnpm exec turbo run test --filter=@evlog/cli
+
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -113,7 +127,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    needs: [lint, typecheck, test, telemetry, coverage]
+    needs: [lint, typecheck, test, telemetry, coverage, cli]
     permissions:
       contents: read
       pull-requests: write
@@ -133,4 +147,4 @@ jobs:
       - name: Build package
         run: pnpm run build:package
       - name: Publish
-        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub' './packages/telemetry'
+        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/evlog' './packages/nuxthub' './packages/telemetry' './packages/cli'


### PR DESCRIPTION
## Problem

`packages/cli` (`@evlog/cli`) has 15 test files / 84 tests, but nothing in `.github/workflows/` ran them:
- the `test` job only runs `vitest` inside `packages/evlog`
- the `publish` (pkg-pr-new) job only published `./packages/evlog`, `./packages/nuxthub`, `./packages/telemetry`

So the CLI had no CI test coverage and no PR preview install link.

## Fix

- add a dedicated `cli` job that runs `pnpm exec turbo run test --filter=@evlog/cli` (same pattern as the existing `telemetry` job)
- add `cli` to the `publish` job's `needs`
- add `./packages/cli` to the pkg-pr-new publish command

No changeset — internal CI config only, doesn't touch the published package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated testing for the CLI package as part of continuous integration.
  * Publishing now waits for CLI tests to complete successfully.

* **New Features**
  * The CLI package is now included in preview package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->