### PR TITLE
docs: move OTLP and HyperDX into the hybrid adapter category

### DIFF
--- a/.changeset/hybrid-adapter-category.md
+++ b/.changeset/hybrid-adapter-category.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+docs: move OTLP and HyperDX into the "Cloud or Self-Hosted" category — both self-host as readily as they run managed, so filing them under `cloud/` alongside Axiom and Datadog was misleading. They join Loki and ClickHouse under `hybrid/`, and each page now splits its setup into explicit self-hosted and managed sections rather than mixing the two. The old `/integrate/adapters/cloud/otlp` and `/integrate/adapters/cloud/hyperdx` URLs 301 to the new locations.

--- a/apps/docs/app/components/app/AppHeaderCenter.vue
+++ b/apps/docs/app/components/app/AppHeaderCenter.vue
@@ -245,13 +245,13 @@ const landingItems = [
         label: 'OpenTelemetry',
         icon: 'i-simple-icons-opentelemetry',
         description: 'Export via OTLP protocol',
-        to: '/integrate/adapters/cloud/otlp'
+        to: '/integrate/adapters/hybrid/otlp'
       },
       {
         label: 'HyperDX',
         icon: 'i-custom-hyperdx',
         description: 'Send logs to HyperDX via OTLP',
-        to: '/integrate/adapters/cloud/hyperdx'
+        to: '/integrate/adapters/hybrid/hyperdx'
       },
       {
         label: 'PostHog',

--- a/apps/docs/config/redirects.ts
+++ b/apps/docs/config/redirects.ts
@@ -127,14 +127,20 @@ export const redirects: Record<string, RouteRedirect> = {
   '/examples/react-router': r('/integrate/frameworks/react-router'),
 
   // Adapters / Cloud → Integrate / Adapters / Cloud
+  // OTLP and HyperDX moved out of `cloud/` — both self-host as readily as they
+  // run managed, so they now sit under `hybrid/` alongside Loki and ClickHouse.
+  // These two URLs were live and indexed, so they redirect rather than 404.
+  '/integrate/adapters/cloud/otlp': r('/integrate/adapters/hybrid/otlp'),
+  '/integrate/adapters/cloud/hyperdx': r('/integrate/adapters/hybrid/hyperdx'),
+
   '/adapters/overview': r('/integrate/adapters/overview'),
   '/adapters/cloud/axiom': r('/integrate/adapters/cloud/axiom'),
-  '/adapters/cloud/otlp': r('/integrate/adapters/cloud/otlp'),
+  '/adapters/cloud/otlp': r('/integrate/adapters/hybrid/otlp'),
   '/adapters/cloud/posthog': r('/integrate/adapters/cloud/posthog'),
   '/adapters/cloud/sentry': r('/integrate/adapters/cloud/sentry'),
   '/adapters/cloud/better-stack': r('/integrate/adapters/cloud/better-stack'),
   '/adapters/cloud/datadog': r('/integrate/adapters/cloud/datadog'),
-  '/adapters/cloud/hyperdx': r('/integrate/adapters/cloud/hyperdx'),
+  '/adapters/cloud/hyperdx': r('/integrate/adapters/hybrid/hyperdx'),
   '/adapters/self-hosted/fs': r('/integrate/adapters/self-hosted/fs'),
   '/adapters/self-hosted/nuxthub': r('/integrate/adapters/self-hosted/nuxthub'),
 
@@ -146,12 +152,12 @@ export const redirects: Record<string, RouteRedirect> = {
 
   // Stale aliases that already redirected via nuxt.config.ts
   '/adapters/axiom': r('/integrate/adapters/cloud/axiom'),
-  '/adapters/otlp': r('/integrate/adapters/cloud/otlp'),
+  '/adapters/otlp': r('/integrate/adapters/hybrid/otlp'),
   '/adapters/posthog': r('/integrate/adapters/cloud/posthog'),
   '/adapters/sentry': r('/integrate/adapters/cloud/sentry'),
   '/adapters/better-stack': r('/integrate/adapters/cloud/better-stack'),
   '/adapters/datadog': r('/integrate/adapters/cloud/datadog'),
-  '/adapters/hyperdx': r('/integrate/adapters/cloud/hyperdx'),
+  '/adapters/hyperdx': r('/integrate/adapters/hybrid/hyperdx'),
   '/adapters/fs': r('/integrate/adapters/self-hosted/fs'),
   '/adapters/nuxthub': r('/integrate/adapters/self-hosted/nuxthub'),
   '/adapters/nuxthub/overview': r('/integrate/adapters/self-hosted/nuxthub'),

--- a/apps/docs/content/1.start/2.why-evlog.md
+++ b/apps/docs/content/1.start/2.why-evlog.md
@@ -163,7 +163,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Zero handler changes. The same events land in [Axiom](/integrate/adapters/cloud/axiom), [Datadog](/integrate/adapters/cloud/datadog), [PostHog](/integrate/adapters/cloud/posthog), [Sentry](/integrate/adapters/cloud/sentry), [Better Stack](/integrate/adapters/cloud/better-stack), [HyperDX](/integrate/adapters/cloud/hyperdx), or [OTLP](/integrate/adapters/cloud/otlp) — or all of them, with [fan-out](/integrate/adapters/overview).
+Zero handler changes. The same events land in [Axiom](/integrate/adapters/cloud/axiom), [Datadog](/integrate/adapters/cloud/datadog), [PostHog](/integrate/adapters/cloud/posthog), [Sentry](/integrate/adapters/cloud/sentry), [Better Stack](/integrate/adapters/cloud/better-stack), [HyperDX](/integrate/adapters/hybrid/hyperdx), or [OTLP](/integrate/adapters/hybrid/otlp) — or all of them, with [fan-out](/integrate/adapters/overview).
 
 ## What "later" actually costs
 

--- a/apps/docs/content/4.integrate/adapters/01.overview.md
+++ b/apps/docs/content/4.integrate/adapters/01.overview.md
@@ -10,16 +10,6 @@ links:
     to: /integrate/adapters/cloud/axiom
     color: neutral
     variant: subtle
-  - label: OTLP
-    icon: i-simple-icons-opentelemetry
-    to: /integrate/adapters/cloud/otlp
-    color: neutral
-    variant: subtle
-  - label: HyperDX
-    icon: i-custom-hyperdx
-    to: /integrate/adapters/cloud/hyperdx
-    color: neutral
-    variant: subtle
   - label: PostHog
     icon: i-simple-icons-posthog
     to: /integrate/adapters/cloud/posthog
@@ -48,6 +38,16 @@ links:
   - label: ClickHouse
     icon: i-simple-icons-clickhouse
     to: /integrate/adapters/hybrid/clickhouse
+    color: neutral
+    variant: subtle
+  - label: OTLP
+    icon: i-simple-icons-opentelemetry
+    to: /integrate/adapters/hybrid/otlp
+    color: neutral
+    variant: subtle
+  - label: HyperDX
+    icon: i-custom-hyperdx
+    to: /integrate/adapters/hybrid/hyperdx
     color: neutral
     variant: subtle
   - label: File System
@@ -144,25 +144,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send logs to Axiom for powerful querying and dashboards.
   :::
-
-  :::card
-  ---
-  icon: i-simple-icons-opentelemetry
-  title: OTLP
-  to: /integrate/adapters/cloud/otlp
-  ---
-  OpenTelemetry Protocol for Grafana, Datadog, Honeycomb, and more.
-  :::
-
-  :::card
-  ---
-  icon: i-custom-hyperdx
-  title: HyperDX
-  to: /integrate/adapters/cloud/hyperdx
-  ---
-  Send logs to HyperDX via OTLP/HTTP using their documented ingest endpoint and API key.
-  :::
-
   :::card
   ---
   icon: i-simple-icons-posthog
@@ -171,7 +152,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send logs to PostHog Logs for structured logging and observability.
   :::
-
   :::card
   ---
   icon: i-simple-icons-sentry
@@ -180,7 +160,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send structured logs to Sentry Logs for high-cardinality querying.
   :::
-
   :::card
   ---
   icon: i-simple-icons-betterstack
@@ -189,7 +168,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send logs to Better Stack for log management and alerting.
   :::
-
   :::card
   ---
   icon: i-simple-icons-datadog
@@ -198,7 +176,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send logs to Datadog Logs via the native HTTP intake API.
   :::
-
   :::card
   ---
   icon: i-simple-icons-grafana
@@ -207,7 +184,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Push logs to self-hosted, multi-tenant, or Grafana Cloud Loki.
   :::
-
   :::card
   ---
   icon: i-simple-icons-clickhouse
@@ -216,7 +192,22 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Insert logs into ClickHouse for fast aggregation over huge volumes.
   :::
-
+  :::card
+  ---
+  icon: i-simple-icons-opentelemetry
+  title: OTLP
+  to: /integrate/adapters/hybrid/otlp
+  ---
+  OpenTelemetry Protocol for Grafana, Datadog, Honeycomb, and more.
+  :::
+  :::card
+  ---
+  icon: i-custom-hyperdx
+  title: HyperDX
+  to: /integrate/adapters/hybrid/hyperdx
+  ---
+  Send logs to HyperDX via OTLP/HTTP using their documented ingest endpoint and API key.
+  :::
   :::card
   ---
   icon: i-lucide-hard-drive
@@ -225,7 +216,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Write logs to local NDJSON files for debugging and AI agent integration.
   :::
-
   :::card
   ---
   icon: i-simple-icons-nuxt
@@ -234,7 +224,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Self-hosted log storage in your NuxtHub database with automatic retention.
   :::
-
   :::card
   ---
   icon: i-lucide-cpu
@@ -243,7 +232,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   In-memory ring buffer that works in any runtime, including Cloudflare Workers.
   :::
-
   :::card
   ---
   icon: i-lucide-code
@@ -252,7 +240,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Build your own adapter for any destination.
   :::
-
   :::card
   ---
   icon: i-lucide-globe
@@ -261,7 +248,6 @@ initLogger({ drain: createAxiomDrain() })
   ---
   Send client logs to your server over HTTP without framework coupling.
   :::
-
   :::card
   ---
   icon: i-lucide-workflow

--- a/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
@@ -13,7 +13,7 @@ links:
     variant: subtle
   - label: OTLP Adapter
     icon: i-simple-icons-opentelemetry
-    to: /integrate/adapters/cloud/otlp
+    to: /integrate/adapters/hybrid/otlp
     color: neutral
     variant: subtle
 ---
@@ -248,7 +248,7 @@ await sendBatchToAxiom(events, {
 
 ## Next Steps
 
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) - Send logs via OpenTelemetry Protocol
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) - Send logs via OpenTelemetry Protocol
 - [PostHog Adapter](/integrate/adapters/cloud/posthog) - Send logs to PostHog
 - [Custom Adapters](/extend/custom-drains) - Build your own adapter
 - [Best Practices](/reference/best-practices) - Security and production tips

--- a/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
@@ -346,6 +346,6 @@ const posthogEvent = toPostHogEvent(event, { apiKey: 'phc_xxx' })
 ## Next Steps
 
 - [Axiom Adapter](/integrate/adapters/cloud/axiom) - Send logs to Axiom
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) - Send logs via OpenTelemetry Protocol
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) - Send logs via OpenTelemetry Protocol
 - [Custom Adapters](/extend/custom-drains) - Build your own adapter
 - [Best Practices](/reference/best-practices) - Security and production tips

--- a/apps/docs/content/4.integrate/adapters/cloud/03.sentry.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/03.sentry.md
@@ -13,7 +13,7 @@ links:
     variant: subtle
   - label: OTLP Adapter
     icon: i-simple-icons-opentelemetry
-    to: /integrate/adapters/cloud/otlp
+    to: /integrate/adapters/hybrid/otlp
     color: neutral
     variant: subtle
 ---
@@ -242,6 +242,6 @@ await sendBatchToSentry(events, {
 ## Next Steps
 
 - [Axiom Adapter](/integrate/adapters/cloud/axiom) - Send logs to Axiom for querying and dashboards
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) - Send logs via OpenTelemetry Protocol
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) - Send logs via OpenTelemetry Protocol
 - [PostHog Adapter](/integrate/adapters/cloud/posthog) - Send logs to PostHog
 - [Custom Adapters](/extend/custom-drains) - Build your own adapter

--- a/apps/docs/content/4.integrate/adapters/cloud/04.better-stack.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/04.better-stack.md
@@ -232,5 +232,5 @@ await sendBatchToBetterStack(events, {
 ## Next Steps
 
 - [Axiom Adapter](/integrate/adapters/cloud/axiom) - Send logs to Axiom for querying and dashboards
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) - Send logs via OpenTelemetry Protocol
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) - Send logs via OpenTelemetry Protocol
 - [Custom Adapters](/extend/custom-drains) - Build your own adapter

--- a/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
@@ -13,14 +13,14 @@ links:
     variant: subtle
   - label: OTLP Adapter
     icon: i-simple-icons-opentelemetry
-    to: /integrate/adapters/cloud/otlp
+    to: /integrate/adapters/hybrid/otlp
     color: neutral
     variant: subtle
 ---
 
 [Datadog](https://www.datadoghq.com) is a monitoring and security platform. The evlog Datadog adapter sends your wide events to [Datadog Logs](https://docs.datadoghq.com/logs/) using the **HTTP Logs intake API (v2)** with the `DD-API-KEY` header.
 
-For OpenTelemetry-based ingestion instead, see the [OTLP adapter](/integrate/adapters/cloud/otlp).
+For OpenTelemetry-based ingestion instead, see the [OTLP adapter](/integrate/adapters/hybrid/otlp).
 
 ::prompt
 ---
@@ -270,5 +270,5 @@ await sendBatchToDatadog(events, {
 
 ## Next Steps
 
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) — Send logs via OpenTelemetry (works with Datadog Agent / OTLP endpoint)
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) — Send logs via OpenTelemetry (works with Datadog Agent / OTLP endpoint)
 - [Custom Adapters](/extend/custom-drains) — Build your own destination

--- a/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
@@ -49,7 +49,7 @@ Add the OTLP drain adapter to send evlog wide events via OpenTelemetry Protocol.
 6. Optionally set OTLP_HEADERS for authentication
 7. Test by triggering a request and checking your OTLP backend (Grafana, Datadog, Honeycomb, etc.)
 
-Adapter docs: https://www.evlog.dev/integrate/adapters/cloud/otlp
+Adapter docs: https://www.evlog.dev/integrate/adapters/hybrid/otlp
 Framework setup: https://www.evlog.dev/integrate/frameworks/overview
 
 ::
@@ -176,33 +176,14 @@ const drain = createOTLPDrain({
 | `resourceAttributes` | `object` | - | Additional OTLP resource attributes |
 | `timeout` | `number` | `5000` | Request timeout in milliseconds |
 
-## Provider-Specific Setup
+## Deployment
 
-### Grafana Cloud
+OTLP is a protocol, not a product — the same adapter talks to a collector you
+run yourself and to a managed gateway. Only the endpoint and headers change.
 
-1. Go to your Grafana Cloud portal
-2. Navigate to **Connections** > **Collector** > **OpenTelemetry**
-3. Copy your OTLP endpoint and generate credentials
+### Self-hosted
 
-```bash [.env]
-OTLP_ENDPOINT=https://otlp-gateway-prod-us-central-0.grafana.net/otlp
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20base64-encoded-credentials
-```
-
-::callout{icon="i-lucide-info" color="info"}
-Grafana uses URL-encoded headers. The `%20` is a space character. The adapter automatically decodes this format.
-::
-
-### Datadog
-
-```bash [.env]
-OTLP_ENDPOINT=https://http-intake.logs.datadoghq.com
-OTLP_HEADERS=DD-API-KEY=your-api-key
-```
-
-### Local OpenTelemetry Collector
-
-For development and testing, run a local collector:
+Run an OpenTelemetry Collector and point evlog at it. Nothing else to configure:
 
 ```yaml [otel-collector.yaml]
 receivers:
@@ -231,6 +212,36 @@ docker run --rm -p 4318:4318 \
 ```bash [.env]
 OTLP_ENDPOINT=http://localhost:4318
 ```
+
+From there the collector fans out wherever you want — Loki, ClickHouse,
+Elasticsearch, a managed backend, or several at once. That indirection is the
+reason to pick OTLP over a direct adapter.
+
+### Managed gateways
+
+Same adapter, a credentialed endpoint:
+
+::code-group
+```bash [Grafana Cloud]
+OTLP_ENDPOINT=https://otlp-gateway-prod-us-central-0.grafana.net/otlp
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20base64-encoded-credentials
+```
+
+```bash [Datadog]
+OTLP_ENDPOINT=https://http-intake.logs.datadoghq.com
+OTLP_HEADERS=DD-API-KEY=your-api-key
+```
+
+```bash [Honeycomb]
+OTLP_ENDPOINT=https://api.honeycomb.io
+OTLP_HEADERS=x-honeycomb-team=your-api-key
+```
+::
+
+::callout{icon="i-lucide-info" color="info"}
+Grafana Cloud uses URL-encoded headers — the `%20` is a space. The adapter
+decodes that format automatically.
+::
 
 ## OTLP Log Format
 

--- a/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
@@ -13,7 +13,7 @@ links:
     variant: subtle
   - label: OTLP Adapter
     icon: i-simple-icons-opentelemetry
-    to: /integrate/adapters/cloud/otlp
+    to: /integrate/adapters/hybrid/otlp
     color: neutral
     variant: subtle
 ---
@@ -39,7 +39,7 @@ Add the HyperDX drain adapter to send evlog wide events to HyperDX.
 5. Set HYPERDX_API_KEY environment variable in .env
 6. Test by triggering a request and checking HyperDX
 
-Adapter docs: https://www.evlog.dev/integrate/adapters/cloud/hyperdx
+Adapter docs: https://www.evlog.dev/integrate/adapters/hybrid/hyperdx
 Framework setup: https://www.evlog.dev/integrate/frameworks/overview
 
 ::
@@ -184,9 +184,48 @@ For self-hosted HyperDX, set `endpoint` to your OTLP HTTP base URL (same role as
 | `timeout` | `number` | `5000` | Request timeout in milliseconds |
 | `retries` | `number` | `2` | Retry attempts on transient failures |
 
+## Deployment
+
+HyperDX is open source, so the adapter targets a managed account and a cluster
+you run yourself with the same code — only `endpoint` changes.
+
+### HyperDX Cloud
+
+The default. Set the API key and nothing else:
+
+```typescript [server/plugins/evlog.ts]
+createHyperDXDrain()
+```
+
+```bash [.env]
+HYPERDX_API_KEY=your-ingestion-key
+```
+
+The endpoint defaults to `https://in-otel.hyperdx.io`.
+
+### Self-hosted
+
+Point `endpoint` at your own OTLP HTTP collector — the same value you would put
+in an `otlphttp` exporter's `endpoint`:
+
+```typescript [server/plugins/evlog.ts]
+createHyperDXDrain({ endpoint: 'http://hyperdx.internal:4318' })
+```
+
+```bash [.env]
+HYPERDX_OTLP_ENDPOINT=http://hyperdx.internal:4318
+# Only if your deployment enforces auth:
+HYPERDX_API_KEY=your-key
+```
+
+::callout{icon="i-lucide-info" color="info"}
+Give the **base** URL, not the signal path — evlog appends `/v1/logs` itself.
+A self-hosted collector on the default OTLP HTTP port is `http://host:4318`.
+::
+
 ## How It Works
 
-Under the hood, `createHyperDXDrain()` maps your HyperDX settings to the shared [OTLP adapter](/integrate/adapters/cloud/otlp) and calls `sendBatchToOTLP()`:
+Under the hood, `createHyperDXDrain()` maps your HyperDX settings to the shared [OTLP adapter](/integrate/adapters/hybrid/otlp) and calls `sendBatchToOTLP()`:
 
 - **Endpoint**: OTLP HTTP base URL, defaulting to `https://in-otel.hyperdx.io` (evlog posts to `{endpoint}/v1/logs`)
 - **Auth**: `authorization` header set to your API key (same as HyperDX’s documented `otlphttp` exporter)
@@ -262,7 +301,7 @@ await sendBatchToHyperDX(events, {
 
 ## Next Steps
 
-- [OTLP Adapter](/integrate/adapters/cloud/otlp) - Send logs via OpenTelemetry Protocol to any OTLP backend
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp) - Send logs via OpenTelemetry Protocol to any OTLP backend
 - [PostHog Adapter](/integrate/adapters/cloud/posthog) - Send logs to PostHog Logs via OTLP
 - [Custom Adapters](/extend/custom-drains) - Build your own adapter
 - [Best Practices](/reference/best-practices) - Security and production tips

--- a/packages/cli/src/lib/init/catalog.ts
+++ b/packages/cli/src/lib/init/catalog.ts
@@ -69,7 +69,7 @@ export const DESTINATIONS: readonly Destination[] = [
       { name: 'OTEL_EXPORTER_OTLP_ENDPOINT', hint: 'collector URL' },
       { name: 'OTEL_SERVICE_NAME', hint: 'defaults to your evlog service name' },
     ],
-    docs: '/integrate/adapters/cloud/otlp',
+    docs: '/integrate/adapters/hybrid/otlp',
     productionSafe: true,
   },
   {
@@ -125,7 +125,7 @@ export const DESTINATIONS: readonly Destination[] = [
     specifier: 'evlog/hyperdx',
     factory: 'createHyperDXDrain()',
     env: [{ name: 'HYPERDX_API_KEY', hint: 'ingestion key' }],
-    docs: '/integrate/adapters/cloud/hyperdx',
+    docs: '/integrate/adapters/hybrid/hyperdx',
     productionSafe: true,
   },
   {

--- a/packages/evlog/test/e2e/grafana-dashboards/wide-events.json
+++ b/packages/evlog/test/e2e/grafana-dashboards/wide-events.json
@@ -8,7 +8,7 @@
   "schemaVersion": 39,
   "refresh": "10s",
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "panels": [
@@ -29,7 +29,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT count() AS events FROM evlog_events WHERE $__timeFilter(timestamp)",
+          "rawSql": "SELECT count() AS events FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service)",
           "format": 1,
           "queryType": "sql"
         }
@@ -59,7 +59,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT countIf(level = 'error') AS errors FROM evlog_events WHERE $__timeFilter(timestamp)",
+          "rawSql": "SELECT countIf(level = 'error') AS errors FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service)",
           "format": 1,
           "queryType": "sql"
         }
@@ -107,7 +107,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT uniqExact(service) AS services FROM evlog_events WHERE $__timeFilter(timestamp)",
+          "rawSql": "SELECT uniqExact(service) AS services FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service)",
           "format": 1,
           "queryType": "sql"
         }
@@ -137,7 +137,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT uniqExact(path) AS routes FROM evlog_events WHERE $__timeFilter(timestamp) AND path != ''",
+          "rawSql": "SELECT uniqExact(path) AS routes FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service) AND path != ''",
           "format": 1,
           "queryType": "sql"
         }
@@ -167,7 +167,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, level, count() AS n FROM evlog_events WHERE $__timeFilter(timestamp) GROUP BY time, level ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, level, count() AS n FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service) GROUP BY time, level ORDER BY time",
           "format": 1,
           "queryType": "sql"
         }
@@ -201,11 +201,19 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT path, count() AS hits FROM evlog_events WHERE $__timeFilter(timestamp) AND path != '' GROUP BY path ORDER BY hits DESC LIMIT 10",
+          "rawSql": "SELECT path, count() AS hits FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service) AND path != '' GROUP BY path ORDER BY hits DESC LIMIT 10",
           "format": 1,
           "queryType": "sql"
         }
