### PR TITLE
docs: promote @evlog/cli across skills and onboarding

### DIFF
--- a/apps/docs/app/components/content/MapRulesMatrix.vue
+++ b/apps/docs/app/components/content/MapRulesMatrix.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Motion } from 'motion-v'
-import type { TimedEvent } from '~/composables/useTimedSequence'
+import type { TimedEvent, UseTimedSequenceOptions } from '~/composables/useTimedSequence'
 
 type Cell = 'pending' | 'pass' | 'fail' | 'na' | 'disabled'
 
@@ -11,7 +11,7 @@ interface RuleCol {
   initial: Exclude<Cell, 'pending'>
   /** Verdict after fixes (step >= 2), before any disable. */
   fixed?: Exclude<Cell, 'pending'>
-  /** When true, step >= 3 turns this cell into disabled n/a. */
+  /** Step at which this cell becomes disabled n/a. */
   disableAt?: number
 }
 
@@ -22,7 +22,7 @@ interface RuleCol {
 const rules: RuleCol[] = [
   { id: 'log', kind: 'requirement', initial: 'fail', fixed: 'pass' },
   { id: 'ctx', kind: 'requirement', initial: 'fail', fixed: 'pass' },
-  { id: 'audit', kind: 'requirement', initial: 'fail', fixed: 'fail', disableAt: 3 },
+  { id: 'audit', kind: 'requirement', initial: 'fail', fixed: 'fail', disableAt: 4 },
   { id: 'err', kind: 'requirement', initial: 'na' },
   { id: 'catch', kind: 'requirement', initial: 'na' },
   { id: 'fetch', kind: 'requirement', initial: 'na' },
@@ -55,21 +55,22 @@ const events: TimedEvent[] = STEP_AT.map((at, i) => ({
 
 const totalDuration = (STEP_AT.at(-1) ?? 0) + TAIL_HOLD
 
-const { start, toggle, restart, paused, started } = useTimedSequence({
+const sequenceOpts: UseTimedSequenceOptions = {
   events,
   totalDuration,
   loop: true,
+  reducedMotion: false,
   onReset: resetState,
-})
+}
+
+const { start, toggle, restart, paused, started } = useTimedSequence(sequenceOpts)
 
 let observer: IntersectionObserver | undefined
 
 onMounted(() => {
   prefersReducedMotion.value = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  if (prefersReducedMotion.value) {
-    step.value = 4
-    return
-  }
+  sequenceOpts.reducedMotion = prefersReducedMotion.value
+
   if (!wrapperRef.value) {
     start()
     return
@@ -141,7 +142,7 @@ const failingReqs = computed(() =>
     :in-view-options="{ once: true, amount: 0.2 }"
     class="not-prose my-8"
   >
-    <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
+    <div ref="wrapperRef" class="w-full min-h-[248px] overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-list-checks" class="size-3 text-primary shrink-0" />
         <span class="font-mono text-[11px] text-dimmed truncate">evlog map — rules</span>
@@ -221,7 +222,7 @@ const failingReqs = computed(() =>
         >{{ statusLabel }}</span>
         <span
           class="ml-auto tabular-nums transition-opacity duration-500 whitespace-nowrap"
-          :class="step >= 3 ? 'opacity-100 text-amber-400' : 'opacity-0'"
+          :class="step >= 4 ? 'opacity-100 text-amber-400' : 'opacity-0'"
         >
           ○ = disabled (still visible)
         </span>

--- a/apps/docs/app/components/content/MapRulesMatrix.vue
+++ b/apps/docs/app/components/content/MapRulesMatrix.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { Motion } from 'motion-v'
+import type { TimedEvent } from '~/composables/useTimedSequence'
+
+type Cell = 'pending' | 'pass' | 'fail' | 'na' | 'disabled'
+
+interface RuleCol {
+  id: string
+  kind: 'requirement' | 'opportunity'
+  /** Initial verdict once the scan lands (step >= 1). */
+  initial: Exclude<Cell, 'pending'>
+  /** Verdict after fixes (step >= 2), before any disable. */
+  fixed?: Exclude<Cell, 'pending'>
+  /** When true, step >= 3 turns this cell into disabled n/a. */
+  disableAt?: number
+}
+
+/**
+ * One handler through the rule engine: requirements move the score,
+ * opportunities never do, and a disable comment turns a fail into ○ n/a.
+ */
+const rules: RuleCol[] = [
+  { id: 'log', kind: 'requirement', initial: 'fail', fixed: 'pass' },
+  { id: 'ctx', kind: 'requirement', initial: 'fail', fixed: 'pass' },
+  { id: 'audit', kind: 'requirement', initial: 'fail', fixed: 'fail', disableAt: 3 },
+  { id: 'err', kind: 'requirement', initial: 'na' },
+  { id: 'catch', kind: 'requirement', initial: 'na' },
+  { id: 'fetch', kind: 'requirement', initial: 'na' },
+  { id: 'catalog', kind: 'opportunity', initial: 'na' },
+  { id: 'audit+', kind: 'opportunity', initial: 'fail', fixed: 'fail' },
+  { id: 'ai', kind: 'opportunity', initial: 'na' },
+  { id: 'identity', kind: 'opportunity', initial: 'na' },
+]
+
+const requirements = rules.filter(r => r.kind === 'requirement')
+const opportunities = rules.filter(r => r.kind === 'opportunity')
+
+const step = ref(0)
+const prefersReducedMotion = ref(false)
+const wrapperRef = ref<HTMLElement>()
+
+function resetState() {
+  step.value = 0
+}
+
+const STEP_AT = [600, 2200, 4000, 5200]
+const TAIL_HOLD = 3800
+
+const events: TimedEvent[] = STEP_AT.map((at, i) => ({
+  at,
+  run: () => {
+    step.value = i + 1
+  },
+}))
+
+const totalDuration = (STEP_AT.at(-1) ?? 0) + TAIL_HOLD
+
+const { start, toggle, restart, paused, started } = useTimedSequence({
+  events,
+  totalDuration,
+  loop: true,
+  onReset: resetState,
+})
+
+let observer: IntersectionObserver | undefined
+
+onMounted(() => {
+  prefersReducedMotion.value = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  if (prefersReducedMotion.value) {
+    step.value = 4
+    return
+  }
+  if (!wrapperRef.value) {
+    start()
+    return
+  }
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry?.isIntersecting) {
+        start()
+        observer?.disconnect()
+      }
+    },
+    { threshold: 0.25 },
+  )
+  observer.observe(wrapperRef.value)
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+})
+
+function cellFor(rule: RuleCol): Cell {
+  if (step.value < 1) return 'pending'
+  if (rule.disableAt !== undefined && step.value >= rule.disableAt) return 'disabled'
+  if (step.value >= 2 && rule.fixed) return rule.fixed
+  return rule.initial
+}
+
+function glyph(cell: Cell): string {
+  switch (cell) {
+    case 'pass': return '✓'
+    case 'fail': return '✗'
+    case 'na': return '·'
+    case 'disabled': return '○'
+    default: return ' '
+  }
+}
+
+function cellClass(cell: Cell): string {
+  switch (cell) {
+    case 'pass': return 'text-emerald-500'
+    case 'fail': return 'text-rose-400'
+    case 'disabled': return 'text-amber-400'
+    case 'na': return 'text-dimmed/60'
+    default: return 'text-dimmed/30'
+  }
+}
+
+const statusLabel = computed(() => {
+  if (step.value >= 4) return 'disable → n/a · score ignores it'
+  if (step.value >= 3) return 'evlog-map-disable-next-line audit'
+  if (step.value >= 2) return 'useLogger + log.set landed'
+  if (step.value >= 1) return 'requirements cost score · opportunities never'
+  return 'waiting for scan'
+})
+
+const failingReqs = computed(() =>
+  requirements.filter((r) => {
+    const c = cellFor(r)
+    return c === 'fail'
+  }).length,
+)
+</script>
+
+<template>
+  <Motion
+    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
+    :while-in-view="{ opacity: 1, y: 0 }"
+    :transition="{ duration: 0.5 }"
+    :in-view-options="{ once: true, amount: 0.2 }"
+    class="not-prose my-8"
+  >
+    <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
+      <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
+        <UIcon name="i-lucide-list-checks" class="size-3 text-primary shrink-0" />
+        <span class="font-mono text-[11px] text-dimmed truncate">evlog map — rules</span>
+        <span class="text-dimmed text-[10px]">·</span>
+        <span class="font-mono text-[9px] text-muted truncate">api/checkout.post.ts</span>
+        <div class="ml-auto flex items-center gap-0.5">
+          <button
+            type="button"
+            class="size-5 inline-flex items-center justify-center text-dimmed hover:text-default focus:text-default focus:outline-none transition-colors"
+            :aria-label="paused ? 'Play animation' : 'Pause animation'"
+            :disabled="!started"
+            @click="toggle"
+          >
+            <UIcon :name="paused ? 'i-lucide-play' : 'i-lucide-pause'" class="size-3" />
+          </button>
+          <button
+            type="button"
+            class="size-5 inline-flex items-center justify-center text-dimmed hover:text-default focus:text-default focus:outline-none transition-colors"
+            aria-label="Restart animation"
+            :disabled="!started"
+            @click="restart"
+          >
+            <UIcon name="i-lucide-rotate-ccw" class="size-3" />
+          </button>
+        </div>
+      </div>
+
+      <div class="px-3 py-2.5 space-y-2.5">
+        <div>
+          <div class="flex items-baseline justify-between mb-1">
+            <span class="font-mono text-[9px] uppercase tracking-widest text-dimmed">Requirements</span>
+            <span
+              class="font-mono text-[9px] tabular-nums transition-colors duration-300"
+              :class="failingReqs === 0 ? 'text-emerald-500' : 'text-rose-400'"
+            >{{ failingReqs }} failing</span>
+          </div>
+          <div class="grid grid-cols-6 gap-1">
+            <div
+              v-for="rule in requirements"
+              :key="rule.id"
+              class="h-[44px] flex flex-col items-center justify-center gap-0.5 border border-muted/40 bg-muted/10"
+            >
+              <span
+                class="font-mono text-[12px] leading-none transition-colors duration-300"
+                :class="cellClass(cellFor(rule))"
+              >{{ glyph(cellFor(rule)) }}</span>
+              <span class="font-mono text-[9px] text-dimmed">{{ rule.id }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="flex items-baseline justify-between mb-1">
+            <span class="font-mono text-[9px] uppercase tracking-widest text-dimmed">Opportunities</span>
+            <span class="font-mono text-[9px] text-dimmed">never move the score</span>
+          </div>
+          <div class="grid grid-cols-4 gap-1">
+            <div
+              v-for="rule in opportunities"
+              :key="rule.id"
+              class="h-[44px] flex flex-col items-center justify-center gap-0.5 border border-muted/40 bg-muted/5"
+            >
+              <span
+                class="font-mono text-[12px] leading-none transition-colors duration-300"
+                :class="cellClass(cellFor(rule))"
+              >{{ glyph(cellFor(rule)) }}</span>
+              <span class="font-mono text-[9px] text-dimmed">{{ rule.id }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="border-t border-muted/50 px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[9px] text-dimmed">
+        <span
+          class="transition-opacity duration-300 truncate"
+          :class="step >= 1 ? 'opacity-100' : 'opacity-40'"
+        >{{ statusLabel }}</span>
+        <span
+          class="ml-auto tabular-nums transition-opacity duration-500 whitespace-nowrap"
+          :class="step >= 3 ? 'opacity-100 text-amber-400' : 'opacity-0'"
+        >
+          ○ = disabled (still visible)
+        </span>
+      </div>
+    </div>
+  </Motion>
+</template>

--- a/apps/docs/content/1.start/1.introduction.md
+++ b/apps/docs/content/1.start/1.introduction.md
@@ -19,7 +19,7 @@ links:
 
 **evlog** is a modern TypeScript logger built for everything you ship. It gives you simple structured logs (a drop-in for `console.log`, pino, or consola), wide events that accumulate context across an operation, and structured errors that explain why they happened — all in one API, all behind the same drain pipeline. Use it in CLIs, libraries, background jobs, edge workers, and HTTP handlers without switching loggers.
 
-Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x.com/boristane).
+Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x.com/boristane). When you want a static score of which entry points can tell you what went wrong, try the separate [`@evlog/cli`](/cli/overview) (`evlog map`) — early, no config, one command.
 
 ## Philosophy
 

--- a/apps/docs/content/1.start/3.installation.md
+++ b/apps/docs/content/1.start/3.installation.md
@@ -64,6 +64,17 @@ npx skills add https://www.evlog.dev
 
 Your AI assistant can then help you set up evlog, review your logging patterns, and migrate existing code to wide events. See [Agent Skills](/reference/agent-skills) for details.
 
+::callout{icon="i-lucide-radar" color="neutral"}
+**Try `@evlog/cli`.** Separate package, early days — but one command scores which entry points are still dark. No install required:
+
+```bash
+npx @evlog/cli map
+# or: pnpm dlx @evlog/cli map
+```
+
+See [CLI overview](/cli/overview) and [`evlog map`](/cli/map). Pin as a dev dependency only when you want it in CI.
+::
+
 ## Choose Your Framework
 
 After installing the package, follow the setup guide for your framework:

--- a/apps/docs/content/1.start/4.quick-start.md
+++ b/apps/docs/content/1.start/4.quick-start.md
@@ -314,7 +314,7 @@ See [Client Logging](/use-cases/client-logging) for transport configuration, ide
 
 ## Next Steps
 
-- [`evlog map`](/cli/map): Score what you just wired up and see which entry points are still dark
+- [`evlog map`](/cli/map): See what you just unlocked — score coverage and find entry points that are still dark (`npx @evlog/cli map`)
 - [Logging Overview](/learn/overview): Understand all three logging modes
 - [Wide Events](/learn/wide-events): Learn how to design effective wide events
 - [Typed Fields](/learn/typed-fields): Add compile-time type safety to your wide events

--- a/apps/docs/content/3.cli/2.rules.md
+++ b/apps/docs/content/3.cli/2.rules.md
@@ -45,6 +45,9 @@ Every rule returns one of three verdicts for an entry point.
 
 `n/a` is doing real work. A handler that throws nothing is never asked whether its errors carry `why` and `fix`; a handler with no `catch` is never asked whether its catches log. Those used to pass for free, which made the report claim a file handled errors it did not have. Now they are dots in the matrix, and the score is calculated over the rules that actually applied.
 
+::map-rules-matrix
+::
+
 ## Requirements
 
 Six rules move the score. They apply to handler-like entry points — API handlers, middleware, scheduled jobs, and server actions — except `fetch`, which is the pages-only rule.

--- a/apps/docs/content/4.integrate/0.overview.md
+++ b/apps/docs/content/4.integrate/0.overview.md
@@ -24,6 +24,8 @@ Once you understand the [logging modes](/learn/overview), there are two question
 
 The two are independent. A Nuxt app can drain to Axiom, an Express app can drain to OTLP + Sentry simultaneously, a SvelteKit app can drain to a local file in dev and to Datadog in production.
 
+Once something is wired, try [`evlog map`](/cli/map) (`npx @evlog/cli map`) to see which entry points are still dark — or [`evlog doctor`](/cli/doctor) if nothing is showing up. Separate early package; optional, worth a run.
+
 ::card-group
   :::card
   ---

--- a/apps/docs/content/7.reference/6.agent-skills.md
+++ b/apps/docs/content/7.reference/6.agent-skills.md
@@ -51,7 +51,7 @@ The skill analyzes your codebase for:
 - **Unhelpful errors**: `throw new Error()` without structured fields
 - **Correlation gaps**: Missing request IDs or trace IDs
 
-On Nuxt, Nitro, Next.js, and TanStack Start, ask the assistant to try [`evlog map`](/cli/map) first (`npx @evlog/cli map`) — it scores every entry point and lists FIX FIRST. Agents that prefer structured output can use `npx @evlog/cli map --json --no-write`. The skill still works without the CLI; map is a separate early package that makes the review faster when available.
+On Nuxt, Nitro, Next.js, and TanStack Start, ask the assistant to try [`evlog map`](/cli/map) first (`npx @evlog/cli map --no-write`) — it scores every entry point and lists FIX FIRST. Agents that prefer structured output can use `npx @evlog/cli map --json --no-write`. The skill still works without the CLI; map is a separate early package that makes the review faster when available.
 ### Adoption Guidance
 
 The skill helps you:
@@ -98,12 +98,12 @@ actions:
   - claude
 ---
 
-Run `npx @evlog/cli map` in this project and read the report.
+Run `npx @evlog/cli map --no-write` in this project and read the report.
 
 - Fix the entry points listed under FIX FIRST, in order
-- For each one, run `npx @evlog/cli map <file>` first to see the suggested shape
+- For each one, run `npx @evlog/cli map <file> --no-write` first to see the suggested shape
 - Keep the changes minimal: add `useLogger()`, `log.set()`, `log.audit()`, or `createError({ why, fix })` where the report says they are missing
-- Re-run `npx @evlog/cli map` and confirm the score went up
+- Re-run `npx @evlog/cli map --no-write` and confirm the score went up
 
 Docs: https://www.evlog.dev/cli/map
 Rules: https://www.evlog.dev/cli/rules

--- a/apps/docs/content/7.reference/6.agent-skills.md
+++ b/apps/docs/content/7.reference/6.agent-skills.md
@@ -12,7 +12,7 @@ links:
     variant: subtle
 ---
 
-evlog includes agent skills that help AI assistants review your logging patterns and guide evlog adoption.
+evlog includes agent skills that help AI assistants review your logging patterns and guide evlog adoption. Pair them with [`@evlog/cli`](/cli/overview) when you want a scoreable coverage map — the skills teach the patterns; `evlog map` points at the dark entry points.
 
 ## What are Agent Skills?
 
@@ -26,7 +26,7 @@ evlog includes agent skills that help AI assistants review your logging patterns
 
 | Skill | Description |
 |-------|-------------|
-| `skills/review-logging-patterns` | Review code for logging patterns, suggest evlog adoption, guide wide event design |
+| `skills/review-logging-patterns` | Review logging patterns, suggest evlog adoption; optionally use `evlog map` for coverage |
 | `skills/build-audit-logs` | Design, wire, and review tamper-aware audit trails: policy, `auditEnricher`, `auditOnly`, `signed`, denials, redaction, tests |
 | `skills/analyze-logs` | Analyze application logs from `.evlog/logs/` to debug errors, investigate performance, and understand behavior |
 
@@ -51,6 +51,7 @@ The skill analyzes your codebase for:
 - **Unhelpful errors**: `throw new Error()` without structured fields
 - **Correlation gaps**: Missing request IDs or trace IDs
 
+On Nuxt, Nitro, Next.js, and TanStack Start, ask the assistant to try [`evlog map`](/cli/map) first (`npx @evlog/cli map`) — it scores every entry point and lists FIX FIRST. Agents that prefer structured output can use `npx @evlog/cli map --json --no-write`. The skill still works without the CLI; map is a separate early package that makes the review faster when available.
 ### Adoption Guidance
 
 The skill helps you:
@@ -84,6 +85,28 @@ actions:
 ---
 
 Review this file for logging anti-patterns
+
+::
+
+::prompt
+---
+description: Raise my evlog map score
+icon: i-lucide-radar
+actions:
+  - copy
+  - cursor
+  - claude
+---
+
+Run `npx @evlog/cli map` in this project and read the report.
+
+- Fix the entry points listed under FIX FIRST, in order
+- For each one, run `npx @evlog/cli map <file>` first to see the suggested shape
+- Keep the changes minimal: add `useLogger()`, `log.set()`, `log.audit()`, or `createError({ why, fix })` where the report says they are missing
+- Re-run `npx @evlog/cli map` and confirm the score went up
+
+Docs: https://www.evlog.dev/cli/map
+Rules: https://www.evlog.dev/cli/rules
 
 ::
 

--- a/apps/docs/skills/analyze-logs/SKILL.md
+++ b/apps/docs/skills/analyze-logs/SKILL.md
@@ -46,7 +46,7 @@ Files are named by date: `2026-03-14.jsonl`. Start with the most recent file.
 
 ## If no logs are found
 
-Before wiring a new drain, you can try `npx @evlog/cli doctor` — it checks whether `evlog` is installed and whether a local `.evlog/logs` sink already exists. Optional; skip if the CLI is unavailable.
+Before wiring a new drain, you can try `npx @evlog/cli doctor --json` — it checks whether `evlog` is installed and whether a local `.evlog/logs` sink already exists (read-only). Optional; skip if the CLI is unavailable.
 
 The file system drain may not be enabled. Guide the user to set it up:
 

--- a/apps/docs/skills/analyze-logs/SKILL.md
+++ b/apps/docs/skills/analyze-logs/SKILL.md
@@ -46,6 +46,8 @@ Files are named by date: `2026-03-14.jsonl`. Start with the most recent file.
 
 ## If no logs are found
 
+Before wiring a new drain, you can try `npx @evlog/cli doctor` — it checks whether `evlog` is installed and whether a local `.evlog/logs` sink already exists. Optional; skip if the CLI is unavailable.
+
 The file system drain may not be enabled. Guide the user to set it up:
 
 ```typescript

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -376,7 +376,7 @@ rg -n "createError\(.*403|throw .*Forbidden|status:\s*403|statusCode:\s*403" --t
 rg -n "(?i)\b(delete|update|create|refund|grant|revoke|promote|demote|reset|impersonate)\b.*async\s+function|defineEventHandler" --type ts
 ```
 
-On Nuxt, Nitro, Next.js, or TanStack Start, you can also run `npx @evlog/cli map` — the `audit` / `audit-coverage` checks flag sensitive routes that log nothing. Useful as a second pass; keep the greps above for denials and actor shape, which the CLI does not fully cover.
+On Nuxt, Nitro, Next.js, or TanStack Start, you can also run `npx @evlog/cli map --no-write` — the `audit` / `audit-coverage` checks flag sensitive routes that log nothing. Useful as a second pass; keep the greps above for denials and actor shape, which the CLI does not fully cover.
 
 For each match, check:
 - Mutating endpoint without a `log.audit()` or `withAudit()` → coverage gap.

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -376,6 +376,8 @@ rg -n "createError\(.*403|throw .*Forbidden|status:\s*403|statusCode:\s*403" --t
 rg -n "(?i)\b(delete|update|create|refund|grant|revoke|promote|demote|reset|impersonate)\b.*async\s+function|defineEventHandler" --type ts
 ```
 
+On Nuxt, Nitro, Next.js, or TanStack Start, you can also run `npx @evlog/cli map` — the `audit` / `audit-coverage` checks flag sensitive routes that log nothing. Useful as a second pass; keep the greps above for denials and actor shape, which the CLI does not fully cover.
+
 For each match, check:
 - Mutating endpoint without a `log.audit()` or `withAudit()` → coverage gap.
 - `403` / `Forbidden` thrown without a paired `log.audit.deny()` → silent denial. This is the single most common gap.

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -58,8 +58,8 @@ npm install evlog
 **Try without installing:**
 
 ```bash
-npx @evlog/cli map
-# or: pnpm dlx @evlog/cli map
+npx @evlog/cli map --no-write
+# or: pnpm dlx @evlog/cli map --no-write
 # agents: npx @evlog/cli map --json --no-write
 ```
 
@@ -67,10 +67,10 @@ What you get:
 
 - A project score and which entry points are still dark
 - **FIX FIRST** — the three most valuable places to fix
-- Per-file inspect: `npx @evlog/cli map <file>` shows the shape the handler could take
+- Per-file inspect: `npx @evlog/cli map <file> --no-write` shows the shape the handler could take
 - Re-run after fixes and watch the score move
 
-If the user is open to it: work FIX FIRST in order, keep changes minimal (`useLogger()`, `log.set()`, `log.audit()`, `createError({ why, fix })`), then re-run. Prefer `npx` / `dlx` for a one-shot; only suggest `pnpm add -D @evlog/cli` if they want it pinned for CI — **ask first, never install silently**.
+If the user is open to it: work FIX FIRST in order, keep changes minimal (`useLogger()`, `log.set()`, `log.audit()`, `createError({ why, fix })`), then re-run with `--no-write`. Prefer `npx` / `dlx` for a one-shot; only suggest `pnpm add -D @evlog/cli` if they want it pinned for CI — **ask first, never install silently**. Omit `--no-write` only when the user wants `evlog.map.json` written.
 
 If the CLI is unavailable, the framework has no map adapter yet, or the user declines — **continue with the manual checklist** below. The skill does not depend on the CLI.
 

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: review-logging-patterns
-description: Review code for logging patterns and suggest evlog adoption. Guides setup on Nuxt, Next.js, SvelteKit, Nitro, TanStack Start, React Router, NestJS, Express, Hono, Fastify, Elysia, oRPC, Cloudflare Workers, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog), sampling, enrichers, and AI SDK integration (token usage, tool calls, streaming metrics, telemetry integration, cost estimation, embedding metadata).
+description: Review code for logging patterns and suggest evlog adoption. Optionally use @evlog/cli (`evlog map`) to score entry-point coverage on Nuxt, Nitro, Next.js, and TanStack Start. Guides setup on those plus SvelteKit, React Router, NestJS, Express, Hono, Fastify, Elysia, oRPC, Cloudflare Workers, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog), sampling, enrichers, and AI SDK integration.
 license: MIT
 metadata:
   author: HugoRCD
-  version: "0.5"
+  version: "0.6"
 ---
 
 # Review logging patterns
@@ -23,6 +23,7 @@ Review and improve logging patterns in TypeScript/JavaScript codebases. Transfor
 
 | Working on...           | Resource                                                           |
 | ----------------------- | ------------------------------------------------------------------ |
+| Coverage map (CLI)      | [`evlog map`](https://www.evlog.dev/cli/map) — score dark entry points |
 | Wide events patterns    | [references/wide-events.md](references/wide-events.md)             |
 | Error handling          | [references/structured-errors.md](references/structured-errors.md) |
 | Code review checklist   | [references/code-review.md](references/code-review.md)             |
@@ -49,6 +50,31 @@ Docs: https://www.evlog.dev/use-cases/audit/overview
 ```bash
 npm install evlog
 ```
+
+## Score coverage with the CLI (recommended)
+
+`@evlog/cli` is a **separate package** from `evlog` — early, but worth trying. It reads the project on disk (no traffic, no config) and scores every entry point for wide-event coverage. On Nuxt, Nitro, Next.js, and TanStack Start it is usually faster and more complete than grepping for `console.log`.
+
+**Try without installing:**
+
+```bash
+npx @evlog/cli map
+# or: pnpm dlx @evlog/cli map
+# agents: npx @evlog/cli map --json --no-write
+```
+
+What you get:
+
+- A project score and which entry points are still dark
+- **FIX FIRST** — the three most valuable places to fix
+- Per-file inspect: `npx @evlog/cli map <file>` shows the shape the handler could take
+- Re-run after fixes and watch the score move
+
+If the user is open to it: work FIX FIRST in order, keep changes minimal (`useLogger()`, `log.set()`, `log.audit()`, `createError({ why, fix })`), then re-run. Prefer `npx` / `dlx` for a one-shot; only suggest `pnpm add -D @evlog/cli` if they want it pinned for CI — **ask first, never install silently**.
+
+If the CLI is unavailable, the framework has no map adapter yet, or the user declines — **continue with the manual checklist** below. The skill does not depend on the CLI.
+
+Early days: adapters and rules are still evolving; expect scores to move between releases. Docs: https://www.evlog.dev/cli/map · Rules: https://www.evlog.dev/cli/rules
 
 ---
 

--- a/apps/docs/skills/review-logging-patterns/references/code-review.md
+++ b/apps/docs/skills/review-logging-patterns/references/code-review.md
@@ -2,6 +2,30 @@
 
 Use this checklist when reviewing code for logging best practices and evlog adoption.
 
+## Prefer `evlog map` when you can
+
+On **Nuxt, Nitro, Next.js App Router, and TanStack Start**, start with `@evlog/cli` if the user is open to it — one command finds dark entry points and names the fixes:
+
+```bash
+npx @evlog/cli map
+npx @evlog/cli map <file>   # suggested shape for one entry point
+```
+
+Map rule ids (requirements that move the score) map to the anti-patterns below:
+
+| Map rule id | What it expects | Related anti-pattern |
+|-------------|-----------------|----------------------|
+| `wide-event` | `useLogger()` / request logger | No logging in handlers |
+| `context` | `log.set(...)` | Flat / missing request context |
+| `structured-errors` | `createError({ why, fix })` | `throw new Error('...')` |
+| `error-handling` | log or rethrow in `catch` | `console.error(e); throw e` |
+| `audit` | `log.audit(...)` on sensitive routes | Missing audit on auth/billing |
+| `page-error-handling` | fetch error handling on pages | Unhandled page fetches |
+
+Full rule reference: https://www.evlog.dev/cli/rules
+
+Map tells you the **shape** is present — not that the context is useful at runtime. Keep the scans below for frameworks without adapters, for quality of context, drains, redaction, and AI SDK usage. If the user skips the CLI, use this checklist alone.
+
 ## Quick Scan
 
 Run through these checks first to identify improvement opportunities:

--- a/apps/docs/skills/review-logging-patterns/references/code-review.md
+++ b/apps/docs/skills/review-logging-patterns/references/code-review.md
@@ -7,8 +7,8 @@ Use this checklist when reviewing code for logging best practices and evlog adop
 On **Nuxt, Nitro, Next.js App Router, and TanStack Start**, start with `@evlog/cli` if the user is open to it — one command finds dark entry points and names the fixes:
 
 ```bash
-npx @evlog/cli map
-npx @evlog/cli map <file>   # suggested shape for one entry point
+npx @evlog/cli map --no-write
+npx @evlog/cli map <file> --no-write   # suggested shape for one entry point
 ```
 
 Map rule ids (requirements that move the score) map to the anti-patterns below:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,34 +13,33 @@
 
 **Digging through logs is not observability. It's hope.**
 
-The official command line for [evlog](https://evlog.dev).
+The official command line for [evlog](https://evlog.dev) — a **separate package** from the logger itself.
 
-Diagnose your install. Score what your app can tell you when something goes wrong.
+Score what your app can tell you when something goes wrong. Diagnose your install when nothing shows up.
 
 > **Early days.** Safe to run on any project — it reads your source and writes a single `evlog.map.json` at the root (`--no-write` to skip), and it is covered by tests — but young. `evlog map` has adapters for four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases: pin the CLI as a dev dependency when you gate CI on the number.
 
 ## Usage
 
+Try without installing:
+
 ```bash
-pnpm add -D @evlog/cli
-pnpm evlog doctor
+npx @evlog/cli map
+npx @evlog/cli map --json --no-write
 ```
 
-Or without installing:
+Or pin it for repeatable scores / CI:
 
 ```bash
-npx @evlog/cli doctor
-npx @evlog/cli doctor --json
-npx @evlog/cli doctor --cwd apps/web
+pnpm add -D @evlog/cli
+pnpm evlog map
+pnpm evlog doctor
 ```
 
 ## Commands
 
 | Command | What it does |
 | --- | --- |
-| `evlog doctor` | Monorepo-aware diagnosis: Node, project/workspace, stack, evlog install, `.evlog/logs` |
-| `evlog doctor --cwd <dir>` | Run against another directory |
-| `evlog doctor --debug` | Same, plus a debug wide event (see Debug) |
 | `evlog map` | Static observability score for the current app — Lighthouse for wide events |
 | `evlog map <route-or-file>` | Explain one entry point: why it was scanned, each verdict, the shape it could take |
 | `evlog map --all` | Every entry point as a check matrix, grouped by directory |
@@ -49,6 +48,9 @@ npx @evlog/cli doctor --cwd apps/web
 | `evlog map --no-write` | Skip writing `evlog.map.json` to the project root |
 | `evlog map --verbose` | Show per-file parse warnings |
 | `evlog map --cwd <dir>` | Scan another app in the workspace |
+| `evlog doctor` | Monorepo-aware diagnosis: Node, project/workspace, stack, evlog install, `.evlog/logs` |
+| `evlog doctor --cwd <dir>` | Run against another directory |
+| `evlog doctor --debug` | Same, plus a debug wide event (see Debug) |
 | `evlog telemetry status` | Show telemetry status and disclosure |
 | `evlog telemetry enable` / `disable` | Change telemetry preference (disable purges buffered data) |
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1425,10 +1425,11 @@ try {
 
 ## CLI
 
-[`@evlog/cli`](https://npmjs.com/package/@evlog/cli) scores what your app can tell you when something goes wrong. It reads your project on disk — no traffic, no instrumentation — finds every entry point, and names the ones to fix first.
+[`@evlog/cli`](https://npmjs.com/package/@evlog/cli) is a **separate package** — still early — that scores what your app can tell you when something goes wrong. It reads your project on disk — no traffic, no instrumentation — finds every entry point, and names the ones to fix first. Worth trying once you have anything wired; hand the report to an agent if you like.
 
 ```bash
 npx @evlog/cli map
+# or: pnpm dlx @evlog/cli map
 ```
 
 ```
@@ -1453,7 +1454,7 @@ Same code in, same verdict out, with the file and line for every finding — whi
 
 > **Early days:** the CLI is tested and safe to run on any project, but it is young — four framework adapters today, rules still being refined. Expect verdicts and scores to move between releases; pin it as a dev dependency when you gate CI on the number.
 
-Docs: [CLI](https://www.evlog.dev/cli/overview) · [`evlog map`](https://www.evlog.dev/cli/map) · [Rules](https://www.evlog.dev/cli/rules) · [Scoring](https://www.evlog.dev/cli/scoring)
+Docs: [CLI](https://www.evlog.dev/cli/overview) · [`evlog map`](https://www.evlog.dev/cli/map) · [Rules](https://www.evlog.dev/cli/rules) · [Scoring](https://www.evlog.dev/cli/scoring) · [CI](https://www.evlog.dev/cli/ci)
 
 ## Agent Skills
 
@@ -1472,12 +1473,14 @@ Once installed, your AI assistant will:
 - Help refactor scattered `console.log` calls into structured events
 - Guide you to use `createError()` for self-documenting errors
 - Ensure proper use of `useLogger(event)` in Nuxt/Nitro routes
+- Optionally run [`evlog map`](https://www.evlog.dev/cli/map) (`npx @evlog/cli map`) to score dark entry points — separate early CLI package, worth trying
 
 ### Examples
 
 ```
 Add logging to this endpoint
 Review my logging code
+Raise my evlog map score
 Help me set up logging for this service
 ```
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1477,7 +1477,7 @@ Once installed, your AI assistant will:
 
 ### Examples
 
-```
+```text
 Add logging to this endpoint
 Review my logging code
 Raise my evlog map score


### PR DESCRIPTION
## Summary
- Invite trying `@evlog/cli` / `evlog map` from public agent skills, Start/Integrate docs, and READMEs — soft sell (`npx`/`dlx`), not a required install
- Wire `review-logging-patterns` (+ siblings) and agent-skills prompts so agents can score coverage when the user is open to it
- Add `MapRulesMatrix` animation on the CLI rules page (requirements vs opportunities, disable → `n/a`)

## Test plan
- [ ] Skim Start → Installation callout and Integrate overview for tone (invite, early, separate package)
- [ ] Confirm `review-logging-patterns` still works without the CLI (manual checklist path)
- [ ] Open `/cli/rules` and check `MapRulesMatrix` plays, respects reduced motion, no layout shift
- [ ] Agent-skills page shows the “Raise my evlog map score” prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated rules matrix to visualize scan-time verdicts, disabled rules, and reduced-motion behavior.
  * Added guidance for using `evlog map` to score coverage and identify dark entry points.
  * Added optional CLI examples for mapping and diagnostics, including `npx` and `pnpm dlx` usage.

* **Documentation**
  * Expanded CLI, integration, installation, quick-start, and agent skill documentation.
  * Added rule guidance, coverage workflows, review recommendations, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->