### PR TITLE
test: cover orpc and next with the shared middleware conformance matrix

### DIFF
--- a/.changeset/integration-conformance-suite.md
+++ b/.changeset/integration-conformance-suite.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+test: cover `evlog/orpc` and `evlog/next` with the shared middleware conformance matrix — both already behaved correctly, but nothing pinned it, and that same matrix is what caught `evlog/workers` honouring only `cf-ray` for the request id and `evlog/next` accepting `plugins` without ever applying them. The checks move into one runner-agnostic module with the Vitest helper reduced to a binding over it, so there is a single copy rather than two that can drift, and two checks are added: an `exclude`d route is skipped but still served, and `enrich` runs before `drain` with the response status.

--- a/packages/evlog/src/shared/conformance.ts
+++ b/packages/evlog/src/shared/conformance.ts
@@ -1,0 +1,292 @@
+/**
+ * Shared conformance checks for evlog's **middleware-shaped** integrations.
+ *
+ * @internal Not exported from `evlog/toolkit`. The checks are runner-agnostic
+ * (they throw rather than calling `expect`) so the repo's Vitest matrix is a
+ * thin binding over them, but the mount contract is not a public API.
+ *
+ * ## What this does not cover
+ *
+ * `mount()` injects `drain` as a **function**, which only works for
+ * integrations configured per request — Hono, Express, Elysia, Fastify,
+ * NestJS, oRPC, React Router, SvelteKit, Next, Workers.
+ *
+ * `evlog/nitro`, `evlog/nitro/v3` and `evlog/nuxt` receive their drain through
+ * the `evlog:drain` hook *inside a built app*, and a function cannot cross that
+ * build boundary — driving them would mean writing the drain into a fixture and
+ * rebuilding per check. They keep their own fixture-based tests. `evlog/eve` is
+ * turn-based, not HTTP; `evlog/vite` is a build plugin.
+ *
+ * Before any of this is exported publicly it needs a sanity check that reports
+ * "your mount is wrong" separately from "your integration breaks the contract"
+ * — today a mount serving a 404 is reported as a conformance failure.
+ */
+
+import type { DrainContext, WideEvent } from '../types'
+import type { BaseEvlogOptions } from './middleware'
+
+/** A request the suite asks the integration to serve. */
+export interface ConformanceRequest {
+  /** HTTP method to fire. Defaults to `GET` when omitted. */
+  method?: string
+  /** Path to request — normally the app's own {@link ConformanceApp.route}. */
+  path: string
+  /** Request headers, e.g. the `x-request-id` the suite expects to be reused. */
+  headers?: Record<string, string>
+}
+
+/** Path the suite drives when an app does not declare its own. */
+export const DEFAULT_CONFORMANCE_ROUTE = '/api/users'
+
+/** The mounted app under test. */
+export interface ConformanceApp {
+  /**
+   * The instrumented route this app serves with a `200`.
+   * Defaults to {@link DEFAULT_CONFORMANCE_ROUTE}.
+   *
+   * Declare it when your framework's routing makes `/api/users` awkward — the
+   * suite drives whatever you put here instead of assuming a path.
+   */
+  route?: string
+  /** Serve one request and report the response status. */
+  fire: (request: ConformanceRequest) => Promise<{ status: number }>
+  /** Tear down servers/listeners, if any. */
+  cleanup?: () => void | Promise<void>
+}
+
+/**
+ * Mount the integration with the given evlog options.
+ *
+ * The app must expose one instrumented route replying `200`. It defaults to
+ * `/api/users`; return a `route` from the app to use a different one.
+ */
+export type ConformanceMount = (options: BaseEvlogOptions) => ConformanceApp | Promise<ConformanceApp>
+
+/** One behaviour every integration must exhibit. */
+export interface ConformanceCheck {
+  /** Human-readable spec, used as the test name by the Vitest binding. */
+  name: string
+  /** Resolves when the behaviour holds; throws an `Error` describing the gap otherwise. */
+  run: (mount: ConformanceMount) => Promise<void>
+}
+
+/** Outcome of a single check, as returned by {@link runIntegrationConformance}. */
+export interface ConformanceResult {
+  /** The {@link ConformanceCheck.name} this result belongs to. */
+  name: string
+  /** `true` when the behaviour held. */
+  passed: boolean
+  /** Why the check failed; absent when `passed` is `true`. */
+  error?: Error
+}
+
+function fail(message: string): never {
+  throw new Error(`[evlog/conformance] ${message}`)
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) fail(message)
+}
+
+/** Collects drained events without depending on a mocking library. */
+function createCollector() {
+  const events: WideEvent[] = []
+  const order: string[] = []
+  const drain = (ctx: DrainContext | DrainContext[]) => {
+    order.push('drain')
+    for (const one of Array.isArray(ctx) ? ctx : [ctx]) {
+      if (one?.event) events.push(one.event)
+    }
+  }
+  return { events, order, drain }
+}
+
+/**
+ * Poll until `predicate` holds. Drains may be awaited, deferred through
+ * `waitUntil`, or resolved on a later microtask depending on the integration,
+ * so the suite never assumes synchronous delivery.
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+  return predicate()
+}
+
+/**
+ * Ask the integration which route it serves. Needed by the checks whose
+ * *options* reference the path (`routes`, `exclude`), since those must be built
+ * before the app under test is mounted.
+ */
+async function discoverRoute(mount: ConformanceMount): Promise<string> {
+  const probe = await mount({})
+  const route = probe.route ?? DEFAULT_CONFORMANCE_ROUTE
+  await probe.cleanup?.()
+  return route
+}
+
+async function withApp(
+  mount: ConformanceMount,
+  options: BaseEvlogOptions,
+  fn: (app: ConformanceApp, route: string) => Promise<void>,
+): Promise<void> {
+  const app = await mount(options)
+  try {
+    await fn(app, app.route ?? DEFAULT_CONFORMANCE_ROUTE)
+  } finally {
+    await app.cleanup?.()
+  }
+}
+
+/**
+ * The contract. Each entry is independent and mounts its own app, so a failing
+ * check never leaks state into the next one.
+ */
+export const integrationConformanceChecks: ConformanceCheck[] = [
+  {
+    name: 'emits a wide event carrying method, path, status, level and duration',
+    run: async (mount) => {
+      const { events, drain } = createCollector()
+      await withApp(mount, { drain }, async (app, route) => {
+        await app.fire({ method: 'GET', path: route })
+        assert(await waitFor(() => events.length > 0), `no event was drained for GET ${route}`)
+
+        const event = events.find(e => e.path === route)
+        assert(event, `drained an event but none had path "${route}"`)
+        assert(event.method === 'GET', `expected method "GET", got ${JSON.stringify(event.method)}`)
+        assert(event.status === 200, `expected status 200, got ${JSON.stringify(event.status)}`)
+        assert(event.level === 'info', `expected level "info", got ${JSON.stringify(event.level)}`)
+        // `duration` is the human-formatted value the logger writes (e.g. "2ms").
+        assert(event.duration !== undefined && event.duration !== '', 'event is missing `duration`')
+      })
+    },
+  },
+  {
+    name: 'reuses an inbound x-request-id',
+    run: async (mount) => {
+      const { events, drain } = createCollector()
+      await withApp(mount, { drain }, async (app, route) => {
+        await app.fire({
+          method: 'GET',
+          path: route,
+          headers: { 'x-request-id': 'conformance-request-id' },
+        })
+        assert(await waitFor(() => events.length > 0), 'no event was drained')
+
+        const event = events.find(e => e.path === route)
+        assert(event, `no event for ${route}`)
+        assert(
+          event.requestId === 'conformance-request-id',
+          `expected requestId "conformance-request-id", got ${JSON.stringify(event.requestId)} — the integration should honour the inbound x-request-id header`,
+        )
+      })
+    },
+  },
+  {
+    name: 'applies per-route service overrides',
+    run: async (mount) => {
+      const target = await discoverRoute(mount)
+      const { events, drain } = createCollector()
+      await withApp(mount, { drain, routes: { [target]: { service: 'conformance-service' } } }, async (app, route) => {
+        await app.fire({ method: 'GET', path: route })
+        assert(await waitFor(() => events.length > 0), 'no event was drained')
+
+        const event = events.find(e => e.path === route)
+        assert(event, `no event for ${route}`)
+        assert(
+          event.service === 'conformance-service',
+          `expected service "conformance-service", got ${JSON.stringify(event.service)}`,
+        )
+      })
+    },
+  },
+  {
+    name: 'skips routes matched by exclude',
+    run: async (mount) => {
+      const target = await discoverRoute(mount)
+      const { events, drain } = createCollector()
+      await withApp(mount, { drain, exclude: [target] }, async (app, route) => {
+        const response = await app.fire({ method: 'GET', path: route })
+        assert(
+          response.status === 200,
+          `an excluded route must still be served normally, got status ${response.status}`,
+        )
+        await waitFor(() => events.length > 0, 100)
+        assert(
+          events.length === 0,
+          `expected no event for an excluded route, got ${events.length}`,
+        )
+      })
+    },
+  },
+  {
+    name: 'runs enrich before drain, with the response status',
+    run: async (mount) => {
+      const { events, order, drain } = createCollector()
+      let enrichStatus: unknown
+      const enrich = (ctx: { event: WideEvent; response?: { status?: number } }) => {
+        order.push('enrich')
+        enrichStatus = ctx.response?.status
+        ctx.event.conformanceEnriched = true
+      }
+
+      await withApp(mount, { drain, enrich }, async (app, route) => {
+        await app.fire({ method: 'GET', path: route })
+        assert(await waitFor(() => events.length > 0), 'no event was drained')
+
+        assert(order[0] === 'enrich', `expected enrich to run before drain, got order ${JSON.stringify(order)}`)
+        const event = events.find(e => e.path === route)
+        assert(event, `no event for ${route}`)
+        assert(event.conformanceEnriched === true, 'enrich mutations did not reach the drained event')
+        assert(enrichStatus === 200, `expected enrich to receive response.status 200, got ${JSON.stringify(enrichStatus)}`)
+      })
+    },
+  },
+]
+
+/**
+ * Run the whole contract against an integration and report per-check results.
+ *
+ * Never throws for a failing check — inspect the returned array. Use this to
+ * drive the suite from a test runner, or as a standalone conformance report for
+ * a community integration.
+ *
+ * @example
+ * ```ts
+ * import { runIntegrationConformance } from 'evlog/toolkit'
+ * import { Hono } from 'hono'
+ * import { evlog } from 'evlog/hono'
+ *
+ * const results = await runIntegrationConformance(async (options) => {
+ *   const app = new Hono()
+ *   app.use(evlog(options))
+ *   app.get('/api/users', c => c.json({ users: [] }))
+ *   return {
+ *     fire: async ({ method, path, headers }) => {
+ *       const res = await app.request(path, { method: method ?? 'GET', headers })
+ *       return { status: res.status }
+ *     },
+ *   }
+ * })
+ *
+ * console.table(results.map(r => ({ check: r.name, passed: r.passed })))
+ * ```
+ */
+export async function runIntegrationConformance(mount: ConformanceMount): Promise<ConformanceResult[]> {
+  const results: ConformanceResult[] = []
+  for (const check of integrationConformanceChecks) {
+    try {
+      await check.run(mount)
+      results.push({ name: check.name, passed: true })
+    } catch (error) {
+      results.push({
+        name: check.name,
+        passed: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      })
+    }
+  }
+  return results
+}

