### PR TITLE
chore: finish consistency audit cleanups

### DIFF
--- a/.agents/skills/create-adapter/SKILL.md
+++ b/.agents/skills/create-adapter/SKILL.md
@@ -28,8 +28,9 @@ The exact wording may vary depending on the adapter (e.g., `feat: add OTLP adapt
 | 5 | `apps/docs/content/4.integrate/adapters/{category}/{NN}.{name}.md` | Create adapter doc page in `cloud`, `hybrid`, or `self-hosted` |
 | 6 | `apps/docs/content/4.integrate/adapters/01.overview.md` | Add adapter to overview (links, card, env vars) |
 | 7 | `skills/review-logging-patterns/SKILL.md` | Add adapter row in the Drain Adapters table |
+| 8 | `.changeset/{name}-adapter.md` | Add a minor changeset for the new adapter |
 
-**Important**: Do NOT consider the task complete until all 7 touchpoints have been addressed.
+**Important**: Do NOT consider the task complete until all 8 touchpoints have been addressed.
 
 ## Naming Conventions
 
@@ -140,11 +141,24 @@ In `skills/review-logging-patterns/SKILL.md` (the public skill distributed to us
 
 Follow the pattern of the existing rows (Axiom, OTLP, PostHog, Sentry, Better Stack).
 
+## Step 8: Changeset
+
+Create `.changeset/{name}-adapter.md`:
+
+```markdown
+---
+"evlog": minor
+---
+
+Add the {Name} adapter for sending wide events to {Name}
+```
+
 ## Verification
 
-After completing all steps, run:
+After a clean install, prepare generated workspace types from the repo root before running the package checks:
 
 ```bash
+pnpm run dev:prepare
 cd packages/evlog
 pnpm run lint
 pnpm run typecheck

--- a/.agents/skills/create-adapter/SKILL.md
+++ b/.agents/skills/create-adapter/SKILL.md
@@ -25,12 +25,11 @@ The exact wording may vary depending on the adapter (e.g., `feat: add OTLP adapt
 | 2 | `packages/evlog/tsdown.config.ts` | Add build entry |
 | 3 | `packages/evlog/package.json` | Add `exports` + `typesVersions` entries |
 | 4 | `packages/evlog/test/adapters/{name}.test.ts` | Create tests |
-| 5 | `apps/docs/content/4.adapters/{n}.{name}.md` | Create adapter doc page (before `custom.md`) |
-| 6 | `apps/docs/content/4.adapters/1.overview.md` | Add adapter to overview (links, card, env vars) |
+| 5 | `apps/docs/content/4.integrate/adapters/{category}/{NN}.{name}.md` | Create adapter doc page in `cloud`, `hybrid`, or `self-hosted` |
+| 6 | `apps/docs/content/4.integrate/adapters/01.overview.md` | Add adapter to overview (links, card, env vars) |
 | 7 | `skills/review-logging-patterns/SKILL.md` | Add adapter row in the Drain Adapters table |
-| 8 | Renumber `custom.md` | Ensure `custom.md` stays last after the new adapter |
 
-**Important**: Do NOT consider the task complete until all 8 touchpoints have been addressed.
+**Important**: Do NOT consider the task complete until all 7 touchpoints have been addressed.
 
 ## Naming Conventions
 
@@ -117,15 +116,15 @@ Required test categories:
 
 ## Step 5: Adapter Documentation Page
 
-Create `apps/docs/content/4.adapters/{n}.{name}.md` where `{n}` is the next number before `custom.md` (custom should always be last).
+Create `apps/docs/content/4.integrate/adapters/{category}/{NN}.{name}.md`, choosing the matching `cloud`, `hybrid`, or `self-hosted` category and the next number in that directory.
 
-Use the existing Axiom adapter page (`apps/docs/content/4.adapters/2.axiom.md`) as a reference for frontmatter structure, tone, and sections. Key sections: intro, quick setup, configuration (env vars table + priority), advanced usage, querying in the target service, troubleshooting, direct API usage, next steps.
+Use the existing Axiom adapter page (`apps/docs/content/4.integrate/adapters/cloud/01.axiom.md`) as a reference for frontmatter structure, tone, and sections. Key sections: intro, quick setup, configuration (env vars table + priority), advanced usage, querying in the target service, troubleshooting, direct API usage, next steps.
 
 **Important: multi-framework examples.** The Quick Start section must include a `::code-group` with tabs for all supported frameworks (Nuxt/Nitro, Hono, Express, Fastify, Elysia, NestJS, Standalone). Do not only show Nitro examples. See any existing adapter page for the pattern.
 
 ## Step 6: Update Adapters Overview Page
 
-Edit `apps/docs/content/4.adapters/1.overview.md` to add the new adapter in **three** places (follow the pattern of existing adapters):
+Edit `apps/docs/content/4.integrate/adapters/01.overview.md` to add the new adapter in **three** places (follow the pattern of existing adapters):
 
 1. **Frontmatter `links` array** — add a link entry with icon and path
 2. **`::card-group` section** — add a card block before the Custom card
@@ -140,10 +139,6 @@ In `skills/review-logging-patterns/SKILL.md` (the public skill distributed to us
 ```
 
 Follow the pattern of the existing rows (Axiom, OTLP, PostHog, Sentry, Better Stack).
-
-## Step 8: Renumber `custom.md`
-
-If the new adapter's number conflicts with `custom.md`, renumber `custom.md` to be the last entry. For example, if the new adapter is `5.{name}.md`, rename `5.custom.md` to `6.custom.md`.
 
 ## Verification
 

--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -19,7 +19,7 @@ Manifest mode covers ~80% of integrations and reduces glue from 50–80 lines to
 Recommended format for the pull request title:
 
 ```
-feat({framework}): add {Framework} middleware integration
+feat: add {Framework} middleware integration
 ```
 
 ## Touchpoints Checklist
@@ -464,7 +464,7 @@ Add {Framework} middleware integration (`evlog/{framework}`) with automatic wide
 
 ## Step 15 & 16: PR Scopes
 
-Add the framework name as a valid scope in **both** files so PR title validation passes:
+Add the framework name as a valid scope in **both** files for future PRs. The semantic PR check reads its scope list from the base branch, so the integration PR must either use an unscoped title (as recommended above) or follow a preceding PR that registers the scope.
 
 **`.github/workflows/semantic-pull-request.yml`** — add `{framework}` to the `scopes` list:
 

--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -464,7 +464,7 @@ Add {Framework} middleware integration (`evlog/{framework}`) with automatic wide
 
 ## Step 15 & 16: PR Scopes
 
-Add the framework name as a valid scope in **both** files for future PRs. The semantic PR check reads its scope list from the base branch, so the integration PR must either use an unscoped title (as recommended above) or follow a preceding PR that registers the scope.
+Add the framework name as a valid scope in **both** files for future PRs, keeping both scope lists alphabetically sorted. The semantic PR check reads its scope list from the base branch, so the integration PR must either use an unscoped title (as recommended above) or follow a preceding PR that registers the scope.
 
 **`.github/workflows/semantic-pull-request.yml`** — add `{framework}` to the `scopes` list:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ PR titles and commits follow [Conventional Commits](https://conventionalcommits.
 - **Subject must not start with an uppercase letter.** `feat: add stream server` ✓ — `feat: Add stream server` ✗.
 - **Omit the scope when the change is cross-cutting** (touches multiple subsystems, or is repo-wide). Don't use `evlog` as a scope: the whole monorepo *is* evlog, so a no-scope title already means "evlog itself".
 - **Use a scope only to point at one subsystem.** Adapters get their own scope (one per entrypoint, e.g. `axiom`, `datadog`, `fs`); framework integrations get the framework's name (`nuxt`, `next`, `hono`, ...); core internals (logger, pipeline, error, redact, catalog) go under `core`.
-- **When you add a new subsystem** (adapter, integration, top-level entrypoint), add its scope to **both** the workflow and the template in the same PR. Keep both lists alphabetically sorted.
+- **When you add a new subsystem** (adapter, integration, top-level entrypoint), add its scope to **both** the workflow and the template. Keep both lists alphabetically sorted. Because title validation reads the base branch's scope list, either register the scope in a preceding PR or omit the scope from the subsystem PR title.
 
 ### Doc animation components (`apps/docs/app/components/content/`)
 

--- a/packages/evlog/src/nitro-v3/plugin.ts
+++ b/packages/evlog/src/nitro-v3/plugin.ts
@@ -70,6 +70,7 @@ function buildHookContext(
   }
 }
 
+// eslint-disable-next-line max-params
 async function callDrainHook(
   hooks: Hooks,
   emittedEvent: WideEvent | null,
@@ -123,6 +124,7 @@ async function callDrainHook(
   }
 }
 
+// eslint-disable-next-line max-params
 async function callEnrichAndDrain(
   hooks: Hooks,
   emittedEvent: WideEvent | null,


### PR DESCRIPTION
## Summary

- silence the two intentional Nitro v3 `max-params` warnings using the existing local exemption pattern
- update the adapter skill for the current categorized documentation paths and remove obsolete `custom.md` renumbering
- explain that new PR scopes must already exist on the base branch or the subsystem PR title must remain unscoped

## Validation

- `git diff --check`
- verified all documented paths exist and no stale `4.adapters` / `custom.md` instructions remain
- full local install could not complete because the C: drive reached `ENOSPC`; the incomplete `node_modules` and pnpm cache were removed, so the complete lint/typecheck/test matrix is left to Draft PR CI

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated adapter creation guidance to reflect the current documentation structure and validation steps.
  * Clarified framework integration PR title and scope-registration requirements.
  * Updated new-subsystem guidance for scope registration across pull requests.

* **Code Quality**
  * Resolved linting warnings in event processing without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->