### PR TITLE
fix(core): forward waitUntil through defineEvlog and detect it on hono

### DIFF
--- a/.changeset/waituntil-propagation.md
+++ b/.changeset/waituntil-propagation.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+fix(core): stop dropping `waitUntil` when a `defineEvlog()` config is passed to middleware — `toMiddlewareOptions()` copied every other `BaseEvlogOptions` field but silently omitted `waitUntil`, so `defineEvlog({ waitUntil })` lost the serverless drain hook on its way to the framework integration and drains were awaited inline instead of being registered with the platform. `evlog/hono` now also picks up `c.executionCtx.waitUntil` on its own, so drains on Cloudflare Workers and Vercel Edge complete after the response is returned with no manual wiring; adapters without an `ExecutionContext` (Node, Bun, Deno) keep draining inline, and an explicit `waitUntil` option still wins

--- a/packages/evlog/src/hono/index.ts
+++ b/packages/evlog/src/hono/index.ts
@@ -33,6 +33,18 @@ const integration = defineFrameworkIntegration<Context>({
   attachLogger: (c, logger) => {
     c.set('log', logger)
   },
+  extractWaitUntil: (c) => {
+    // Hono's `executionCtx` getter throws when the adapter has none (Node,
+    // Bun, Deno). Only Workers / Vercel Edge provide one.
+    try {
+      const { executionCtx } = c
+      return typeof executionCtx?.waitUntil === 'function'
+        ? executionCtx.waitUntil.bind(executionCtx)
+        : undefined
+    } catch {
+      return undefined
+    }
+  },
 })
 
 /**

--- a/packages/evlog/src/shared/define.ts
+++ b/packages/evlog/src/shared/define.ts
@@ -94,5 +94,6 @@ export function toMiddlewareOptions<T extends BaseEvlogOptions>(config: EvlogCon
   if (config.keep) out.keep = config.keep
   if (config.redact !== undefined) out.redact = config.redact
   if (config.plugins) out.plugins = config.plugins
+  if (config.waitUntil) out.waitUntil = config.waitUntil
   return out as T
 }

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -177,6 +177,53 @@ describe('evlog/hono', () => {
     expect(logValue).toBeUndefined()
   })
 
+  describe('waitUntil', () => {
+    it('defers drain to executionCtx.waitUntil when the adapter provides one', async () => {
+      const { drain } = createPipelineSpies()
+      const pending: Promise<unknown>[] = []
+      const executionCtx = { waitUntil: (p: Promise<unknown>) => pending.push(p), passThroughOnException: () => {} }
+
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+      app.get('/api/test', (c) => c.json({ ok: true }))
+
+      await app.request('/api/test', {}, {}, executionCtx)
+
+      expect(pending.length).toBeGreaterThan(0)
+      await Promise.all(pending)
+      assertDrainCalledWith(drain, { path: '/api/test', method: 'GET', status: 200 })
+    })
+
+    it('drains inline when the runtime has no executionCtx', async () => {
+      const { drain } = createPipelineSpies()
+
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+      app.get('/api/test', (c) => c.json({ ok: true }))
+
+      await app.request('/api/test')
+
+      assertDrainCalledWith(drain, { path: '/api/test', method: 'GET', status: 200 })
+    })
+
+    it('per-request options.waitUntil takes precedence over executionCtx', async () => {
+      const { drain } = createPipelineSpies()
+      const fromOption: Promise<unknown>[] = []
+      const fromCtx: Promise<unknown>[] = []
+      const executionCtx = { waitUntil: (p: Promise<unknown>) => fromCtx.push(p), passThroughOnException: () => {} }
+
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain, waitUntil: (p) => fromOption.push(p) }))
+      app.get('/api/test', (c) => c.json({ ok: true }))
+
+      await app.request('/api/test', {}, {}, executionCtx)
+
+      expect(fromOption.length).toBeGreaterThan(0)
+      expect(fromCtx).toHaveLength(0)
+      await Promise.all(fromOption)
+    })
+  })
+
   describe('drain / enrich / keep', () => {
     it('calls drain with emitted event (shared helpers)', async () => {
       const { drain } = createPipelineSpies()

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -178,8 +178,15 @@ describe('evlog/hono', () => {
   })
 
   describe('waitUntil', () => {
-    it('defers drain to executionCtx.waitUntil when the adapter provides one', async () => {
-      const { drain } = createPipelineSpies()
+    it('returns the response before a slow drain settles, via executionCtx.waitUntil', async () => {
+      // A drain that stays pending until we release it: if the response only
+      // resolved after the drain, this test would time out rather than pass.
+      let releaseDrain!: () => void
+      const drainDone = new Promise<void>((resolve) => {
+        releaseDrain = resolve
+      })
+      const drain = vi.fn().mockReturnValue(drainDone)
+
       const pending: Promise<unknown>[] = []
       const executionCtx = { waitUntil: (p: Promise<unknown>) => pending.push(p), passThroughOnException: () => {} }
 
@@ -187,10 +194,24 @@ describe('evlog/hono', () => {
       app.use(evlog({ drain }))
       app.get('/api/test', (c) => c.json({ ok: true }))
 
-      await app.request('/api/test', {}, {}, executionCtx)
+      const response = await app.request('/api/test', {}, {}, executionCtx)
 
-      expect(pending.length).toBeGreaterThan(0)
+      // Response is done while the drain is still in flight.
+      expect(response.status).toBe(200)
+      expect(drain).toHaveBeenCalledTimes(1)
+      expect(pending).toHaveLength(1)
+
+      let settled = false
+      void Promise.all(pending).then(() => {
+        settled = true
+      })
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      releaseDrain()
       await Promise.all(pending)
+      expect(settled).toBe(true)
+
       assertDrainCalledWith(drain, { path: '/api/test', method: 'GET', status: 200 })
     })
 

--- a/packages/evlog/test/toolkit/toolkit.test.ts
+++ b/packages/evlog/test/toolkit/toolkit.test.ts
@@ -559,6 +559,12 @@ describe('defineEvlog / toLoggerConfig / toMiddlewareOptions', () => {
     expect(mw.enrich).toBe(enrich)
     expect(mw.plugins).toEqual([{ name: 'p' }])
   })
+
+  it('toMiddlewareOptions forwards waitUntil', () => {
+    const waitUntil = vi.fn()
+    const mw = toMiddlewareOptions(defineEvlog({ waitUntil }))
+    expect(mw.waitUntil).toBe(waitUntil)
+  })
 })
 
 describe('defineFrameworkIntegration', () => {


### PR DESCRIPTION
## What

Two related `waitUntil` gaps:

1. **`toMiddlewareOptions()` dropped `waitUntil`.** `shared/define.ts` copies `BaseEvlogOptions` onto the middleware surface field by field, and `waitUntil` was missing from the list. `defineEvlog({ waitUntil })` therefore silently lost the hook, and drains were awaited inline instead of being registered with the platform.

2. **`extractWaitUntil` was a dead extension point.** `FrameworkIntegrationSpec.extractWaitUntil` is declared and consumed by `defineFrameworkIntegration` (`shared/integration.ts:110`), but no integration ever passed it. It is now wired on `evlog/hono`.

## Why it matters

On Cloudflare Workers and Vercel Edge, drain work awaited inline delays the response; registered with `waitUntil` it completes after the response is returned. That is what `evlog/workers` and the Nitro plugin already do — Hono now matches with no manual wiring.

## Notes

Hono's `c.executionCtx` getter **throws** when the adapter has no `ExecutionContext` (Node, Bun, Deno), so the lookup is guarded by try/catch and falls back to inline draining. An explicit `options.waitUntil` still wins over the auto-detected one.

Part of a series of PRs standardising how framework integrations reuse the shared layer.

## Verification

- `pnpm run test` — 1632/1632 pass (4 new)
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts` untouched)
- `pnpm run typecheck` — 26/26 tasks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hono integrations now automatically use the available execution context to defer background logging tasks.
  * Explicit per-request `waitUntil` options remain supported and take precedence.
  * Environments without an execution context continue to process deferred tasks inline.

* **Bug Fixes**
  * Improved `waitUntil` propagation through middleware and framework integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->