### PR TITLE
ci(release): give each package GitHub-style release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,8 @@ changelog:
       - ignore-for-release
     authors:
       - octocat
+      # The release bot's own "version packages" PR is not a change anyone reads about.
+      - github-actions[bot]
   categories:
     - title: Breaking Changes 💥
       labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,26 @@ jobs:
           title: "chore(repo): version packages"
           version: pnpm run version
           publish: pnpm run release
+          # Releases are created here, then their bodies are rewritten below.
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      # createGithubReleases publishes one release per package, tagged pkg@version, whose body is
-      # that version's section of the package CHANGELOG. Generating notes from the commit range
-      # instead cross-contaminates packages: monorepo tags interleave, so the range between two
-      # consecutive @evlog/cli tags sweeps up every core/telemetry/docs commit landed in between.
+      # createGithubReleases gives us one release per package, tagged pkg@version — that part
+      # we keep. Its *body* is the CHANGELOG section, which for a dependent package is a wall of
+      # "Updated dependencies [<hash>, <hash>, …]" and is empty for packages with no changeset
+      # of their own. `--generate-notes` is not the answer either: GitHub builds those from a
+      # commit range, and monorepo tags interleave, so each package would list everybody's PRs.
+      # So we rewrite each body from the PRs that actually touched that package's directory,
+      # grouped by the same categories as .github/release.yml.
       - name: Push tags
         if: steps.changesets.outputs.published == 'true'
         run: git push --tags