-      ]
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        }
+      }
     },
     {
       "type": "table",
@@ -225,7 +233,7 @@
             "type": "grafana-clickhouse-datasource",
             "uid": "evlog-clickhouse"
           },
-          "rawSql": "SELECT timestamp, level, service, method, path, status, duration, request_id, error_name, error_message, data FROM evlog_events WHERE $__timeFilter(timestamp) ORDER BY timestamp DESC LIMIT 100",
+          "rawSql": "SELECT timestamp, level, service, method, path, status, duration, request_id, error_name, error_message, data FROM evlog_events WHERE $__timeFilter(timestamp) AND service IN ($service) ORDER BY timestamp DESC LIMIT 100",
           "format": 1,
           "queryType": "sql"
         }
@@ -237,5 +245,32 @@
         }
       }
     }
-  ]
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "evlog-clickhouse"
+        },
+        "rawSql": "SELECT DISTINCT service FROM evlog_events ORDER BY service",
+        "query": "SELECT DISTINCT service FROM evlog_events ORDER BY service",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": [
+            "evlog-sandbox"
+          ],
+          "value": [
+            "evlog-sandbox"
+          ],
+          "selected": true
+        }
+      }
+    ]
+  }
 }

--- a/packages/evlog/test/e2e/seed.mjs
+++ b/packages/evlog/test/e2e/seed.mjs
@@ -15,6 +15,8 @@ import { initLogger, createRequestLogger } from 'evlog'
 const LOKI = process.env.LOKI_ENDPOINT ?? 'http://localhost:3100'
 const CLICKHOUSE = process.env.CLICKHOUSE_ENDPOINT ?? 'http://localhost:8123'
 const COUNT = Number(process.env.SEED_COUNT ?? 40)
