### PR TITLE
perf(core): cache iso timestamp prefix across emits

### DIFF
--- a/apps/docs/content/7.reference/2.performance.md
+++ b/apps/docs/content/7.reference/2.performance.md
@@ -75,7 +75,7 @@ The numbers above aren't magic, they come from deliberate architectural choices:
 
 **No serialization until drain.** Context stays as plain JavaScript objects throughout the request lifecycle. `JSON.stringify` runs exactly once, at emit time. Traditional loggers serialize on every `.info()` call, that's 4x serialization for 4 log lines.
 
-**Lazy allocation.** Timestamps, sampling context, and override objects are only created when actually needed. If tail sampling is disabled (the common case), its context object is never allocated. The `Date` instance used for ISO timestamps is reused across calls.
+**Lazy allocation.** Timestamps, sampling context, and override objects are only created when actually needed. If tail sampling is disabled (the common case), its context object is never allocated. ISO timestamps cache the formatted second-prefix and only append milliseconds on each call (invalidated on second rollover), so hot emit paths avoid re-running `toISOString()` every time.
 
 **One event, not N lines.** For a typical request, pino emits 4+ JSON lines that all need serializing, transporting, and indexing. evlog emits one. That's 75% less work for your log drain, fewer bytes on the wire, and one row to query instead of four.
 
@@ -103,10 +103,10 @@ For a typical API request:
 |-----------|-----:|
 | Logger creation | 52ns |
 | 3x `set()` calls | 105ns |
-| `emit()` | 588ns |
+| `emit()` | 400ns |
 | Sampling | 22ns |
 | Enricher pipeline | 2.14µs |
-| **Total** | **~2.9µs** |
+| **Total** | **~2.7µs** |
 
 For context, a database query takes 1-50ms, an HTTP call takes 10-500ms. evlog's overhead is **invisible**.
 
@@ -154,9 +154,9 @@ A typical Node.js bundle (`initLogger` + `createLogger`) measures **~6.3 kB gzip
 
 | Operation | ops/sec | Mean |
 |-----------|--------:|-----:|
-| Emit minimal event | 1.93M | 519ns |
-| Emit with context | 1.70M | 588ns |
-| Full lifecycle (create + 3 sets + emit) | 1.59M | 628ns |
+| Emit minimal event | 2.72M | 400ns |
+| Emit with context | 2.28M | 400ns |
+| Full lifecycle (create + 3 sets + emit) | 2.04M | 500ns |
 | Emit with error | 65.9K | 15.17µs |
 
 ::callout{icon="i-lucide-triangle-alert" color="amber"}

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -8,7 +8,7 @@ import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER } f
 import type { ResolvedPrettyError } from './shared/dev-terminal'
 import { resolveDevTerminal } from './shared/dev-terminal'
 import { EvlogError } from './error'
-import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, matchesPattern } from './utils'
+import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, isoNow, matchesPattern } from './utils'
 
 const nativeStdoutWrite =
   typeof process !== 'undefined' && typeof process.stdout?.write === 'function'
