### PR TITLE
refactor: reuse defineFrameworkIntegration across the remaining integrations

### DIFF
--- a/.changeset/framework-integration-consistency.md
+++ b/.changeset/framework-integration-consistency.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+refactor: route `evlog/nestjs`, `evlog/react-router` and `evlog/sveltekit` through `defineFrameworkIntegration()` — the three integrations each rebuilt the same request extraction, `crypto.randomUUID()` fallback, `attachForkToLogger()` call and `storage.run()` wrapper by hand instead of using the helper Hono, Express, Elysia, Fastify and oRPC already share. Behaviour is unchanged, but they now inherit anything the helper gains (including `waitUntil` extraction) for free. A new `pickBaseEvlogOptions()` toolkit export becomes the single place listing the `BaseEvlogOptions` fields, replacing the copy in `toMiddlewareOptions()` and the hand-written field list in `evlog/eve` — which silently dropped `waitUntil`, and would have dropped every option added later

--- a/packages/evlog/src/eve/index.ts
+++ b/packages/evlog/src/eve/index.ts
@@ -5,7 +5,7 @@ import type { AIToolExecution, AIEventData, ModelCost } from '../ai/index'
 import { initLogger, isLoggerInitialized, isLoggerLocked } from '../logger'
 import type { LoggerConfig } from '../types'
 import type { BaseEvlogOptions, MiddlewareLoggerOptions } from '../shared/middleware'
-import { createMiddlewareLogger } from '../shared/middleware'
+import { createMiddlewareLogger, pickBaseEvlogOptions } from '../shared/middleware'
 import {
   bindAsyncLocalStorage,
   clearAsyncLocalStorage,
@@ -529,14 +529,7 @@ function getOrCreateTurnState(
     method: 'EVE',
     path,
     requestId: turnId,
-    drain: options.drain,
-    enrich: options.enrich,
-    keep: options.keep,
-    redact: options.redact,
-    plugins: options.plugins,
-    include: options.include,
-    exclude: options.exclude,
-    routes: options.routes,
+    ...pickBaseEvlogOptions(options),
   }
 
   const { logger, finish, skipped } = createMiddlewareLogger(middlewareOptions)

--- a/packages/evlog/src/nestjs/index.ts
+++ b/packages/evlog/src/nestjs/index.ts
@@ -2,9 +2,8 @@ import type { ServerResponse } from 'node:http'
 import type { Request } from 'express'
 import type { DynamicModule, MiddlewareConsumer, NestModule } from '@nestjs/common'
 import type { AuditableLogger } from '../audit'
-import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
-import { attachForkToLogger } from '../shared/fork'
-import { extractSafeNodeHeaders } from '../shared/headers'
+import { defineFrameworkIntegration } from '../shared/integration'
+import type { BaseEvlogOptions } from '../shared/middleware'
 import { bindNodeResponseLifecycle } from '../shared/nodeResponse'
 import { createLoggerStorage } from '../shared/storage'
 
@@ -38,32 +37,32 @@ declare module 'express-serve-static-core' {
   }
 }
 
+const integration = defineFrameworkIntegration<Request>({
+  name: 'nestjs',
+  extractRequest: (req) => ({
+    method: req.method || 'GET',
+    path: new URL(req.originalUrl || req.url || '/', 'http://localhost').pathname,
+    headers: req.headers,
+    requestId: typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined,
+  }),
+  attachLogger: (req, logger) => {
+    req.log = logger
+  },
+  storage,
+})
+
 function createEvlogMiddleware(getOptions: () => EvlogNestJSOptions) {
   return (req: Request, res: ServerResponse, next: () => void) => {
-    const options = getOptions()
-    const headers = extractSafeNodeHeaders(req.headers)
-    const url = new URL(req.originalUrl || req.url || '/', 'http://localhost')
-
-    const middlewareOpts = {
-      method: req.method || 'GET',
-      path: url.pathname,
-      requestId: headers['x-request-id'] || crypto.randomUUID(),
-      headers,
-      ...options,
-    }
-    const { logger, finish, skipped } = createMiddlewareLogger(middlewareOpts)
+    const { logger, finish, skipped, runWith } = integration.start(req, getOptions())
 
     if (skipped) {
       next()
       return
     }
 
-    attachForkToLogger(storage, logger, middlewareOpts)
-    req.log = logger
-
     bindNodeResponseLifecycle(res, logger, finish)
 
-    storage.run(logger, () => next())
+    void runWith(() => next())
   }
 }
 

--- a/packages/evlog/src/react-router/index.ts
+++ b/packages/evlog/src/react-router/index.ts
@@ -1,8 +1,7 @@
 import { createContext } from 'react-router'
 import type { AuditableLogger } from '../audit'