+/** Total wall-clock the run is spread over, so the timeseries is not one spike. */
+const SPREAD_MS = Number(process.env.SEED_SPREAD_MS ?? 120_000)
 
 const loki = createLokiDrain({ endpoint: LOKI })
 const clickhouse = createClickHouseDrain({ endpoint: CLICKHOUSE })
@@ -61,6 +63,9 @@ async function emitRequest(index) {
     db: { queries: 1 + Math.floor(Math.random() * 6) },
   })
 
+  // Actually spend time, so `duration` is a real measurement rather than 0ms.
+  await new Promise(r => setTimeout(r, 5 + Math.floor(Math.random() * 60)))
+
   // ~12% errors, ~8% slow, rest healthy — enough variety to make dashboards useful.
   const roll = Math.random()
   if (roll < 0.12) {
@@ -77,6 +82,8 @@ async function emitRequest(index) {
   }
 
   if (roll < 0.20) {
+    // A slow request: an extra beat on the clock makes p95 panels meaningful.
+    await new Promise(r => setTimeout(r, 400 + Math.floor(Math.random() * 900)))
     log.set({ cache: { hit: false }, slowQuery: true })
     log.emit({ status: 200 })
     return 200
@@ -87,16 +94,47 @@ async function emitRequest(index) {
   return 200
 }
 
-console.log(`Seeding ${COUNT} wide events`)
+/**
+ * Drains swallow their errors by design — a failing destination must never break
+ * a request. That makes a silent "Done" the default when the sandbox is down, so
+ * check the backends are actually reachable before claiming anything was seeded.
+ */
+async function preflight() {
+  const checks = [
+    ['Loki', `${LOKI}/ready`],
+    ['ClickHouse', `${CLICKHOUSE}/ping`],
+  ]
+  const down = []
+  for (const [name, url] of checks) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(3000) })
+      if (!res.ok) down.push(`${name} (HTTP ${res.status})`)
+    } catch {
+      down.push(`${name} (unreachable at ${url})`)
+    }
+  }
+  if (down.length > 0) {
+    console.error(`\nCannot seed — backend not reachable: ${down.join(', ')}`)
+    console.error('Start the sandbox first:  pnpm run sandbox:up\n')
+    process.exit(1)
+  }
+}
+
+await preflight()
+
+console.log(`Seeding ${COUNT} wide events over ${Math.round(SPREAD_MS / 1000)}s`)
 console.log(`  Loki       ${LOKI}`)
 console.log(`  ClickHouse ${CLICKHOUSE}\n`)
 
 const statuses = []