+
+      - name: Rewrite release notes
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/release-notes.mjs '${{ steps.changesets.outputs.publishedPackages }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,249 @@
+/**
+ * Rewrite each published package's GitHub release body with GitHub-style notes:
+ * merged pull requests, grouped into the categories from `.github/release.yml`.
+ *
+ * ## Why this exists
+ *
+ * `createGithubReleases: true` gives changesets' own body — the CHANGELOG
+ * section. For a dependent package that reads:
+ *
+ *     ### Patch Changes
+ *     - Updated dependencies [[`f39ab30`](…), [`899464a`](…), [`d7f482a`](…), …]
+ *       - evlog@2.23.0
+ *
+ * ...which says nothing a reader can use, and packages with no changeset of
+ * their own get an empty release.
+ *
+ * The obvious alternative, `gh release create --generate-notes`, has the
+ * opposite problem: GitHub builds those notes from a commit *range*, and in a
+ * monorepo the per-package tags interleave. The range between two consecutive
+ * `@evlog/cli` tags sweeps up every core / telemetry / docs PR that landed in
+ * between, so each package's notes list everybody's work.
+ *
+ * So we build the list ourselves: take the commits in the range that actually
+ * touched the package's directory, resolve each to its pull request, and group
+ * them with the same label → category mapping GitHub uses. The output is
+ * indistinguishable from GitHub's, but correctly scoped.
+ *
+ * ## Usage
+ *
+ *     node scripts/release-notes.mjs '[{"name":"evlog","version":"2.24.0"}]'
+ *
+ * Rehearse it locally before a tag exists:
+ *
+ *     GITHUB_TOKEN=$(gh auth token) DRY_RUN=1 RELEASE_NOTES_REF=HEAD \
+ *       node scripts/release-notes.mjs '[{"name":"evlog","version":"2.24.0"}]'
+ *
+ * ## Env
+ *
+ * - `GITHUB_TOKEN`       required, used for the PR lookups and `gh release edit`
+ * - `GITHUB_REPOSITORY`  owner/repo (set by Actions; falls back to the git remote)
+ * - `DRY_RUN=1`          print the notes instead of editing the releases
+ * - `RELEASE_NOTES_REF`  end of the commit range (default: the release tag)
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+
+function resolveRepo() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY
+  const url = git('remote', 'get-url', 'origin')
+  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
+  if (!match) throw new Error(`cannot derive owner/repo from remote "${url}"`)
+  return match[1]
+}
+
+/** Map every workspace package name to its directory. */
+function packageDirs() {
+  const root = resolve(process.cwd(), 'packages')
+  const out = new Map()
+  for (const entry of readdirSync(root)) {
+    try {
+      const pkg = JSON.parse(readFileSync(resolve(root, entry, 'package.json'), 'utf8'))
+      if (pkg.name) out.set(pkg.name, `packages/${entry}`)
+    } catch {
+      // not a package directory
+    }
+  }
+  return out
+}
+
+/**
+ * Read the category order out of `.github/release.yml` so the sections match
+ * what GitHub produces for a hand-generated release. Minimal parse — the file
+ * is a fixed shape we own, and this avoids a YAML dependency in CI.
+ */
+function releaseConfig() {
+  let text
+  try {
+    text = readFileSync(resolve(process.cwd(), '.github/release.yml'), 'utf8')
+  } catch {
+    return { categories: [], excludedLabels: [], excludedAuthors: [] }
+  }
+
+  const categories = []
+  const excludedLabels = []
+  const excludedAuthors = []
+  let section = null      // 'exclude' | 'categories'
+  let excludeKey = null   // 'labels' | 'authors' — they are separate lists
+  let current = null
+
+  for (const line of text.split('\n')) {
+    if (/^\s{2}exclude:/.test(line)) { section = 'exclude'; excludeKey = null; continue }
+    if (/^\s{2}categories:/.test(line)) { section = 'categories'; continue }
+    if (section === 'exclude') {
+      if (/^\s*labels:/.test(line)) { excludeKey = 'labels'; continue }
+      if (/^\s*authors:/.test(line)) { excludeKey = 'authors'; continue }
+    }
+
+    const title = line.match(/^\s*-\s*title:\s*(.+?)\s*$/)
+    if (title && section === 'categories') {
+      current = { title: title[1], labels: [] }
+      categories.push(current)
+      continue
+    }
+    const item = line.match(/^\s*-\s*(\S.*?)\s*$/)
+    if (item && !line.includes(':')) {
+      if (section === 'categories' && current) current.labels.push(item[1])
+      else if (section === 'exclude' && excludeKey === 'labels') excludedLabels.push(item[1])
+      else if (section === 'exclude' && excludeKey === 'authors') excludedAuthors.push(item[1])
+    }
+  }
+  return { categories, excludedLabels, excludedAuthors }
+}
+
+/**
+ * The tag this package was released under last time.
+ *
+ * Falls back to the newest `v*` tag from before the repo moved to per-package
+ * tags, so an early per-package release still gets a bounded range instead of
+ * the entire history.
+ */
+function previousTag(name, currentTag) {
+  const scoped = git('tag', '--list', `${name}@*`, '--sort=-creatordate')
+    .split('\n')
+    .filter(t => t && t !== currentTag)
+  if (scoped.length > 0) return scoped[0]
+
+  const legacy = git('tag', '--list', 'v*', '--sort=-creatordate').split('\n').filter(Boolean)
+  return legacy[0] ?? null
+}
+
+/** Commits in (from, to] that touched the package directory. */
+function commitsTouching(dir, from, to) {
+  const range = from ? `${from}..${to}` : to
+  const out = git('log', range, '--format=%H', '--no-merges', '--', dir)
+  return out ? out.split('\n').filter(Boolean) : []
+}
+
+async function pullsForCommit(repo, sha, token) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/commits/${sha}/pulls`, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    console.warn(`[release-notes] PR lookup failed for ${sha.slice(0, 8)}: ${res.status}`)
+    return []
+  }
+  return await res.json()
+}
+
+/** Render in GitHub's own shape, so the result reads like a generated release. */
+function renderNotes({ repo, pulls, previous, tag, config }) {
+  const line = pr => `* ${pr.title} by @${pr.author} in https://github.com/${repo}/pull/${pr.number}`
+  const remaining = new Set(pulls.map(p => p.number))
+  const sections = []
+
+  for (const category of config.categories) {
+    const matched = pulls.filter(p =>
+      remaining.has(p.number) && p.labels.some(l => category.labels.includes(l)),
+    )
+    if (matched.length === 0) continue
+    for (const p of matched) remaining.delete(p.number)
+    sections.push(`### ${category.title}\n${matched.map(line).join('\n')}`)
+  }
+
+  // GitHub files anything unlabelled under "Other Changes".
+  const others = pulls.filter(p => remaining.has(p.number))
+  if (others.length > 0) sections.push(`### Other Changes 🔨\n${others.map(line).join('\n')}`)
+
+  const body = sections.length > 0
+    ? `## What's Changed\n${sections.join('\n')}`
+    : `## What's Changed\n_No pull requests touched this package in this release._`
+
+  const compare = previous
+    ? `\n\n**Full Changelog**: https://github.com/${repo}/compare/${previous}...${tag}`
+    : ''
+  return body + compare
+}
+
+async function main() {
+  const raw = process.argv[2]
+  if (!raw) throw new Error('usage: release-notes.mjs \'[{"name":"evlog","version":"1.0.0"}]\'')
+
+  const published = JSON.parse(raw)
+  if (!Array.isArray(published) || published.length === 0) {
+    console.log('[release-notes] nothing published, skipping')
+    return
+  }
+
+  const token = process.env.GITHUB_TOKEN
+  if (!token) throw new Error('GITHUB_TOKEN is required')
+  const repo = resolveRepo()
+  const dirs = packageDirs()
+  const config = releaseConfig()
+  const dryRun = process.env.DRY_RUN === '1'
+
+  for (const { name, version } of published) {
+    const tag = `${name}@${version}`
+    const dir = dirs.get(name)
+    if (!dir) {
+      console.warn(`[release-notes] no directory for ${name}, skipping`)
+      continue
+    }
+
+    const previous = previousTag(name, tag)
+    const head = process.env.RELEASE_NOTES_REF ?? tag
+    const shas = commitsTouching(dir, previous, head)
+
+    // One PR can carry several commits; keep first-seen order (newest first).
+    const seen = new Map()
+    for (const sha of shas) {
+      for (const pr of await pullsForCommit(repo, sha, token)) {
+        if (!pr.merged_at || seen.has(pr.number)) continue
+        const author = pr.user?.login ?? 'unknown'
+        if (config.excludedAuthors.includes(author)) continue
+        const labels = (pr.labels ?? []).map(l => l.name)
+        if (labels.some(l => config.excludedLabels.includes(l))) continue
+        seen.set(pr.number, {
+          number: pr.number,
+          title: pr.title,
+          author,
+          labels,
+        })
+      }
+    }
+
+    const pulls = [...seen.values()]
+    const notes = renderNotes({ repo, pulls, previous, tag, config })
+    console.log(`\n── ${tag}  (${pulls.length} PR${pulls.length === 1 ? '' : 's'} since ${previous ?? 'repo start'})`)
+
+    if (dryRun) {
+      console.log(notes)
+      continue
+    }
+
+    execFileSync('gh', ['release', 'edit', tag, '--notes', notes], {
+      stdio: 'inherit',
+      env: { ...process.env, GH_TOKEN: token },
+    })
+    console.log(`[release-notes] updated ${tag}`)
+  }
+}
+
+await main()


