### PR TITLE
feat(hono): export useLogger() and enable log.fork()

### DIFF
--- a/.changeset/hono-use-logger.md
+++ b/.changeset/hono-use-logger.md
@@ -1,0 +1,7 @@
+---
+"evlog": minor
+---
+
+feat(hono): export `useLogger()` and enable `log.fork()` — Hono was the only framework integration without `useLogger()`, so reaching the request logger from a service or repository meant threading the Hono `Context` down through every call. `import { useLogger } from 'evlog/hono'` now resolves the same logger `c.get('log')` returns, and `c.get('log')` is unchanged — it stays the idiomatic accessor inside route handlers. Attaching AsyncLocalStorage also enables `log.fork()` on Hono, for background work that emits its own wide event correlated by `_parentRequestId`.
+
+**Cloudflare Workers:** `useLogger()` is backed by `AsyncLocalStorage`, so `evlog/hono` now imports `node:async_hooks`. Workers deployments need the `nodejs_compat` (or `nodejs_als`) compatibility flag in `wrangler.toml`. If you cannot enable it, use `evlog/workers`, which stays free of `node:async_hooks` by design.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ packages/evlog/            Main package
 - `README.md` at root is a **symlink** to `packages/evlog/README.md` — edit the source directly.
 - `evlog/toolkit` is the public entrypoint for `src/shared/`. Never use `evlog/shared`.
 - `evlog/browser` is deprecated — use `evlog/http` instead.
-- Hono does **not** export `useLogger()`. Logger access is `c.get('log')`.
+- Every framework integration exposes the **same contract**: `evlog()` middleware, `useLogger()`, `log.fork()`, and the full `BaseEvlogOptions` surface. Framework-native accessors (`c.get('log')`, `req.log`, `event.locals.log`, `context.get(loggerContext)`) stay alongside it — they are the idiomatic path inside handlers, `useLogger()` is for the layers underneath. When adding an integration, provide both.
+- `useLogger()` is backed by `AsyncLocalStorage`. On Cloudflare Workers that needs the `nodejs_compat` / `nodejs_als` flag, so `evlog/workers` deliberately has no `useLogger()` and passes the logger as the handler's fourth argument instead.
 - New export? Update both `packages/evlog/package.json` exports and `packages/evlog/tsdown.config.ts`.
 - Creating a new adapter, enricher, or framework integration? Read the matching skill at `.agents/skills/` **before starting**:
   - `.agents/skills/create-adapter/SKILL.md`

--- a/apps/docs/content/4.integrate/frameworks/08.hono.md
+++ b/apps/docs/content/4.integrate/frameworks/08.hono.md
@@ -12,7 +12,7 @@ links:
     variant: subtle
 ---
 
-The `evlog/hono` middleware auto-creates a request-scoped logger accessible via `c.get('log')` and emits a wide event when the response completes.
+The `evlog/hono` middleware auto-creates a request-scoped logger accessible via `c.get('log')` — or `useLogger()` anywhere deeper in the call stack — and emits a wide event when the response completes.
 
 ::prompt
 ---
@@ -31,7 +31,7 @@ Set up evlog in my Hono app.
 - Alternatively, use evlog/vite plugin in vite.config.ts for auto-init (replaces initLogger)
 - Import evlog middleware and EvlogVariables type from 'evlog/hono'
 - Add app.use(evlog()) and type the app with Hono<EvlogVariables>
-- Access the logger via c.get('log') in route handlers
+- Access the logger via c.get('log') in route handlers, or useLogger() from 'evlog/hono' in nested functions
 - Use log.set() to accumulate context throughout the request
 - Optionally pass drain, enrich, include, and keep options to evlog()
 