+const gap = Math.max(0, Math.floor(SPREAD_MS / COUNT))
 for (let i = 0; i < COUNT; i++) {
   statuses.push(await emitRequest(i))
-  // Spread events over time so the Grafana graph is not a single spike.
-  await new Promise(r => setTimeout(r, 40))
+  process.stdout.write(`\r  ${i + 1}/${COUNT}`)
+  // Spread the run out so the Grafana timeseries has a shape, not one spike.
+  await new Promise(r => setTimeout(r, gap))
 }
+process.stdout.write('\r')
 
 // Drains are fire-and-forget from emit(); give them a beat to flush.
 await new Promise(r => setTimeout(r, 1500))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,16 @@ importers:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
+  examples/repro:
+    dependencies:
+      evlog:
+        specifier: workspace:*
+        version: link:../../packages/evlog
+    devDependencies:
+      tsx:
+        specifier: ^4.20.7
+        version: 4.23.1
+
   examples/solidstart:
     dependencies:
       '@solidjs/router':


### PR DESCRIPTION
## Why

`cloud/` vs `self-hosted/` never fit four of the adapters. OTLP is a *protocol* — the most common setup is a collector you run yourself. HyperDX is open source. Both were filed under `cloud/` next to Axiom and Datadog, which misrepresents them.