### PR DESCRIPTION
Keeps the per-package release scheme exactly as it is — one release per package, tagged `pkg@version`. **Only the body changes.**

## The problem

`createGithubReleases: true` uses the CHANGELOG section as the release body. Live examples from the release that just shipped:

**`@evlog/cli@0.3.1`** —
```
### Patch Changes
- Updated dependencies [[`f39ab30`](…), [`899464a`](…), [`d7f482a`](…), [`f5d7474`](…), … 16 hashes]
  - evlog@2.23.0
```

**`@evlog/nuxthub@2.0.1`** and **`@evlog/telemetry@0.2.0`** — completely empty, because neither had a changeset of its own.

## Why not `--generate-notes`

That was the previous approach and the comment in `release.yml` explains why it was dropped: GitHub builds those notes from a commit **range**, and in a monorepo the per-package tags interleave. The range between two consecutive `@evlog/cli` tags sweeps up every core / telemetry / docs PR that landed in between, so every package lists everybody's work.

## What this does

`scripts/release-notes.mjs` runs after publish and rewrites each body:

1. commits in `previousTag..tag` that **touched that package's directory**
2. each commit → its merged PR (the repo uses merge commits, so the PR number isn't in the subject — it goes through the API)
3. grouped with the same label → category mapping GitHub reads from `.github/release.yml`

Output is indistinguishable from a hand-generated GitHub release:

```markdown
## What's Changed
### Features 🚀
* feat(clickhouse): add the ClickHouse drain adapter by @HugoRCD in https://github.com/HugoRCD/evlog/pull/481
### Bug Fixes 🐞
* fix(elysia): defer the wide event until a streaming body closes by @HugoRCD in https://github.com/HugoRCD/evlog/pull/478

**Full Changelog**: https://github.com/HugoRCD/evlog/compare/evlog@2.22.4...evlog@2.23.0
```

## Rehearsed against the real releases

| Package | Today | With this |
|---|---|---|
| `evlog@2.23.0` | changeset content | **19 PRs**, categorised |
| `@evlog/cli@0.3.1` | wall of dependency hashes | **1 PR** — the only one that touched `packages/cli` |
| `@evlog/nuxthub@2.0.1` | *empty* | **12 PRs** |
| `@evlog/telemetry@0.2.0` | *empty* | **1 PR** |

The cli number is the proof the scoping works: 1 instead of 19.

Rehearse it yourself before merging — this needs no tag to exist:

```bash
GITHUB_TOKEN=$(gh auth token) DRY_RUN=1 \
  node scripts/release-notes.mjs '[{"name":"evlog","version":"2.23.0"}]'
```

## Also

Adds `github-actions[bot]` to `exclude.authors` in `.github/release.yml`, so the release bot's own "version packages" PR stops showing up as a change.

## One thing worth knowing

Several recent PRs land in **Other Changes 🔨** because they carry no category label — `feat(loki)`, `feat(hono)`, `refactor(next)` among them. That is a labelling gap, not a script one: GitHub's own generator would file them the same way. Worth checking the auto-labeller covers every merged PR, otherwise the categories stay half-empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release notes are now generated for each published package.
  - Notes group changes by configured categories and include links to the changelog.
  - Package-specific release notes are automatically updated after publishing.

- **Improvements**
  - Automated release activity is excluded from generated changelogs for cleaner, more relevant notes.
  - Release notes now focus on pull requests associated with the published package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->