### PR TITLE
fix(cli): detect Nuxt 4 app/pages in evlog map

### DIFF
--- a/.changeset/cli-map-nuxt4-app-pages.md
+++ b/.changeset/cli-map-nuxt4-app-pages.md
@@ -1,0 +1,5 @@
+---
+"@evlog/cli": patch
+---
+
+fix(cli): detect Nuxt 4 `app/pages` (and `src/pages`) in `evlog map` — pages under the Nuxt 4 default layout were invisible, which could leave a project at 100/100 with zero entry points

--- a/apps/docs/content/3.cli/1.map.md
+++ b/apps/docs/content/3.cli/1.map.md
@@ -227,11 +227,11 @@ Detection is per framework, from the file layout. `--framework` overrides it whe
 
 ::code-group
 ```text [Nuxt]
-server/api/**        → API handler, path prefixed /api, method from the filename suffix
-server/routes/**     → API handler, path as written
-pages/**/*.vue       → page
-server/middleware/** → middleware
-server/tasks/**      → scheduled job
+server/api/**             → API handler, path prefixed /api, method from the filename suffix
+server/routes/**          → API handler, path as written
+app/pages/**/*.vue        → page (Nuxt 4 default; also pages/ and src/pages/)
+server/middleware/**      → middleware
+server/tasks/**           → scheduled job
 ```
 ```text [Nitro]
 routes/**      → API handler, path as written

--- a/packages/cli/src/lib/map/adapters/nuxt.ts
+++ b/packages/cli/src/lib/map/adapters/nuxt.ts
@@ -36,7 +36,15 @@ const MIDDLEWARE_DIR: Record<'nuxt' | 'nitro', string> = {
   nitro: 'middleware',
 }
 
-const PAGE_GLOBS = ['pages/**/*.vue']
+/**
+ * Where Nuxt keeps file-based pages.
+ *
+ * Nuxt 4 defaults to `app/pages`; older layouts use `pages/` or `src/pages`.
+ * Several can coexist in odd projects — scan every root that actually has
+ * `.vue` files rather than picking one and leaving the others invisible.
+ */
+const PAGE_DIRS = ['app/pages', 'pages', 'src/pages'] as const
+
 const CRON_GLOBS = [`server/tasks/**/*.${HANDLER_EXT}`]
 
 /** What both Nitro-based adapters need to turn a file into an entry point. */
@@ -44,6 +52,17 @@ interface ExtractContext {
   root: string
   parse: ParseFn
   framework: 'nuxt' | 'nitro'
+}
+
+/**
+ * Page directories under `root` that contain at least one `.vue` file.
+ * Falls back to `pages` when nothing is present so globs stay predictable.
+ */
+function resolvePageDirs(root: string): readonly string[] {
+  const found = PAGE_DIRS.filter(
+    dir => globSync(`${dir}/**/*.vue`, { cwd: root }).length > 0,
+  )
+  return found.length > 0 ? found : ['pages']
 }
 
 function fileToApiRoute(file: string, apiRoot: RouteRoot, { root, parse, framework }: ExtractContext): RawRouteEntry {
@@ -65,9 +84,12 @@ function fileToApiRoute(file: string, apiRoot: RouteRoot, { root, parse, framewo
   }
 }
 
-function fileToPageRoute(file: string, root: string): RawRouteEntry {
+function fileToPageRoute(file: string, root: string, pageDir: string): RawRouteEntry {
   const rel = relativeFromRoot(root, file)
-  const segments = rel.slice('pages/'.length).split('/')
+  const prefix = `${pageDir}/`
+  const segments = rel.startsWith(prefix)
+    ? rel.slice(prefix.length).split('/')
+    : rel.split('/')
   const last = segments.length - 1
   segments[last] = stripRouteFilename(segments[last] ?? '')
   const path = segmentsToPath(segments) || '/'
@@ -149,7 +171,7 @@ function extractServerRoutes(ctx: ScanContext, framework: 'nuxt' | 'nitro'): Raw
   return routes
 }
 
-/** Nuxt project: `server/api`, `server/routes`, `server/middleware`, `server/tasks` and `pages`. */
+/** Nuxt project: `server/api`, `server/routes`, `server/middleware`, `server/tasks` and pages. */
 export const nuxtAdapter: FrameworkAdapter = {
   framework: 'nuxt',
   evlogAutoImports: NUXT_EVLOG_AUTO_IMPORTS,
@@ -160,9 +182,9 @@ export const nuxtAdapter: FrameworkAdapter = {
     const root = ctx.projectRoot
     const parse = ctx.parse ?? parseFile
 
-    for (const pattern of PAGE_GLOBS) {
-      for (const file of globSync(pattern, { cwd: root, absolute: true })) {
-        routes.push(fileToPageRoute(file, root))
+    for (const pageDir of resolvePageDirs(root)) {
+      for (const file of globSync(`${pageDir}/**/*.vue`, { cwd: root, absolute: true })) {
+        routes.push(fileToPageRoute(file, root, pageDir))
       }
     }
 

--- a/packages/cli/src/lib/map/adapters/nuxt.ts
+++ b/packages/cli/src/lib/map/adapters/nuxt.ts
@@ -54,15 +54,24 @@ interface ExtractContext {
   framework: 'nuxt' | 'nitro'
 }
 
+/** One page root and the `.vue` files already discovered under it. */
+interface PageRoot {
+  dir: string
+  files: readonly string[]
+}
+
 /**
  * Page directories under `root` that contain at least one `.vue` file.
- * Falls back to `pages` when nothing is present so globs stay predictable.
+ * Returns the matched files with each directory so extractors do not glob twice.
+ * Falls back to an empty `pages` root when nothing is present.
  */
-function resolvePageDirs(root: string): readonly string[] {
-  const found = PAGE_DIRS.filter(
-    dir => globSync(`${dir}/**/*.vue`, { cwd: root }).length > 0,
-  )
-  return found.length > 0 ? found : ['pages']
+function resolvePageRoots(root: string): readonly PageRoot[] {
+  const found: PageRoot[] = []
+  for (const dir of PAGE_DIRS) {
+    const files = globSync(`${dir}/**/*.vue`, { cwd: root, absolute: true })
+    if (files.length > 0) found.push({ dir, files })
+  }
+  return found.length > 0 ? found : [{ dir: 'pages', files: [] }]
 }
 
 function fileToApiRoute(file: string, apiRoot: RouteRoot, { root, parse, framework }: ExtractContext): RawRouteEntry {
@@ -182,9 +191,9 @@ export const nuxtAdapter: FrameworkAdapter = {
     const root = ctx.projectRoot
     const parse = ctx.parse ?? parseFile
 
-    for (const pageDir of resolvePageDirs(root)) {
-      for (const file of globSync(`${pageDir}/**/*.vue`, { cwd: root, absolute: true })) {
-        routes.push(fileToPageRoute(file, root, pageDir))
+    for (const { dir, files } of resolvePageRoots(root)) {
+      for (const file of files) {
+        routes.push(fileToPageRoute(file, root, dir))
       }
     }
 

--- a/packages/cli/test/map/adapters.test.ts
+++ b/packages/cli/test/map/adapters.test.ts
@@ -129,6 +129,34 @@ describe('nuxt adapter', () => {
 
     expect(routes.map(route => `${route.method} ${route.path}`)).toEqual(['GET /health'])
   })
+
+  it.each(['app/pages', 'pages', 'src/pages'] as const)(
+    'maps a page under %s and strips that root from the path',
+    async (pageDir) => {
+      const root = await project({
+        [`${pageDir}/blog/[...slug].vue`]: '<script setup lang="ts"></script>',
+      })
+
+      const routes = await routesOf('nuxt', root)
+
+      expect(routes.map(route => `${route.kind} ${route.path}`)).toEqual(['page /blog/:slug*'])
+      expect(routes[0]?.file).toBe(`${pageDir}/blog/[...slug].vue`)
+    },
+  )
+
+  it('collects pages from every populated root', async () => {
+    const root = await project({
+      'app/pages/index.vue': '<script setup lang="ts"></script>',
+      'pages/about.vue': '<script setup lang="ts"></script>',
+    })
+
+    const routes = await routesOf('nuxt', root)
+
+    expect(routes.map(route => `${route.path} (${route.file})`).sort()).toEqual([
+      '/ (app/pages/index.vue)',
+      '/about (pages/about.vue)',
+    ])
+  })
 })
 
 describe('nitro adapter', () => {


### PR DESCRIPTION
## Summary
- `evlog map`'s Nuxt adapter only scanned root `pages/**`, so Nuxt 4 apps using `app/pages` (and `src/pages`) had every page invisible — including fake 100/100 with zero entry points
- Resolve page roots among `app/pages`, `pages`, and `src/pages`, and strip the matching prefix for route paths
- Docs + patch changeset for `@evlog/cli`

## Test plan
- [ ] `pnpm --filter @evlog/cli run build`
- [ ] `node packages/cli/bin/evlog.mjs map --all --no-write --cwd ~/Dev/hr-folio` — pages under `app/pages` appear
- [ ] same on `~/Dev/shelve/apps/shelve` and `~/Dev/shelve/apps/lp` — LP is no longer 100 with 0 entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Nuxt page mapping to correctly detect Nuxt 4 page entry points in `app/pages`, `pages`, and `src/pages`.
  - Prevents Nuxt 4 projects from incorrectly reporting complete progress when no entry points are detected.
- **Documentation**
  - Revised the Nuxt “What counts as an entry point” guidance to treat `app/pages/**/*.vue` as page entry points (Nuxt 4 default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->