They join Loki and ClickHouse under **`hybrid/`** ("Cloud or Self-Hosted"):

| Category | Adapters |
|---|---|
| Cloud | Axiom, PostHog, Sentry, Better Stack, Datadog |
| **Cloud or Self-Hosted** | **Loki, ClickHouse, OTLP, HyperDX** |
| Self-Hosted | File System, NuxtHub, Memory |

## Each page now splits the two modes

Rather than interleaving them, both moved pages get a `## Deployment` section matching the Loki and ClickHouse shape:

- **OTLP** — a collector-first self-hosted section explaining *why* you'd pick the protocol over a direct adapter (it fans out to Loki, ClickHouse, a managed backend, or several at once), then managed gateways as a `code-group` (Grafana Cloud, Datadog, Honeycomb)
- **HyperDX** — Cloud as the default, then pointing `endpoint` at your own OTLP collector, with a callout that evlog appends `/v1/logs` so you pass the *base* URL

## URLs

`/integrate/adapters/cloud/otlp` and `.../cloud/hyperdx` were live and indexed, so they 301 to the new paths. The pre-existing legacy redirects (`/adapters/otlp`, `/adapters/cloud/hyperdx`, …) are repointed too — otherwise they'd have chained into a 404.

`cloud/` is renumbered, and every in-repo reference is updated: the adapters overview (links + cards regrouped by category), `1.start/2.why-evlog.md`, the five remaining cloud pages, the docs header component, and `packages/cli/src/lib/init/catalog.ts`.

