### PR TITLE
refactor: derive adapter send helpers from their drain encoder

### DIFF
--- a/.changeset/adapter-encode-reuse.md
+++ b/.changeset/adapter-encode-reuse.md
@@ -1,0 +1,5 @@
+---
+"evlog": minor
+---
+
+refactor: build each adapter's HTTP request once instead of twice — every HTTP adapter (`axiom`, `better-stack`, `datadog`, `otlp`, `sentry`, `posthog` in `events` mode) constructed its URL, headers and body in two places: the `encode()` passed to `defineHttpDrain()` and again inside its standalone `sendBatchTo*` helper. The two copies had already drifted, reporting the same failure under different names (`axiom API error` from the drain, `Axiom API error` from the helper), and Axiom's and Better Stack's `encode()` ignored the deprecated `token` / `sourceToken` aliases the helper honoured. Both paths now share one encoder per adapter and report failures identically. `defineHttpDrain()` accepts an optional `label` for the human-readable name used in error messages, and `sendEncodedDrainRequest()` is exported from `evlog/toolkit` so custom adapters can reuse their own encoder the same way

--- a/packages/evlog/src/adapters/axiom.ts
+++ b/packages/evlog/src/adapters/axiom.ts
@@ -1,8 +1,8 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { applyDeprecatedAlias, formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineHttpDrain } from '../shared/drain'
-import { httpPost } from '../shared/http'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 
 interface BaseAxiomConfig {
   /** Axiom dataset name. */
@@ -109,16 +109,23 @@ export function createAxiomDrain(overrides?: Partial<AxiomConfig>) {
       }
       return config as AxiomConfig
     },
-    encode: (events, config) => {
-      const url = resolveIngestUrl(config)
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${config.apiKey}`,
-      }
-      if (config.orgId) headers['X-Axiom-Org-Id'] = config.orgId
-      return { url, headers, body: JSON.stringify(events) }
-    },
+    label: 'Axiom',
+    encode: encodeAxiomRequest,
   })
+}
+
+/**
+ * Encode a batch of wide events into the Axiom ingest request. Shared by
+ * {@link createAxiomDrain} and {@link sendBatchToAxiom} so both paths build
+ * the same URL, headers and body.
+ */
+function encodeAxiomRequest(events: WideEvent[], config: AxiomConfig): HttpDrainRequest {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${config.apiKey ?? config.token}`,
+  }
+  if (config.orgId) headers['X-Axiom-Org-Id'] = config.orgId
+  return { url: resolveIngestUrl(config), headers, body: JSON.stringify(events) }
 }
 
 /**
@@ -132,24 +139,14 @@ export async function sendToAxiom(event: WideEvent, config: AxiomConfig): Promis
  * Send a batch of events to Axiom.
  */
 export async function sendBatchToAxiom(events: WideEvent[], config: AxiomConfig): Promise<void> {
-  const apiKey = config.apiKey ?? config.token
-  if (!apiKey) {
+  if (!(config.apiKey ?? config.token)) {
     throw new Error('[evlog/axiom] Missing apiKey')
   }
-  const url = resolveIngestUrl(config)
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${apiKey}`,
-  }
-  if (config.orgId) headers['X-Axiom-Org-Id'] = config.orgId
-  await httpPost({
-    url,
-    headers,
-    body: JSON.stringify(events),
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
+  await sendEncodedDrainRequest(encodeAxiomRequest(events, config), {
     label: 'Axiom',
     source: 'axiom',
+    timeout: config.timeout,
+    retries: config.retries,
   })
 }
 

--- a/packages/evlog/src/adapters/better-stack.ts
+++ b/packages/evlog/src/adapters/better-stack.ts
@@ -1,8 +1,8 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { applyDeprecatedAlias, formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineHttpDrain } from '../shared/drain'
-import { httpPost } from '../shared/http'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 
 export interface BetterStackConfig {
   /** Better Stack API key (replaces deprecated `sourceToken`). */
@@ -74,15 +74,24 @@ export function createBetterStackDrain(overrides?: Partial<BetterStackConfig>) {
       }
       return config
     },
-    encode: (events, config) => ({
-      url: (config.endpoint ?? 'https://in.logs.betterstack.com').replace(/\/+$/, ''),
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${config.apiKey}`,
-      },
-      body: JSON.stringify(events.map(toBetterStackEvent)),
-    }),
+    label: 'Better Stack',
+    encode: encodeBetterStackRequest,
   })
