### PR TITLE
fix(docs): make micro-animations static

### DIFF
--- a/apps/docs/app/components/content/AiSdkWideEvent.vue
+++ b/apps/docs/app/components/content/AiSdkWideEvent.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface TimelineStep {
@@ -140,13 +139,7 @@ const estimatedCost = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-sparkles" class="size-3.5 text-primary" />
@@ -338,5 +331,5 @@ const estimatedCost = computed(() => {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/AuditCompositionFlow.vue
+++ b/apps/docs/app/components/content/AuditCompositionFlow.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Stage {
@@ -148,13 +147,7 @@ const fanOutReached = computed(() => phase.value === 'fan-out' || phase.value ==
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -325,5 +318,5 @@ const fanOutReached = computed(() => phase.value === 'fan-out' || phase.value ==
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/AuditDualSink.vue
+++ b/apps/docs/app/components/content/AuditDualSink.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface SourceEvent {
@@ -156,13 +155,7 @@ const recentAudit = computed(() =>
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-git-fork" class="size-3.5 text-primary" />
@@ -385,5 +378,5 @@ const recentAudit = computed(() =>
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/AuditForceKeep.vue
+++ b/apps/docs/app/components/content/AuditForceKeep.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface EventRow {
@@ -137,13 +136,7 @@ const stats = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-filter" class="size-3.5 text-primary" />
@@ -253,5 +246,5 @@ const stats = computed(() => {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/BenchBarRace.vue
+++ b/apps/docs/app/components/content/BenchBarRace.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Lib {
@@ -146,13 +145,7 @@ const collapsed = computed(() => phase.value === 'collapsed' || phase.value === 
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -312,5 +305,5 @@ const collapsed = computed(() => phase.value === 'collapsed' || phase.value === 
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/BetterAuthIdentify.vue
+++ b/apps/docs/app/components/content/BetterAuthIdentify.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface IdField {
@@ -169,13 +168,7 @@ function valueColor(value: string) {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -350,5 +343,5 @@ function valueColor(value: string) {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/ClientServerBeacon.vue
+++ b/apps/docs/app/components/content/ClientServerBeacon.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface BrowserEvent {
@@ -153,13 +152,7 @@ const isReceived = computed(() => phase.value === 'received' || phase.value === 
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-radio-tower" class="size-3.5 text-primary" />
@@ -310,5 +303,5 @@ const isReceived = computed(() => phase.value === 'received' || phase.value === 
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/DrainFanOut.vue
+++ b/apps/docs/app/components/content/DrainFanOut.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 type AdapterState = 'pending' | 'inflight' | 'ok' | 'failing' | 'backoff' | 'retrying'
@@ -187,13 +186,7 @@ function statusLabel(adapter: Adapter, s: AdapterState) {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-3">
         <div class="flex gap-1.5">
@@ -373,7 +366,7 @@ function statusLabel(adapter: Adapter, s: AdapterState) {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>
 
 <style scoped>

--- a/apps/docs/app/components/content/DrainPipelineBatching.vue
+++ b/apps/docs/app/components/content/DrainPipelineBatching.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 const BATCH_SIZE = 10
@@ -224,13 +223,7 @@ const fillPct = computed(() => Math.min(100, (buffer.value.length / BATCH_SIZE) 
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -417,5 +410,5 @@ const fillPct = computed(() => Math.min(100, (buffer.value.length / BATCH_SIZE) 
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/EnricherChain.vue
+++ b/apps/docs/app/components/content/EnricherChain.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Enricher {
@@ -153,13 +152,7 @@ const totalEnrichedFields = computed(() =>
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-sparkles" class="size-3.5 text-primary" />
@@ -328,5 +321,5 @@ const totalEnrichedFields = computed(() =>
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/HashChainTamper.vue
+++ b/apps/docs/app/components/content/HashChainTamper.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface AuditRow {
@@ -229,13 +228,7 @@ function outcomeClass(outcome: 'success' | 'denied' | 'failure') {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-link-2" class="size-3.5 text-primary" />
@@ -398,5 +391,5 @@ function outcomeClass(outcome: 'success' | 'denied' | 'failure') {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/HeadSamplingPlinko.vue
+++ b/apps/docs/app/components/content/HeadSamplingPlinko.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface LevelRow {
@@ -172,13 +171,7 @@ const allDone = computed(() => phase.value === 'done')
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -277,5 +270,5 @@ const allDone = computed(() => phase.value === 'done')
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/LifecycleFlow.vue
+++ b/apps/docs/app/components/content/LifecycleFlow.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Stage {
@@ -179,13 +178,7 @@ const isDone = computed(() => phase.value >= stages.length - 1)
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -351,5 +344,5 @@ const isDone = computed(() => phase.value >= stages.length - 1)
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/MapPrGate.vue
+++ b/apps/docs/app/components/content/MapPrGate.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 type RunState = 'queued' | 'running' | 'failed' | 'passed'
@@ -141,13 +140,7 @@ const gateLine = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-git-pull-request" class="size-3 text-primary shrink-0" />
@@ -257,5 +250,5 @@ const gateLine = computed(() => {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/MapRulesMatrix.vue
+++ b/apps/docs/app/components/content/MapRulesMatrix.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent, UseTimedSequenceOptions } from '~/composables/useTimedSequence'
 
 type Cell = 'pending' | 'pass' | 'fail' | 'na' | 'disabled'
@@ -135,13 +134,7 @@ const failingReqs = computed(() =>
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="w-full min-h-[248px] overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-list-checks" class="size-3 text-primary shrink-0" />
@@ -228,5 +221,5 @@ const failingReqs = computed(() =>
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/MapScanFlow.vue
+++ b/apps/docs/app/components/content/MapScanFlow.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 type Verdict = 'pending' | 'dark' | 'partial' | 'instrumented'
@@ -166,13 +165,7 @@ const status = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radar" class="size-3 text-primary shrink-0" />
@@ -301,5 +294,5 @@ const status = computed(() => {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/MapScoreClimb.vue
+++ b/apps/docs/app/components/content/MapScoreClimb.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Rule {
@@ -138,13 +137,7 @@ function accentClass(line: Line) {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-gauge" class="size-3 text-primary shrink-0" />
@@ -246,5 +239,5 @@ function accentClass(line: Line) {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/NdjsonTail.vue
+++ b/apps/docs/app/components/content/NdjsonTail.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Line {
@@ -125,13 +124,7 @@ const progress = computed(() => cursor.value < 0 ? 0 : ((cursor.value + 1) / lin
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-1.5">
         <UIcon name="i-lucide-folder-search" class="size-3 text-primary" />
@@ -238,5 +231,5 @@ const progress = computed(() => cursor.value < 0 ? 0 : ((cursor.value + 1) / lin
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/RedactionStream.vue
+++ b/apps/docs/app/components/content/RedactionStream.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Field {
@@ -117,13 +116,7 @@ function display(field: Field, idx: number) {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-3">
         <div class="flex gap-1.5">
@@ -251,5 +244,5 @@ function display(field: Field, idx: number) {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/SseWire.vue
+++ b/apps/docs/app/components/content/SseWire.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 type FrameType = 'hello' | 'replay' | 'event' | 'ping'
@@ -107,13 +106,7 @@ const replayCount = computed(() => visible.value.filter((v, i) => v && frames[i]
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radio" class="size-3 text-primary" />
@@ -181,5 +174,5 @@ const replayCount = computed(() => visible.value.filter((v, i) => v && frames[i]
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/StreamBus.vue
+++ b/apps/docs/app/components/content/StreamBus.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 type DeliveryState = 'idle' | 'inflight' | 'delivered'
@@ -163,13 +162,7 @@ const stage = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radio-tower" class="size-3 text-primary" />
@@ -296,5 +289,5 @@ const stage = computed(() => {
         </span>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/StructuredErrorBranching.vue
+++ b/apps/docs/app/components/content/StructuredErrorBranching.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Branch {
@@ -188,13 +187,7 @@ function statusClass() {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -406,5 +399,5 @@ function statusClass() {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/StructuredErrorContext.vue
+++ b/apps/docs/app/components/content/StructuredErrorContext.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface ErrorField {
@@ -125,13 +124,7 @@ const reachedRendered = computed(() => phase.value === 'rendered')
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-shield-alert" class="size-3.5 text-primary" />
@@ -259,5 +252,5 @@ err.fix     <span class="text-dimmed">→</span> <span class="text-rose-400/80">
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/TailSampleDecision.vue
+++ b/apps/docs/app/components/content/TailSampleDecision.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Rule {
@@ -186,13 +185,7 @@ const stats = computed(() => {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-funnel" class="size-3.5 text-primary" />
@@ -320,5 +313,5 @@ const stats = computed(() => {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/TypedFieldsIntellisense.vue
+++ b/apps/docs/app/components/content/TypedFieldsIntellisense.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface Suggestion {
@@ -217,13 +216,7 @@ function statusClass() {
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -438,5 +431,5 @@ function statusClass() {
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/ViteStripBuild.vue
+++ b/apps/docs/app/components/content/ViteStripBuild.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface SourceLine {
@@ -134,13 +133,7 @@ const injectCount = computed(() => sourceLines.filter(l => l.kind === 'info-obj'
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">
@@ -267,5 +260,5 @@ const injectCount = computed(() => sourceLines.filter(l => l.kind === 'info-obj'
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>

--- a/apps/docs/app/components/content/WideEventCollapse.vue
+++ b/apps/docs/app/components/content/WideEventCollapse.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Motion } from 'motion-v'
 import type { TimedEvent } from '~/composables/useTimedSequence'
 
 interface NarrowLine {
@@ -152,13 +151,7 @@ const collapsedCount = computed(() => lineCollapsed.value.filter(Boolean).length
 </script>
 
 <template>
-  <Motion
-    :initial="prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }"
-    :while-in-view="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.5 }"
-    :in-view-options="{ once: true, amount: 0.2 }"
-    class="not-prose my-8"
-  >
+  <div class="not-prose my-8">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-shrink" class="size-3.5 text-primary" />
@@ -270,5 +263,5 @@ const collapsedCount = computed(() => lineCollapsed.value.filter(Boolean).length
         </div>
       </div>
     </div>
-  </Motion>
+  </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No linked issue -->

### 📚 Description

Some documentation demo capsules were wrapped in a `<Motion>` component (`motion-v`) with a scroll-triggered entry animation — they faded in while sliding along the Y axis (`initial: { opacity: 0, y: 16 }` → `while-in-view: { opacity: 1, y: 0 }`). This made the capsule *itself* move and fade on appearance.

This change makes all doc capsules fully static: no fade, no movement, no entry transition on the capsule. Only the micro-animation **inside** each capsule stays animated (driven by `useTimedSequence` / reactive state / CSS transitions on inner elements) — that behavior is untouched.

Across the 27 components in `apps/docs/app/components/content/`:
- Replaced the outer `<Motion>` wrapper with a plain static `<div class="not-prose my-8">`.
- Removed the now-unused `import { Motion } from 'motion-v'`.

Landing-page feature animations (`app/components/features/`, `LandingCta`) are a separate design and were intentionally left unchanged.

Verified locally: `eslint` clean and `vue-tsc --noEmit` passes with no errors.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo4uYyGeyNSqWqtrgzEc2N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified documentation demos by removing entrance and viewport-triggered animations.
  * Preserved existing interactive sequences, controls, state changes, and reduced-motion behavior.
  * Documentation examples now render with simpler, more consistent containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->