## Sandbox fixes folded in

Three defects in what shipped with the ClickHouse PR, all found by actually looking at the dashboard:

**The seeder lied.** Drains swallow their errors by design — a failing destination must never break a request. So with the sandbox stopped, `sandbox:seed` printed a cheerful `Done — 40 events` against an empty backend. It now preflights `/ready` and `/ping` and exits non-zero with what's unreachable.

**Durations were `0ms`.** The seeder emitted without doing any work, so the logger correctly measured nothing. Requests now spend real time — 5-65ms normally, 400-1300ms on the slow path — which also makes latency panels meaningful.

**The dashboard was polluted and unreadable.** `evlog-e2e` events mixed into every panel (`Services: 2`, blank rows in the table); there's now a `service` variable defaulting to `evlog-sandbox`. All 40 events landed in one 2-second spike; the run now spreads over `SEED_SPREAD_MS` (120s default). The route bar chart is horizontal so labels stop colliding.

## Verification

- `pnpm run build:docs` — passes, which is what catches a broken content link
- `pnpm run test` — 1722/1722
- `pnpm run lint` — 0 errors (2 pre-existing `max-params` warnings in `nitro-v3/plugin.ts`)
- `pnpm run typecheck` — 26/26
- seeder preflight verified by running it against a stopped sandbox — exits 1 with both endpoints named

**Not verified:** the dashboard changes were not re-checked in a running Grafana — Docker stopped mid-session. The JSON is valid and the panel queries are unchanged apart from the `AND service IN ($service)` clause, but the visual result deserves a look after `pnpm run sandbox:up && pnpm run sandbox:seed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized OTLP and HyperDX integrations under Hybrid adapters.
  * Added setup guidance for self-hosted deployments and managed gateways, including endpoints and authentication.
  * Updated related integration links and navigation to the new locations.
* **Bug Fixes**
  * Added redirects from previous Cloud adapter URLs to prevent broken links.
* **Improvements**
  * Enhanced the Grafana dashboard with service filtering, a shorter default time range, and improved route visualization.
  * Improved test data generation with configurable timing, readiness checks, and progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->