-import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
-import { attachForkToLogger } from '../shared/fork'
-import { extractSafeHeaders } from '../shared/headers'
+import { defineFrameworkIntegration } from '../shared/integration'
+import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
 
 const { storage, useLogger } = createLoggerStorage(
@@ -30,6 +29,25 @@ export type EvlogReactRouterOptions = BaseEvlogOptions
 
 export { useLogger }
 
+interface ReactRouterContext {
+  request: Request
+  context: { set(ctx: unknown, value: unknown): void }
+}
+
+const integration = defineFrameworkIntegration<ReactRouterContext>({
+  name: 'react-router',
+  extractRequest: ({ request }) => ({
+    method: request.method,
+    path: new URL(request.url).pathname,
+    headers: request.headers,
+    requestId: request.headers.get('x-request-id') ?? undefined,
+  }),
+  attachLogger: ({ context }, logger) => {
+    context.set(loggerContext, logger)
+  },
+  storage,
+})
+
 /**
  * Create an evlog middleware for React Router.
  *
@@ -45,28 +63,17 @@ export { useLogger }
  */
 export function evlog(options: EvlogReactRouterOptions = {}) {
   return async (
-    { request, context }: { request: Request; context: { set(ctx: unknown, value: unknown): void } },
+    ctx: ReactRouterContext,
     next: () => Promise<Response>,
   ): Promise<Response> => {
-    const url = new URL(request.url)
-    const middlewareOpts = {
-      method: request.method,
-      path: url.pathname,
-      requestId: request.headers.get('x-request-id') || crypto.randomUUID(),
-      headers: extractSafeHeaders(request.headers),
-      ...options,
-    }
-    const { logger, finish, finishResponse, skipped } = createMiddlewareLogger(middlewareOpts)
+    const { finish, finishResponse, skipped, runWith } = integration.start(ctx, options)
 
     if (skipped) {
       return next()
     }
 
-    attachForkToLogger(storage, logger, middlewareOpts)
-    context.set(loggerContext, logger)
-
     try {
-      const response = await storage.run(logger, () => next())
+      const response = await runWith(next)
       return finishResponse(response, { status: response.status })
     } catch (error) {
       await finish({ error: error as Error })

--- a/packages/evlog/src/shared/define.ts
+++ b/packages/evlog/src/shared/define.ts
@@ -1,6 +1,7 @@
 import type { EnvironmentContext, LoggerConfig, SamplingConfig } from '../types'
 import type { DevTerminalInput } from './dev-terminal'
 import type { BaseEvlogOptions } from './middleware'
+import { pickBaseEvlogOptions } from './middleware'
 
 /**
  * Single-config shape accepted everywhere evlog is bootstrapped: at
@@ -85,15 +86,5 @@ export function toLoggerConfig(config: EvlogConfig): LoggerConfig {
 
 /** Project an {@link EvlogConfig} onto the surface accepted by framework middleware. */
 export function toMiddlewareOptions<T extends BaseEvlogOptions>(config: EvlogConfig): T {
-  const out: BaseEvlogOptions = {}
-  if (config.include) out.include = config.include
-  if (config.exclude) out.exclude = config.exclude
-  if (config.routes) out.routes = config.routes
-  if (config.drain) out.drain = config.drain
-  if (config.enrich) out.enrich = config.enrich
-  if (config.keep) out.keep = config.keep
-  if (config.redact !== undefined) out.redact = config.redact
-  if (config.plugins) out.plugins = config.plugins
-  if (config.waitUntil) out.waitUntil = config.waitUntil
-  return out as T
+  return pickBaseEvlogOptions(config) as T
 }

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -44,6 +44,28 @@ export interface BaseEvlogOptions {
   waitUntil?: (promise: Promise<unknown>) => void
 }
 
+/**
+ * Project any superset of {@link BaseEvlogOptions} onto just the middleware
+ * surface, dropping caller-specific extras.
+ *
+ * This is the single place listing the {@link BaseEvlogOptions} fields — adding
+ * an option here makes it flow through `defineEvlog()` and every integration
+ * that builds middleware options from its own richer option type.
+ */
+export function pickBaseEvlogOptions(options: BaseEvlogOptions): BaseEvlogOptions {
+  const out: BaseEvlogOptions = {}
+  if (options.include) out.include = options.include
+  if (options.exclude) out.exclude = options.exclude
+  if (options.routes) out.routes = options.routes
+  if (options.drain) out.drain = options.drain
+  if (options.enrich) out.enrich = options.enrich
+  if (options.keep) out.keep = options.keep
+  if (options.redact !== undefined) out.redact = options.redact
+  if (options.plugins) out.plugins = options.plugins
+  if (options.waitUntil) out.waitUntil = options.waitUntil
+  return out
+}
+
 /** Internal options accepted by `createMiddlewareLogger`. */
 export interface MiddlewareLoggerOptions extends BaseEvlogOptions {
   method: string

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -1,8 +1,7 @@
 import type { RequestLogger } from '../types'
 import { registerDiskPrettyErrorSnippetReader } from '../shared/register-disk-snippet'
-import { createMiddlewareLogger, type BaseEvlogOptions } from '../shared/middleware'
-import { attachForkToLogger } from '../shared/fork'
-import { extractSafeHeaders } from '../shared/headers'
+import { defineFrameworkIntegration } from '../shared/integration'
+import type { BaseEvlogOptions } from '../shared/middleware'
 import { createLoggerStorage } from '../shared/storage'
 import { resolveEvlogError, extractErrorStatus, serializeEvlogErrorResponse } from '../nitro'
 import { EvlogError } from '../error'
@@ -22,9 +21,30 @@ export { useLogger }
  * SvelteKit `Handle` function signature — avoids a hard dependency on `@sveltejs/kit`.
  */
 type SvelteKitHandle = (input: {
-  event: { request: Request; url: URL; locals: Record<string, any> }
+  event: SvelteKitRequestEvent
   resolve: (...args: any[]) => Response | Promise<Response>
 }) => Promise<Response>
+
+/** The subset of SvelteKit's `RequestEvent` the integration reads. */
+interface SvelteKitRequestEvent {
+  request: Request
+  url: URL
+  locals: Record<string, any>
+}
+
+const integration = defineFrameworkIntegration<SvelteKitRequestEvent>({
+  name: 'sveltekit',
+  extractRequest: ({ request, url }) => ({
+    method: request.method,
+    path: url.pathname,
+    headers: request.headers,
+    requestId: request.headers.get('x-request-id') ?? undefined,
+  }),
+  attachLogger: (event, logger) => {
+    event.locals.log = logger
+  },
+  storage,
+})
 
 /**
  * SvelteKit `HandleServerError` signature — avoids a hard dependency on `@sveltejs/kit`.
@@ -133,23 +153,13 @@ function readEvlogResponseData(response: Record<string, unknown>): { why?: strin
  */
 export function evlog(options: EvlogSvelteKitOptions = {}): SvelteKitHandle {
   return async ({ event, resolve }) => {
-    const middlewareOpts = {
-      method: event.request.method,
-      path: event.url.pathname,
-      requestId: event.request.headers.get('x-request-id') || crypto.randomUUID(),
-      headers: extractSafeHeaders(event.request.headers),
-      ...options,
-    }
-    const { logger, finish, finishResponse, skipped } = createMiddlewareLogger(middlewareOpts)
+    const { logger, finish, finishResponse, skipped, runWith } = integration.start(event, options)
 
     if (skipped) {
       return await resolve(event)
     }
 
-    attachForkToLogger(storage, logger, middlewareOpts)
-    event.locals.log = logger
-
-    return storage.run(logger, async () => {
+    return runWith(async () => {
       try {
         const response = await resolve(event)
 

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -265,6 +265,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "isStreamingResponse",
     "mergeEventField",
     "normalizeNumber",
+    "pickBaseEvlogOptions",
     "resolveAdapterConfig",
     "resolveMiddlewarePluginRunner",
     "runEnrichAndDrain",


### PR DESCRIPTION
## What

Removes the third tier of framework integrations. Before this PR they fell into three groups:

| | Integrations | Reuse |
|---|---|---|
| A | hono, express, elysia, fastify, orpc | `defineFrameworkIntegration()` |
| B | **nestjs, react-router, sveltekit, eve** | `createMiddlewareLogger()` directly, boilerplate re-implemented |
| C | next | whole pipeline re-implemented |

This PR moves **nestjs**, **react-router** and **sveltekit** from B to A. (Tier C is a separate PR.)

## Why

Each of the three rebuilt the exact same four things by hand:

- request extraction + `extractSafeHeaders` / `extractSafeNodeHeaders`
- the `|| crypto.randomUUID()` request-id fallback
- `attachForkToLogger(storage, logger, opts)`
- the `storage.run(logger, ...)` wrapper

That is precisely `defineFrameworkIntegration().start()`. Keeping the copies means every future pipeline change has to be applied in four places — and they had already drifted: none of them picked up `extractWaitUntil`.

## `pickBaseEvlogOptions()`

New toolkit export, and the **single** place listing the `BaseEvlogOptions` fields.

It replaces two duplicated copies of that list:

- `toMiddlewareOptions()` in `shared/define.ts`
- a hand-written field list in `evlog/eve`, which omitted `waitUntil` and would have omitted every option added later

This is the mechanism that makes "add an option once, every integration benefits" actually hold.

## `evlog/eve`

Deliberately **not** migrated to `defineFrameworkIntegration()`. Eve is turn-based, not HTTP — no headers, no response, `method: 'EVE'` — so the helper would buy nothing. It adopts the shared option projection only.

## Behaviour

No intended behaviour change. The API snapshot diff is a single additive line (`pickBaseEvlogOptions`).

## Verification

- `pnpm run test` — 1628/1628 pass
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run api:snapshot` — updated, diff is `+ "pickBaseEvlogOptions"` only

The shared `describeStandardHttpMatrix` conformance suite already covers all three migrated integrations and passes unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized request logging behavior across NestJS, React Router, and SvelteKit integrations.
  * Improved consistency for request metadata, request IDs, logger context, and asynchronous request handling.
  * Ensured shared logging options are applied consistently, including explicit redaction settings.
* **Documentation**
  * Added release documentation covering the framework integration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->