### PR TITLE
fix(repo): order the turbo tasks that share an output directory

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
   ],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "dev:prepare"],
       "outputs": [
         "dist/**",
         ".nuxt/**",
@@ -54,7 +54,7 @@
       ]
     },
     "dev:prepare": {
-      "dependsOn": ["^dev:prepare"],
+      "dependsOn": ["^dev:prepare", "^build"],
       "outputs": ["dist/**", ".nuxt/**", ".output/**"],
       "inputs": ["$TURBO_DEFAULT$", ".env", ".env.*"]
     },


### PR DESCRIPTION
`build` only depended on `^build` and `dev:prepare` only on `^dev:prepare`, so within one package `nuxt build` and `nuxt prepare` could run in parallel against the same `.nuxt` directory. On `evlog-telemetry` that races NuxtHub's schema generation and the telemetry job fails with `UNRESOLVED_ENTRY: Cannot resolve entry module .nuxt/hub/db/schema.entry.ts`, intermittently.

`build` now depends on its own `dev:prepare`, and `dev:prepare` on `^build`, so the two never overlap and an upstream package is always built before a downstream prepare.

Split out of #448. Internal only, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and development task sequencing for more reliable project preparation and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->