+}
+
+/**
+ * Encode a batch of wide events into the Better Stack ingest request. Shared by
+ * {@link createBetterStackDrain} and {@link sendBatchToBetterStack}.
+ */
+function encodeBetterStackRequest(events: WideEvent[], config: BetterStackConfig): HttpDrainRequest {
+  return {
+    url: (config.endpoint ?? 'https://in.logs.betterstack.com').replace(/\/+$/, ''),
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${config.apiKey ?? config.sourceToken}`,
+    },
+    body: JSON.stringify(events.map(toBetterStackEvent)),
+  }
 }
 
 /**
@@ -96,20 +105,11 @@ export async function sendToBetterStack(event: WideEvent, config: BetterStackCon
  * Send a batch of events to Better Stack.
  */
 export async function sendBatchToBetterStack(events: WideEvent[], config: BetterStackConfig): Promise<void> {
-  const apiKey = config.apiKey ?? config.sourceToken
-  if (!apiKey) throw new Error('[evlog/better-stack] Missing apiKey')
-  const endpoint = (config.endpoint ?? 'https://in.logs.betterstack.com').replace(/\/+$/, '')
-
-  await httpPost({
-    url: endpoint,
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(events.map(toBetterStackEvent)),
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
+  if (!(config.apiKey ?? config.sourceToken)) throw new Error('[evlog/better-stack] Missing apiKey')
+  await sendEncodedDrainRequest(encodeBetterStackRequest(events, config), {
     label: 'Better Stack',
     source: 'better-stack',
+    timeout: config.timeout,
+    retries: config.retries,
   })
 }

--- a/packages/evlog/src/adapters/datadog.ts
+++ b/packages/evlog/src/adapters/datadog.ts
@@ -1,8 +1,8 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineHttpDrain } from '../shared/drain'
-import { httpPost } from '../shared/http'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 
 export interface DatadogConfig {
   /** Datadog API key with Logs intake permission */
@@ -191,15 +191,24 @@ export function createDatadogDrain(overrides?: Partial<DatadogConfig>) {
       }
       return config as DatadogConfig
     },
-    encode: (events, config) => ({
-      url: resolveDatadogIntakeUrl(config),
-      headers: {
-        'Content-Type': 'application/json',
-        'DD-API-KEY': config.apiKey,
-      },
-      body: JSON.stringify(events.map(toDatadogLog)),
-    }),
+    label: 'Datadog',
+    encode: encodeDatadogRequest,
   })
+}
+
+/**
+ * Encode a batch of wide events into the Datadog Logs intake request. Shared by
+ * {@link createDatadogDrain} and {@link sendBatchToDatadog}.
+ */
+function encodeDatadogRequest(events: WideEvent[], config: DatadogConfig): HttpDrainRequest {
+  return {
+    url: resolveDatadogIntakeUrl(config),
+    headers: {
+      'Content-Type': 'application/json',
+      'DD-API-KEY': config.apiKey,
+    },
+    body: JSON.stringify(events.map(toDatadogLog)),
+  }
 }
 
 /**
@@ -214,19 +223,10 @@ export async function sendToDatadog(event: WideEvent, config: DatadogConfig): Pr
  */
 export async function sendBatchToDatadog(events: WideEvent[], config: DatadogConfig): Promise<void> {
   if (events.length === 0) return
-
-  const url = resolveDatadogIntakeUrl(config)
-
-  await httpPost({
-    url,
-    headers: {
-      'Content-Type': 'application/json',
-      'DD-API-KEY': config.apiKey,
-    },
-    body: JSON.stringify(events.map(toDatadogLog)),
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
+  await sendEncodedDrainRequest(encodeDatadogRequest(events, config), {
     label: 'Datadog',
     source: 'datadog',
+    timeout: config.timeout,
+    retries: config.retries,
   })
 }

--- a/packages/evlog/src/adapters/otlp.ts
+++ b/packages/evlog/src/adapters/otlp.ts
@@ -1,9 +1,9 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineHttpDrain } from '../shared/drain'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 import { toOtlpAttributeValue } from '../shared/event'
-import { httpPost } from '../shared/http'
 import { OTEL_SEVERITY_NUMBER, OTEL_SEVERITY_TEXT } from '../shared/severity'
 
 export interface OTLPConfig {
@@ -247,18 +247,24 @@ export function createOTLPDrain(overrides?: Partial<OTLPConfig>) {
       }
       return config as OTLPConfig
     },
-    encode: (events, config) => {
-      if (events.length === 0) return null
-      return {
-        url: `${config.endpoint.replace(/\/$/, '')}/v1/logs`,
-        headers: {
-          'Content-Type': 'application/json',
-          ...config.headers,
-        },
-        body: JSON.stringify(buildOTLPPayload(events, config)),
-      }
-    },
+    label: 'OTLP',
+    encode: (events, config) => (events.length === 0 ? null : encodeOTLPRequest(events, config)),
   })
+}
+
+/**
+ * Encode a batch of wide events into the OTLP/HTTP logs request. Shared by
+ * {@link createOTLPDrain} and {@link sendBatchToOTLP}.
+ */
+function encodeOTLPRequest(events: WideEvent[], config: OTLPConfig): HttpDrainRequest {
+  return {
+    url: `${config.endpoint.replace(/\/$/, '')}/v1/logs`,
+    headers: {
+      'Content-Type': 'application/json',
+      ...config.headers,
+    },
+    body: JSON.stringify(buildOTLPPayload(events, config)),
+  }
 }
 
 function buildOTLPPayload(events: WideEvent[], config: OTLPConfig): ExportLogsServiceRequest {
@@ -308,22 +314,10 @@ export async function sendToOTLP(event: WideEvent, config: OTLPConfig): Promise<
  */
 export async function sendBatchToOTLP(events: WideEvent[], config: OTLPConfig): Promise<void> {
   if (events.length === 0) return
-
-  const url = `${config.endpoint.replace(/\/$/, '')}/v1/logs`
-  const payload = buildOTLPPayload(events, config)
-
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...config.headers,
-  }
-
-  await httpPost({
-    url,
-    headers,
-    body: JSON.stringify(payload),
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
+  await sendEncodedDrainRequest(encodeOTLPRequest(events, config), {
     label: 'OTLP',
     source: 'otlp',
+    timeout: config.timeout,
+    retries: config.retries,
   })
 }

--- a/packages/evlog/src/adapters/posthog.ts
+++ b/packages/evlog/src/adapters/posthog.ts
@@ -1,8 +1,8 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineDrain, defineHttpDrain } from '../shared/drain'
-import { httpPost } from '../shared/http'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineDrain, defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 import { sendBatchToOTLP } from './otlp'
 import type { OTLPConfig } from './otlp'
 
@@ -134,14 +134,8 @@ export function createPostHogDrain(overrides?: Partial<PostHogConfig>) {
         }
         return config as PostHogConfig
       },
-      encode: (events, config) => ({
-        url: `${resolveHost(config)}/batch/`,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          api_key: config.apiKey,
-          batch: events.map(event => toPostHogEvent(event, config)),
-        }),
-      }),
+      label: 'PostHog',
+      encode: encodePostHogEventsRequest,
     })
   }
 
@@ -196,16 +190,26 @@ export async function sendToPostHogEvents(event: WideEvent, config: PostHogConfi
  */
 export async function sendBatchToPostHogEvents(events: WideEvent[], config: PostHogConfig): Promise<void> {
   if (events.length === 0) return
-  await httpPost({
+  await sendEncodedDrainRequest(encodePostHogEventsRequest(events, config), {
+    label: 'PostHog',
+    source: 'posthog',
+    timeout: config.timeout,
+    retries: config.retries,
+  })
+}
+
+/**
+ * Encode a batch of wide events into the PostHog custom-events `/batch/`
+ * request. Shared by {@link createPostHogDrain} in `events` mode and
+ * {@link sendBatchToPostHogEvents}.
+ */
+function encodePostHogEventsRequest(events: WideEvent[], config: PostHogConfig): HttpDrainRequest {
+  return {
     url: `${resolveHost(config)}/batch/`,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       api_key: config.apiKey,
       batch: events.map(event => toPostHogEvent(event, config)),
     }),
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
-    label: 'PostHog',
-    source: 'posthog',
-  })
+  }
 }

--- a/packages/evlog/src/adapters/sentry.ts
+++ b/packages/evlog/src/adapters/sentry.ts
@@ -1,8 +1,8 @@
 import type { WideEvent } from '../types'
 import type { ConfigField } from '../shared/config'
 import { formatPublicEnvKeys, resolveAdapterConfig } from '../shared/config'
-import { defineHttpDrain } from '../shared/drain'
-import { httpPost } from '../shared/http'
+import type { HttpDrainRequest } from '../shared/drain'
+import { defineHttpDrain, sendEncodedDrainRequest } from '../shared/drain'
 import { OTEL_SEVERITY_NUMBER } from '../shared/severity'
 
 export interface SentryConfig {
@@ -232,19 +232,26 @@ export function createSentryDrain(overrides?: Partial<SentryConfig>) {
       }
       return config as SentryConfig
     },
-    encode: (events, config) => {
-      const { url, authHeader } = getSentryEnvelopeUrl(config.dsn)
-      const logs = events.map(event => toSentryLog(event, config))
-      return {
-        url,
-        headers: {
-          'Content-Type': 'application/x-sentry-envelope',
-          'X-Sentry-Auth': authHeader,
-        },
-        body: buildEnvelopeBody(logs, config.dsn),
-      }
-    },
+    label: 'Sentry',
+    encode: encodeSentryRequest,
   })
+}
+
+/**
+ * Encode a batch of wide events into the Sentry envelope request. Shared by
+ * {@link createSentryDrain} and {@link sendBatchToSentry}.
+ */
+function encodeSentryRequest(events: WideEvent[], config: SentryConfig): HttpDrainRequest {
+  const { url, authHeader } = getSentryEnvelopeUrl(config.dsn)
+  const logs = events.map(event => toSentryLog(event, config))
+  return {
+    url,
+    headers: {
+      'Content-Type': 'application/x-sentry-envelope',
+      'X-Sentry-Auth': authHeader,
+    },
+    body: buildEnvelopeBody(logs, config.dsn),
+  }
 }
 
 /**
@@ -273,22 +280,10 @@ export async function sendToSentry(event: WideEvent, config: SentryConfig): Prom
  */
 export async function sendBatchToSentry(events: WideEvent[], config: SentryConfig): Promise<void> {
   if (events.length === 0) return
-
-  const { url, authHeader } = getSentryEnvelopeUrl(config.dsn)
-
-  const logs = events.map(event => toSentryLog(event, config))
-  const body = buildEnvelopeBody(logs, config.dsn)
-
-  await httpPost({
-    url,
-    headers: {
-      'Content-Type': 'application/x-sentry-envelope',
-      'X-Sentry-Auth': authHeader,
-    },
-    body,
-    timeout: config.timeout ?? 5000,
-    retries: config.retries,
+  await sendEncodedDrainRequest(encodeSentryRequest(events, config), {
     label: 'Sentry',
     source: 'sentry',
+    timeout: config.timeout,
+    retries: config.retries,
   })
 }

--- a/packages/evlog/src/shared/drain.ts
+++ b/packages/evlog/src/shared/drain.ts
@@ -56,6 +56,13 @@ export interface HttpDrainRequest {
 export interface HttpDrainOptions<TConfig> {
   /** Stable identifier used in error logs. */
   name: string
+  /**
+   * Human-readable name prefixing HTTP error messages (`"Axiom API error: …"`).
+   * Defaults to {@link HttpDrainOptions.name}. Set it to the same value the
+   * adapter's standalone `sendBatchTo*` helper passes so both paths report a
+   * failure identically.
+   */
+  label?: string
   /** Return `null` to skip draining (e.g. missing API key in dev). */
   resolve: () => TConfig | null | Promise<TConfig | null>
   /** Return `null` to skip the batch without raising. */
@@ -71,6 +78,39 @@ export interface HttpDrainOptions<TConfig> {
 }
 
 const DEFAULT_HTTP_TIMEOUT = 5000
+
+/**
+ * POST an already-encoded {@link HttpDrainRequest} with the adapter's
+ * timeout/retry defaults and evlog identity headers.
+ *
+ * Lets an adapter's standalone `sendBatchTo*` helper reuse the very same
+ * encoder its `defineHttpDrain({ encode })` uses, instead of rebuilding the
+ * URL, headers and body a second time.
+ *
+ * @example
+ * ```ts
+ * export async function sendBatchToMy(events: WideEvent[], config: MyConfig) {
+ *   if (events.length === 0) return
+ *   await sendEncodedDrainRequest(encodeMyRequest(events, config), {
+ *     label: 'My', source: 'my', timeout: config.timeout, retries: config.retries,
+ *   })
+ * }
+ * ```
+ */
+export async function sendEncodedDrainRequest(
+  request: HttpDrainRequest,
+  options: { label: string; source: string; timeout?: number; retries?: number },
+): Promise<void> {
+  await httpPost({
+    url: request.url,
+    headers: request.headers,
+    body: request.body,
+    timeout: options.timeout ?? DEFAULT_HTTP_TIMEOUT,
+    retries: options.retries,
+    label: options.label,
+    source: options.source,
+  })
+}
 
 /**
  * Build an HTTP drain. Timeouts/retries are resolved from the config (with
@@ -116,7 +156,7 @@ export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): (c
         body: request.body,
         timeout,
         retries,
-        label: options.name,
+        label: options.label ?? options.name,
         source: options.name,
       })
     },

--- a/packages/evlog/test/adapters/encode-parity.test.ts
+++ b/packages/evlog/test/adapters/encode-parity.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WideEvent } from '../../src/types'
+import { createAxiomDrain, sendBatchToAxiom } from '../../src/adapters/axiom'
+import { createBetterStackDrain, sendBatchToBetterStack } from '../../src/adapters/better-stack'
+import { createDatadogDrain, sendBatchToDatadog } from '../../src/adapters/datadog'
+import { createOTLPDrain, sendBatchToOTLP } from '../../src/adapters/otlp'
+import { createSentryDrain, sendBatchToSentry } from '../../src/adapters/sentry'
+
+const event: WideEvent = {
+  timestamp: '2024-01-01T12:00:00.000Z',
+  level: 'info',
+  service: 'test',
+  environment: 'test',
+  method: 'GET',
+  path: '/api/users',
+  status: 200,
+}
+
+const DSN = 'https://abc123@o1.ingest.sentry.io/42'
+
+/**
+ * Each adapter builds its request once and uses it from both the drain path
+ * (`defineHttpDrain({ encode })`) and the standalone `sendBatchTo*` helper.
+ * These specs pin that the two paths stay byte-identical on the wire and
+ * report failures with the same label.
+ */
+interface ParityCase {
+  name: string
+  label: string
+  drain: () => (ctx: { event: WideEvent }) => Promise<void>
+  send: () => Promise<void>
+  /** Mask fields that differ per call by design (timestamps, generated ids). */
+  normalize?: (body: string) => string
+}
+
+const ADAPTERS: ParityCase[] = [
+  {
+    name: 'axiom',
+    label: 'Axiom',
+    drain: () => createAxiomDrain({ dataset: 'ds', apiKey: 'key' }),
+    send: () => sendBatchToAxiom([event], { dataset: 'ds', apiKey: 'key' }),
+  },
+  {
+    name: 'better-stack',
+    label: 'Better Stack',
+    drain: () => createBetterStackDrain({ apiKey: 'key' }),
+    send: () => sendBatchToBetterStack([event], { apiKey: 'key' }),
+  },
+  {
+    name: 'datadog',
+    label: 'Datadog',
+    drain: () => createDatadogDrain({ apiKey: 'key' }),
+    send: () => sendBatchToDatadog([event], { apiKey: 'key' }),
+  },
+  {
+    name: 'otlp',
+    label: 'OTLP',
+    drain: () => createOTLPDrain({ endpoint: 'http://localhost:4318' }),
+    send: () => sendBatchToOTLP([event], { endpoint: 'http://localhost:4318' }),
+  },
+  {
+    name: 'sentry',
+    label: 'Sentry',
+    drain: () => createSentryDrain({ dsn: DSN }),
+    send: () => sendBatchToSentry([event], { dsn: DSN }),
+    // The envelope header carries a send timestamp, and events without trace
+    // context get a freshly generated trace id — both differ per call by
+    // design, so they are not part of the parity comparison.
+    normalize: (body: string) =>
+      body
+        .replace(/"sent_at":"[^"]+"/g, '"sent_at":"<ts>"')
+        .replace(/"trace_id":"[^"]+"/g, '"trace_id":"<trace>"'),
+  },
+]
+
+describe('adapter encode parity', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each(ADAPTERS)('$name: drain and sendBatch issue the same request', async (adapter) => {
+    await adapter.drain()({ event })
+    await adapter.send()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    const [drainUrl, drainInit] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const [sendUrl, sendInit] = fetchSpy.mock.calls[1] as [string, RequestInit]
+
+    const normalize = adapter.normalize ?? ((body: string) => body)
+    expect(drainUrl).toBe(sendUrl)
+    expect(normalize(drainInit.body as string)).toEqual(normalize(sendInit.body as string))
+    expect(drainInit.headers).toEqual(sendInit.headers)
+  })
+
+  it.each(ADAPTERS)('$name: both paths report failures with the same label', async (adapter) => {
+    fetchSpy.mockResolvedValue(new Response('nope', { status: 400, statusText: 'Bad Request' }))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(adapter.send()).rejects.toThrow(`${adapter.label} API error: 400 Bad Request`)
+
+    // The drain path swallows the error but logs it — same label.
+    await adapter.drain()({ event })
+    const logged = errorSpy.mock.calls.flat().map(String).join(' ')
+    expect(logged).toContain(`${adapter.label} API error: 400 Bad Request`)
+  })
+})

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -268,6 +268,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "resolveAdapterConfig",
     "resolveMiddlewarePluginRunner",
     "runEnrichAndDrain",
+    "sendEncodedDrainRequest",
     "shouldDeferEmitForResponse",
     "shouldLog",
     "toLoggerConfig",


### PR DESCRIPTION
## What

Every HTTP adapter built its request **twice** — once in the `encode()` passed to `defineHttpDrain()`, and again inside its standalone `sendBatchTo*` helper:

`axiom` · `better-stack` · `datadog` · `otlp` · `sentry` · `posthog` (events mode)

Six adapters, twelve copies of the same URL + headers + body construction. Each now has one `encodeXRequest(events, config)` used by both paths.

## The copies had already drifted

Two real inconsistencies this surfaced:

1. **Error labels differed per path.** The drain path passed `label: options.name` and reported `axiom API error: 400 …`; the standalone helper passed `label: 'Axiom'` and reported `Axiom API error: 400 …`. Same failure, two different messages depending on which path you were on.

2. **Deprecated aliases were honoured inconsistently.** Axiom's and Better Stack's `encode()` read only `config.apiKey`, relying on `applyDeprecatedAlias()` having run in `resolve()`. The standalone helpers accepted `config.token` / `config.sourceToken` directly. A caller passing the deprecated field to a hand-built drain got an `undefined` bearer token.

Both are fixed by construction now that there is one encoder.

## New toolkit surface

- `defineHttpDrain({ label })` — optional human-readable name for error messages, defaults to `name`
- `sendEncodedDrainRequest(request, { label, source, timeout, retries })` — exported from `evlog/toolkit` so custom adapters can reuse their own encoder for a standalone send helper the same way the built-ins do

## Verification

- `pnpm run test` — 1638/1638 pass, including a new `test/adapters/encode-parity.test.ts` that pins, for all five HTTP adapters, that the drain path and the `sendBatchTo*` path issue a **byte-identical request** (same URL, headers, body) and report failures under the **same label**
- Sentry's parity check masks `sent_at` and the generated `trace_id`, which differ per call by design
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run api:snapshot` — diff is `+ "sendEncodedDrainRequest"` only