@@ -119,7 +119,46 @@ All fields are merged into a single wide event emitted when the request complete
   └─ requestId: 4a8ff3a8-...
 ```
 
-Hono does not attach **`log.fork()`** yet (access the logger via `c.get('log')` only). If you schedule async work after the response, post-emit **`[evlog]` warnings** still help you notice stale `set()` calls. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+## Accessing the logger deeper in the stack
+
+`c.get('log')` is the idiomatic accessor inside a route handler. Once you are a few
+layers down — a service, a repository — threading `c` everywhere gets noisy. `useLogger()`
+resolves the same request logger without it:
+
+```typescript [src/services/payment.ts]
+import { useLogger } from 'evlog/hono'
+
+export async function chargeCard(amount: number) {
+  const log = useLogger()
+  log.set({ payment: { amount } })
+}
+```
+
+Both return the same logger — pick whichever reads better at the call site.
+
+::callout{icon="i-lucide-info" color="info"}
+`useLogger()` is backed by `AsyncLocalStorage`. On Cloudflare Workers this requires the
+`nodejs_compat` (or `nodejs_als`) compatibility flag in `wrangler.toml`. `c.get('log')`
+works with or without it, so deployments that cannot enable the flag keep using it.
+::
+
+### Background work
+
+**`log.fork()`** runs work under a child logger that emits its own wide event, correlated
+to the request via `_parentRequestId`:
+
+```typescript [src/index.ts]
+app.post('/api/orders', (c) => {
+  c.get('log').fork('send-receipt', async () => {
+    await sendReceipt()
+    useLogger().set({ email: { sent: true } })
+  })
+  return c.json({ ok: true })
+})
+```
+
+If you schedule async work after the response without forking, post-emit **`[evlog]` warnings**
+help you notice stale `set()` calls. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
 
 ## Error Handling
 

--- a/packages/evlog/src/hono/index.ts
+++ b/packages/evlog/src/hono/index.ts
@@ -2,9 +2,39 @@ import type { Context, MiddlewareHandler } from 'hono'
 import type { AuditableLogger } from '../audit'
 import { defineFrameworkIntegration } from '../shared/integration'
 import type { BaseEvlogOptions } from '../shared/middleware'
+import { createLoggerStorage } from '../shared/storage'
 import { shouldDeferEmitForResponse } from '../shared/streamResponse'
 
+const { storage, useLogger } = createLoggerStorage(
+  'middleware context. Make sure app.use(evlog()) is registered before your routes.',
+  'evlog:hono',
+)
+
 export type EvlogHonoOptions = BaseEvlogOptions
+
+/**
+ * Get the request-scoped logger from anywhere in the call stack, without
+ * threading the Hono `Context` through every function.
+ *
+ * `c.get('log')` stays the idiomatic accessor inside route handlers — this is
+ * for the layers underneath (services, repositories) where `c` is not in hand.
+ * Both return the same logger.
+ *
+ * Backed by `AsyncLocalStorage`, so on Cloudflare Workers this requires the
+ * `nodejs_compat` (or `nodejs_als`) compatibility flag. `c.get('log')` works
+ * with or without it.
+ *
+ * @example
+ * ```ts
+ * import { useLogger } from 'evlog/hono'
+ *
+ * async function chargeCard(amount: number) {
+ *   const log = useLogger()
+ *   log.set({ payment: { amount } })
+ * }
+ * ```
+ */
+export { useLogger }
 
 /**
  * Hono variables type for typed `c.get('log')` access.
@@ -33,6 +63,7 @@ const integration = defineFrameworkIntegration<Context>({
   attachLogger: (c, logger) => {
     c.set('log', logger)
   },
+  storage,
   extractWaitUntil: (c) => {
     // Hono's `executionCtx` getter throws when the adapter has none (Node,
     // Bun, Deno). Only Workers / Vercel Edge provide one.
@@ -67,13 +98,13 @@ const integration = defineFrameworkIntegration<Context>({
  */
 export function evlog(options: EvlogHonoOptions = {}): MiddlewareHandler {
   return async (c, next) => {
-    const { skipped, finish, finishResponse } = integration.start(c, options)
+    const { skipped, finish, finishResponse, runWith } = integration.start(c, options)
     if (skipped) {
       await next()
       return
     }
     try {
-      await next()
+      await runWith(next)
       if (shouldDeferEmitForResponse(c.res)) {
         // Assign directly — Hono's compose ignores middleware return values when
         // context.finalized is already true, so returning the wrapped response

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Hono } from 'hono'
 import { initLogger } from '../../src/logger'
-import { evlog, type EvlogVariables } from '../../src/hono/index'
+import { evlog, useLogger, type EvlogVariables } from '../../src/hono/index'
 import {
   assertDrainCalledWith,
   assertEnrichBeforeDrain,
@@ -455,6 +455,94 @@ describe('evlog/hono', () => {
 
       expect(warnSpy.mock.calls.some(([message]) => String(message).includes('Keys dropped: ai'))).toBe(false)
       expect(drain.mock.calls[0]?.[0]?.event?.ai).toEqual({ calls: 1, totalTokens: 42 })
+    })
+  })
+
+  describe('useLogger', () => {
+    it('returns the same logger as c.get("log")', async () => {
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog())
+
+      let fromContext: unknown
+      let fromUseLogger: unknown
+      app.get('/api/test', (c) => {
+        fromContext = c.get('log')
+        fromUseLogger = useLogger()
+        return c.json({ ok: true })
+      })
+
+      await app.request('/api/test')
+      expect(fromUseLogger).toBe(fromContext)
+    })
+
+    it('reaches nested async calls without threading the context', async () => {
+      const { drain } = createPipelineSpies()
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+
+      async function chargeCard() {
+        await Promise.resolve()
+        useLogger().set({ payment: { amount: 42 } })
+      }
+
+      app.get('/api/pay', async (c) => {
+        await chargeCard()
+        return c.json({ ok: true })
+      })
+
+      await app.request('/api/pay')
+      await waitForDrainCalls(drain)
+
+      const event = defined(findEventViaDrain(drain, e => e.path === '/api/pay'), 'payment event')
+      expect(event.payment).toEqual({ amount: 42 })
+    })
+
+    it('throws a helpful error outside a request', () => {
+      expect(() => useLogger()).toThrow('useLogger() was called outside of an evlog middleware context')
+    })
+
+    it('throws on a route filtered out by exclude', async () => {
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ exclude: ['/health'] }))
+
+      let thrown = false
+      app.get('/health', (c) => {
+        try {
+          useLogger()
+        } catch {
+          thrown = true
+        }
+        return c.json({ ok: true })
+      })
+
+      await app.request('/health')
+      expect(thrown).toBe(true)
+    })
+
+    // Attaching AsyncLocalStorage also enables `log.fork()` on Hono, which
+    // previously had no storage and so no fork.
+    it('exposes log.fork() for post-response work', async () => {
+      const { drain } = createPipelineSpies()
+      const app = new Hono<EvlogVariables>()
+      app.use(evlog({ drain }))
+
+      app.get('/api/test', (c) => {
+        const log = c.get('log')
+        expect(typeof log.fork).toBe('function')
+        log.fork!('cleanup', () => {
+          useLogger().set({ cleaned: true })
+        })
+        return c.json({ ok: true })
+      })
+
+      await app.request('/api/test')
+      await vi.waitFor(() => {
+        expect(findEventViaDrain(drain, e => e.operation === 'cleanup')).toBeDefined()
+      })
+
+      const child = defined(findEventViaDrain(drain, e => e.operation === 'cleanup'), 'forked event')
+      expect(child.cleaned).toBe(true)
+      expect(child._parentRequestId).toBeDefined()
     })
   })
 })

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -122,6 +122,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
   ],
   "./hono": [
     "evlog",
+    "useLogger",
   ],
   "./http": [
     "createHttpDrain",


### PR DESCRIPTION
> **Stacked on #470** — both touch the same `defineFrameworkIntegration` call in `src/hono/index.ts`. Merge #470 first; the base retargets to `main` automatically.

## What

Hono was the last integration without `useLogger()`. It now uses `createLoggerStorage()` like every other one:

```ts
// route handler — unchanged, still idiomatic
app.get('/api/pay', (c) => c.get('log').set({ route: 'pay' }))

