### PR TITLE
chore(core): remove unused internal adapter shims

### DIFF
--- a/packages/evlog/src/adapters/_config.ts
+++ b/packages/evlog/src/adapters/_config.ts
@@ -1,3 +1,0 @@
-/** @deprecated Internal shim. Use `evlog/toolkit` instead. */
-export { getRuntimeConfig, resolveAdapterConfig } from '../shared/config'
-export type { ConfigField } from '../shared/config'

--- a/packages/evlog/src/adapters/_drain.ts
+++ b/packages/evlog/src/adapters/_drain.ts
@@ -1,3 +1,0 @@
-/** @deprecated Internal shim. Use `evlog/toolkit` instead. */
-export { defineDrain, defineHttpDrain } from '../shared/drain'
-export type { DrainOptions, HttpDrainOptions, HttpDrainRequest } from '../shared/drain'

--- a/packages/evlog/src/adapters/_http.ts
+++ b/packages/evlog/src/adapters/_http.ts
@@ -1,3 +1,0 @@
-/** @deprecated Internal shim. Use `evlog/toolkit` instead. */
-export { httpPost } from '../shared/http'
-export type { HttpPostOptions } from '../shared/http'

--- a/packages/evlog/src/adapters/_severity.ts
+++ b/packages/evlog/src/adapters/_severity.ts
@@ -1,2 +1,0 @@
-/** @deprecated Internal shim. Use `evlog/toolkit` instead. */
-export { OTEL_SEVERITY_NUMBER, OTEL_SEVERITY_TEXT } from '../shared/severity'


### PR DESCRIPTION
## What

Deletes four dead files under `packages/evlog/src/adapters/`:

- `_config.ts`
- `_drain.ts`
- `_http.ts`
- `_severity.ts`

They were deprecated re-export shims (`/** @deprecated Internal shim. Use \`evlog/toolkit\` instead. */`) forwarding to `src/shared/`.

## Why

They are unreachable:

- no importers left in `src/`, `test/` or `bench/`
- absent from `packages/evlog/package.json#exports`
- absent from `packages/evlog/tsdown.config.ts` entries

So they were never built, never published, and never part of the API surface snapshot. Pure dead weight.

## Notes

Internal-only change — no changeset per `AGENTS.md`.

Found during a repo-wide consistency audit; first of a series of PRs standardising how framework integrations and adapters reuse the shared layer.

## Verification

- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run test` — 1628/1628 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated internal adapter shims and their legacy exports.
  * Updated the public surface by removing obsolete configuration, drain, HTTP, and severity re-exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->