### PR TITLE
feat(workers): run cloudflare workers through the shared middleware pipeline

### DIFF
--- a/.changeset/workers-middleware-pipeline.md
+++ b/.changeset/workers-middleware-pipeline.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+feat(workers): add `withEvlog()` so Cloudflare Workers get the full middleware pipeline — `evlog/workers` was the only integration that never ran `createMiddlewareLogger`, so `include` / `exclude`, per-route `routes` overrides, `redact`, `enrich`, `keep` tail sampling and `plugins` simply had no effect there. Wrap your fetch handler with `withEvlog(handler, options)` and the wide event is emitted for you when the handler returns, with the same option surface every other framework accepts; `ctx.waitUntil` is picked up from the third argument so drains outlive the response, streaming bodies defer the emit until they complete, and `requestId` now honours `x-request-id` before falling back to `cf-ray`. `defineWorkerFetch()` and `createWorkersLogger()` are unchanged and remain the manual-emit path. The entrypoint stays free of `node:async_hooks`, so it still runs without `nodejs_compat`

--- a/apps/docs/content/4.integrate/frameworks/12.cloudflare-workers.md
+++ b/apps/docs/content/4.integrate/frameworks/12.cloudflare-workers.md
@@ -6,7 +6,9 @@ navigation:
   icon: i-simple-icons-cloudflare
 ---
 
-The `evlog/workers` adapter provides factory functions for creating request-scoped loggers with Cloudflare-specific context. Unlike framework integrations, Workers require manual `log.emit()` calls since there is no middleware lifecycle to hook into.
+The `evlog/workers` adapter instruments Cloudflare Workers and Durable Objects with request-scoped loggers carrying Cloudflare-specific context.
+
+Use **`withEvlog`** to get the same middleware pipeline as every other framework integration — route filtering, redaction, enrich, tail sampling, plugins, drains, and automatic emit. Reach for `defineWorkerFetch` or `createWorkersLogger` when you'd rather own the emit yourself.
 
 ::prompt
 ---
@@ -21,11 +23,11 @@ actions:
 Set up evlog in my Cloudflare Worker.
 
 - Install evlog: pnpm add evlog
-- Import initWorkersLogger and defineWorkerFetch from 'evlog/workers'
+- Import initWorkersLogger and withEvlog from 'evlog/workers'
 - Call initWorkersLogger({ env: { service: 'my-worker' } }) at the top level
-- In the fetch handler, use **defineWorkerFetch** (recommended) or createWorkersLogger(request, { executionCtx: ctx })
+- Wrap the fetch handler with **withEvlog** (recommended) — it emits the wide event for you and accepts include/exclude, routes, redact, enrich, keep, plugins and drain
 - Use log.set() to accumulate context throughout the request
-- Call log.emit() manually before returning the response (no middleware lifecycle)
+- Only use defineWorkerFetch or createWorkersLogger if you want to call log.emit() yourself
 
 Docs: https://www.evlog.dev/integrate/frameworks/cloudflare-workers
 Adapters: https://www.evlog.dev/integrate/adapters/overview
@@ -51,31 +53,76 @@ npm install evlog
 ```
 ::
 
-### 2. Initialize and create request loggers
+### 2. Wrap your fetch handler
 
 ```typescript [src/worker.ts]
-import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
+import { initWorkersLogger, withEvlog } from 'evlog/workers'
 
 initWorkersLogger({
   env: { service: 'my-worker' },
 })
 