// a few layers down — no more threading `c` through everything
import { useLogger } from 'evlog/hono'

export async function chargeCard(amount: number) {
  useLogger().set({ payment: { amount } })
}
```

`c.get('log')` is **not** removed or deprecated — both return the same logger.

## Bonus: `log.fork()`

Attaching AsyncLocalStorage also enables `log.fork()` on Hono, which it previously lacked — the docs explicitly said so:

> ~~Hono does not attach `log.fork()` yet~~

Background work now emits its own wide event correlated to the request via `_parentRequestId`.

## ⚠️ Tradeoff: `node:async_hooks` on Workers

This is the reason Hono was carved out in the first place, so it deserves a straight answer.

`evlog/hono` now imports `node:async_hooks` transitively through `evlog/toolkit/storage`. I verified this against the built bundle:

```
dist/hono/index.mjs → ../toolkit/storage.mjs → node:async_hooks
```

**Cloudflare Workers deployments need `nodejs_compat` (or `nodejs_als`) in `wrangler.toml`.** Without it, the import fails at build/deploy time. This puts `evlog/hono` in the same position as `express`, `fastify`, `nestjs`, `sveltekit`, `react-router`, `orpc` and `elysia`, all of which already import it.

`evlog/workers` is untouched and **stays async_hooks-free** — re-verified against `dist/workers.mjs` (0 references). It remains the path for Workers deployments that cannot enable the flag.

**If you'd rather not take that on**, the alternative is a separate `evlog/hono/logger` subpath so the base entry stays clean. I did not do that because it breaks the "same contract everywhere" goal — but say the word and I'll switch it.

## Docs & conventions

- Hono page: new "Accessing the logger deeper in the stack" section, the `log.fork()` note replaced with a working example, and a callout about the Workers flag
- `AGENTS.md`: the `Hono does not export useLogger()` carve-out is replaced by the general contract every integration is now expected to satisfy, plus the documented reason `evlog/workers` is the one exception

## Verification

- `pnpm run test` — 1637/1637 pass (5 new: parity with `c.get('log')`, resolution through nested async calls, the out-of-request error, filtered-route behaviour, and `log.fork()` emitting a correlated child event)
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run api:snapshot` — diff is `+ "useLogger"` on `./hono` only