@@ -28,12 +28,6 @@ function writePrettyStdout(text: string): void {
 
 function isPlainObject(val: unknown): val is Record<string, unknown> {
   return val !== null && typeof val === 'object' && !Array.isArray(val)
-}
-
-const _tsDate = new Date()
-function isoNow(): string {
-  _tsDate.setTime(Date.now())
-  return _tsDate.toISOString()
 }
 
 /** Shown after post-emit warnings so users can fix fire-and-forget / ALS continuations. */

--- a/packages/evlog/src/runtime/client/log.ts
+++ b/packages/evlog/src/runtime/client/log.ts
@@ -1,5 +1,5 @@
 import type { Log, LogLevel, TransportConfig } from '../../types'
-import { cssColors, escapeFormatString, getCssLevelColor, isBrowser, isLevelEnabled } from '../../utils'
+import { cssColors, escapeFormatString, getCssLevelColor, isBrowser, isLevelEnabled, isoNow } from '../../utils'
 
 /**
  * Browser DevTools often hide or bucket `console.debug` under "Verbose" in a way that looks like
@@ -69,7 +69,7 @@ function emitLog(level: LogLevel, event: Record<string, unknown>): void {
   if (!isLevelEnabled(level, clientMinLevel)) return
 
   const formatted = {
-    timestamp: new Date().toISOString(),
+    timestamp: isoNow(),
     level,
     service: clientService,
     ...identityContext,
@@ -97,7 +97,7 @@ function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
       console[browserConsoleMethod(level)](`%c[${escapeFormatString(tag)}]%c ${escapeFormatString(message)}`, getCssLevelColor(level), cssColors.reset)
     }
     sendToServer({
-      timestamp: new Date().toISOString(),
+      timestamp: isoNow(),
       level,
       service: clientService,
       ...identityContext,

--- a/packages/evlog/src/utils.ts
+++ b/packages/evlog/src/utils.ts
@@ -181,3 +181,26 @@ export function globToRegExp(pattern: string, separator: '/' | '.' = '/'): RegEx
 export function matchesPattern(path: string, pattern: string): boolean {
   return globToRegExp(pattern, '/').test(path)
 }
+
+/** Reused Date for ISO formatting — avoids allocating on second rollover. */
+const _isoDate = new Date()
+let _isoCachedSecond = -1
+let _isoCachedPrefix = ''
+
+/**
+ * Current wall-clock time as an ISO-8601 UTC string (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+ *
+ * Caches the formatted prefix through the second and only appends milliseconds on
+ * each call — same technique as pino / h3's logger, so hot emit paths avoid
+ * re-running `toISOString()` thousands of times per second.
+ */
+export function isoNow(): string {
+  const now = Date.now()
+  const sec = Math.floor(now / 1000)
+  if (sec !== _isoCachedSecond) {
+    _isoCachedSecond = sec
+    _isoDate.setTime(now)
+    _isoCachedPrefix = _isoDate.toISOString().slice(0, 19)
+  }
+  return `${_isoCachedPrefix}.${String(now % 1000).padStart(3, '0')}Z`
+}

--- a/packages/evlog/test/core/utils.test.ts
+++ b/packages/evlog/test/core/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { colors, formatDuration, getLevelColor, isBrowser, isClient, isDev, isLevelEnabled, isServer, matchesPattern } from '../../src/utils'
+import { colors, formatDuration, getLevelColor, isBrowser, isClient, isDev, isLevelEnabled, isServer, isoNow, matchesPattern } from '../../src/utils'
 import { shouldLog } from '../../src/shared/routes'
 
 describe('formatDuration', () => {
@@ -18,6 +18,48 @@ describe('formatDuration', () => {
   it('rounds milliseconds', () => {
     expect(formatDuration(42.7)).toBe('43ms')
     expect(formatDuration(42.3)).toBe('42ms')
+  })
+})
+
+describe('isoNow', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('matches Date.toISOString() for a fixed wall-clock time', () => {
+    const now = Date.parse('2024-01-15T12:00:00.123Z')
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    expect(isoNow()).toBe('2024-01-15T12:00:00.123Z')
+    expect(isoNow()).toBe(new Date(now).toISOString())
+  })
+
+  it('formats correctly across a second boundary', () => {
+    const before = Date.parse('2024-01-15T12:00:00.999Z')
+    const after = Date.parse('2024-01-15T12:00:01.000Z')
+    const now = vi.spyOn(Date, 'now')
+
+    now.mockReturnValue(before)
+    expect(isoNow()).toBe('2024-01-15T12:00:00.999Z')
+
+    now.mockReturnValue(after)
+    expect(isoNow()).toBe('2024-01-15T12:00:01.000Z')
+  })
+
+  it('updates milliseconds within the same second', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValue(Date.parse('2024-01-15T12:00:00.001Z'))
+    expect(isoNow()).toBe('2024-01-15T12:00:00.001Z')
+
+    now.mockReturnValue(Date.parse('2024-01-15T12:00:00.042Z'))
+    expect(isoNow()).toBe('2024-01-15T12:00:00.042Z')
+
+    now.mockReturnValue(Date.parse('2024-01-15T12:00:00.999Z'))
+    expect(isoNow()).toBe('2024-01-15T12:00:00.999Z')
+  })
+
+  it('zero-pads single-digit milliseconds', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2024-01-15T12:00:00.005Z'))
+    expect(isoNow()).toBe('2024-01-15T12:00:00.005Z')
   })
 })
 


### PR DESCRIPTION
Avoid re-running toISOString() on every emit by caching the second-level prefix and only appending milliseconds — same path for server and client.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved timestamp generation efficiency for logging.
  * Reduced measured event-emission overhead, with updated benchmark results showing faster throughput and lower average times.

* **Bug Fixes**
  * Standardized timestamps across structured log formats using consistent UTC ISO-8601 output with millisecond precision.

* **Tests**
  * Added coverage for timestamp accuracy across second boundaries, changing milliseconds, and zero-padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->