### PR TITLE
ci(release): generate a GitHub release per package and gate PRs on changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,7 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "privatePackages": false,
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,33 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  changeset:
+    name: Changeset
+    if: |
+      github.event_name == 'pull_request'
+      && github.actor != 'renovate[bot]'
+      && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Fetch base branch
+        run: git fetch --no-tags origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+      # Only the four published packages are considered — apps/* and examples/* carry no `version`
+      # field, so changesets never sees them and a docs-only PR passes with no changeset. The
+      # privatePackages: false in .changeset/config.json keeps that true if one ever gains a
+      # version. Label a PR `skip-changeset` to bypass.
+      - name: Require a changeset
+        run: pnpm exec changeset status --since=origin/${{ github.base_ref }}
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,26 +46,16 @@ jobs:
           title: "chore(repo): version packages"
           version: pnpm run version
           publish: pnpm run release
-          createGithubReleases: false
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
+      # createGithubReleases publishes one release per package, tagged pkg@version, whose body is
+      # that version's section of the package CHANGELOG. Generating notes from the commit range
+      # instead cross-contaminates packages: monorepo tags interleave, so the range between two
+      # consecutive @evlog/cli tags sweeps up every core/telemetry/docs commit landed in between.
       - name: Push tags
         if: steps.changesets.outputs.published == 'true'
         run: git push --tags
-
-      - name: Create GitHub Releases
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          for pkg in $(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | .name + "@" + .version'); do
-            tag="$pkg"
-            if gh release view "$tag" > /dev/null 2>&1; then
-              echo "Release $tag already exists, skipping"
-            else
-              gh release create "$tag" --draft --generate-notes --title "$tag"
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ packages/evlog/            Main package
 - **Bump type:** `patch` for fixes, `minor` for features, `major` for breaking changes.
 - **Description:** write from the consumer's perspective — what changed and how to use it. See existing changesets in `.changeset/` for tone and level of detail.
 
-A PR without a changeset for a user-facing change will not be merged.
+A PR without a changeset for a user-facing change will not be merged. The `changeset` job in `.github/workflows/ci.yml` enforces this: it fails when a published package changed with no changeset in the PR. Changes confined to `apps/*` or `examples/*` — docs included — never trigger it. For the rare published-package change that genuinely needs no release note, add the `skip-changeset` label or run `pnpm changeset add --empty`.
 
 ### Commits & PR titles
 


### PR DESCRIPTION
## Problem

GitHub releases were built by an ad-hoc step running `gh release create --generate-notes`, which asks GitHub to derive notes from the commit range between two tags. In a monorepo, tags interleave — `@evlog/cli@0.3.0`, `@evlog/cli@0.2.0`, `evlog@2.22.4`, `@evlog/cli@0.1.5`, … — so the range between two consecutive CLI tags sweeps up every unrelated commit landed in between.

The published [`@evlog/cli@0.3.0`](https://github.com/HugoRCD/evlog/releases/tag/@evlog/cli@0.3.0) release shows it:

```
### Performance Improvements ⚡️
* perf(core): cache iso timestamp prefix across emits
* perf(telemetry): only recompute the dashboard when data changed
### Documentation 📚
* docs: promote @evlog/cli across skills and onboarding
```

None of that is CLI work. Meanwhile the per-package `CHANGELOG.md` files that changesets already generates — accurate, one entry per PR, with author and links — went unused.

## Changes

**Release notes come from the changelogs.** `createGithubReleases: true` replaces the custom step. Changesets now creates one release per published package, tagged `pkg@version`, whose body is exactly that version's section of the package's own `CHANGELOG.md`.

**PRs are gated on changesets.** A `changeset` job runs `changeset status --since=origin/<base>` and fails when a published package changed with no changeset. This enforces the rule `AGENTS.md` already stated but nothing checked.

**`privatePackages: false`** guards the docs exemption. `apps/*` and `examples/*` have no `version` field today, so changesets already ignores them; this keeps that true if one ever gains a version.

## Verified

Ran `changeset status` against real commits of this repo, in throwaway worktrees:

| Case | Commit | Exit |
|---|---|---|
| Docs-only PR, no changeset | `67076ed0` (27 files, 0 under `packages/`) | `0` — passes |
| `packages/` change **with** changeset | `06be5193` (17 files under `packages/`) | `0` — passes |
| Same commit, changeset deleted | `06be5193` | `1` — blocks |

## Notes

- Releases are no longer created as drafts — changesets publishes them directly. Say the word if you want drafts back.
- `.github/release.yml` (label-based note categories) is now unused for package releases, kept because GitHub's manual "auto-generate release notes" button still reads it.
- Renovate PRs are excluded from the gate; the `skip-changeset` label bypasses it.

## Follow-ups (manual)

- Install the [changeset-bot](https://github.com/apps/changeset-bot) GitHub App so every PR gets an "add a changeset" comment.
- `gh label create skip-changeset --description "Bypass the changeset CI gate" --color ededed`
