### PR TITLE
feat(datadog): add trace context correlation support

### DIFF
--- a/.changeset/datadog-trace-correlation.md
+++ b/.changeset/datadog-trace-correlation.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+fix(datadog): lift `event.traceId` / `event.spanId` into a root `dd` block — Datadog's log-to-trace correlation only reads `dd.trace_id` / `dd.span_id` at the payload root, so the ids `createDefaultEnrichers()` already sets arrived nested under `evlog` and never correlated. The nested copy stays, so `@evlog.*` facets keep working, and `resolveDatadogTraceContext` is exported for custom drains

--- a/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
@@ -189,7 +189,7 @@ For advanced use, `sanitizeWideEventForDatadog(event)` returns only the sanitize
 
 ## Trace correlation
 
-Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.span_id`** attributes at the **root** of the payload — nested copies (`@evlog.traceId`) are searchable but never correlate. The adapter lifts `event.traceId` and `event.spanId` into a root `dd` block for you:
+Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.span_id`** attributes at the **root** of the payload. Nested copies (`@evlog.traceId`) are searchable but do not correlate on their own — that takes a [Trace Id Remapper](https://docs.datadoghq.com/logs/log_configuration/processors/trace_remapper/) in a Datadog log pipeline, configuration living outside your codebase. The adapter lifts `event.traceId` and `event.spanId` into a root `dd` block instead, so correlation works with no pipeline setup:
 
 ```json
 {

--- a/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
@@ -202,7 +202,7 @@ Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.sp
 }
 ```
 
-The nested copy under `evlog` stays, so existing `@evlog.*` facets and dashboards keep working. When the event carries neither id, the `dd` key is simply absent.
+The nested copy under `evlog` stays, so existing `@evlog.*` facets and dashboards keep working. Only **non-empty strings** are lifted — an empty or non-string `traceId` / `spanId` is skipped rather than sent as an id Datadog would fail to resolve, and the `dd` key is absent when neither id survives that check.
 
 Those fields are populated by `createTraceContextEnricher`, included in [`createDefaultEnrichers()`](/use-cases/enrichers) — it parses the incoming W3C `traceparent` header into `event.traceId` / `event.spanId`:
 

--- a/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/06.datadog.md
@@ -179,12 +179,50 @@ Each wide event becomes one Datadog log with:
 
 - **`message`** — short one-line summary for the list view (e.g. `ERROR GET /api/checkout (400)`), built with `formatDatadogMessageLine`. Easier to scan than a full JSON blob in Live Tail.
 - **`evlog`** — full wide event as a **JSON object** (not a string). Numeric HTTP **`status`** fields anywhere in the tree are renamed to **`httpStatusCode`** so they never clash with Datadog’s reserved severity `status`.
+- **`dd`** — `{ trace_id, span_id }` when the event carries trace context. See [Trace correlation](#trace-correlation).
 - **`service`**, **`status`** (Datadog severity — drives Live Tail color), **`ddsource`**: `evlog`, **`ddtags`**: `env:…` and optional `version:…`
 - **`timestamp`**: Unix milliseconds from `WideEvent.timestamp`
 
 **Severity (`status`)** at intake root is computed by the adapter from the wide event’s **`level`** and HTTP **`status`** (`resolveDatadogLogStatus` in `evlog/datadog`). Business-only fields on **HTTP 200** stay **`info`** unless you call **`log.error()`**.
 
 For advanced use, `sanitizeWideEventForDatadog(event)` returns only the sanitized object you would store under `evlog`.
+
+## Trace correlation
+
+Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.span_id`** attributes at the **root** of the payload — nested copies (`@evlog.traceId`) are searchable but never correlate. The adapter lifts `event.traceId` and `event.spanId` into a root `dd` block for you:
+
+```json
+{
+  "message": "ERROR GET /api/checkout (400)",
+  "evlog": { "traceId": "4bf92f35…", "spanId": "00f067aa…", "…": "full wide event" },
+  "dd": { "trace_id": "4bf92f35…", "span_id": "00f067aa…" },
+  "service": "my-app",
+  "status": "error",
+  "ddsource": "evlog"
+}
+```
+
+The nested copy under `evlog` stays, so existing `@evlog.*` facets and dashboards keep working. When the event carries neither id, the `dd` key is simply absent.
+
+Those fields are populated by `createTraceContextEnricher`, included in [`createDefaultEnrichers()`](/use-cases/enrichers) — it parses the incoming W3C `traceparent` header into `event.traceId` / `event.spanId`:
+
+```typescript [server/plugins/evlog-enrich.ts]
+import { createDefaultEnrichers } from 'evlog/enrichers'
+
+const enrich = createDefaultEnrichers()
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:enrich', enrich)
+})
+```
+
+If your ids come from somewhere else (a tracer SDK, a vendor header), set `event.traceId` / `event.spanId` yourself and the adapter picks them up the same way:
+
+```typescript
+log.set({ traceId: tracer.scope().active()?.context().toTraceId() })
+```
+
+`resolveDatadogTraceContext(event)` is exported from `evlog/datadog` if you need the same mapping in a custom drain.
 
 ## Querying in Datadog
 

--- a/apps/lab/app/pages/index.vue
+++ b/apps/lab/app/pages/index.vue
@@ -1997,7 +1997,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
       v-model="projectsOpen"
       :projects
       :active-id="activeProjectId"
-      :suggested-name="suggestedName"
+      :suggested-name
       :busy="projectBusy"
       :storage
       :persisted="storagePersisted"

--- a/apps/lab/app/utils/lab/assets.ts
+++ b/apps/lab/app/utils/lab/assets.ts
@@ -91,6 +91,7 @@ export async function putAssetWithId(id: string, blob: Blob, name: string): Prom
   await put<AssetRecord>(ASSETS, { id, blob, name, type: blob.type, bytes: blob.size })
 }
 
+/** One stored blob by id, `undefined` on a machine that never received it. */
 export function getAsset(id: string): Promise<AssetRecord | undefined> {
   return get<AssetRecord>(ASSETS, id)
 }

--- a/apps/lab/app/utils/lab/assets.ts
+++ b/apps/lab/app/utils/lab/assets.ts
@@ -91,7 +91,7 @@ export async function putAssetWithId(id: string, blob: Blob, name: string): Prom
   await put<AssetRecord>(ASSETS, { id, blob, name, type: blob.type, bytes: blob.size })
 }
 
-export async function getAsset(id: string): Promise<AssetRecord | undefined> {
+export function getAsset(id: string): Promise<AssetRecord | undefined> {
   return get<AssetRecord>(ASSETS, id)
 }
 

--- a/apps/lab/app/utils/lab/db.ts
+++ b/apps/lab/app/utils/lab/db.ts
@@ -96,7 +96,7 @@ export async function put<T>(store: string, value: T): Promise<void> {
   await request(store, 'readwrite', target => target.put(value))
 }
 
-export async function get<T>(store: string, key: string): Promise<T | undefined> {
+export function get<T>(store: string, key: string): Promise<T | undefined> {
   return request<T | undefined>(store, 'readonly', target => target.get(key))
 }
 

--- a/apps/lab/app/utils/lab/db.ts
+++ b/apps/lab/app/utils/lab/db.ts
@@ -96,6 +96,7 @@ export async function put<T>(store: string, value: T): Promise<void> {
   await request(store, 'readwrite', target => target.put(value))
 }
 
+/** One record by key, `undefined` when the store holds nothing under it. */
 export function get<T>(store: string, key: string): Promise<T | undefined> {
   return request<T | undefined>(store, 'readonly', target => target.get(key))
 }

--- a/packages/evlog/src/adapters/datadog.ts
+++ b/packages/evlog/src/adapters/datadog.ts
@@ -99,11 +99,33 @@ export function resolveDatadogLogStatus(event: WideEvent): 'error' | 'warn' | 'i
 }
 
 /**
+ * Lift `event.traceId` / `event.spanId` into Datadog’s reserved **`dd`** block.
+ *
+ * Datadog’s log-to-trace correlation only reads `dd.trace_id` / `dd.span_id` at the **root** of the
+ * log payload — the copies nested under `evlog` are searchable but never correlate. Populated by
+ * `createTraceContextEnricher` (part of `createDefaultEnrichers()`), so this works out of the box.
+ *
+ * Returns `undefined` when neither id is a non-empty string, so the key stays absent for anyone
+ * not running trace context.
+ */
+export function resolveDatadogTraceContext(event: WideEvent): Record<string, string> | undefined {
+  const dd: Record<string, string> = {}
+  if (typeof event.traceId === 'string' && event.traceId.length > 0) {
+    dd.trace_id = event.traceId
+  }
+  if (typeof event.spanId === 'string' && event.spanId.length > 0) {
+    dd.span_id = event.spanId
+  }
+  return Object.keys(dd).length > 0 ? dd : undefined
+}
+
+/**
  * Map an evlog wide event to a [Datadog Logs API v2](https://docs.datadoghq.com/api/latest/logs/) log object.
  *
  * Shape:
  * - **`message`** — short line for the list view (`formatDatadogMessageLine`)
  * - **`evlog`** — full sanitized wide event (HTTP codes as `httpStatusCode`); use facets like `@evlog.path`
+ * - **`dd`** — `{ trace_id, span_id }` when the event carries trace context, for log-to-trace correlation
  * - **`status`**, **`service`**, **`ddsource`**, **`ddtags`**, **`timestamp`** — Datadog standard fields
  */
 export function toDatadogLog(event: WideEvent): Record<string, unknown> {
@@ -114,6 +136,8 @@ export function toDatadogLog(event: WideEvent): Record<string, unknown> {
     tags.push(`version:${String(versionTag)}`)
   }
 
+  const dd = resolveDatadogTraceContext(event)
+
   return {
     message: formatDatadogMessageLine(event),
     evlog: sanitizeWideEventForDatadog(event),
@@ -121,6 +145,7 @@ export function toDatadogLog(event: WideEvent): Record<string, unknown> {
     status: resolveDatadogLogStatus(event),
     ddsource: 'evlog',
     ddtags: tags.join(','),
+    ...(dd ? { dd } : {}),
     ...(Number.isFinite(ms) ? { timestamp: ms } : {}),
   }
 }

--- a/packages/evlog/test/adapters/datadog.test.ts
+++ b/packages/evlog/test/adapters/datadog.test.ts
@@ -4,6 +4,7 @@ import {
   formatDatadogMessageLine,
   resolveDatadogIntakeUrl,
   resolveDatadogLogStatus,
+  resolveDatadogTraceContext,
   sanitizeWideEventForDatadog,
   sendBatchToDatadog,
   sendToDatadog,
@@ -125,6 +126,32 @@ describe('datadog adapter', () => {
     })
   })
 
+  describe('resolveDatadogTraceContext', () => {
+    it('maps traceId and spanId to Datadog reserved names', () => {
+      expect(resolveDatadogTraceContext(createTestEvent({
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        spanId: '00f067aa0ba902b7',
+      }))).toEqual({
+        trace_id: '4bf92f3577b34da6a3ce929d0e0e4736',
+        span_id: '00f067aa0ba902b7',
+      })
+    })
+
+    it('keeps whichever id is present on its own', () => {
+      expect(resolveDatadogTraceContext(createTestEvent({ traceId: 'abc' }))).toEqual({ trace_id: 'abc' })
+      expect(resolveDatadogTraceContext(createTestEvent({ spanId: 'def' }))).toEqual({ span_id: 'def' })
+    })
+
+    it('returns undefined without trace context', () => {
+      expect(resolveDatadogTraceContext(createTestEvent())).toBeUndefined()
+    })
+
+    it('ignores empty and non-string ids', () => {
+      expect(resolveDatadogTraceContext(createTestEvent({ traceId: '', spanId: '' }))).toBeUndefined()
+      expect(resolveDatadogTraceContext(createTestEvent({ traceId: 123, spanId: null }))).toBeUndefined()
+    })
+  })
+
   describe('formatDatadogMessageLine', () => {
     it('includes level, method, path, and status code', () => {
       const line = formatDatadogMessageLine(
@@ -157,6 +184,28 @@ describe('datadog adapter', () => {
         path: '/api/hello',
         userId: 'u1',
       })
+    })
+
+    it('lifts trace context to a root dd block while keeping the nested copy', () => {
+      const event = createTestEvent({
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        spanId: '00f067aa0ba902b7',
+      })
+      const row = toDatadogLog(event)
+
+      expect(row.dd).toEqual({
+        trace_id: '4bf92f3577b34da6a3ce929d0e0e4736',
+        span_id: '00f067aa0ba902b7',
+      })
+      expect(row.evlog).toMatchObject({
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        spanId: '00f067aa0ba902b7',
+      })
+    })
+
+    it('omits dd when the event carries no trace context', () => {
+      const row = toDatadogLog(createTestEvent({ path: '/api/hello' }))
+      expect(row).not.toHaveProperty('dd')
     })
 
     it('adds version to tags when present', () => {

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -82,6 +82,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "formatDatadogMessageLine",
     "resolveDatadogIntakeUrl",
     "resolveDatadogLogStatus",
+    "resolveDatadogTraceContext",
     "sanitizeWideEventForDatadog",
     "sendBatchToDatadog",
     "sendToDatadog",


### PR DESCRIPTION
### 📚 Description

Adds support for Datadog log-to-trace correlation by lifting `event.traceId` and `event.spanId` into Datadog's reserved `dd` block at the root of the log payload.

**What changed:**
- New `resolveDatadogTraceContext()` function that maps `event.traceId` → `dd.trace_id` and `event.spanId` → `dd.span_id`, returning `undefined` when neither id is present
- Updated `toDatadogLog()` to include the `dd` block in the output when trace context exists
- The nested copies under `evlog` are preserved for searchability via existing `@evlog.*` facets
- Comprehensive test coverage for the new function and integration with `toDatadogLog()`
- Documentation explaining trace correlation, how it works with `createTraceContextEnricher`, and how to set trace ids from custom sources

**Why:** Datadog only correlates logs to traces when `dd.trace_id` and `dd.span_id` are at the root level of the payload. This change enables automatic correlation for users running the default enrichers or manually setting trace context on events.

### 📝 Checklist

- [x] I have updated the documentation accordingly.
- [x] Added comprehensive unit tests covering all scenarios (both ids, single id, no ids, empty/non-string values)
- [x] Updated public API surface snapshot

https://claude.ai/code/session_01Tm9v1TpA5xvNkFaQ5WfLsg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Datadog log-to-trace correlation using `trace_id` and `span_id`.
  * Trace context is automatically included in a root-level `dd` field when available.
  * Existing event details remain preserved in the nested `evlog` payload.
  * Added support for W3C trace context enrichment, manual assignment, and reuse.

* **Documentation**
  * Expanded Datadog integration documentation with trace-correlation guidance and configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->