-export default defineWorkerFetch(async (request, _env, _ctx, log) => {
+export default withEvlog(async (request, _env, _ctx, log) => {
   log.set({ action: 'handle_request' })
 
   // ... your handler logic
 
+  return Response.json({ ok: true })
+})
+```
+
+`withEvlog` emits one wide event per request when the handler returns — no manual `log.emit()`. It reads `ExecutionContext` off the third argument, so async **`drain`** calls (PostHog, Axiom, …) are registered with `waitUntil` and stay alive after the response is returned. Streaming responses defer the emit until the body completes.
+
+`requestId` comes from `x-request-id` when the caller sends one, falling back to `cf-ray`. `method`, `path`, `cf-ray`, `traceparent` and the safe subset of `request.cf` are captured automatically.
+
+### Options
+
+`withEvlog` accepts the same options as every other framework integration:
+
+```typescript [src/worker.ts]
+import { initWorkersLogger, withEvlog } from 'evlog/workers'
+import { createAxiomDrain } from 'evlog/axiom'
+
+initWorkersLogger({ env: { service: 'my-worker' } })
+
+export default withEvlog(
+  async (request, env, ctx, log) => {
+    log.set({ route: 'checkout' })
+    return Response.json({ ok: true })
+  },
+  {
+    drain: createAxiomDrain(),
+    exclude: ['/health'],
+    routes: { '/api/**': { service: 'api' } },
+    redact: true,
+    enrich: (ctx) => {
+      ctx.event.colo = ctx.event.colo ?? 'unknown'
+    },
+    keep: (ctx) => {
+      if (ctx.duration > 1000) ctx.shouldKeep = true
+    },
+  },
+)
+```
+
+### Emitting manually
+
+Prefer to own the emit? `defineWorkerFetch` wires `ExecutionContext` for you but leaves `log.emit()` to you:
+
+```typescript [src/worker.ts]
+import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
+
+initWorkersLogger({ env: { service: 'my-worker' } })
+
+export default defineWorkerFetch(async (request, _env, _ctx, log) => {
+  log.set({ action: 'handle_request' })
   log.emit()
   return Response.json({ ok: true })
 })
 ```
 
-`defineWorkerFetch` passes `ExecutionContext` into `createWorkersLogger` for you, so async **`drain`** calls (PostHog, Axiom, …) stay alive via `waitUntil` after the response is returned. Use raw `export default { fetch }` + `createWorkersLogger(request, { executionCtx: ctx })` only if you prefer not to use the wrapper.
-
-`createWorkersLogger` still auto-extracts `method`, `path`, and `cf-ray` from the request.
-
 ::callout{icon="i-lucide-info" color="info"}
-You must call `log.emit()` manually before returning a response. Workers don't have a request lifecycle hook to auto-emit. With **`defineWorkerFetch`**, async `drain` work is tied to `waitUntil` automatically; with a raw `{ fetch }` handler, pass `{ executionCtx: ctx }` to `createWorkersLogger`.
+`defineWorkerFetch` and `createWorkersLogger` are the low-level path: they create the logger and leave the lifecycle to you, so `include` / `exclude`, `routes`, `redact`, `enrich`, `keep` and `plugins` do **not** apply. Use `withEvlog` to get them.
 ::
 
 ## Wide Events

--- a/packages/evlog/src/workers/index.ts
+++ b/packages/evlog/src/workers/index.ts
@@ -1,6 +1,8 @@
 import { initLogger, createRequestLogger } from '../logger'
 import type { AuditableLogger } from '../audit'
 import type { LoggerConfig } from '../types'
+import { defineFrameworkIntegration } from '../shared/integration'
+import type { BaseEvlogOptions } from '../shared/middleware'
 
 /**
  * Minimal Cloudflare Workers execution context (`fetch` third argument).
@@ -119,6 +121,108 @@ function pickCfContext(request: Request): Record<string, unknown> {
   if (typeof cf.country === 'string') out.country = cf.country
   if (typeof cf.asn === 'number') out.asn = cf.asn
   return out
+}
+
+/** Options accepted by {@link withEvlog}. */
+export type EvlogWorkersOptions = BaseEvlogOptions
+
+interface WorkersRequestContext {
+  request: Request
+  ctx?: WorkerExecutionContext
+}
+
+/**
+ * Cloudflare-specific context every wide event carries: `cf-ray`, the
+ * `traceparent` header, and the safe subset of `request.cf`.
+ */
+function applyCloudflareContext(request: Request, logger: AuditableLogger): void {
+  logger.set({
+    cfRay: request.headers.get('cf-ray') ?? undefined,
+    traceparent: request.headers.get('traceparent') ?? undefined,
+    ...pickCfContext(request),
+  })
+}
+
+// No AsyncLocalStorage: `evlog/workers` must stay free of `node:async_hooks`
+// so it runs without `nodejs_compat`. The logger reaches user code as the
+// handler's fourth argument instead of through `useLogger()`.
+const integration = defineFrameworkIntegration<WorkersRequestContext>({
+  name: 'workers',
+  extractRequest: ({ request }) => ({
+    method: request.method,
+    path: new URL(request.url).pathname,
+    headers: request.headers,
+    // `x-request-id` first to match every other integration; `cf-ray` is the
+    // Cloudflare-native fallback when the caller sends no explicit id.
+    requestId: request.headers.get('x-request-id') ?? request.headers.get('cf-ray') ?? undefined,
+  }),
+  attachLogger: ({ request }, logger) => {
+    applyCloudflareContext(request, logger as AuditableLogger)
+  },
+  extractWaitUntil: ({ ctx }) =>
+    ctx ? ctx.waitUntil.bind(ctx) : undefined,
+})
+
+/**
+ * Wrap a Workers `fetch` handler so each request emits one wide event through
+ * the same middleware pipeline every other evlog integration uses.
+ *
+ * Unlike {@link defineWorkerFetch}, the event is emitted for you when the
+ * handler returns, and the full {@link BaseEvlogOptions} surface applies:
+ * `include` / `exclude`, per-route `routes` overrides, `redact`, `enrich`,
+ * `keep` tail sampling, `plugins` and `drain`. Streaming responses defer the
+ * emit until the body completes, and `ctx.waitUntil` is picked up
+ * automatically so drains finish after the response is returned.
+ *
+ * Filtered-out routes run the handler with no instrumentation.
+ *
+ * @example
+ * ```ts
+ * import { initWorkersLogger, withEvlog } from 'evlog/workers'
+ * import { createAxiomDrain } from 'evlog/axiom'
+ *
+ * initWorkersLogger({ env: { service: 'my-api' } })
+ *
+ * export default withEvlog(
+ *   async (request, env, ctx, log) => {
+ *     log.set({ route: 'health' })
+ *     return new Response('ok')
+ *   },
+ *   {
+ *     drain: createAxiomDrain(),
+ *     exclude: ['/health'],
+ *   },
+ * )
+ * ```
+ */
+export function withEvlog<TEnv = unknown>(
+  handler: (
+    request: Request,
+    env: TEnv,
+    ctx: WorkerExecutionContext,
+    log: AuditableLogger,
+  ) => Response | Promise<Response>,
+  options: EvlogWorkersOptions = {},
+): {
+  fetch: (request: Request, env: TEnv, ctx: WorkerExecutionContext) => Promise<Response>
+} {
+  return {
+    async fetch(request, env, ctx) {
+      const { logger, finish, finishResponse, skipped } = integration.start({ request, ctx }, options)
+
+      if (skipped) {
+        return await handler(request, env, ctx, createWorkersLogger(request, { executionCtx: ctx }))
+      }
+
+      try {
+        const response = await handler(request, env, ctx, logger)
+        return await finishResponse(response, { status: response.status })
+      } catch (error) {
+        await finish({ error: error as Error })
+        throw error
+      }
+    },
+  }
 }
 
 /**

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -290,6 +290,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "createWorkersLogger",
     "defineWorkerFetch",
     "initWorkersLogger",
+    "withEvlog",
   ],
 }
 `;

--- a/packages/evlog/test/workers/with-evlog.test.ts
+++ b/packages/evlog/test/workers/with-evlog.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initWorkersLogger, withEvlog } from '../../src/workers'
+import {
+  assertHttpEventEmitted,
+  createPipelineSpies,
+  findEventViaDrain,
+  waitForDrainCalls,
+} from '../helpers/framework'
+import { defined } from '../helpers/defined'
+import { describeStandardHttpMatrix } from '../helpers/frameworkMatrix'
+import { createDeferredStream } from '../helpers/stream'
+
+function fireWorker(
+  worker: { fetch: (r: Request, e: unknown, c: { waitUntil: (p: Promise<unknown>) => void }) => Promise<Response> },
+  req: { method?: string, path: string, headers?: Record<string, string> },
+  executionCtx: { waitUntil: (p: Promise<unknown>) => void } = { waitUntil: () => {} },
+): Promise<Response> {
+  return worker.fetch(
+    new Request(`https://example.com${req.path}`, { method: req.method || 'GET', headers: req.headers }),
+    {},
+    executionCtx,
+  )
+}
+
+describeStandardHttpMatrix({
+  name: 'workers',
+  mount(options) {
+    const worker = withEvlog(() => new Response(JSON.stringify({ users: [] }), { status: 200 }), options)
+    return Promise.resolve({
+      async fire(req) {
+        const res = await fireWorker(worker, req)
+        return { status: res.status }
+      },
+    })
+  },
+})
+
+describe('evlog/workers withEvlog', () => {
+  beforeEach(() => {
+    initWorkersLogger({ env: { service: 'workers-test' } })
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits without the handler calling log.emit()', async () => {
+    const { drain } = createPipelineSpies()
+    const worker = withEvlog((_req, _env, _ctx, log) => {
+      log.set({ route: 'health' })
+      return new Response('ok')
+    }, { drain })
+
+    await fireWorker(worker, { path: '/api/health' })
+    await waitForDrainCalls(drain)
+
+    const event = assertHttpEventEmitted(drain, { path: '/api/health', method: 'GET', status: 200 })
+    expect(event.route).toBe('health')
+  })
+
+  it('carries Cloudflare context onto the event', async () => {
+    const { drain } = createPipelineSpies()
+    const worker = withEvlog(() => new Response('ok'), { drain })
+
+    await fireWorker(worker, { path: '/api/x', headers: { 'cf-ray': 'ray-abc' } })
+    await waitForDrainCalls(drain)
+
+    const event = defined(findEventViaDrain(drain, e => e.path === '/api/x'), 'cf event')
+    expect(event.cfRay).toBe('ray-abc')
+    expect(event.requestId).toBe('ray-abc')
+  })
+
+  it('skips excluded routes and still runs the handler', async () => {
+    const { drain } = createPipelineSpies()
+    let ran = false
+    const worker = withEvlog(() => {
+      ran = true
+      return new Response('ok')
+    }, { drain, exclude: ['/health'] })
+
+    const res = await fireWorker(worker, { path: '/health' })
+
+    expect(ran).toBe(true)
+    expect(res.status).toBe(200)
+    expect(findEventViaDrain(drain, e => e.path === '/health')).toBeUndefined()
+  })
+
+  it('runs enrich before drain', async () => {
+    const { drain, enrich } = createPipelineSpies()
+    enrich.mockImplementation((ctx) => {
+      ctx.event.region = 'cdg'
+    })
+    const worker = withEvlog(() => new Response('ok'), { drain, enrich })
+
+    await fireWorker(worker, { path: '/api/x' })
+    await waitForDrainCalls(drain)
+
+    expect(drain.mock.calls[0][0].event.region).toBe('cdg')
+  })
+
+  it('registers drain work with ctx.waitUntil', async () => {
+    const { drain } = createPipelineSpies()
+    const scheduled: Promise<unknown>[] = []
+    const worker = withEvlog(() => new Response('ok'), { drain })
+
+    await fireWorker(worker, { path: '/api/x' }, { waitUntil: p => scheduled.push(p) })
+
+    expect(scheduled.length).toBeGreaterThan(0)
+    await Promise.all(scheduled)
+    await waitForDrainCalls(drain)
+    assertHttpEventEmitted(drain, { path: '/api/x', status: 200 })
+  })
+
+  it('records the error and rethrows when the handler throws', async () => {
+    const { drain } = createPipelineSpies()
+    const worker = withEvlog(() => {
+      throw new Error('boom')
+    }, { drain })
+
+    await expect(fireWorker(worker, { path: '/api/fail' })).rejects.toThrow('boom')
+    await waitForDrainCalls(drain)
+
+    assertHttpEventEmitted(drain, { path: '/api/fail', level: 'error', status: 500 })
+  })
+
+  it('defers the emit until a streaming body completes', async () => {
+    const { drain } = createPipelineSpies()
+    const { stream, close } = createDeferredStream()
+
+    const worker = withEvlog((_req, _env, _ctx, log) => {
+      queueMicrotask(() => log.set({ ai: { calls: 1 } }))
+      return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+    }, { drain })
+
+    const res = await fireWorker(worker, { path: '/api/chat' })
+    expect(drain).not.toHaveBeenCalled()
+
+    close()
+    await expect(res.text()).resolves.toBe('hello world')
+    await vi.waitFor(() => expect(drain).toHaveBeenCalledTimes(1))
+
+    expect(drain.mock.calls[0][0].event.ai).toEqual({ calls: 1 })
+  })
+})


### PR DESCRIPTION
## The gap

`evlog/workers` was the only integration that never called `createMiddlewareLogger`. It built a request logger directly from `createRequestLogger`, which meant the shared option surface stopped at the Workers boundary:

| Option | Every other integration | `evlog/workers` (before) |
|---|---|---|
| `include` / `exclude` | ✅ | ❌ |
| `routes` (per-route service) | ✅ | ❌ |
| `redact` | ✅ | ❌ |
| `enrich` | ✅ | ❌ |
| `keep` (tail sampling) | ✅ | ❌ |
| `plugins` | ✅ | ❌ |
| `drain` | ✅ | global only |

This is the sharpest violation of "use an option once, every integration benefits".

## What this adds

`withEvlog(handler, options)` — built on `defineFrameworkIntegration`, emits the wide event when the handler returns, and accepts the full `BaseEvlogOptions` surface.

```ts
import { initWorkersLogger, withEvlog } from 'evlog/workers'
import { createAxiomDrain } from 'evlog/axiom'

initWorkersLogger({ env: { service: 'my-worker' } })

export default withEvlog(
  async (request, env, ctx, log) => {
    log.set({ route: 'checkout' })
    return Response.json({ ok: true })
  },
  { drain: createAxiomDrain(), exclude: ['/health'], redact: true },
)
```

- `ExecutionContext#waitUntil` is read off the third argument via `extractWaitUntil`, so drains outlive the response
- streaming bodies defer the emit via `finishResponse`
- filtered-out routes run the handler with no instrumentation

## No `node:async_hooks`

The integration is registered **without** AsyncLocalStorage on purpose. The logger reaches user code as the handler's fourth argument rather than through `useLogger()`, so the entrypoint keeps running without `nodejs_compat`.

`shared/integration.ts` imports `AsyncLocalStorage` as a *type only*, so it erases at build. Verified against the built bundle — `dist/workers.mjs` contains zero `async_hooks` references, and `test/workers/preset-dist-imports.test.ts` still passes.

## Backwards compatibility

`defineWorkerFetch()` and `createWorkersLogger()` are **untouched** and remain the manual-emit path. `emit()` is idempotent-with-a-warning, so auto-emitting from the existing wrappers would have made every current user noisy — hence a new entry point rather than a behaviour change.

The docs now state plainly that the low-level path does not apply the middleware options.

## A real bug the matrix caught

Wiring Workers into the shared `describeStandardHttpMatrix` conformance suite immediately failed one spec: Workers honoured only `cf-ray` for the request id, while **every other integration** honours `x-request-id`. `withEvlog` now prefers `x-request-id` and falls back to `cf-ray`.

`createWorkersLogger` keeps its documented `cf-ray`-first behaviour — changing it would be a silent breaking change.

## Verification

- `pnpm run test` — 1638/1638 pass (10 new, incl. the 3 shared matrix specs)
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run api:snapshot` — diff is `+ "withEvlog"` only
- built bundle re-checked for `node:async_hooks`