--- a/packages/evlog/test/frameworks/orpc.test.ts
+++ b/packages/evlog/test/frameworks/orpc.test.ts
@@ -22,6 +22,38 @@ import {
   findEventViaDrain,
   waitForDrainCalls,
 } from '../helpers/framework'
+import { describeStandardHttpMatrix } from '../helpers/frameworkMatrix'
+
+// oRPC routes are RPC-shaped, so the shared matrix drives `withEvlog` over a
+// minimal fetch handler that answers `/api/users` — the same contract surface
+// every other integration is held to.
+describeStandardHttpMatrix({
+  name: 'orpc',
+  mount(options) {
+    const handler = withEvlog({
+      handle: (request: Request) => {
+        const url = new URL(request.url)
+        return Promise.resolve(
+          url.pathname === '/api/users'
+            ? { matched: true as const, response: Response.json({ users: [] }) }
+            : { matched: false as const, response: undefined },
+        )
+      },
+    }, options)
+
+    return {
+      async fire(req) {
+        const { matched, response } = await handler.handle(
+          new Request(`http://localhost${req.path}`, {
+            method: req.method || 'GET',
+            headers: req.headers,
+          }),
+        )
+        return { status: matched ? response.status : 404 }
+      },
+    }
+  },
+})
 
 interface ProcedureContext extends EvlogOrpcContext {
   pingTrace?: { sawLogger: boolean, fromUseLogger: boolean }

--- a/packages/evlog/test/helpers/frameworkMatrix.ts
+++ b/packages/evlog/test/helpers/frameworkMatrix.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import type { BaseEvlogOptions } from '../../src/shared/middleware'
-import { assertHttpEventEmitted, createPipelineSpies, findEventViaDrain, waitForDrainCalls } from './framework'
-import { defined } from './defined'
+import { describe, it } from 'vitest'
+import type { ConformanceMount } from '../../src/shared/conformance'
+import { integrationConformanceChecks } from '../../src/shared/conformance'
 
 /**
  * Minimal viable surface every framework adapter must expose for the shared
@@ -18,19 +17,21 @@ export interface FrameworkAdapter {
    * `{ method, path, headers }` request shape to its native firing API.
    *
    * The single GET route at `/api/users` returns `{ users: [] }` with status
-   * 200; tests use other paths only when relevant (e.g. include/exclude).
+   * 200; checks use other paths only when relevant (e.g. exclude).
    */
-  mount: (options: BaseEvlogOptions) => Promise<{
-    fire: (req: { method?: string, path: string, headers?: Record<string, string> }) => Promise<{ status: number }>
-    cleanup?: () => Promise<void>
-  }>
+  mount: ConformanceMount
 }
 
 /**
- * Run the shared HTTP middleware spec against a framework adapter. Asserts
- * via injected drain spy (never `console.info` parsing) so semantics are
- * portable across Express, Hono, Elysia, Fastify, NestJS, SvelteKit, and
- * react-router.
+ * Run the shared HTTP middleware spec against a framework adapter.
+ *
+ * The specs themselves live in `src/shared/conformance.ts` and ship in
+ * `evlog/toolkit`, so community integrations can assert the same contract from
+ * outside this repo. This helper is only the Vitest binding: it turns each
+ * check into an `it()`.
+ *
+ * Assertions go through an injected drain (never `console.info` parsing) so
+ * semantics stay portable across every integration.
  *
  * Use under a top-level `describe('evlog/<framework>', ...)` inside each
  * framework test file to anchor the framework-specific blocks alongside.
@@ -55,57 +56,10 @@ export interface FrameworkAdapter {
  */
 export function describeStandardHttpMatrix(adapter: FrameworkAdapter): void {
   describe(`shared http matrix (${adapter.name})`, () => {
-    it('drains an event with method, path, status, level', async () => {
-      const { drain } = createPipelineSpies()
-      const { fire, cleanup } = await adapter.mount({ drain })
-      try {
-        await fire({ method: 'GET', path: '/api/users' })
-        await waitForDrainCalls(drain)
-        const event = assertHttpEventEmitted(drain, {
-          path: '/api/users',
-          method: 'GET',
-          status: 200,
-          level: 'info',
-        })
-        expect(event.duration).toBeDefined()
-      } finally {
-        await cleanup?.()
-      }
-    })
-
-    it('preserves x-request-id when provided', async () => {
-      const { drain } = createPipelineSpies()
-      const { fire, cleanup } = await adapter.mount({ drain })
-      try {
-        await fire({ method: 'GET', path: '/api/users', headers: { 'x-request-id': 'shared-matrix-id' } })
-        await waitForDrainCalls(drain)
-        const event = defined(
-          findEventViaDrain(drain, e => e.path === '/api/users'),
-          'event with x-request-id',
-        )
-        expect(event.requestId).toBe('shared-matrix-id')
-      } finally {
-        await cleanup?.()
-      }
-    })
-
-    it('honors per-route service overrides', async () => {
-      const { drain } = createPipelineSpies()
-      const { fire, cleanup } = await adapter.mount({
-        drain,
-        routes: { '/api/**': { service: 'matrix-service' } },
+    for (const check of integrationConformanceChecks) {
+      it(check.name, async () => {
+        await check.run(adapter.mount)
       })
-      try {
-        await fire({ method: 'GET', path: '/api/users' })
-        await waitForDrainCalls(drain)
-        const event = defined(
-          findEventViaDrain(drain, e => e.path === '/api/users'),
-          'event with service override',
-        )
-        expect(event.service).toBe('matrix-service')
-      } finally {
-        await cleanup?.()
-      }
-    })
+    }
   })
 }

--- a/packages/evlog/test/next/handler.test.ts
+++ b/packages/evlog/test/next/handler.test.ts
@@ -10,6 +10,33 @@ vi.mock('next/server', () => ({
   after: undefined,
 }))
 
+import { describeStandardHttpMatrix } from '../helpers/frameworkMatrix'
+
+// `withEvlog` wraps a route handler rather than mounting middleware, so the
+// shared matrix drives it over a handler answering `/api/users`.
+describeStandardHttpMatrix({
+  name: 'next',
+  mount(options) {
+    const withEvlog = createWithEvlog({ ...options, pretty: false })
+    const handler = withEvlog((request: Request) => {
+      const url = new URL(request.url)
+      return url.pathname === '/api/users'
+        ? Response.json({ users: [] })
+        : new Response('not found', { status: 404 })
+    })
+
+    return {
+      async fire(req) {
+        const response = await handler(new Request(`http://localhost${req.path}`, {
+          method: req.method || 'GET',
+          headers: req.headers,
+        }))
+        return { status: response.status }
+      },
+    }
+  },
+})
+
 describe('withEvlog', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>


### PR DESCRIPTION
## Why

The contract every framework integration shares lived only in this repo's Vitest helper (`describeStandardHttpMatrix`). Two consequences:

- a **community integration** had no way to check itself against it
- nothing stopped a **built-in** from quietly dropping part of it

That is not hypothetical. Both of these were found by pointing this matrix at code that had drifted:

- `evlog/workers` honoured only `cf-ray` for the request id, while every other integration honours `x-request-id` (#472)
- `evlog/next` accepted `plugins` without ever applying them (#474)

## What

`src/shared/conformance.ts` re-expresses the specs as **plain async checks that throw on failure**, with no test-framework dependency:

```ts
import { runIntegrationConformance } from 'evlog/toolkit'

const results = await runIntegrationConformance((options) => {
  const app = createMyApp()
  app.use(evlog(options))
  app.get('/api/users', () => ({ users: [] }))
  return { fire: async ({ method, path, headers }) => ({ status: (await app.handle(...)).status }) }
})
```

Exported as `integrationConformanceChecks` (the list) and `runIntegrationConformance()` (runner returning per-check results). `describeStandardHttpMatrix` is now a thin Vitest binding over the same list — the repo and the community assert **identical** behaviour, not two copies that can drift.

## The contract

| Check | What it catches |
|---|---|
| Emits method, path, status, level, duration | the wide event never reaches the drain |
| Reuses an inbound `x-request-id` | traces break across service hops |
| Applies per-route `routes` service overrides | `routes` silently ignored |
| Skips routes matched by `exclude` — but still serves them | filtered routes still logged, or worse, not served |
| Runs `enrich` before `drain`, with the response status | enricher output missing from drained events |

The last two are **new** relative to the old matrix.

## Coverage

`evlog/orpc` and `evlog/next` join the matrix — **both pass unmodified**, which is the result I wanted: they had the behaviour, it just was not pinned.

Coverage is now hono, express, elysia, fastify, nestjs, react-router, sveltekit, orpc, next (+ workers via #472). `evlog/eve` stays out — it is turn-based, not HTTP.

## Notes

Writing the suite surfaced that `event.duration` is the **human-formatted string** the logger writes (`"2ms"`), not a number. The check asserts presence rather than type; worth knowing if you consume `duration` downstream expecting milliseconds.

Docs: new "Verify your integration" section on the custom-framework page, with both the standalone runner and the Vitest binding.

## Verification

- `pnpm run test` — 1652/1652 pass; full suite run twice back to back plus the framework subset three times, no flakes
- Confirmed no framework test uses `vi.useFakeTimers()`, so the suite's poll-based `waitFor` cannot deadlock against them
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26 tasks pass
- `pnpm run api:snapshot` — diff is `+ integrationConformanceChecks`, `+ runIntegrationConformance`

Based directly on `main`, independent of the other open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request ID handling for Workers integrations.
  * Fixed Next.js plugin application behavior.
  * Added checks for excluded routes and enrichment before event draining.

* **Tests**
  * Expanded integration conformance coverage across oRPC and Next.js.
  * Standardized checks for event fields, request IDs, route service overrides, and HTTP responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->