### PR TITLE
fix(elysia): defer the wide event until a streaming body closes

### DIFF
--- a/.changeset/elysia-streaming-emit.md
+++ b/.changeset/elysia-streaming-emit.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+fix(elysia): defer the wide event until a streaming body closes — `evlog/elysia` emitted from `onAfterResponse`, which fires as soon as the response is handed off. For an SSE or chunked body that is long before the stream finishes, so anything the handler set mid-stream (AI token counts, tool calls, final status) was dropped with a post-emit `[evlog]` warning. Streaming responses are now claimed in `mapResponse` and their body wrapped, so the emit waits for the stream to close — the same behaviour Hono, oRPC, SvelteKit, React Router and Next already had (#321). Non-streaming responses are unaffected and still emit immediately.

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -7,6 +7,7 @@ import {
   createSharedEnterWithStorage,
 } from '../shared/asyncStorageScope'
 import { defineFrameworkIntegration } from '../shared/integration'
+import { bindStreamingResponseLifecycle, shouldDeferEmitForResponse } from '../shared/streamResponse'
 import type { BaseEvlogOptions } from '../shared/middleware'
 import { attachForkToLogger } from '../shared/fork'
 
@@ -87,6 +88,12 @@ interface RequestState {
   logger: AuditableLogger
 }
 
+/** Release the request logger once its wide event has been emitted. */
+function releaseLogger(logger: AuditableLogger): void {
+  activeLoggers.delete(logger)
+  clearAsyncLocalStorage(storage)
+}
+
 /**
  * Create an evlog plugin for Elysia.
  *
@@ -128,22 +135,37 @@ export function evlog(options: EvlogElysiaOptions = {}) {
     .derive({ as: 'global' }, ({ request }) => {
       return { log: requestState.get(request)?.logger as AuditableLogger }
     })
+    // Claim streaming responses here: `onAfterResponse` fires once the response
+    // is handed off, which for an SSE / chunked body is long before the stream
+    // finishes. Wrapping the body defers the emit until it actually closes, so
+    // context set mid-stream still lands on the wide event (#321).
+    .mapResponse({ as: 'global' }, (ctx) => {
+      const { request } = ctx
+      const state = requestState.get(request)
+      if (!state || state.skipped || emitted.has(request)) return
+      const value = (ctx as { responseValue?: unknown; response?: unknown }).responseValue
+        ?? (ctx as { response?: unknown }).response
+      if (!(value instanceof Response) || !shouldDeferEmitForResponse(value)) return
+
+      emitted.add(request)
+      return bindStreamingResponseLifecycle(value, async (meta) => {
+        await state.finish({ status: meta.status, error: meta.error })
+        releaseLogger(state.logger)
+      })
+    })
     .onAfterResponse({ as: 'global' }, async ({ request, set }) => {
       const state = requestState.get(request)
       if (!state || state.skipped || emitted.has(request)) return
       emitted.add(request)
       await state.finish({ status: set.status as number || 200 })
-      activeLoggers.delete(state.logger)
-      clearAsyncLocalStorage(storage)
+      releaseLogger(state.logger)
     })
     .onError({ as: 'global' }, async ({ request, error }) => {
       const state = requestState.get(request)
       if (!state || state.skipped || emitted.has(request)) return
       emitted.add(request)
       const err = error instanceof Error ? error : new Error(String(error))
-      state.logger.error(err)
       await state.finish({ error: err })
-      activeLoggers.delete(state.logger)
-      clearAsyncLocalStorage(storage)
+      releaseLogger(state.logger)
     })
 }

--- a/packages/evlog/test/frameworks/elysia.test.ts
+++ b/packages/evlog/test/frameworks/elysia.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../helpers/framework'
 import { defined, getDrainCallArg } from '../helpers/defined'
 import { describeStandardHttpMatrix } from '../helpers/frameworkMatrix'
+import { createDeferredStream } from '../helpers/stream'
 
 describeStandardHttpMatrix({
   name: 'elysia',
@@ -386,6 +387,52 @@ describe('evlog/elysia', () => {
       await waitForDrainCalls(drain)
 
       expect(findEventViaDrain(drain, e => e.fromService === true)).toBeDefined()
+    })
+  })
+
+  describe('streaming responses', () => {
+    it('defers emit until the SSE stream closes and captures mid-stream context (#321)', async () => {
+      const { drain } = createPipelineSpies()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      let closeStream!: () => void
+      const app = new Elysia()
+        .use(evlog({ drain }))
+        .get('/api/chat', ({ log }) => {
+          const { stream, close } = createDeferredStream()
+          closeStream = close
+          queueMicrotask(() => {
+            log.set({ ai: { calls: 1, totalTokens: 42 } })
+          })
+          return new Response(stream, {
+            headers: { 'content-type': 'text/event-stream' },
+          })
+        })
+
+      const res = await app.handle(new Request('http://localhost/api/chat'))
+      await delay()
+      expect(drain).not.toHaveBeenCalled()
+
+      closeStream()
+      await expect(res.text()).resolves.toBe('hello world')
+      await vi.waitFor(() => {
+        expect(drain).toHaveBeenCalledTimes(1)
+      })
+
+      expect(warnSpy.mock.calls.some(([m]) => String(m).includes('Keys dropped: ai'))).toBe(false)
+      expect(drain.mock.calls[0]?.[0]?.event?.ai).toEqual({ calls: 1, totalTokens: 42 })
+    })
+
+    it('still emits immediately for non-streaming responses', async () => {
+      const { drain } = createPipelineSpies()
+      const app = new Elysia()
+        .use(evlog({ drain }))
+        .get('/api/plain', () => ({ ok: true }))
+
+      await request(app, '/api/plain')
+      await waitForDrainCalls(drain)
+
+      assertHttpEventEmitted(drain, { path: '/api/plain', status: 200 })
     })
   })
 })


### PR DESCRIPTION
## The bug

`evlog/elysia` emitted its wide event from `onAfterResponse`. That hook fires as soon as the response is handed off to the adapter — for an SSE or chunked body, long before the stream actually finishes.

Anything the handler set **mid-stream** therefore hit an already-sealed logger and was dropped, with a post-emit `[evlog] Keys dropped: …` warning:

```ts
app.get('/api/chat', ({ log }) => {
  const stream = streamAiResponse()
  onTokens((n) => log.set({ ai: { totalTokens: n } }))  // ← silently lost
  return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
})
```

Elysia was the last integration with this gap — Hono, oRPC, SvelteKit, React Router and Next all fixed it under #321.

## The fix

Streaming responses are claimed in `mapResponse` (the one hook that can replace the response) and their body wrapped with the shared `bindStreamingResponseLifecycle`, so the emit waits for the stream to close, error, or cancel.

- `onAfterResponse` / `onError` skip requests already claimed by `mapResponse`
- the request logger is released when the stream settles, not when the response is handed off
- non-streaming responses are untouched and still emit immediately
- detection uses the shared `shouldDeferEmitForResponse`, so SSE / NDJSON / chunked / AI-UI-stream are all covered consistently

Also folds the duplicated `activeLoggers.delete` + `clearAsyncLocalStorage` pair into one `releaseLogger()` helper, and drops a redundant `logger.error()` in `onError` — `finish({ error })` already records it.

## Verification

**The regression test fails without the fix.** Removing the `mapResponse` hook locally:

```
× defers emit until the SSE stream closes and captures mid-stream context (#321)
  AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

— the drain fires before the stream closes, which is exactly the bug.

- `pnpm run test` — 1630/1630 pass (2 new: the streaming defer, plus a guard that non-streaming responses still emit immediately)
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass

Found during the repo-wide consistency audit; independent of the other open PRs and based directly on `main`.