### PR TITLE
fix(core): share request scope, logger config and error identity

### DIFF
--- a/.changeset/duplicate-install-shared-registry.md
+++ b/.changeset/duplicate-install-shared-registry.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+fix(core): key request scope, logger config and error identity to a versioned `globalThis` registry — evlog declares 18 optional peers, and pnpm/bun (isolated linker) hash resolved peers into store paths, so two workspaces that resolve `ai` or `zod` differently end up with physically distinct copies of the *same* evlog version. Each copy used to carry its own `AsyncLocalStorage` (so `useLogger()` threw inside another copy's `withEvlog()`), its own logger configuration (so events emitted through the second copy were silently undrained and unredacted), and its own `EvlogError` class (so `instanceof` downgraded structured errors to bare 500s). All three are now shared per major version. `createLoggerStorage()` takes an optional storage id, and `EvlogError.isEvlogError()` replaces `instanceof` for cross-copy checks

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -4,14 +4,17 @@ import type { AuditableLogger } from '../audit'
 import {
   bindAsyncLocalStorage,
   clearAsyncLocalStorage,
-  patchAsyncLocalStorageEnterWith,
+  createSharedEnterWithStorage,
 } from '../shared/asyncStorageScope'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 
-const storage = new AsyncLocalStorage<AuditableLogger>()
-patchAsyncLocalStorageEnterWith(storage)
+/** @internal Every registered instance is a real ALS; the registry only widens the type. */
+const storage = createSharedEnterWithStorage(
+  'evlog:elysia',
+  () => new AsyncLocalStorage<AuditableLogger>(),
+) as AsyncLocalStorage<AuditableLogger>
 
 const activeLoggers = new WeakSet<AuditableLogger>()
 

--- a/packages/evlog/src/error.ts
+++ b/packages/evlog/src/error.ts
@@ -5,6 +5,13 @@ import { colors, isServer } from './utils'
 const evlogErrorInternalKey = Symbol.for('evlog.error.internal')
 
 /**
+ * Prototype brand read by {@link EvlogError.isEvlogError}. `instanceof` compares
+ * class identity, which differs between duplicate installs of evlog — a
+ * registry-shared symbol does not.
+ */
+const evlogErrorBrand = Symbol.for('evlog.error.brand')
+
+/**
  * Structured error with context for better debugging
  *
  * @example
@@ -21,6 +28,18 @@ const evlogErrorInternalKey = Symbol.for('evlog.error.internal')
  * ```
  */
 export class EvlogError extends Error {
+
+  /**
+   * Whether `error` is an `EvlogError`, including one thrown by a different
+   * copy of evlog. Prefer this to `instanceof`: package managers routinely
+   * install more than one physical copy (see #462), and `instanceof` then
+   * silently reports `false`, downgrading a structured error to a bare 500.
+   */
+  static isEvlogError(error: unknown): error is EvlogError {
+    return typeof error === 'object'
+      && error !== null
+      && (error as Record<symbol, unknown>)[evlogErrorBrand] === true
+  }
 
   /** Stable, machine-readable identifier (e.g. `'PAYMENT_DECLINED'`). */
   readonly code?: string
@@ -139,6 +158,11 @@ export class EvlogError extends Error {
   }
 
 }
+
+Object.defineProperty(EvlogError.prototype, evlogErrorBrand, {
+  value: true,
+  enumerable: false,
+})
 
 /**
  * Create a structured error with context for debugging and user-facing messages.

--- a/packages/evlog/src/eve/index.ts
+++ b/packages/evlog/src/eve/index.ts
@@ -9,7 +9,7 @@ import { createMiddlewareLogger } from '../shared/middleware'
 import {
   bindAsyncLocalStorage,
   clearAsyncLocalStorage,
-  patchAsyncLocalStorageEnterWith,
+  createSharedEnterWithStorage,
 } from '../shared/asyncStorageScope'
 
 const DEFAULT_MAX_SESSIONS = 256
@@ -213,8 +213,10 @@ function ensureInit(options: EvlogEveOptions): void {
   setEveInitialized(true)
 }
 
-const turnLoggerStorage = new AsyncLocalStorage<AuditableLogger>()
-patchAsyncLocalStorageEnterWith(turnLoggerStorage)
+const turnLoggerStorage = createSharedEnterWithStorage(
+  'evlog:eve-turn',
+  () => new AsyncLocalStorage<AuditableLogger>(),
+)
 const activeTurnLoggers = new WeakSet<AuditableLogger>()
 
 function bindTurnLogger(logger: AuditableLogger): void {

--- a/packages/evlog/src/express/index.ts
+++ b/packages/evlog/src/express/index.ts
@@ -7,6 +7,7 @@ import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
   'middleware context. Make sure app.use(evlog()) is registered before your routes.',
+  'evlog:express',
 )
 
 export type EvlogExpressOptions = BaseEvlogOptions

--- a/packages/evlog/src/fastify/index.ts
+++ b/packages/evlog/src/fastify/index.ts
@@ -7,6 +7,7 @@ import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
   'plugin context. Make sure app.register(evlog) is called before your routes.',
+  'evlog:fastify',
 )
 
 void registerDiskPrettyErrorSnippetReader()

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -1,12 +1,12 @@
 import type { AuditableLogger, AuditInput, AuditMethod } from './audit'
-import type { DrainContext, EnvironmentContext, FieldContext, Log, LogLevel, LoggerConfig, RedactConfig, RequestLogger, RequestLoggerOptions, SamplingConfig, TailSamplingContext, WideEvent } from './types'
+import type { DrainContext, EnvironmentContext, FieldContext, Log, LogLevel, LoggerConfig, RequestLogger, RequestLoggerOptions, TailSamplingContext, WideEvent } from './types'
 import { buildAuditFields, consumeAuditForceKeep, finalizeAudit } from './audit'
 import { markGloballyRedacted, redactEvent, resolveRedactConfig } from './redact'
 import type { PluginRunner } from './shared/plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './shared/plugin'
 import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER } from './shared/pretty-error'
-import type { ResolvedPrettyError } from './shared/dev-terminal'
 import { resolveDevTerminal } from './shared/dev-terminal'
+import { globalConfig } from './shared/globalRegistry'
 import { EvlogError } from './error'
 import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, isoNow, matchesPattern } from './utils'
 
@@ -79,39 +79,22 @@ export function markWideEventDrainStarted(event: WideEvent | null): void {
  */
 export { mergeInto as mergeWideEventFields }
 
-let globalEnv: EnvironmentContext = {
-  service: 'app',
-  environment: 'development',
-}
-
-let globalPretty = isDev()
-let globalPrettyError: ResolvedPrettyError = {
-  snippet: isDev(),
-  stackDepth: 2,
-  compact: isDev(),
-  detail: 'full',
-}
-let globalSampling: SamplingConfig = {}
-let globalStringify = true
-let globalDrain: ((ctx: DrainContext) => void | Promise<void>) | undefined
-let globalRedact: RedactConfig | undefined
-let globalEnabled = true
-let globalSilent = false
-/** Minimum level for the global `log` API only (`ownsEvent === false`). Default: all levels. */
-let globalMinLevel: LogLevel = 'debug'
-let _locked = false
-let _loggerInitialized = false
-let globalPluginRunner: PluginRunner = getEmptyPluginRunner()
+/**
+ * Process-wide configuration, shared with every other copy of evlog the package
+ * manager may have installed (see `shared/globalRegistry.ts`). The reference is
+ * stable, so reads stay a plain property access on the hot path.
+ */
+const state = globalConfig
 
 /**
  * Initialize the logger with configuration.
  * Call this once at application startup.
  */
 export function initLogger(config: LoggerConfig = {}): void {
-  globalEnabled = config.enabled ?? true
+  state.enabled = config.enabled ?? true
   const detected = detectEnvironment()
 
-  globalEnv = {
+  state.env = {
     service: config.env?.service ?? detected.service ?? 'app',
     environment: config.env?.environment ?? detected.environment ?? 'development',
     version: config.env?.version ?? detected.version,
@@ -119,28 +102,28 @@ export function initLogger(config: LoggerConfig = {}): void {
     region: config.env?.region ?? detected.region,
   }
 
-  globalPretty = config.pretty ?? isDev()
-  globalPrettyError = resolveDevTerminal(config).prettyError
-  globalSampling = config.sampling ?? {}
-  globalStringify = config.stringify ?? true
-  globalDrain = config.drain
-  globalRedact = resolveRedactConfig(config.redact ?? !isDev())
-  globalSilent = config.silent ?? false
-  globalMinLevel = config.minLevel ?? 'debug'
-  globalPluginRunner = config.plugins?.length
+  state.pretty = config.pretty ?? isDev()
+  state.prettyError = resolveDevTerminal(config).prettyError
+  state.sampling = config.sampling ?? {}
+  state.stringify = config.stringify ?? true
+  state.drain = config.drain
+  state.redact = resolveRedactConfig(config.redact ?? !isDev())
+  state.silent = config.silent ?? false
+  state.minLevel = config.minLevel ?? 'debug'
+  state.pluginRunner = config.plugins?.length
     ? createPluginRunner(config.plugins)
     : getEmptyPluginRunner()
 
-  if (globalPluginRunner.plugins.length > 0) {
-    void globalPluginRunner.runSetup({ env: { ...globalEnv } })
+  if (state.pluginRunner.plugins.length > 0) {
+    void state.pluginRunner.runSetup({ env: { ...state.env } })
   }
 
-  const hasAnyDrain = !!globalDrain || globalPluginRunner.hasDrain
-  if (globalSilent && !hasAnyDrain && !config._suppressDrainWarning) {
+  const hasAnyDrain = !!state.drain || state.pluginRunner.hasDrain
+  if (state.silent && !hasAnyDrain && !config._suppressDrainWarning) {
     console.warn('[evlog] silent mode is enabled but no drain is configured. Events will be built and sampled but not output anywhere. Set a drain via initLogger({ drain }) or a framework hook (evlog:drain).')
   }
 
-  _loggerInitialized = true
+  state.initialized = true
 }
 
 /**
@@ -149,14 +132,14 @@ export function initLogger(config: LoggerConfig = {}): void {
  * the middleware-level options.
  */
 export function getGlobalPluginRunner(): PluginRunner {
-  return globalPluginRunner
+  return state.pluginRunner
 }
 
 /**
  * Check if logging is globally enabled.
  */
 export function isEnabled(): boolean {
-  return globalEnabled
+  return state.enabled
 }
 
 /**
@@ -165,21 +148,21 @@ export function isEnabled(): boolean {
  * Prevents configureHandler() from overwriting the drain config.
  */
 export function lockLogger(): void {
-  _locked = true
+  state.locked = true
 }
 
 /**
  * @internal Check if the logger has been locked by instrumentation.
  */
 export function isLoggerLocked(): boolean {
-  return _locked
+  return state.locked
 }
 
 /**
  * @internal Whether {@link initLogger} has completed at least once.
  */
 export function isLoggerInitialized(): boolean {
-  return _loggerInitialized
+  return state.initialized
 }
 
 /**
@@ -188,7 +171,7 @@ export function isLoggerInitialized(): boolean {
  * when no middleware-level drain is provided.
  */
 export function getGlobalDrain(): ((ctx: DrainContext) => void | Promise<void>) | undefined {
-  return globalDrain
+  return state.drain
 }
 
 /**
@@ -196,7 +179,7 @@ export function getGlobalDrain(): ((ctx: DrainContext) => void | Promise<void>) 
  * Error level defaults to 100% (always logged) unless explicitly configured otherwise.
  */
 function shouldSample(level: LogLevel): boolean {
-  const { rates } = globalSampling
+  const { rates } = state.sampling
   if (!rates) {
     return true // No sampling configured, log everything
   }
@@ -218,7 +201,7 @@ function shouldSample(level: LogLevel): boolean {
  * Returns true if ANY condition matches (OR logic).
  */
 export function shouldKeep(ctx: TailSamplingContext): boolean {
-  const { keep } = globalSampling
+  const { keep } = state.sampling
   if (!keep?.length) return false
 
   return keep.some((condition) => {
@@ -247,10 +230,10 @@ function emitWideEvent(
   options: EmitWideEventOptions = {},
 ): WideEvent | null {
   const { deferDrain = false, ownsEvent = false, waitUntil } = options
-  if (!globalEnabled) return null
+  if (!state.enabled) return null
 
   if (!ownsEvent) {
-    if (!isLevelEnabled(level, globalMinLevel)) {
+    if (!isLevelEnabled(level, state.minLevel)) {
       return null
     }
     if (!shouldSample(level)) {
@@ -262,32 +245,32 @@ function emitWideEvent(
   if (ownsEvent) {
     event.timestamp = isoNow()
     event.level = level
-    if (event.service === undefined) event.service = globalEnv.service
-    if (event.environment === undefined) event.environment = globalEnv.environment
-    if (globalEnv.version !== undefined && event.version === undefined) event.version = globalEnv.version
-    if (globalEnv.commitHash !== undefined && event.commitHash === undefined) event.commitHash = globalEnv.commitHash
-    if (globalEnv.region !== undefined && event.region === undefined) event.region = globalEnv.region
+    if (event.service === undefined) event.service = state.env.service
+    if (event.environment === undefined) event.environment = state.env.environment
+    if (state.env.version !== undefined && event.version === undefined) event.version = state.env.version
+    if (state.env.commitHash !== undefined && event.commitHash === undefined) event.commitHash = state.env.commitHash
+    if (state.env.region !== undefined && event.region === undefined) event.region = state.env.region
     formatted = event as WideEvent
   } else {
     formatted = {
       timestamp: isoNow(),
       level,
-      ...globalEnv,
+      ...state.env,
       ...event,
     }
   }
 
   finalizeAudit(formatted)
 
-  if (globalRedact) {
-    formatted = redactEvent(formatted, globalRedact) as WideEvent
+  if (state.redact) {
+    formatted = redactEvent(formatted, state.redact) as WideEvent
     markGloballyRedacted(formatted)
   }
 
-  if (!globalSilent) {
-    if (globalPretty) {
+  if (!state.silent) {
+    if (state.pretty) {
       prettyPrintWideEvent(formatted)
-    } else if (globalStringify) {
+    } else if (state.stringify) {
       console[getConsoleMethod(level)](JSON.stringify(formatted))
     } else {
       console[getConsoleMethod(level)](formatted)
@@ -296,19 +279,19 @@ function emitWideEvent(
 
   if (!deferDrain) {
     const drainPromises: Array<Promise<unknown>> = []
-    if (globalDrain) {
+    if (state.drain) {
       drainPromises.push(
         (async () => {
           try {
-            await globalDrain!({ event: formatted })
+            await state.drain!({ event: formatted })
           } catch (err) {
             console.error('[evlog] drain failed:', err)
           }
         })(),
       )
     }
-    if (globalPluginRunner.hasDrain) {
-      drainPromises.push(globalPluginRunner.runDrain({ event: formatted }))
+    if (state.pluginRunner.hasDrain) {
+      drainPromises.push(state.pluginRunner.runDrain({ event: formatted }))
     }
     if (drainPromises.length > 0 && waitUntil) {
       waitUntil(Promise.all(drainPromises))
@@ -319,10 +302,10 @@ function emitWideEvent(
 }
 
 function emitTaggedLog(level: LogLevel, tag: string, message: string): void {
-  if (!globalEnabled) return
+  if (!state.enabled) return
 
-  if (globalPretty && !globalSilent) {
-    if (!isLevelEnabled(level, globalMinLevel)) {
+  if (state.pretty && !state.silent) {
+    if (!isLevelEnabled(level, state.minLevel)) {
       return
     }
     if (!shouldSample(level)) {
@@ -660,7 +643,7 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
   const restEntries = Object.entries(rest).filter(([_, v]) => v !== undefined)
   const aiEntries = aiData ? buildAIEntries(aiData) : []
   const errorEntries = errorData !== undefined
-    ? buildErrorEntries(errorData, globalPrettyError)
+    ? buildErrorEntries(errorData, state.prettyError)
     : []
   const contextEntries: TreeEntry[] = [
     ...restEntries.map(([key, value]) => ({ key, value: formatValue(value) })),
@@ -796,7 +779,7 @@ interface CreateLoggerInternalOptions {
  * ```
  */
 export function createLogger<T extends object = Record<string, unknown>>(initialContext: Record<string, unknown> = {}, internalOptions?: CreateLoggerInternalOptions): AuditableLogger<T> {
-  if (!globalEnabled) return noopLogger as unknown as AuditableLogger<T>
+  if (!state.enabled) return noopLogger as unknown as AuditableLogger<T>
 
   const deferDrain = internalOptions?._deferDrain ?? false
   const waitUntil = internalOptions?.waitUntil
@@ -892,7 +875,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
         if (k in err) errorObj[k] = errRecord[k]
       }
 
-      if (err instanceof EvlogError) {
+      if (EvlogError.isEvlogError(err)) {
         if (err.code) errorObj.code = err.code
         if (err.why) errorObj.why = err.why
         if (err.fix) errorObj.fix = err.fix
@@ -953,7 +936,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
         forceKeep = true
       } else if (auditForceKeep) {
         forceKeep = true
-      } else if (globalSampling.keep?.length) {
+      } else if (state.sampling.keep?.length) {
         const status = (overrides as Record<string, unknown> | undefined)?.status ?? context.status
         forceKeep = shouldKeep({
           status: status as number | undefined,
@@ -1037,7 +1020,7 @@ export function createRequestLogger<T extends object = Record<string, unknown>>(
  * Get the current environment context.
  */
 export function getEnvironment(): EnvironmentContext {
-  return { ...globalEnv }
+  return { ...state.env }
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -89,6 +89,13 @@ const state = globalConfig
 /**
  * Initialize the logger with configuration.
  * Call this once at application startup.
+ *
+ * Every field is overwritten on each call, and the state is process-wide —
+ * shared with any duplicate install of the same major. Last call wins, so a
+ * second `initLogger()` without a `drain` clears the drain for every copy.
+ * Integrations that initialize implicitly must therefore check
+ * {@link isLoggerLocked} / {@link isLoggerInitialized} first, as `next/handler`
+ * and `eve` do.
  */
 export function initLogger(config: LoggerConfig = {}): void {
   state.enabled = config.enabled ?? true

--- a/packages/evlog/src/nestjs/index.ts
+++ b/packages/evlog/src/nestjs/index.ts
@@ -10,6 +10,7 @@ import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
   'middleware context. Make sure EvlogModule.forRoot() is imported in your AppModule.',
+  'evlog:nestjs',
 )
 
 export type EvlogNestJSOptions = BaseEvlogOptions

--- a/packages/evlog/src/next/handler.ts
+++ b/packages/evlog/src/next/handler.ts
@@ -299,7 +299,7 @@ export function createWithEvlog(options: NextEvlogOptions) {
         await emitRequestEvent(logger, { method, path, requestId }, headers, errorStatus)
 
         // Return structured JSON response for EvlogErrors (like H3 does for Nuxt)
-        if (isRequest && error instanceof EvlogError) {
+        if (isRequest && EvlogError.isEvlogError(error)) {
           return Response.json(error.toJSON(), { status: error.status }) as Awaited<TReturn>
         }
 

--- a/packages/evlog/src/next/storage.ts
+++ b/packages/evlog/src/next/storage.ts
@@ -1,7 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { AuditableLogger } from '../audit'
+import { getSharedStorage } from '../shared/globalRegistry'
 
-export const evlogStorage = new AsyncLocalStorage<AuditableLogger>()
+/** @internal Every registered instance is a real ALS; the registry only widens the type. */
+export const evlogStorage = getSharedStorage(
+  'evlog:next',
+  () => new AsyncLocalStorage<AuditableLogger>(),
+) as AsyncLocalStorage<AuditableLogger>
 
 /**
  * Get the current request-scoped logger.

--- a/packages/evlog/src/nitro-v3/middleware.ts
+++ b/packages/evlog/src/nitro-v3/middleware.ts
@@ -37,7 +37,7 @@ export async function evlogErrorHandler(
   try {
     return (await Promise.resolve(next())) as RequestServerResult<any, any, any>
   } catch (error: unknown) {
-    if (error instanceof EvlogError || (error && typeof error === 'object' && (error as Error).name === 'EvlogError')) {
+    if (EvlogError.isEvlogError(error)) {
       const evlogError = error as EvlogError
 
       try {

--- a/packages/evlog/src/orpc/index.ts
+++ b/packages/evlog/src/orpc/index.ts
@@ -8,6 +8,7 @@ import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
   'oRPC handler. Wrap your handler with `withEvlog()` from evlog/orpc.',
+  'evlog:orpc',
 )
 
 /** Options accepted by {@link withEvlog} for oRPC request instrumentation. */
@@ -145,10 +146,6 @@ export function withEvlog<THandler extends OrpcFetchHandlerLike>(
   })
 }
 
-function isEvlogError(error: unknown): error is EvlogError {
-  return error instanceof EvlogError || (error instanceof Error && error.name === 'EvlogError')
-}
-
 /**
  * Procedure-level middleware. Three responsibilities:
  *
@@ -195,7 +192,7 @@ export function evlog<TContext extends Partial<EvlogOrpcContext> & Context = Evl
       return await next()
     } catch (error) {
       if (log) log.error(error as Error)
-      if (isEvlogError(error)) {
+      if (EvlogError.isEvlogError(error)) {
         throw toOrpcError(error)
       }
       throw error

--- a/packages/evlog/src/react-router/index.ts
+++ b/packages/evlog/src/react-router/index.ts
@@ -7,6 +7,7 @@ import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
   'middleware context. Make sure the evlog middleware is added to your route.',
+  'evlog:react-router',
 )
 
 /**

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -1,3 +1,5 @@
+import { getSharedStorage } from './globalRegistry'
+
 /**
  * Structural stand-in for `AsyncLocalStorage` so this module does not import
  * `node:async_hooks`. Callers that construct storage (Elysia, eve) keep their
@@ -48,6 +50,24 @@ export function bindAsyncLocalStorage<T>(
 /** Clear a value previously bound with {@link bindAsyncLocalStorage}. */
 export function clearAsyncLocalStorage<T>(storage: AsyncLocalStorageLike<T>): void {
   storage.enterWith(undefined as unknown as T)
+}
+
+/**
+ * Registry-shared storage for integrations that bind with `enterWith()` rather
+ * than `run()` (Elysia, eve). The `enterWith` polyfill is applied once, by
+ * whichever copy of evlog wins the race to register `id`.
+ *
+ * @param create - Passed in so this module stays free of `node:async_hooks`.
+ */
+export function createSharedEnterWithStorage<T>(
+  id: string,
+  create: () => AsyncLocalStorageLike<T>,
+): AsyncLocalStorageLike<T> {
+  return getSharedStorage(id, () => {
+    const storage = create()
+    patchAsyncLocalStorageEnterWith(storage)
+    return storage
+  })
 }
 
 /**

--- a/packages/evlog/src/shared/globalRegistry.ts
+++ b/packages/evlog/src/shared/globalRegistry.ts
@@ -9,7 +9,7 @@ import { getEmptyPluginRunner } from './plugin'
  * Major version this build belongs to. Bump on every major release — the
  * registry key embeds it so two majors never share mutable state.
  *
- * Kept in sync with `package.json` by `test/toolkit/global-registry.test.ts`.
+ * Kept in sync with `package.json` by `test/toolkit/duplicate-install.test.ts`.
  */
 const EVLOG_MAJOR = 2
 
@@ -129,9 +129,14 @@ export function getSharedStorage<T>(
   return storage as AsyncLocalStorageLike<T>
 }
 
-/** @internal Reset shared state between tests. */
+/**
+ * @internal Reset shared state between tests. Also drops the recorded majors so
+ * the multi-major warning can fire again — `vi.resetModules()` re-evaluates
+ * modules but leaves `globalThis` untouched.
+ */
 export function resetGlobalRegistry(): void {
   const host = globalThis as RegistryHost
   Object.assign(globalConfig, createConfig())
   host[REGISTRY_KEY]?.storages.clear()
+  host[MAJORS_KEY]?.clear()
 }

--- a/packages/evlog/src/shared/globalRegistry.ts
+++ b/packages/evlog/src/shared/globalRegistry.ts
@@ -1,0 +1,137 @@
+import type { DrainContext, EnvironmentContext, LogLevel, RedactConfig, SamplingConfig } from '../types'
+import { isDev } from '../utils'
+import type { AsyncLocalStorageLike } from './asyncStorageScope'
+import type { ResolvedPrettyError } from './dev-terminal'
+import type { PluginRunner } from './plugin'
+import { getEmptyPluginRunner } from './plugin'
+
+/**
+ * Major version this build belongs to. Bump on every major release — the
+ * registry key embeds it so two majors never share mutable state.
+ *
+ * Kept in sync with `package.json` by `test/toolkit/global-registry.test.ts`.
+ */
+const EVLOG_MAJOR = 2
+
+/**
+ * Registry key. Every 2.x copy of evlog in a dependency graph resolves the
+ * same slot, so `initLogger()` and `withEvlog()` work across duplicate installs
+ * (pnpm/bun hash our 18 optional peers into store paths, so two workspaces
+ * resolving `ai` or `zod` differently get physically distinct evlog copies).
+ */
+const REGISTRY_KEY = Symbol.for(`evlog.registry.v${EVLOG_MAJOR}`)
+
+/** Unversioned slot used only to detect — and warn about — multi-major installs. */
+const MAJORS_KEY = Symbol.for('evlog.majors')
+
+/**
+ * Process-wide logger configuration, shared by every evlog copy of this major.
+ *
+ * Fields are read through a stable object reference rather than module-local
+ * `let` bindings so that a copy which never ran `initLogger()` still sees the
+ * drain and redaction policy the application configured.
+ *
+ * Adding a field within a major is safe (older copies ignore it). Changing the
+ * meaning of an existing field is not — an older copy in the same process will
+ * still read it with the old semantics.
+ */
+export interface EvlogGlobalConfig {
+  env: EnvironmentContext
+  pretty: boolean
+  prettyError: ResolvedPrettyError
+  sampling: SamplingConfig
+  stringify: boolean
+  drain: ((ctx: DrainContext) => void | Promise<void>) | undefined
+  redact: RedactConfig | undefined
+  enabled: boolean
+  silent: boolean
+  /** Minimum level for the global `log` API only (`ownsEvent === false`). */
+  minLevel: LogLevel
+  locked: boolean
+  initialized: boolean
+  pluginRunner: PluginRunner
+}
+
+interface EvlogRegistry {
+  config: EvlogGlobalConfig
+  /** Request-scoped `AsyncLocalStorage` instances, keyed by integration id. */
+  storages: Map<string, AsyncLocalStorageLike<unknown>>
+}
+
+type RegistryHost = typeof globalThis & {
+  [REGISTRY_KEY]?: EvlogRegistry
+  [MAJORS_KEY]?: Set<number>
+}
+
+function createConfig(): EvlogGlobalConfig {
+  return {
+    env: { service: 'app', environment: 'development' },
+    pretty: isDev(),
+    prettyError: { snippet: isDev(), stackDepth: 2, compact: isDev(), detail: 'full' },
+    sampling: {},
+    stringify: true,
+    drain: undefined,
+    redact: undefined,
+    enabled: true,
+    silent: false,
+    minLevel: 'debug',
+    locked: false,
+    initialized: false,
+    pluginRunner: getEmptyPluginRunner(),
+  }
+}
+
+function warnOnMultiMajor(host: RegistryHost): void {
+  const majors = (host[MAJORS_KEY] ??= new Set<number>())
+  if (majors.has(EVLOG_MAJOR)) return
+  majors.add(EVLOG_MAJOR)
+  if (majors.size > 1) {
+    console.warn(
+      `[evlog] Multiple major versions of evlog are loaded in this process (${[...majors].map(m => `${m}.x`).join(', ')}). `
+      + 'They cannot share request scope or logger configuration: events emitted through the other copy will be undrained '
+      + 'and unredacted, and useLogger() may throw. Deduplicate evlog to a single major.',
+    )
+  }
+}
+
+function getRegistry(): EvlogRegistry {
+  const host = globalThis as RegistryHost
+  warnOnMultiMajor(host)
+  return (host[REGISTRY_KEY] ??= { config: createConfig(), storages: new Map() })
+}
+
+/**
+ * The shared logger configuration record. The reference is stable for the
+ * lifetime of the process, so callers may hold it at module scope.
+ */
+export const globalConfig: EvlogGlobalConfig = getRegistry().config
+
+/**
+ * Get — creating on first use — the `AsyncLocalStorage` backing `useLogger()`
+ * for one integration. Every copy of evlog resolves the same instance for a
+ * given `id`, so a `withEvlog()` from one copy is visible to a `useLogger()`
+ * from another.
+ *
+ * @param id - Stable, integration-scoped identifier (e.g. `'next'`). Third
+ *   parties should namespace theirs to avoid colliding with evlog's own.
+ * @param create - Factory invoked only when this copy wins the race to register.
+ */
+export function getSharedStorage<T>(
+  id: string,
+  create: () => AsyncLocalStorageLike<T>,
+): AsyncLocalStorageLike<T> {
+  const { storages } = getRegistry()
+  let storage = storages.get(id)
+  if (!storage) {
+    storage = create() as AsyncLocalStorageLike<unknown>
+    storages.set(id, storage)
+  }
+  return storage as AsyncLocalStorageLike<T>
+}
+
+/** @internal Reset shared state between tests. */
+export function resetGlobalRegistry(): void {
+  const host = globalThis as RegistryHost
+  Object.assign(globalConfig, createConfig())
+  host[REGISTRY_KEY]?.storages.clear()
+}

--- a/packages/evlog/src/shared/storage.ts
+++ b/packages/evlog/src/shared/storage.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { AuditableLogger } from '../audit'
+import { getSharedStorage } from './globalRegistry'
 
 /**
  * Create a request-scoped `AsyncLocalStorage` and matching `useLogger`
@@ -14,9 +15,14 @@ import type { AuditableLogger } from '../audit'
  * @param contextHint - Appended to the error message when `useLogger()` is
  *   called outside of a request, e.g. `"middleware context. Make sure
  *   app.use(evlog()) is registered before your routes."`.
+ * @param id - Stable identifier for the shared storage slot. Copies of evlog
+ *   duplicated by the package manager resolve the same instance for a given
+ *   `id`, so a request opened by one copy is visible to the other. Defaults to
+ *   `contextHint`; third-party callers should pass a namespaced id.
  */
-export function createLoggerStorage(contextHint: string) {
-  const storage = new AsyncLocalStorage<AuditableLogger>()
+export function createLoggerStorage(contextHint: string, id: string = contextHint) {
+  /** @internal Every registered instance is a real ALS; the registry only widens the type. */
+  const storage = getSharedStorage(id, () => new AsyncLocalStorage<AuditableLogger>()) as AsyncLocalStorage<AuditableLogger>
 
   function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
     const logger = storage.getStore()

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -9,6 +9,7 @@ import { EvlogError } from '../error'
 
 const { storage, useLogger } = createLoggerStorage(
   'handle context. Make sure evlog() handle is added to your hooks.server.ts.',
+  'evlog:sveltekit',
 )
 
 void registerDiskPrettyErrorSnippetReader()
@@ -172,7 +173,7 @@ export function evlog(options: EvlogSvelteKitOptions = {}): SvelteKitHandle {
         await finish({ error: error instanceof Error ? error : new Error(String(error)) })
 
         // Return structured JSON for EvlogError (like NextJS withEvlog / Nuxt errorHandler)
-        if (error instanceof EvlogError) {
+        if (EvlogError.isEvlogError(error)) {
           const status = error.status ?? 500
           const body = serializeEvlogErrorResponse(error, event.url.pathname)
           return new Response(JSON.stringify(body), {

--- a/packages/evlog/test/toolkit/duplicate-install.test.ts
+++ b/packages/evlog/test/toolkit/duplicate-install.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import pkg from '../../package.json' with { type: 'json' }
+
+/**
+ * Regression tests for #462 — duplicate installs of the same major.
+ *
+ * pnpm and bun (isolated linker) hash evlog's optional peers into the store
+ * path, so two workspaces that resolve `ai` or `zod` differently end up with
+ * physically distinct copies of the *same* evlog version. Before the shared
+ * registry, each copy had its own `AsyncLocalStorage` (so `useLogger()` threw
+ * inside another copy's `withEvlog()`) and its own logger configuration (so
+ * events emitted through the second copy were silently undrained and
+ * unredacted).
+ *
+ * `vi.resetModules()` reproduces this faithfully: the second `import()`
+ * re-evaluates every module in the graph, exactly like a second physical copy.
+ */
+
+/** Load a fresh evaluation of a module graph, as a duplicate install would. */
+function loadCopy<T>(load: () => Promise<T>): Promise<T> {
+  vi.resetModules()
+  return load()
+}
+
+afterEach(async () => {
+  vi.resetModules()
+  const { resetGlobalRegistry } = await import('../../src/shared/globalRegistry')
+  resetGlobalRegistry()
+  vi.restoreAllMocks()
+})
+
+describe('duplicate installs (#462)', () => {
+  it('shares the next.js request scope across copies', async () => {
+    const copyA = await loadCopy(() => import('../../src/next/storage'))
+    const copyB = await loadCopy(() => import('../../src/next/storage'))
+
+    expect(copyA).not.toBe(copyB)
+    expect(copyA.evlogStorage).toBe(copyB.evlogStorage)
+
+    const logger = { marker: 'from-copy-a' } as never
+    const seen = copyA.evlogStorage.run(logger, () => copyB.useLogger())
+    expect(seen).toBe(logger)
+  })
+
+  it('shares request scope for storages created through createLoggerStorage', async () => {
+    const copyA = await loadCopy(() => import('../../src/shared/storage'))
+    const copyB = await loadCopy(() => import('../../src/shared/storage'))
+
+    const a = copyA.createLoggerStorage('express hint', 'evlog:express')
+    const b = copyB.createLoggerStorage('express hint', 'evlog:express')
+    expect(a.storage).toBe(b.storage)
+
+    const logger = { marker: 'shared' } as never
+    expect(a.storage.run(logger, () => b.useLogger())).toBe(logger)
+  })
+
+  it('keeps distinct integrations on distinct storages', async () => {
+    const { createLoggerStorage } = await import('../../src/shared/storage')
+    const express = createLoggerStorage('express hint', 'evlog:express')
+    const fastify = createLoggerStorage('fastify hint', 'evlog:fastify')
+
+    expect(express.storage).not.toBe(fastify.storage)
+    express.storage.run({} as never, () => {
+      expect(() => fastify.useLogger()).toThrow(/outside of an evlog fastify hint/)
+    })
+  })
+
+  it('applies a drain configured by one copy to events emitted by another', async () => {
+    const copyA = await loadCopy(() => import('../../src/logger'))
+    const copyB = await loadCopy(() => import('../../src/logger'))
+
+    const drained: unknown[] = []
+    copyA.initLogger({
+      silent: true,
+      drain: ({ event }) => {
+        drained.push(event)
+      },
+    })
+
+    expect(copyB.getGlobalDrain()).toBe(copyA.getGlobalDrain())
+    expect(copyB.isLoggerInitialized()).toBe(true)
+
+    copyB.log.info({ name: 'from-copy-b' })
+    await vi.waitFor(() => expect(drained).toHaveLength(1))
+    expect(drained[0]).toMatchObject({ name: 'from-copy-b' })
+  })
+
+  it('shares enabled/locked state across copies', async () => {
+    const copyA = await loadCopy(() => import('../../src/logger'))
+    const copyB = await loadCopy(() => import('../../src/logger'))
+
+    copyA.initLogger({ enabled: false, silent: true, _suppressDrainWarning: true })
+    expect(copyB.isEnabled()).toBe(false)
+
+    copyA.lockLogger()
+    expect(copyB.isLoggerLocked()).toBe(true)
+  })
+
+  it('recognizes an EvlogError thrown by another copy', async () => {
+    const copyA = await loadCopy(() => import('../../src/error'))
+    const copyB = await loadCopy(() => import('../../src/error'))
+
+    const error = copyA.createError({ code: 'PAYMENT_DECLINED', status: 402, why: 'insufficient funds' })
+
+    expect(error instanceof copyB.EvlogError).toBe(false)
+    expect(copyB.EvlogError.isEvlogError(error)).toBe(true)
+  })
+
+  it('does not mistake a look-alike error for an EvlogError', async () => {
+    const errorModule = await import('../../src/error')
+    const impostor = Object.assign(new Error('nope'), { name: 'EvlogError', status: 402 })
+
+    expect(errorModule.EvlogError.isEvlogError(impostor)).toBe(false)
+    expect(errorModule.EvlogError.isEvlogError(null)).toBe(false)
+    expect(errorModule.EvlogError.isEvlogError('EvlogError')).toBe(false)
+  })
+
+  it('keys the registry to the package major so majors never share state', async () => {
+    const major = Number(pkg.version.split('.')[0])
+    const { globalConfig } = await import('../../src/shared/globalRegistry')
+    const slot = (globalThis as Record<symbol, { config: unknown } | undefined>)[
+      Symbol.for(`evlog.registry.v${major}`)
+    ]
+
+    expect(slot?.config).toBe(globalConfig)
+  })
+
+  it('warns once when a second major joins the process', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const major = Number(pkg.version.split('.')[0])
+    const majors = (globalThis as Record<symbol, Set<number> | undefined>)[Symbol.for('evlog.majors')]
+    majors?.delete(major)
+    majors?.add(major + 1)
+
+    await loadCopy(() => import('../../src/shared/globalRegistry'))
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Multiple major versions of evlog'))
+  })
+})

--- a/packages/evlog/test/toolkit/duplicate-install.test.ts
+++ b/packages/evlog/test/toolkit/duplicate-install.test.ts
@@ -96,6 +96,24 @@ describe('duplicate installs (#462)', () => {
     expect(copyB.isLoggerLocked()).toBe(true)
   })
 
+  it('applies a redaction policy configured by one copy to another copy events', async () => {
+    const copyA = await loadCopy(() => import('../../src/logger'))
+    const copyB = await loadCopy(() => import('../../src/logger'))
+
+    const drained: Array<Record<string, unknown>> = []
+    copyA.initLogger({
+      silent: true,
+      redact: { paths: ['user.email'] },
+      drain: ({ event }) => {
+        drained.push(event as Record<string, unknown>)
+      },
+    })
+
+    copyB.log.info({ name: 'checkout', user: { email: 'someone@example.com' } })
+    await vi.waitFor(() => expect(drained).toHaveLength(1))
+    expect((drained[0]!.user as Record<string, unknown>).email).toBe('[REDACTED]')
+  })
+
   it('recognizes an EvlogError thrown by another copy', async () => {
     const copyA = await loadCopy(() => import('../../src/error'))
     const copyB = await loadCopy(() => import('../../src/error'))
@@ -126,14 +144,30 @@ describe('duplicate installs (#462)', () => {
   })
 
   it('warns once when a second major joins the process', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const major = Number(pkg.version.split('.')[0])
-    const majors = (globalThis as Record<symbol, Set<number> | undefined>)[Symbol.for('evlog.majors')]
-    majors?.delete(major)
-    majors?.add(major + 1)
+    const majorsKey = Symbol.for('evlog.majors')
+    const host = globalThis as Record<symbol, Set<number> | undefined>
 
-    await loadCopy(() => import('../../src/shared/globalRegistry'))
+    // Establish the slot ourselves rather than relying on an earlier import,
+    // so the test holds when it runs alone.
+    await import('../../src/shared/globalRegistry')
+    const majors = host[majorsKey]!
+    const previous = new Set(majors)
 
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Multiple major versions of evlog'))
+    try {
+      majors.clear()
+      majors.add(Number(pkg.version.split('.')[0]) + 1)
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      await loadCopy(() => import('../../src/shared/globalRegistry'))
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Multiple major versions of evlog'))
+
+      // A third copy of the same major must stay quiet.
+      await loadCopy(() => import('../../src/shared/globalRegistry'))
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      majors.clear()
+      for (const major of previous) majors.add(major)
+    }
   })
 })


### PR DESCRIPTION
Fixes #462

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate installations now share request-scoped logging state and configuration within the same major version.
  * Added reliable cross-installation recognition for `EvlogError`, including structured error responses.
  * Added optional stable identifiers for logger storage integrations.

* **Bug Fixes**
  * Improved compatibility across supported framework integrations.
  * Added warnings when multiple major versions are loaded together.

* **Tests**
  * Added coverage for shared state, error recognition, version isolation, and integration isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->