### PR TITLE
feat(cli): add the agents command to teach evlog to AI agents

### DIFF
--- a/.changeset/cli-agents-command.md
+++ b/.changeset/cli-agents-command.md
@@ -1,0 +1,13 @@
+---
+"@evlog/cli": minor
+---
+
+feat: add `evlog agents` — teach the AI agents working in a project how to use evlog. It writes a short, marker-delimited block of evlog conventions into `AGENTS.md` (one wide event per operation, grouped context via `log.set()`, `createError({ why, fix, internal })` over bare throws, `defineErrorCatalog()` once an error repeats, `log.audit()` on sensitive actions, and what never gets logged) and creates a `CLAUDE.md` pointing at it with `@AGENTS.md`. The block names the request-logger accessor for the detected framework (`useLogger(event)` on Nuxt and Nitro, `useLogger()` from `lib/evlog.ts` on Next.js, `req.context.log` on TanStack Start) and falls back to a generic one when detection finds nothing, so the command is useful outside the four frameworks `evlog map` covers.
+
+The agent skills are installed by shelling out to `npx skills add https://www.evlog.dev`, the same way `evlog init` runs your package manager rather than unpacking a tarball itself. Each agent reads a different directory (`.claude/skills`, `.agents/skills`, `.codex/skills`, …) and the skills CLI already resolves them, symlinks a canonical copy, and supports a global scope — and since it keeps no manifest, a copy written behind its back would be a second one it could never update. Skills already installed, in any agent directory and either scope, are detected and left for `npx skills update`. `--skills <a,b>` narrows the selection, `--global` installs for every project, `--no-skills` writes the block with nothing spawned, `--source` points at another host, and `--dry-run` prints the plan. Interactive runs hand the terminal to the skills CLI so it can ask which agents to install for; non-interactive runs pass `--yes` so nothing blocks on a prompt nobody will answer.
+
+`evlog init` now offers the same step as its last question — the `AGENTS.md` and `CLAUDE.md` writes are planned alongside the wiring so there is still one plan and one confirmation, and the skills run next to the package-manager install. `--no-agents` skips it. The block never needs the network, so a skills failure is reported without costing the rest of the run.
+
+Both flows report the skills step whether or not it did anything — in the plan, in the written report, and through clack in an interactive run — so "already installed" is never confusable with "forgot to do it".
+
+`CliContext` gains a `home` field, so the search for installed skills reads the home directory through the context like every other `process.*` value rather than calling `os.homedir()` directly.

--- a/.changeset/cli-agents-command.md
+++ b/.changeset/cli-agents-command.md
@@ -8,6 +8,8 @@ The agent skills are installed by shelling out to `npx skills add https://www.ev
 
 `evlog init` now offers the same step as its last question — the `AGENTS.md` and `CLAUDE.md` writes are planned alongside the wiring so there is still one plan and one confirmation, and the skills run next to the package-manager install. `--no-agents` skips it. The block never needs the network, so a skills failure is reported without costing the rest of the run.
 
+`--source` must be an `http:`/`https:` URL and `--skills` entries must be lowercase dashed names, both rejected with a catalog error before anything is spawned — on Windows the spawn needs a shell to resolve `npx`, so those values would otherwise reach a `cmd.exe` command line. If the skills install fails, the `AGENTS.md` block is rewritten without the pointer to a skill that is now known not to be on disk.
+
 Both flows report the skills step whether or not it did anything — in the plan, in the written report, and through clack in an interactive run — so "already installed" is never confusable with "forgot to do it".
 
 `CliContext` gains a `home` field, so the search for installed skills reads the home directory through the context like every other `process.*` value rather than calling `os.homedir()` directly.

--- a/apps/docs/content/3.cli/0.overview.md
+++ b/apps/docs/content/3.cli/0.overview.md
@@ -19,7 +19,7 @@ links:
 
 `@evlog/cli` is a separate package from `evlog` itself. It never runs in your app: it reads your source on disk, so there is nothing to configure and nothing to deploy.
 
-Its main job is [`evlog map`](/cli/map) — a static observability score for your app, in the spirit of Lighthouse. It finds every entry point in your project, checks each one for wide-event coverage, and tells you which three to fix first. [`evlog init`](/cli/init) is the one command that writes code rather than reading it: it wires evlog into the app so there is something to score.
+Its main job is [`evlog map`](/cli/map) — a static observability score for your app, in the spirit of Lighthouse. It finds every entry point in your project, checks each one for wide-event coverage, and tells you which three to fix first. Two commands write rather than read: [`evlog init`](/cli/init) wires evlog into the app so there is something to score, and [`evlog agents`](/cli/agents) teaches the AI agents working in the repository how to use it.
 
 ::warning{icon="i-lucide-flask-conical"}
 **Early days.** The CLI is safe to run on any project — it only reads files, and it is covered by tests — but it is young. `evlog map` understands four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases, and [pin the version](/cli/ci#pin-the-version) when you gate CI on the number.
@@ -66,6 +66,15 @@ Requires Node 20 or later. The package installs a single `evlog` binary.
   color: neutral
   ---
   Install evlog, register the framework integration, and write a local sink.
+  :::
+  :::card
+  ---
+  icon: i-lucide-bot
+  title: agents
+  to: /cli/agents
+  color: neutral
+  ---
+  Write the evlog conventions into AGENTS.md and install the agent skills.
   :::
   :::card
   ---

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -84,7 +84,8 @@ The production picker is a fuzzy search — type `ax` for Axiom — and takes mo
 2. **Installs `evlog`** with the package manager your lockfile implies, unless it is already there. `--no-install` prints the command instead of running it.
 3. **Registers the integration** — the Nuxt module, the Nitro module, or the Next.js instrumentation files.
 4. **Wires your destinations**, dev and production branched in one place, with batching, enrichers and sampling when you asked for them.
-5. **Runs `evlog doctor`** before it finishes, so the run answers "did it work" instead of telling you to go and check.
+5. **Teaches your AI agents**, if you let it — the evlog conventions as a block in `AGENTS.md`, and the [agent skills](/reference/agent-skills) via `npx skills add`. Same thing [`evlog agents`](/cli/agents) does; the writes are planned alongside the wiring so you confirm once. Skills already installed are left for `npx skills update`. `--no-agents` skips it.
+6. **Runs `evlog doctor`** before it finishes, so the run answers "did it work" instead of telling you to go and check.
 
 Everything it writes is reported line by line, including the parts that were already in place.
 
@@ -328,11 +329,13 @@ The directory it writes to is `.evlog/logs`, and evlog gitignores it on first wr
 | `--apps <a,b>` | Workspace packages to set up (monorepo root only) |
 | `--dry-run` | Print the plan, write nothing |
 | `--no-install` | Do not run the package manager; print the command instead |
+| `--no-agents` | Skip the `AGENTS.md` block and the agent skills |
 | `--cwd <dir>` | Set up another app in the workspace |
 | `--json` | The plan and result as JSON on stdout (implies non-interactive) |
 
 ## Next
 
+- [`evlog agents`](/cli/agents) — re-run the agent guidelines on their own, whenever the skills move on
 - [`evlog doctor`](/cli/doctor) — confirm the wiring resolves and logs are being written
 - [`evlog map`](/cli/map) — score what is still dark now that evlog is in place
 - [Quick Start](/start/quick-start) — the concepts behind the wiring

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -84,7 +84,7 @@ The production picker is a fuzzy search — type `ax` for Axiom — and takes mo
 2. **Installs `evlog`** with the package manager your lockfile implies, unless it is already there. `--no-install` prints the command instead of running it.
 3. **Registers the integration** — the Nuxt module, the Nitro module, or the Next.js instrumentation files.
 4. **Wires your destinations**, dev and production branched in one place, with batching, enrichers and sampling when you asked for them.
-5. **Teaches your AI agents**, if you let it — the evlog conventions as a block in `AGENTS.md`, and the [agent skills](/reference/agent-skills) via `npx skills add`. Same thing [`evlog agents`](/cli/agents) does; the writes are planned alongside the wiring so you confirm once. Skills already installed are left for `npx skills update`. `--no-agents` skips it.
+5. **Teaches your AI agents**, if you let it — the evlog conventions as a block in `AGENTS.md`, a `CLAUDE.md` pointing at it, and the [agent skills](/reference/agent-skills) via `npx skills add`. Same thing [`evlog agents`](/cli/agents) does; the writes are planned alongside the wiring so you confirm once. Skills already installed are left for `npx skills update`. `--no-agents` skips it.
 6. **Runs `evlog doctor`** before it finishes, so the run answers "did it work" instead of telling you to go and check.
 
 Everything it writes is reported line by line, including the parts that were already in place.
@@ -329,7 +329,7 @@ The directory it writes to is `.evlog/logs`, and evlog gitignores it on first wr
 | `--apps <a,b>` | Workspace packages to set up (monorepo root only) |
 | `--dry-run` | Print the plan, write nothing |
 | `--no-install` | Do not run the package manager; print the command instead |
-| `--no-agents` | Skip the `AGENTS.md` block and the agent skills |
+| `--no-agents` | Skip all of it — no `AGENTS.md` block, no `CLAUDE.md`, no agent skills |
 | `--cwd <dir>` | Set up another app in the workspace |
 | `--json` | The plan and result as JSON on stdout (implies non-interactive) |
 

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -1,0 +1,95 @@
+---
+title: evlog agents
+description: Teach the AI agents working in your repository how to use evlog — a short block of conventions in AGENTS.md, plus the published agent skills installed through npx skills.
+navigation:
+  title: agents
+  icon: i-lucide-bot
+links:
+  - label: Agent Skills
+    icon: i-lucide-sparkles
+    to: /reference/agent-skills
+    color: neutral
+    variant: subtle
+---
+
+Wiring evlog into an app is half the job. The other half is the assistant writing the handlers, which keeps reaching for `console.log` and `throw new Error(...)` until something in the repository tells it not to.
+
+`evlog agents` writes that something.
+
+```bash [Terminal]
+evlog agents
+```
+
+```text [Output]
+nuxt
+
+✓ created AGENTS.md
+✓ created CLAUDE.md
+✓ installed skills · npx skills add https://www.evlog.dev
+```
+
+## What it writes
+
+| File | What happens |
+| --- | --- |
+| `AGENTS.md` | Created if missing. Otherwise the evlog block is replaced in place, between `<!-- evlog:start -->` and `<!-- evlog:end -->` — everything outside those markers is left exactly as it was. |
+| `CLAUDE.md` | Created as a one-line `@AGENTS.md` if missing. If it exists and already mentions `AGENTS.md`, it is left alone. |
+
+The block is short on purpose — it is loaded into every agent turn. It states the rules (one wide event per operation, grouped context, structured errors, audit on sensitive actions, what never gets logged) and points at the skills for the depth. The logger accessor named in it follows your framework: `useLogger(event)` on Nuxt and Nitro, `useLogger()` from your `lib/evlog.ts` on Next.js, `req.context.log` on TanStack Start. When no framework is detected the block is still written with a generic accessor — the conventions apply just as well on Express or Hono.
+
+## The skills are not ours to install
+
+The [agent skills](/reference/agent-skills) come from [`npx skills`](https://github.com/vercel-labs/skills), which `evlog agents` shells out to — the same way [`evlog init`](/cli/init) runs your package manager instead of unpacking a tarball itself.
+
+That is deliberate. Every agent reads a different directory (`.claude/skills`, `.agents/skills`, `.codex/skills`, …), and the skills CLI already resolves them per agent, symlinks a canonical copy, and supports a global scope. It also keeps no manifest, so any copy we wrote behind its back would be a second one it could never update. Delegating means one copy, and `npx skills update` / `remove` / `list` keep working on it.
+
+Before running anything, `evlog agents` looks for evlog skills already installed — any agent, project-local or global — and leaves them alone if it finds them:
+
+```text [Output]
+· AGENTS.md is up to date
+· CLAUDE.md already points at AGENTS.md
+✓ skills already installed · .agents/skills, .claude/skills
+   npx skills update to refresh them
+```
+
+::callout{icon="i-lucide-info" color="neutral"}
+Interactively, the skills CLI asks its own questions — which agents to install for, project or global. That question is its to ask, so `evlog agents` hands over the terminal rather than answering on your behalf. Non-interactive runs (`--json`, `--yes`, CI, no TTY) pass `--yes` so nothing blocks on a prompt nobody will answer.
+::
+
+## Safe to re-run
+
+Running it again refreshes the block against the current CLI. Anything already identical is reported rather than rewritten, so a second run leaves the working tree clean. Run it after upgrading `@evlog/cli`.
+
+## Flags
+
+| Flag | What it does |
+| --- | --- |
+| `--skills <list>` | Comma-separated skill names, passed to `npx skills add --skill` (default: all of them) |
+| `--no-skills` | Write the `AGENTS.md` block only — nothing is spawned |
+| `--global`, `-g` | Install the skills for every project instead of just this one |
+| `--source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
+| `--dry-run` | Show the plan without writing or running anything |
+| `--yes`, `-y` | Apply without confirming |
+
+```bash [Terminal]
+evlog agents --skills review-logging-patterns
+evlog agents --global
+evlog agents --no-skills
+evlog agents --dry-run
+```
+
+If the skills CLI fails — no network, no `npx` — the block is still on disk and the command reports the failure and exits 1. The `AGENTS.md` block never needs the network.
+
+## As part of `evlog init`
+
+[`evlog init`](/cli/init) offers this as its last question. The `AGENTS.md` and `CLAUDE.md` writes land in the same plan as the evlog wiring — one list, one confirmation — and the skills run alongside the package-manager install. Skip it with `--no-agents`:
+
+```bash [Terminal]
+evlog init --no-agents
+```
+
+## Next Steps
+
+- [Agent Skills](/reference/agent-skills) — what each skill teaches
+- [`evlog map`](/cli/map) — score what your agent still has not covered
+- [Wide Events](/learn/wide-events) — the conventions the block is summarising

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -26,6 +26,7 @@ nuxt
 ✓ created AGENTS.md
 ✓ created CLAUDE.md
 ✓ installed the evlog skills
+  ran      npx --yes skills add https://www.evlog.dev
 ```
 
 ## What it writes
@@ -60,7 +61,7 @@ Interactively, the skills CLI asks its own questions — which agents to install
 
 Delegating means running third-party code, so it is worth being explicit about the trust model.
 
-- **What runs.** Exactly one command, printed in full before it runs and never assembled from anything you did not pass: `npx --yes skills add <source>`, plus a trailing `--yes` when the run is non-interactive and `--skill` / `--global` when you asked for them. The string in the plan and in the report is the command argument for argument, so re-typing it reproduces the run exactly.
+- **What runs.** Exactly one command, never assembled from anything you did not pass: `npx --yes skills add <source>`, plus a trailing `--yes` when the run is non-interactive and `--skill` / `--global` when you asked for them. Interactively it is shown twice — in the plan you confirm, and again as the step starts. Non-interactively (`--json`, `--yes`, CI, no TTY) it appears in the report the run prints afterward. Either way the string is the command argument for argument, so re-typing it reproduces the run exactly; `--dry-run` shows it without running anything.
 - **Not pinned.** `npx` resolves the latest [`skills`](https://www.npmjs.com/package/skills) at run time. That is the point — skills guidance tracks the docs site, not a CLI release — but it does mean the version you get today is not the one you got last month. If your policy needs a fixed version, use `--no-skills` and run your own pinned `npx skills@<version> add https://www.evlog.dev`.
 - **`--source` is validated.** It must be a plain `http:` / `https:` origin — letters, digits, and `. _ ~ : / -` only, so no query string and no shell metacharacters — and `--skills` entries must be lowercase dashed names. On Windows the spawn needs a shell to resolve `npx` (Node refuses to run a `.cmd` without one), so both are checked before anything is spawned rather than trusted down the chain.
 - **Nothing is spawned without a decision.** `--no-skills` skips it entirely, and the interactive flow will not reach the command until you confirm the plan.

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -56,6 +56,17 @@ Before running anything, `evlog agents` looks for evlog skills already installed
 Interactively, the skills CLI asks its own questions — which agents to install for, project or global. That question is its to ask, so `evlog agents` hands over the terminal rather than answering on your behalf. Non-interactive runs (`--json`, `--yes`, CI, no TTY) pass `--yes` so nothing blocks on a prompt nobody will answer.
 ::
 
+### What you are trusting
+
+Delegating means running third-party code, so it is worth being explicit about the trust model.
+
+- **What runs.** Exactly one command, printed in full before it runs and never assembled from anything you did not pass: `npx --yes skills add <source>`. It appears in the plan you confirm, and in the report afterwards, so you can always see and re-type it.
+- **Not pinned.** `npx` resolves the latest [`skills`](https://www.npmjs.com/package/skills) at run time. That is the point — skills guidance tracks the docs site, not a CLI release — but it does mean the version you get today is not the one you got last month. If your policy needs a fixed version, use `--no-skills` and run your own pinned `npx skills@<version> add https://www.evlog.dev`.
+- **`--source` is validated.** It must be an `http:` or `https:` URL, and `--skills` entries must be lowercase dashed names. On Windows the spawn needs a shell to resolve `npx`, so both are checked before anything is spawned rather than trusted down the chain.
+- **Nothing is spawned without a decision.** `--no-skills` skips it entirely, and the interactive flow will not reach the command until you confirm the plan.
+
+If none of that fits your policy, `evlog agents --no-skills` still writes `AGENTS.md` and `CLAUDE.md` — those never touch the network — and you can install the skills however you prefer.
+
 ## Safe to re-run
 
 Running it again refreshes the block against the current CLI. Anything already identical is reported rather than rewritten, so a second run leaves the working tree clean. Run it after upgrading `@evlog/cli`.
@@ -65,7 +76,7 @@ Running it again refreshes the block against the current CLI. Anything already i
 | Flag | What it does |
 | --- | --- |
 | `--skills <list>` | Comma-separated skill names, passed to `npx skills add --skill` (default: all of them) |
-| `--no-skills` | Write the `AGENTS.md` block only — nothing is spawned |
+| `--no-skills` | Still write `AGENTS.md` and `CLAUDE.md`; skip only the skill installation — nothing is spawned |
 | `--global`, `-g` | Install the skills for every project instead of just this one |
 | `--source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
 | `--dry-run` | Show the plan without writing or running anything |

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -25,7 +25,7 @@ nuxt
 
 ✓ created AGENTS.md
 ✓ created CLAUDE.md
-✓ installed skills · npx skills add https://www.evlog.dev
+✓ installed the evlog skills
 ```
 
 ## What it writes
@@ -60,9 +60,9 @@ Interactively, the skills CLI asks its own questions — which agents to install
 
 Delegating means running third-party code, so it is worth being explicit about the trust model.
 
-- **What runs.** Exactly one command, printed in full before it runs and never assembled from anything you did not pass: `npx --yes skills add <source>`. It appears in the plan you confirm, and in the report afterwards, so you can always see and re-type it.
+- **What runs.** Exactly one command, printed in full before it runs and never assembled from anything you did not pass: `npx --yes skills add <source>`, plus a trailing `--yes` when the run is non-interactive and `--skill` / `--global` when you asked for them. The string in the plan and in the report is the command argument for argument, so re-typing it reproduces the run exactly.
 - **Not pinned.** `npx` resolves the latest [`skills`](https://www.npmjs.com/package/skills) at run time. That is the point — skills guidance tracks the docs site, not a CLI release — but it does mean the version you get today is not the one you got last month. If your policy needs a fixed version, use `--no-skills` and run your own pinned `npx skills@<version> add https://www.evlog.dev`.
-- **`--source` is validated.** It must be an `http:` or `https:` URL, and `--skills` entries must be lowercase dashed names. On Windows the spawn needs a shell to resolve `npx`, so both are checked before anything is spawned rather than trusted down the chain.
+- **`--source` is validated.** It must be a plain `http:` / `https:` origin — letters, digits, and `. _ ~ : / -` only, so no query string and no shell metacharacters — and `--skills` entries must be lowercase dashed names. On Windows the spawn needs a shell to resolve `npx` (Node refuses to run a `.cmd` without one), so both are checked before anything is spawned rather than trusted down the chain.
 - **Nothing is spawned without a decision.** `--no-skills` skips it entirely, and the interactive flow will not reach the command until you confirm the plan.
 
 If none of that fits your policy, `evlog agents --no-skills` still writes `AGENTS.md` and `CLAUDE.md` — those never touch the network — and you can install the skills however you prefer.
@@ -78,7 +78,7 @@ Running it again refreshes the block against the current CLI. Anything already i
 | `--skills <list>` | Comma-separated skill names, passed to `npx skills add --skill` (default: all of them) |
 | `--no-skills` | Still write `AGENTS.md` and `CLAUDE.md`; skip only the skill installation — nothing is spawned |
 | `--global`, `-g` | Install the skills for every project instead of just this one |
-| `--source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
+| `--source <url>` | Where the skills are published — a plain http(s) origin (default: `https://www.evlog.dev`) |
 | `--dry-run` | Show the plan without writing or running anything |
 | `--yes`, `-y` | Apply without confirming |
 

--- a/apps/docs/content/7.reference/6.agent-skills.md
+++ b/apps/docs/content/7.reference/6.agent-skills.md
@@ -34,10 +34,16 @@ evlog includes agent skills that help AI assistants review your logging patterns
 
 Compatible agents (Cursor, Claude Code, etc.) can discover and use skills automatically.
 
-To manually install with the skills CLI:
+To install with the skills CLI:
 
 ```bash [Terminal]
 npx skills add https://www.evlog.dev
+```
+
+[`evlog agents`](/cli/agents) runs that same command for you, and additionally writes a short block of evlog conventions into your project's `AGENTS.md` — the rules an agent should follow on every logging change, which the skills then back with the detail:
+
+```bash [Terminal]
+npx @evlog/cli agents
 ```
 
 ## What the Skill Does

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: review-logging-patterns
-description: Review code for logging patterns and suggest evlog adoption. Optionally use @evlog/cli (`evlog init` to wire evlog, `evlog map` to score entry-point coverage, `--baseline` to gate regressions in CI) on Nuxt, Nitro, Next.js, and TanStack Start. Guides setup on those plus SvelteKit, React Router, NestJS, Express, Hono, Fastify, Elysia, oRPC, Cloudflare Workers, AWS Lambda, Astro, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog, Loki, ClickHouse, NuxtHub, Memory), sampling, enrichers, and AI SDK integration.
+description: Review code for logging patterns and suggest evlog adoption. Optionally use @evlog/cli (`evlog init` to wire evlog, `evlog agents` to write the conventions into AGENTS.md, `evlog map` to score entry-point coverage, `--baseline` to gate regressions in CI) on Nuxt, Nitro, Next.js, and TanStack Start. Guides setup on those plus SvelteKit, React Router, NestJS, Express, Hono, Fastify, Elysia, oRPC, Cloudflare Workers, AWS Lambda, Astro, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog, Loki, ClickHouse, NuxtHub, Memory), sampling, enrichers, and AI SDK integration.
 license: MIT
 metadata:
   author: HugoRCD
-  version: "0.8"
+  version: "0.9"
 ---
 
 # Review logging patterns
@@ -24,6 +24,7 @@ Review and improve logging patterns in TypeScript/JavaScript codebases. Transfor
 | Working on...           | Resource                                                           |
 | ----------------------- | ------------------------------------------------------------------ |
 | Setup (CLI)             | [`evlog init`](https://www.evlog.dev/cli/init) — wire evlog into the project |
+| Project conventions (CLI) | [`evlog agents`](https://www.evlog.dev/cli/agents) — write the evlog block into the project's AGENTS.md |
 | Coverage map (CLI)      | [`evlog map`](https://www.evlog.dev/cli/map) — score dark entry points |
 | CI gating (CLI)         | [`evlog map --min-score / --baseline`](https://www.evlog.dev/cli/ci) — gate regressions |
 | Wide events patterns    | [references/wide-events.md](references/wide-events.md)             |

--- a/apps/telemetry/server/utils/allowed-tools.ts
+++ b/apps/telemetry/server/utils/allowed-tools.ts
@@ -53,6 +53,19 @@ export const DEFAULT_ALLOWED_CUSTOM_KEYS: Record<string, string[]> = {
     'initEnricherGeo',
     'initEnricherRequestSize',
     'initEnricherTraceContext',
+    'initAgentGuide',
+    'initAgentSkillsFound',
+    'initAgentSkillsFailed',
+    // evlog agents — how much of the guidance landed
+    'agentsSkillsFound',
+    'agentsSkillsInstalled',
+    'agentsSkillsFailed',
+    'agentsFilesWritten',
+    'agentsAlready',
+    'agentsDetected',
+    'agentsDryRun',
+    'agentsInteractive',
+    'agentsCancelled',
   ],
 }
 

--- a/apps/telemetry/test/allowed-tools.test.ts
+++ b/apps/telemetry/test/allowed-tools.test.ts
@@ -57,4 +57,13 @@ describe('the evlog-cli allowlist against the CLI itself', () => {
       expect(allowed.has(name), `${name} would be dropped by the ingest`).toBe(true)
     }
   })
+
+  it('accepts every field evlog agents can set', async () => {
+    const { agentsTelemetryFieldNames } = await import('../../../packages/cli/src/lib/agents/run')
+    const allowed = new Set(DEFAULT_ALLOWED_CUSTOM_KEYS['evlog-cli'])
+
+    for (const name of agentsTelemetryFieldNames()) {
+      expect(allowed.has(name), `${name} would be dropped by the ingest`).toBe(true)
+    }
+  })
 })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ pnpm evlog doctor
 | `evlog agents --skills <a,b>` | Install only these skills (default: every published one) |
 | `evlog agents --no-skills` | Still write `AGENTS.md` and `CLAUDE.md`; skip only the skills — nothing is spawned |
 | `evlog agents --global` | Install the skills for every project instead of just this one |
-| `evlog agents --source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
+| `evlog agents --source <url>` | Where the skills are published — a plain http(s) origin (default: `https://www.evlog.dev`) |
 | `evlog agents --dry-run` | Print the plan without touching a file |
 | `evlog map` | Static observability score for the current app — Lighthouse for wide events |
 | `evlog map <route-or-file>` | Explain one entry point: why it was scanned, each verdict, the shape it could take |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ Try without installing:
 
 ```bash
 npx @evlog/cli init          # interactive setup — pick a destination, review the plan
+npx @evlog/cli agents        # teach your AI agents the evlog conventions
 npx @evlog/cli map           # score what is still dark
 npx @evlog/cli map --json --no-write
 ```
@@ -50,6 +51,13 @@ pnpm evlog doctor
 | `evlog init --dry-run` | Print the plan without touching a file |
 | `evlog init --service <name>` | Service name on every wide event (default: package name, unscoped) |
 | `evlog init --no-install` | Print the install command instead of running it |
+| `evlog init --no-agents` | Skip the AGENTS.md block and the skills |
+| `evlog agents` | Write the evlog conventions into `AGENTS.md`, point `CLAUDE.md` at it, install the skills via `npx skills add` |
+| `evlog agents --skills <a,b>` | Install only these skills (default: every published one) |
+| `evlog agents --no-skills` | Write the `AGENTS.md` block alone — nothing is spawned |
+| `evlog agents --global` | Install the skills for every project instead of just this one |
+| `evlog agents --source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
+| `evlog agents --dry-run` | Print the plan without touching a file |
 | `evlog map` | Static observability score for the current app — Lighthouse for wide events |
 | `evlog map <route-or-file>` | Explain one entry point: why it was scanned, each verdict, the shape it could take |
 | `evlog map --all` | Every entry point as a check matrix, grouped by directory |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,10 +51,10 @@ pnpm evlog doctor
 | `evlog init --dry-run` | Print the plan without touching a file |
 | `evlog init --service <name>` | Service name on every wide event (default: package name, unscoped) |
 | `evlog init --no-install` | Print the install command instead of running it |
-| `evlog init --no-agents` | Skip the AGENTS.md block and the skills |
+| `evlog init --no-agents` | Skip all of it — no `AGENTS.md`, no `CLAUDE.md`, no skills |
 | `evlog agents` | Write the evlog conventions into `AGENTS.md`, point `CLAUDE.md` at it, install the skills via `npx skills add` |
 | `evlog agents --skills <a,b>` | Install only these skills (default: every published one) |
-| `evlog agents --no-skills` | Write the `AGENTS.md` block alone — nothing is spawned |
+| `evlog agents --no-skills` | Still write `AGENTS.md` and `CLAUDE.md`; skip only the skills — nothing is spawned |
 | `evlog agents --global` | Install the skills for every project instead of just this one |
 | `evlog agents --source <url>` | Where the skills are published (default: `https://www.evlog.dev`) |
 | `evlog agents --dry-run` | Print the plan without touching a file |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,7 +57,8 @@ pnpm evlog doctor
 | `evlog agents --no-skills` | Still write `AGENTS.md` and `CLAUDE.md`; skip only the skills — nothing is spawned |
 | `evlog agents --global` | Install the skills for every project instead of just this one |
 | `evlog agents --source <url>` | Where the skills are published — a plain http(s) origin (default: `https://www.evlog.dev`) |
-| `evlog agents --dry-run` | Print the plan without touching a file |
+| `evlog agents --dry-run` | Print the plan without touching a file or spawning anything |
+| `evlog agents --yes` | Apply without confirming (also implied by `--json`, no TTY, or `CI`) |
 | `evlog map` | Static observability score for the current app — Lighthouse for wide events |
 | `evlog map <route-or-file>` | Explain one entry point: why it was scanned, each verdict, the shape it could take |
 | `evlog map --all` | Every entry point as a check matrix, grouped by directory |

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,12 +1,9 @@
-import { EvlogError } from 'evlog'
 import { EXIT_FAIL } from '../core/output'
 import { formatAgentsReport } from '../lib/agents/report'
 import { runAgents } from '../lib/agents/run'
 import type { AgentsOptions, AgentsResult } from '../lib/agents/run'
-import { defineEvlogCommand } from '../lib/command'
-import type { CliDebug } from '../lib/debug'
+import { defineEvlogCommand, failWith } from '../lib/command'
 import { canPrompt } from '../lib/init/prompts'
-import type { CliUi } from '../lib/ui'
 
 function parseSkillsArg(value: unknown): { skills: string[], noSkills: boolean } {
   if (value === false) return { skills: [], noSkills: true }
@@ -60,7 +57,7 @@ export default defineEvlogCommand('agents', {
     try {
       result = await runAgents(ctx, log, options)
     } catch (error) {
-      return fail(error, { args, log, ui })
+      return failWith(error, { args, log, ui })
     }
 
     ui.done({
@@ -85,22 +82,4 @@ function toJson(result: AgentsResult): Record<string, unknown> {
     dryRun: result.dryRun,
     cancelled: result.cancelled,
   }
-}
-
-/** Render a catalog error and exit 1; rethrow anything unexpected. */
-function fail(
-  error: unknown,
-  io: { args: { json?: boolean }, log: CliDebug, ui: CliUi },
-): void {
-  if (!(error instanceof EvlogError)) throw error
-  io.log.finding(
-    { code: error.code ?? 'cli.COMMAND_FAILED', why: error.why, fix: error.fix, link: error.link },
-    { status: 'fail' },
-  )
-  io.ui.done({
-    jsonMode: io.args.json,
-    json: { error: { code: error.code, message: error.message, why: error.why, fix: error.fix } },
-    human: error.fix ? `${error.message}\n→ ${error.fix}` : error.message,
-  })
-  io.ui.exit(EXIT_FAIL)
 }

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,0 +1,106 @@
+import { EvlogError } from 'evlog'
+import { EXIT_FAIL } from '../core/output'
+import { formatAgentsReport } from '../lib/agents/report'
+import { runAgents } from '../lib/agents/run'
+import type { AgentsOptions, AgentsResult } from '../lib/agents/run'
+import { defineEvlogCommand } from '../lib/command'
+import type { CliDebug } from '../lib/debug'
+import { canPrompt } from '../lib/init/prompts'
+import type { CliUi } from '../lib/ui'
+
+function parseSkillsArg(value: unknown): { skills: string[], noSkills: boolean } {
+  if (value === false) return { skills: [], noSkills: true }
+  if (typeof value !== 'string' || value.length === 0) return { skills: [], noSkills: false }
+  return { skills: value.split(',').map(entry => entry.trim()).filter(Boolean), noSkills: false }
+}
+
+/**
+ * `evlog agents` — teach the agents working in this project how to use evlog.
+ *
+ * Wiring evlog in is half the job: the other half is the assistant writing the
+ * handlers, which will keep reaching for `console.log` until something in the
+ * repository tells it not to. This writes that something — a marker-delimited
+ * block in `AGENTS.md`, and a `CLAUDE.md` that points at it.
+ *
+ * The skills themselves are handed to `npx skills add`. Every agent reads a
+ * different directory and that CLI already resolves them, so copying the files
+ * ourselves would produce a second set nothing could update.
+ */
+export default defineEvlogCommand('agents', {
+  meta: { name: 'agents', description: 'Write evlog conventions into AGENTS.md and install the agent skills' },
+  /* The clack session draws its own intro; two banners read as two programs. */
+  skipHeader: (ctx, args) => args.json !== true && args.yes !== true && canPrompt(ctx),
+  args: {
+    cwd: { type: 'string', description: 'Project directory (default: current)' },
+    // citty negations: declared positive so `--no-skills` works.
+    skills: { type: 'string', default: '', description: 'Skills to install, comma-separated (--no-skills for the AGENTS.md block alone)' },
+    global: { type: 'boolean', alias: 'g', description: 'Install the skills for every project instead of this one' },
+    source: { type: 'string', description: 'Where the skills are published (default: https://www.evlog.dev)' },
+    yes: { type: 'boolean', alias: 'y', description: 'Apply without confirming' },
+    dryRun: { type: 'boolean', description: 'Show what would change without writing anything' },
+  },
+  async run({ args, cli, log, ui }) {
+    const cwd = typeof args.cwd === 'string' && args.cwd.length > 0 ? args.cwd : undefined
+    const ctx = cwd ? { ...cli, cwd } : cli
+    const { skills, noSkills } = parseSkillsArg(args.skills)
+
+    const options: AgentsOptions = {
+      skills,
+      noSkills,
+      global: args.global,
+      source: typeof args.source === 'string' && args.source.length > 0 ? args.source : undefined,
+      dryRun: args.dryRun,
+      yes: args.yes,
+      /* JSON output and a prompt cannot share a terminal: the payload is the
+         contract, and half a TUI on stderr in front of it helps nobody. */
+      nonInteractive: args.json === true,
+    }
+
+    let result: AgentsResult
+    try {
+      result = await runAgents(ctx, log, options)
+    } catch (error) {
+      return fail(error, { args, log, ui })
+    }
+
+    ui.done({
+      jsonMode: args.json,
+      json: toJson(result),
+      /* The interactive flow already narrated itself through clack. */
+      human: result.interactive ? undefined : formatAgentsReport(ctx, result),
+    })
+
+    if (result.skills.status === 'failed') {
+      ui.exit(EXIT_FAIL)
+    }
+  },
+})
+
+function toJson(result: AgentsResult): Record<string, unknown> {
+  return {
+    framework: result.framework,
+    skills: result.skills,
+    written: result.written.map(action => ({ file: action.relative, kind: action.kind })),
+    already: result.already,
+    dryRun: result.dryRun,
+    cancelled: result.cancelled,
+  }
+}
+
+/** Render a catalog error and exit 1; rethrow anything unexpected. */
+function fail(
+  error: unknown,
+  io: { args: { json?: boolean }, log: CliDebug, ui: CliUi },
+): void {
+  if (!(error instanceof EvlogError)) throw error
+  io.log.finding(
+    { code: error.code ?? 'cli.COMMAND_FAILED', why: error.why, fix: error.fix, link: error.link },
+    { status: 'fail' },
+  )
+  io.ui.done({
+    jsonMode: io.args.json,
+    json: { error: { code: error.code, message: error.message, why: error.why, fix: error.fix } },
+    human: error.fix ? `${error.message}\n→ ${error.fix}` : error.message,
+  })
+  io.ui.exit(EXIT_FAIL)
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+import agents from './agents'
 import doctor from './doctor'
 import init from './init'
 import map from './map'
@@ -16,6 +17,7 @@ import telemetry from './telemetry'
  */
 export const subCommands = {
   init,
+  agents,
   doctor,
   map,
   telemetry,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,5 @@
-import { EvlogError } from 'evlog'
 import { EXIT_FAIL } from '../core/output'
-import { defineEvlogCommand } from '../lib/command'
-import type { CliDebug } from '../lib/debug'
-import type { CliUi } from '../lib/ui'
+import { defineEvlogCommand, failWith } from '../lib/command'
 import { cliErrors } from '../lib/errors'
 import { askWorkspaceTargets, canPrompt, closeCancelled, InitCancelled } from '../lib/init/prompts'
 import { formatInitReport, formatWorkspaceHeading } from '../lib/init/report'
@@ -89,7 +86,7 @@ export default defineEvlogCommand('init', {
         nonInteractive: args.json === true,
       }
     } catch (error) {
-      return fail(error, { args, log, ui })
+      return failWith(error, { args, log, ui })
     }
 
     /* A monorepo root has no entry points of its own, so `init` there means
@@ -111,7 +108,7 @@ export default defineEvlogCommand('init', {
           entry => !targets.some(app => app.label === entry || app.name === entry),
         )
         if (unknown.length > 0) {
-          return fail(
+          return failWith(
             cliErrors.INIT_NO_APPS({ value: unknown.join(', '), known: targets.map(app => app.label).join(', ') }),
             { args, log, ui },
           )
@@ -139,7 +136,7 @@ export default defineEvlogCommand('init', {
       }
 
       if (selected.length === 0) {
-        return fail(
+        return failWith(
           cliErrors.INIT_NO_APPS({ value: 'nothing', known: targets.map(app => app.label).join(', ') }),
           { args, log, ui },
         )
@@ -160,7 +157,7 @@ export default defineEvlogCommand('init', {
             closeCancelled()
             break
           }
-          return fail(error, { args, log, ui })
+          return failWith(error, { args, log, ui })
         }
       }
 
@@ -176,7 +173,7 @@ export default defineEvlogCommand('init', {
     try {
       result = await runInit(ctx, log, options)
     } catch (error) {
-      return fail(error, { args, log, ui })
+      return failWith(error, { args, log, ui })
     }
 
     ui.done({
@@ -214,22 +211,4 @@ function toJson(result: InitResult): Record<string, unknown> {
     dryRun: result.dryRun,
     cancelled: result.cancelled,
   }
-}
-
-/** Render a catalog error and exit 1; rethrow anything unexpected. */
-function fail(
-  error: unknown,
-  io: { args: { json?: boolean }, log: CliDebug, ui: CliUi },
-): void {
-  if (!(error instanceof EvlogError)) throw error
-  io.log.finding(
-    { code: error.code ?? 'cli.COMMAND_FAILED', why: error.why, fix: error.fix, link: error.link },
-    { status: 'fail' },
-  )
-  io.ui.done({
-    jsonMode: io.args.json,
-    json: { error: { code: error.code, message: error.message, why: error.why, fix: error.fix } },
-    human: error.fix ? `${error.message}\n→ ${error.fix}` : error.message,
-  })
-  io.ui.exit(EXIT_FAIL)
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -64,6 +64,7 @@ export default defineEvlogCommand('init', {
     dryRun: { type: 'boolean', description: 'Show what would change without writing anything' },
     // citty negations: declared positive so `--no-install` works.
     install: { type: 'boolean', default: true, description: 'Install evlog when missing (--no-install to skip)' },
+    agents: { type: 'boolean', default: true, description: 'Write the AGENTS.md block and install the skills (--no-agents to skip)' },
   },
   async run({ args, cli, log, ui }) {
     const cwd = typeof args.cwd === 'string' && args.cwd.length > 0 ? args.cwd : undefined
@@ -81,6 +82,7 @@ export default defineEvlogCommand('init', {
         sampling: parseSamplingArg(args.sampling),
         dryRun: args.dryRun,
         install: args.install,
+        agentGuide: args.agents,
         yes: args.yes,
         /* JSON output and a prompt cannot share a terminal: the payload is the
            contract, and half a TUI on stderr in front of it helps nobody. */
@@ -208,6 +210,7 @@ function toJson(result: InitResult): Record<string, unknown> {
     dropped: result.dropped,
     insight: result.insight,
     verified: result.verified,
+    agentGuide: result.agentGuide,
     dryRun: result.dryRun,
     cancelled: result.cancelled,
   }

--- a/packages/cli/src/core/context.ts
+++ b/packages/cli/src/core/context.ts
@@ -1,3 +1,5 @@
+import { homedir } from 'node:os'
+
 /**
  * Execution context passed to every command.
  * The only place allowed to read `process.*` — commands stay pure and testable.
@@ -8,6 +10,8 @@
 export interface CliContext {
   /** Working directory used to resolve the host project. */
   cwd: string
+  /** Home directory — where agents keep their global, cross-project files. */
+  home: string
   /** Environment snapshot — commands never touch `process.env` directly. */
   env: Record<string, string | undefined>
   /** Running Node.js version, e.g. `v22.1.0`. */
@@ -47,6 +51,7 @@ export function createContext(overrides: Partial<CliContext> = {}): CliContext {
   const tty = overrides.tty ?? isInteractive()
   return {
     cwd: overrides.cwd ?? process.cwd(),
+    home: overrides.home ?? homedir(),
     env,
     nodeVersion: overrides.nodeVersion ?? process.version,
     tty,

--- a/packages/cli/src/lib/agents/block.ts
+++ b/packages/cli/src/lib/agents/block.ts
@@ -1,0 +1,128 @@
+import type { Framework } from '../map/types'
+
+/**
+ * The evlog section of a project's `AGENTS.md`.
+ *
+ * Everything between the markers is ours to rewrite; everything outside them is
+ * the author's and is never touched. That split is the whole reason this command
+ * can be re-run — the block tracks the CLI, the file tracks the project.
+ */
+
+export const MARKER_START = '<!-- evlog:start -->'
+export const MARKER_END = '<!-- evlog:end -->'
+
+export interface BlockInput {
+  /** `null` when detection found nothing — the block is still worth writing. */
+  framework: Framework | null
+  /** Whether the evlog skills are installed, for the closing pointer. */
+  hasSkills: boolean
+}
+
+/** How a request-scoped logger is obtained, per framework. */
+const ACCESSOR: Record<Framework, string> = {
+  'nuxt': '`useLogger(event)` (auto-imported) inside a `server/api` handler',
+  'nitro': '`useLogger(event)` from `evlog/nitro` inside a route handler',
+  'next': '`useLogger()` from your `lib/evlog.ts` inside a route handler',
+  'tanstack-start': '`req.context.log` inside a server route',
+}
+
+const DEFAULT_ACCESSOR = '`useLogger()` inside a request handler'
+
+/**
+ * Render the block.
+ *
+ * Deliberately short: this lands in a file every agent reads on every turn, so
+ * it carries the rules and points at the skills for the depth. Prose that would
+ * only restate an example is left out.
+ */
+export function renderBlock(input: BlockInput): string {
+  const accessor = input.framework ? ACCESSOR[input.framework] : DEFAULT_ACCESSOR
+
+  /* Which directory the skills landed in is the agent's business, not ours —
+     naming one would be wrong for every agent that reads a different path. */
+  const closing = input.hasSkills
+    ? 'Deeper guidance is in the `review-logging-patterns` skill — read it before a logging change.'
+    : 'Deeper guidance: https://evlog.dev/learn/wide-events'
+
+  return [
+    MARKER_START,
+    '## Logging with evlog',
+    '',
+    'This project uses [evlog](https://evlog.dev). Follow these rules when you add or change logging.',
+    '',
+    '**One wide event per operation.** A request, a job, a user action — each produces exactly one',
+    'event carrying everything about it. Not one log line per step.',
+    '',
+    `- Get the request logger with ${accessor}.`,
+    '- Add context as you learn it: `log.set({ user: { id, plan }, cart: { items, total } })`.',
+    '- Group related fields into objects. Never flat abbreviations like `{ uid, n, t }`.',
+    '- Never pass a raw body — `log.set({ user: body })` leaks passwords. List fields explicitly.',
+    '- Do not time anything by hand; the duration is computed when the event emits.',
+    '- `log.debug()` is for step detail and is stripped from production builds.',
+    '',
+    '**Errors are structured, never bare.**',
+    '',
+    '```ts',
+    'throw createError({',
+    '  message: \'Payment failed\',',
+    '  status: 402,',
+    '  why: \'Card declined by the issuer\',',
+    '  fix: \'Use a different payment method\',',
+    '  internal: { correlationId },   // drains only — never reaches the client',
+    '})',
+    '```',
+    '',
+    'Never `throw new Error(...)`. Never `console.error(e); throw e` — use `log.error(e)`.',
+    'When the same error appears in three or more places, promote it to `defineErrorCatalog()`.',
+    '',
+    '**Sensitive actions get an audit trail.** Call `log.audit({ action, actor, target, outcome })`',
+    'on anything that changes permissions, money, or personal data. Audit entries are never sampled.',
+    '',
+    '**Never log** passwords, tokens, API keys, full card numbers, or session JWTs. Redaction is on',
+    'in production, but it is a safety net — not a substitute for choosing the fields yourself.',
+    '',
+    'Check coverage with `npx @evlog/cli map --no-write`. Diagnose setup with `npx @evlog/cli doctor`.',
+    closing,
+    MARKER_END,
+    '',
+  ].join('\n')
+}
+
+/**
+ * Put `block` into `source`, replacing an existing one.
+ *
+ * Returns `null` when the file already says exactly this, which is what makes a
+ * second run a no-op rather than a no-op-shaped rewrite.
+ */
+export function upsertBlock(source: string, block: string): string | null {
+  const start = source.indexOf(MARKER_START)
+  const end = source.indexOf(MARKER_END)
+
+  if (start === -1 || end === -1 || end < start) {
+    const separator = source.length === 0 || source.endsWith('\n\n') ? '' : source.endsWith('\n') ? '\n' : '\n\n'
+    return `${source}${separator}${block}`
+  }
+
+  const next = `${source.slice(0, start)}${block.trimEnd()}${source.slice(end + MARKER_END.length)}`
+  return next === source ? null : next
+}
+
+/** A fresh `AGENTS.md` for a project that has none. */
+export function renderAgentsFile(projectName: string, block: string): string {
+  return `# ${projectName}\n\nInstructions for AI coding agents working in this repository.\n\n${block}`
+}
+
+/** The line that points Claude Code at `AGENTS.md` instead of duplicating it. */
+export const CLAUDE_POINTER = '@AGENTS.md'
+
+/**
+ * Add the pointer to a `CLAUDE.md`, or `null` when it already refers to AGENTS.md.
+ *
+ * Matches any mention rather than the exact line: a file that already says
+ * "see AGENTS.md" in prose does not need a second instruction.
+ */
+export function upsertClaudePointer(source: string | null): string | null {
+  if (source === null) return `${CLAUDE_POINTER}\n`
+  if (source.includes('AGENTS.md')) return null
+  return `${source.endsWith('\n') ? source : `${source}\n`}\n${CLAUDE_POINTER}\n`
+}

--- a/packages/cli/src/lib/agents/plan.ts
+++ b/packages/cli/src/lib/agents/plan.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { basename, join, relative } from 'node:path'
+import { cliErrors } from '../errors'
 import type { FileAction } from '../init/frameworks'
 import type { Framework } from '../map/types'
 import { renderAgentsFile, renderBlock, upsertBlock, upsertClaudePointer } from './block'
@@ -29,8 +30,20 @@ function action(root: string, path: string, contents: string): FileAction {
   }
 }
 
+/**
+ * Read a file we may be about to rewrite, or `null` when it is not there.
+ *
+ * An existing path that cannot be read — a directory named `AGENTS.md`, or one
+ * the user has no permission on — would otherwise surface as a raw stack trace,
+ * since only catalog errors get a `why` and a `fix`.
+ */
 function read(path: string): string | null {
-  return existsSync(path) ? readFileSync(path, 'utf8') : null
+  if (!existsSync(path)) return null
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    throw cliErrors.AGENTS_UNREADABLE({ file: basename(path) })
+  }
 }
 
 /**

--- a/packages/cli/src/lib/agents/plan.ts
+++ b/packages/cli/src/lib/agents/plan.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import type { FileAction } from '../init/frameworks'
+import type { Framework } from '../map/types'
+import { renderAgentsFile, renderBlock, upsertBlock, upsertClaudePointer } from './block'
+
+export interface AgentsPlanInput {
+  /** Package root — where `AGENTS.md` belongs. */
+  root: string
+  projectName: string
+  framework: Framework | null
+  /** Whether the block should point at the skills for the deeper guidance. */
+  hasSkills: boolean
+}
+
+export interface AgentsPlan {
+  actions: FileAction[]
+  /** Files that already say exactly this — printed so a run is never silent. */
+  already: string[]
+}
+
+function action(root: string, path: string, contents: string): FileAction {
+  const full = join(root, path)
+  return {
+    path: full,
+    relative: relative(root, full) || path,
+    kind: existsSync(full) ? 'patch' : 'create',
+    contents,
+  }
+}
+
+function read(path: string): string | null {
+  return existsSync(path) ? readFileSync(path, 'utf8') : null
+}
+
+/**
+ * What `evlog agents` will write, given the project on disk.
+ *
+ * Pure and synchronous — the whole idempotency story is testable without a
+ * filesystem write. Skill files are not ours to plan; see `./skills`.
+ */
+export function planAgents(input: AgentsPlanInput): AgentsPlan {
+  const actions: FileAction[] = []
+  const already: string[] = []
+
+  const block = renderBlock({ framework: input.framework, hasSkills: input.hasSkills })
+
+  const agentsPath = join(input.root, 'AGENTS.md')
+  const agentsSource = read(agentsPath)
+
+  if (agentsSource === null) {
+    actions.push(action(input.root, 'AGENTS.md', renderAgentsFile(input.projectName, block)))
+  } else {
+    const next = upsertBlock(agentsSource, block)
+    if (next === null) already.push('AGENTS.md is up to date')
+    else actions.push(action(input.root, 'AGENTS.md', next))
+  }
+
+  const claudePath = join(input.root, 'CLAUDE.md')
+  const claude = upsertClaudePointer(read(claudePath))
+  if (claude === null) already.push('CLAUDE.md already points at AGENTS.md')
+  else actions.push(action(input.root, 'CLAUDE.md', claude))
+
+  return { actions, already }
+}

--- a/packages/cli/src/lib/agents/report.ts
+++ b/packages/cli/src/lib/agents/report.ts
@@ -33,7 +33,12 @@ export function skillsReportLines(ctx: CliContext, skills: SkillsLines): string[
         command('refresh', 'npx skills update'),
       ]
     case 'installed':
-      return [`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`]
+      return [
+        `${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`,
+        /* A non-interactive run never saw the command go by, and this is the
+           only record of what was spawned on its behalf. */
+        command('ran    ', skills.command),
+      ]
     case 'failed':
       return [
         `${paint('red', '✗')} ${paint('dim', 'skills not installed')}`,

--- a/packages/cli/src/lib/agents/report.ts
+++ b/packages/cli/src/lib/agents/report.ts
@@ -1,0 +1,64 @@
+import { gradientRule, HEADER_GRADIENT_WIDTH } from '../../core/brand'
+import type { CliContext } from '../../core/context'
+import { DOCS_URL, createStyle } from '../../core/output'
+import type { AgentsResult } from './run'
+
+/**
+ * What `evlog agents` did, for a run that asked nothing.
+ *
+ * Same contract as the `init` report: every outcome gets a line, including the
+ * ones where nothing changed, so "already up to date" is never confusable with
+ * "did not look".
+ */
+export function formatAgentsReport(ctx: CliContext, result: AgentsResult): string {
+  const { paint } = createStyle(ctx)
+  const lines: string[] = []
+
+  if (result.cancelled) {
+    return paint('yellow', 'Cancelled — nothing was written.')
+  }
+
+  lines.push(paint('bold', result.framework ?? 'no framework detected'))
+  lines.push('')
+
+  for (const action of result.written) {
+    const verb = result.dryRun
+      ? (action.kind === 'create' ? 'would create' : 'would update')
+      : (action.kind === 'create' ? 'created' : 'updated')
+    const glyph = result.dryRun ? paint('yellow', '·') : paint('green', '✓')
+    lines.push(`${glyph} ${paint('dim', verb)} ${action.relative}`)
+  }
+
+  for (const note of result.already) {
+    lines.push(paint('dim', `· ${note}`))
+  }
+
+  /* A command to type is a label plus the command, never a sentence with the
+     command inside it — inline, the reader never registers there is one. */
+  const { skills } = result
+  if (skills.status === 'already') {
+    lines.push(`${paint('green', '✓')} ${paint('dim', `skills already installed · ${skills.dirs.join(', ')}`)}`)
+    /* The skills CLI owns their lifecycle, so the refresh command is theirs. */
+    lines.push(`  ${paint('dim', 'refresh')}  ${paint('bold', 'npx skills update')}`)
+  } else if (skills.status === 'installed') {
+    lines.push(`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`)
+  } else if (skills.status === 'skipped') {
+    lines.push(`${paint('yellow', '·')} ${paint('dim', 'skills not installed')}`)
+    lines.push(`  ${paint('dim', 'install')}  ${paint('bold', skills.command)}`)
+  } else {
+    lines.push(`${paint('red', '✗')} ${paint('dim', 'skills not installed')}`)
+    if (skills.error) lines.push(`   ${paint('dim', skills.error)}`)
+    lines.push(`  ${paint('dim', 'retry  ')}  ${paint('bold', skills.command)}`)
+  }
+
+  lines.push('')
+  lines.push(gradientRule(ctx, HEADER_GRADIENT_WIDTH))
+  if (result.dryRun) {
+    lines.push(paint('dim', 'dry run — nothing was written. Drop --dry-run to apply.'))
+  } else {
+    lines.push(`${paint('dim', 'next:')} ${paint('bold', 'evlog map')} ${paint('dim', 'to score what is still dark')}`)
+  }
+  lines.push(`${paint('dim', 'agent skills →')} ${paint('dim', `${DOCS_URL}/reference/agent-skills`)}`)
+
+  return lines.join('\n')
+}

--- a/packages/cli/src/lib/agents/report.ts
+++ b/packages/cli/src/lib/agents/report.ts
@@ -3,6 +3,51 @@ import type { CliContext } from '../../core/context'
 import { DOCS_URL, createStyle } from '../../core/output'
 import type { AgentsResult } from './run'
 
+/** The subset of a skills outcome the report needs — `init` reports one too. */
+export interface SkillsLines {
+  status: 'pending' | 'already' | 'installed' | 'skipped' | 'failed'
+  command: string
+  dirs?: string[]
+  error?: string
+}
+
+/**
+ * How the skills step went, as report lines.
+ *
+ * Shared with the `init` report rather than written twice: it is the same four
+ * outcomes with the same wording, and two copies of a user-facing string are
+ * two copies that drift. A command to type is a label plus the command, never a
+ * sentence with the command inside it — inline, the reader never registers
+ * there is something to run.
+ */
+export function skillsReportLines(ctx: CliContext, skills: SkillsLines): string[] {
+  const { paint } = createStyle(ctx)
+  const command = (label: string, line: string): string =>
+    `  ${paint('dim', label)}  ${paint('bold', line)}`
+
+  switch (skills.status) {
+    case 'already':
+      return [
+        `${paint('green', '✓')} ${paint('dim', `evlog skills already installed${skills.dirs?.length ? ` · ${skills.dirs.join(', ')}` : ''}`)}`,
+        /* The skills CLI owns their lifecycle, so the refresh command is theirs. */
+        command('refresh', 'npx skills update'),
+      ]
+    case 'installed':
+      return [`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`]
+    case 'failed':
+      return [
+        `${paint('red', '✗')} ${paint('dim', 'skills not installed')}`,
+        ...(skills.error ? [`   ${paint('dim', skills.error)}`] : []),
+        command('retry  ', skills.command),
+      ]
+    default:
+      return [
+        `${paint('yellow', '·')} ${paint('dim', 'skills not installed')}`,
+        command('install', skills.command),
+      ]
+  }
+}
+
 /**
  * What `evlog agents` did, for a run that asked nothing.
  *
@@ -33,23 +78,7 @@ export function formatAgentsReport(ctx: CliContext, result: AgentsResult): strin
     lines.push(paint('dim', `· ${note}`))
   }
 
-  /* A command to type is a label plus the command, never a sentence with the
-     command inside it — inline, the reader never registers there is one. */
-  const { skills } = result
-  if (skills.status === 'already') {
-    lines.push(`${paint('green', '✓')} ${paint('dim', `skills already installed · ${skills.dirs.join(', ')}`)}`)
-    /* The skills CLI owns their lifecycle, so the refresh command is theirs. */
-    lines.push(`  ${paint('dim', 'refresh')}  ${paint('bold', 'npx skills update')}`)
-  } else if (skills.status === 'installed') {
-    lines.push(`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`)
-  } else if (skills.status === 'skipped') {
-    lines.push(`${paint('yellow', '·')} ${paint('dim', 'skills not installed')}`)
-    lines.push(`  ${paint('dim', 'install')}  ${paint('bold', skills.command)}`)
-  } else {
-    lines.push(`${paint('red', '✗')} ${paint('dim', 'skills not installed')}`)
-    if (skills.error) lines.push(`   ${paint('dim', skills.error)}`)
-    lines.push(`  ${paint('dim', 'retry  ')}  ${paint('bold', skills.command)}`)
-  }
+  lines.push(...skillsReportLines(ctx, result.skills))
 
   lines.push('')
   lines.push(gradientRule(ctx, HEADER_GRADIENT_WIDTH))

--- a/packages/cli/src/lib/agents/run.ts
+++ b/packages/cli/src/lib/agents/run.ts
@@ -187,6 +187,24 @@ export async function runAgents(
       : { status: 'failed', command: command.display, found: [], dirs: [], error: outcome.error }
   }
 
+  /* The block was written before the install, so it could stand whatever the
+     subprocess did — which means it promises a skill that is now known not to
+     exist. Rewrite it rather than leave an agent chasing a missing file. */
+  if (skills.status === 'failed' && !dryRun) {
+    const corrected = planAgents({
+      root: project.packageDir,
+      projectName: project.packageName ?? 'This project',
+      framework,
+      hasSkills: false,
+    })
+    await log.step('rewriteBlock', async () => {
+      for (const action of corrected.actions) {
+        await writeFile(action.path, action.contents, 'utf8')
+      }
+      return corrected.actions.length
+    })
+  }
+
   if (interactive) {
     noteSkills(ctx, skills)
     closeAgents(ctx, dryRun)
@@ -238,8 +256,8 @@ function cancelled(input: {
  * Which skills exist is already public; how many files a given project rewrote
  * is not interesting enough to justify sending anything shaped like a path.
  */
-function recordAgentsRun(result: AgentsResult): void {
-  telemetry.set({
+function agentsTelemetryFields(result: AgentsResult): Record<string, boolean | number> {
+  return {
     agentsSkillsFound: result.skills.found.length,
     agentsSkillsInstalled: result.skills.status === 'installed',
     agentsSkillsFailed: result.skills.status === 'failed',
@@ -249,20 +267,29 @@ function recordAgentsRun(result: AgentsResult): void {
     agentsDryRun: result.dryRun,
     agentsInteractive: result.interactive,
     agentsCancelled: result.cancelled,
-  })
+  }
 }
 
-/** Every field {@link recordAgentsRun} can emit — used to document the disclosure. */
+function recordAgentsRun(result: AgentsResult): void {
+  telemetry.set(agentsTelemetryFields(result))
+}
+
+/**
+ * Every field {@link recordAgentsRun} can emit — used to document the disclosure.
+ *
+ * Read off the payload rather than listed again: a field added to one and not
+ * the other would leave the disclosure quietly incomplete, and what this CLI
+ * transmits is exactly the thing that must not drift.
+ */
 export function agentsTelemetryFieldNames(): string[] {
-  return [
-    'agentsSkillsFound',
-    'agentsSkillsInstalled',
-    'agentsSkillsFailed',
-    'agentsFilesWritten',
-    'agentsAlready',
-    'agentsDetected',
-    'agentsDryRun',
-    'agentsInteractive',
-    'agentsCancelled',
-  ]
+  return Object.keys(agentsTelemetryFields({
+    project: { cwd: '', root: '', packageDir: '', packageName: null },
+    framework: null,
+    skills: { status: 'skipped', command: '', found: [], dirs: [] },
+    written: [],
+    already: [],
+    dryRun: false,
+    interactive: false,
+    cancelled: false,
+  }))
 }

--- a/packages/cli/src/lib/agents/run.ts
+++ b/packages/cli/src/lib/agents/run.ts
@@ -1,0 +1,268 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { telemetry } from '@evlog/telemetry'
+import type { CliContext } from '../../core/context'
+import type { CliDebug } from '../debug'
+import { createNoopCliDebug } from '../debug'
+import type { FileAction } from '../init/frameworks'
+import {
+  canPrompt,
+  closeAgents,
+  closeCancelled,
+  confirmPlan,
+  InitCancelled,
+  noteSkills,
+  noteSkillsStarting,
+  openInteractive,
+  showPlan,
+} from '../init/prompts'
+import { detectFramework } from '../map/detect'
+import type { Framework } from '../map/types'
+import { resolveProject } from '../project'
+import type { ProjectInfo } from '../project'
+import { planAgents } from './plan'
+import { findInstalledSkills, runSkills, skillsCommand } from './skills'
+
+export interface AgentsOptions {
+  /** Pass through to `npx skills add --skill`; empty means every published one. */
+  skills?: string[]
+  /** Do not touch the skills at all — write the block and stop. */
+  noSkills?: boolean
+  /** Install the skills for every project rather than this one. */
+  global?: boolean
+  /** Where the skills are published. */
+  source?: string
+  /** Plan everything, write nothing, run nothing. */
+  dryRun?: boolean
+  /** Force non-interactive regardless of the terminal (set by `--json`). */
+  nonInteractive?: boolean
+  /** Skip the confirm step and apply. */
+  yes?: boolean
+}
+
+/** What became of the skills step. Mirrors `init`'s install outcome. */
+export interface SkillsOutcome {
+  status: 'already' | 'installed' | 'skipped' | 'failed'
+  /** The command as the user would type it — printed whatever the outcome. */
+  command: string
+  /** Skill names already on disk when the run started. */
+  found: string[]
+  /** Agent directories they were found in. */
+  dirs: string[]
+  error?: string
+}
+
+export interface AgentsResult {
+  project: Pick<ProjectInfo, 'cwd' | 'root' | 'packageDir' | 'packageName'>
+  /** `null` when detection found nothing — the block is written regardless. */
+  framework: Framework | null
+  skills: SkillsOutcome
+  written: FileAction[]
+  already: string[]
+  dryRun: boolean
+  interactive: boolean
+  cancelled: boolean
+}
+
+/**
+ * Framework detection, downgraded to a hint.
+ *
+ * `init` writes framework-specific wiring and must refuse when it cannot tell
+ * what it is looking at. This command writes prose, and prose about wide events
+ * is worth having in an Express app the detector does not cover.
+ */
+function detectSoftly(project: ProjectInfo): Framework | null {
+  try {
+    return detectFramework(project).framework
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Teach the agents working in this project how to use evlog.
+ *
+ * Writes a marker-delimited block into `AGENTS.md`, points `CLAUDE.md` at it,
+ * and hands the skills to `npx skills add`. Safe to re-run: anything already
+ * saying exactly this is reported rather than rewritten, and skills already on
+ * disk are left for `npx skills update`.
+ */
+export async function runAgents(
+  ctx: CliContext,
+  log: CliDebug = createNoopCliDebug(),
+  options: AgentsOptions = {},
+): Promise<AgentsResult> {
+  const project = await log.step(
+    'resolveProject',
+    () => resolveProject(ctx.cwd),
+    p => ({ cwd: ctx.cwd, project: { kind: p.kind, root: p.root, name: p.packageName } }),
+  )
+
+  const framework = await log.step('detectFramework', () => detectSoftly(project), f => ({ framework: f ?? 'none' }))
+
+  const dryRun = options.dryRun === true
+  const interactive = !options.nonInteractive && !options.yes && canPrompt(ctx)
+
+  const installed = await log.step(
+    'findSkills',
+    () => findInstalledSkills(project.packageDir, ctx.home),
+    r => ({ skills: r.names.length }),
+  )
+
+  const command = skillsCommand({
+    source: options.source,
+    skills: options.skills,
+    global: options.global,
+    interactive,
+  })
+
+  /* Already there is the common case on a second run, and re-adding would only
+     ask the skills CLI to redo work it tracks better than we do. */
+  const installing = !options.noSkills && installed.names.length === 0
+
+  const plan = await log.step(
+    'planAgents',
+    () => planAgents({
+      root: project.packageDir,
+      projectName: project.packageName ?? 'This project',
+      framework,
+      hasSkills: installed.names.length > 0 || installing,
+    }),
+    p => ({ writes: p.actions.length, already: p.already.length }),
+  )
+
+  /* In the plan as well as the report: a step nobody sees considered is a step
+     the reader assumes was forgotten. */
+  if (installed.names.length > 0) {
+    plan.already.push(`evlog skills already installed · ${installed.dirs.join(', ')}`)
+  }
+
+  if (interactive) {
+    openInteractive(ctx, 'evlog agents', project.packageName ?? project.packageDir)
+
+    if (dryRun) {
+      showPlan(plan.actions, plan.already, installing ? [command.display] : [])
+    } else {
+      let confirmed: boolean
+      try {
+        confirmed = await confirmPlan(plan.actions, plan.already, installing ? [command.display] : [])
+      } catch (error) {
+        if (error instanceof InitCancelled) {
+          closeCancelled()
+          return cancelled({ project, framework, command: command.display, installed })
+        }
+        throw error
+      }
+      if (!confirmed) {
+        closeCancelled()
+        return cancelled({ project, framework, command: command.display, installed })
+      }
+    }
+  }
+
+  if (!dryRun) {
+    await log.step('write', async () => {
+      for (const action of plan.actions) {
+        await mkdir(dirname(action.path), { recursive: true })
+        await writeFile(action.path, action.contents, 'utf8')
+      }
+      return plan.actions.length
+    })
+  }
+
+  let skills: SkillsOutcome
+  if (installed.names.length > 0) {
+    skills = { status: 'already', command: command.display, found: installed.names, dirs: installed.dirs }
+  } else if (options.noSkills || dryRun) {
+    skills = { status: 'skipped', command: command.display, found: [], dirs: [] }
+  } else {
+    if (interactive) noteSkillsStarting(ctx, command.display)
+    const outcome = await log.step(
+      'runSkills',
+      () => runSkills(command, project.packageDir, interactive),
+      r => ({ installed: r.ok }),
+    )
+    skills = outcome.ok
+      ? { status: 'installed', command: command.display, found: [], dirs: findInstalledSkills(project.packageDir, ctx.home).dirs }
+      : { status: 'failed', command: command.display, found: [], dirs: [], error: outcome.error }
+  }
+
+  if (interactive) {
+    noteSkills(ctx, skills)
+    closeAgents(ctx, dryRun)
+  }
+
+  const result: AgentsResult = {
+    project,
+    framework,
+    skills,
+    written: plan.actions,
+    already: plan.already,
+    dryRun,
+    interactive,
+    cancelled: false,
+  }
+
+  recordAgentsRun(result)
+  return result
+}
+
+function cancelled(input: {
+  project: ProjectInfo
+  framework: Framework | null
+  command: string
+  installed: { names: string[], dirs: string[] }
+}): AgentsResult {
+  const result: AgentsResult = {
+    project: input.project,
+    framework: input.framework,
+    skills: {
+      status: 'skipped',
+      command: input.command,
+      found: input.installed.names,
+      dirs: input.installed.dirs,
+    },
+    written: [],
+    already: [],
+    dryRun: false,
+    interactive: true,
+    cancelled: true,
+  }
+  recordAgentsRun(result)
+  return result
+}
+
+/**
+ * Counts and booleans only.
+ *
+ * Which skills exist is already public; how many files a given project rewrote
+ * is not interesting enough to justify sending anything shaped like a path.
+ */
+function recordAgentsRun(result: AgentsResult): void {
+  telemetry.set({
+    agentsSkillsFound: result.skills.found.length,
+    agentsSkillsInstalled: result.skills.status === 'installed',
+    agentsSkillsFailed: result.skills.status === 'failed',
+    agentsFilesWritten: result.written.length,
+    agentsAlready: result.already.length,
+    agentsDetected: result.framework !== null,
+    agentsDryRun: result.dryRun,
+    agentsInteractive: result.interactive,
+    agentsCancelled: result.cancelled,
+  })
+}
+
+/** Every field {@link recordAgentsRun} can emit — used to document the disclosure. */
+export function agentsTelemetryFieldNames(): string[] {
+  return [
+    'agentsSkillsFound',
+    'agentsSkillsInstalled',
+    'agentsSkillsFailed',
+    'agentsFilesWritten',
+    'agentsAlready',
+    'agentsDetected',
+    'agentsDryRun',
+    'agentsInteractive',
+    'agentsCancelled',
+  ]
+}

--- a/packages/cli/src/lib/agents/skills.ts
+++ b/packages/cli/src/lib/agents/skills.ts
@@ -80,13 +80,22 @@ export interface SkillsCommand {
 const SKILL_NAME = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
 /**
- * Reject anything that is not an http(s) URL.
+ * Characters an origin never needs, and `cmd.exe` reads as syntax.
  *
- * On Windows {@link runSkills} needs a shell to find `npx`, which means this
- * value reaches a `cmd.exe` command line where `&` and `|` separate commands.
- * Nobody types that against themselves, but a `--source` fed from CI config or
- * an interpolated variable is a different question, so the shape is checked
- * once here rather than trusted all the way down.
+ * Being an http(s) URL is not enough on its own: `https://evlog.dev?q=1&calc`
+ * parses, and `&` still separates commands. Node does not escape array
+ * arguments under `shell: true`, so the allowlist is the guard.
+ */
+const SAFE_SOURCE = /^[A-Za-z0-9._~:/-]+$/
+
+/**
+ * Reject anything that is not a plain http(s) origin.
+ *
+ * On Windows {@link runSkills} needs a shell to find `npx` — Node refuses to
+ * spawn a `.cmd` without one — which means this value reaches a `cmd.exe`
+ * command line. Nobody types `&` against themselves, but a `--source` fed from
+ * CI config or an interpolated variable is a different question, so the shape
+ * is checked once here rather than trusted all the way down.
  */
 function checkSource(value: string): string {
   let url: URL
@@ -96,6 +105,9 @@ function checkSource(value: string): string {
     throw cliErrors.AGENTS_INVALID_SOURCE({ value })
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw cliErrors.AGENTS_INVALID_SOURCE({ value })
+  }
+  if (!SAFE_SOURCE.test(value)) {
     throw cliErrors.AGENTS_INVALID_SOURCE({ value })
   }
   return value
@@ -123,9 +135,10 @@ export function skillsCommand(options: {
   if (options.global) args.push('--global')
   if (!options.interactive) args.push('--yes')
 
-  /* `npx --yes` suppresses the install prompt for the skills package itself and
-     is noise in a command somebody may retype. */
-  return { display: `npx ${args.slice(1).join(' ')}`, bin: 'npx', args }
+  /* Every argument, including npx's own `--yes`: this string is what the plan
+     shows and what the report tells you to re-run, so it has to be the command
+     that actually runs rather than a tidied version of it. */
+  return { display: `npx ${args.join(' ')}`, bin: 'npx', args }
 }
 
 /**

--- a/packages/cli/src/lib/agents/skills.ts
+++ b/packages/cli/src/lib/agents/skills.ts
@@ -1,0 +1,139 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The published evlog skills, installed by delegating to `npx skills`.
+ *
+ * We do not copy skill files ourselves. Every agent reads a different directory
+ * (`.claude/skills`, `.agents/skills`, `.codex/skills`, …), the skills CLI
+ * already resolves that per agent, symlinks a canonical copy, and owns
+ * `update` / `remove` / `list` — and it keeps no manifest, so anything we wrote
+ * behind its back would be a second copy it could never update.
+ *
+ * So this module does two things: notice when the skills are already there, and
+ * shell out when they are not. Same shape as `init` running the package manager
+ * rather than unpacking a tarball itself.
+ */
+
+/** Where the skills are published. Overridable so forks can point elsewhere. */
+export const DEFAULT_SOURCE = 'https://www.evlog.dev'
+
+/**
+ * Skill directories published from the docs site.
+ *
+ * Used only to notice an existing install. A name that goes stale here costs
+ * one redundant `npx skills add`, which is why it is not worth a network call.
+ */
+export const EVLOG_SKILLS = ['review-logging-patterns', 'build-audit-logs', 'analyze-logs'] as const
+
+/** Per-agent skill directories, relative to a project root or to `$HOME`. */
+const AGENT_DIRS = [
+  '.claude/skills',
+  '.agents/skills',
+  '.cursor/skills',
+  '.codex/skills',
+  '.opencode/skills',
+]
+
+export interface InstalledSkills {
+  /** Skill names found on disk, in any agent's directory. */
+  names: string[]
+  /** The directories they were found in, relative to the project or `~`. */
+  dirs: string[]
+}
+
+/**
+ * Look for evlog skills already installed, project-local and global.
+ *
+ * Deliberately generous: any agent, either scope. Somebody who ran
+ * `npx skills add` last month should not be told to run it again.
+ *
+ * @param home - The global scope to search, from {@link CliContext.home}.
+ */
+export function findInstalledSkills(root: string, home: string): InstalledSkills {
+  const names = new Set<string>()
+  const dirs = new Set<string>()
+
+  for (const [base, label] of [[root, ''], [home, '~/']] as const) {
+    for (const dir of AGENT_DIRS) {
+      for (const skill of EVLOG_SKILLS) {
+        if (!existsSync(join(base, dir, skill))) continue
+        names.add(skill)
+        dirs.add(`${label}${dir}`)
+      }
+    }
+  }
+
+  return { names: [...names].sort(), dirs: [...dirs].sort() }
+}
+
+export interface SkillsCommand {
+  /** The command line, as the user would type it. */
+  display: string
+  bin: string
+  args: string[]
+}
+
+/**
+ * Build the `npx skills add` invocation.
+ *
+ * `--yes` only when nobody is watching: interactively, the skills CLI asks
+ * which agents to install for, and that question is its to ask.
+ */
+export function skillsCommand(options: {
+  source?: string
+  skills?: readonly string[]
+  global?: boolean
+  interactive: boolean
+}): SkillsCommand {
+  const args = ['--yes', 'skills', 'add', options.source ?? DEFAULT_SOURCE]
+  if (options.skills?.length) args.push('--skill', ...options.skills)
+  if (options.global) args.push('--global')
+  if (!options.interactive) args.push('--yes')
+
+  /* `npx --yes` suppresses the install prompt for the skills package itself and
+     is noise in a command somebody may retype. */
+  return { display: `npx ${args.slice(1).join(' ')}`, bin: 'npx', args }
+}
+
+/**
+ * Run it, returning the failure rather than throwing.
+ *
+ * The `AGENTS.md` block is already on disk by this point and stands on its own;
+ * losing it because a subprocess could not reach the network would be the wrong
+ * trade. Interactive runs inherit the terminal so the skills CLI can ask its
+ * own questions.
+ */
+export function runSkills(
+  command: SkillsCommand,
+  cwd: string,
+  interactive: boolean,
+): Promise<{ ok: true } | { ok: false, error: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(command.bin, command.args, {
+      cwd,
+      stdio: interactive ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+      timeout: 5 * 60_000,
+    })
+
+    let stderr = ''
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    child.on('error', (error) => {
+      resolve({ ok: false, error: error.message })
+    })
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ ok: true })
+        return
+      }
+      const line = stderr.trim().split('\n').filter(Boolean).at(-1)
+      resolve({ ok: false, error: line ?? `npx skills add exited ${code}` })
+    })
+  })
+}

--- a/packages/cli/src/lib/agents/skills.ts
+++ b/packages/cli/src/lib/agents/skills.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { cliErrors } from '../errors'
 
 /**
  * The published evlog skills, installed by delegating to `npx skills`.
@@ -75,6 +76,31 @@ export interface SkillsCommand {
   args: string[]
 }
 
+/** Skill directory names, per the Agent Skills spec. */
+const SKILL_NAME = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+
+/**
+ * Reject anything that is not an http(s) URL.
+ *
+ * On Windows {@link runSkills} needs a shell to find `npx`, which means this
+ * value reaches a `cmd.exe` command line where `&` and `|` separate commands.
+ * Nobody types that against themselves, but a `--source` fed from CI config or
+ * an interpolated variable is a different question, so the shape is checked
+ * once here rather than trusted all the way down.
+ */
+function checkSource(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw cliErrors.AGENTS_INVALID_SOURCE({ value })
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw cliErrors.AGENTS_INVALID_SOURCE({ value })
+  }
+  return value
+}
+
 /**
  * Build the `npx skills add` invocation.
  *
@@ -87,8 +113,13 @@ export function skillsCommand(options: {
   global?: boolean
   interactive: boolean
 }): SkillsCommand {
-  const args = ['--yes', 'skills', 'add', options.source ?? DEFAULT_SOURCE]
-  if (options.skills?.length) args.push('--skill', ...options.skills)
+  const args = ['--yes', 'skills', 'add', checkSource(options.source ?? DEFAULT_SOURCE)]
+  if (options.skills?.length) {
+    for (const skill of options.skills) {
+      if (!SKILL_NAME.test(skill)) throw cliErrors.AGENTS_INVALID_SKILL({ value: skill })
+    }
+    args.push('--skill', ...options.skills)
+  }
   if (options.global) args.push('--global')
   if (!options.interactive) args.push('--yes')
 

--- a/packages/cli/src/lib/command.ts
+++ b/packages/cli/src/lib/command.ts
@@ -1,9 +1,10 @@
 import type { ArgsDef, CommandDef, CommandContext, CommandMeta, ParsedArgs } from 'citty'
 import { defineCommand } from 'citty'
+import { EvlogError } from 'evlog'
 import { createContext } from '../core/context'
 import type { CliContext } from '../core/context'
 import { formatCommandHeader, wantsHeader } from '../core/brand'
-import { writeHuman } from '../core/output'
+import { EXIT_FAIL, writeHuman } from '../core/output'
 import { withCliDebug } from './debug'
 import type { CliDebug, DebugArgs } from './debug'
 import { createUi } from './ui'
@@ -113,6 +114,30 @@ export function defineEvlogCommand<T extends ArgsDef = ArgsDef>(
       })
     },
   } as CommandDef<T & typeof COMMON_ARGS>)
+}
+
+/**
+ * Render a catalog error and exit 1; rethrow anything unexpected.
+ *
+ * Shared because every command that writes needs the same three things from a
+ * failure — the finding on the debug event, the `why` / `fix` for the reader,
+ * and a non-zero exit — and three copies of that would drift.
+ */
+export function failWith(
+  error: unknown,
+  io: { args: { json?: boolean }, log: CliDebug, ui: CliUi },
+): void {
+  if (!(error instanceof EvlogError)) throw error
+  io.log.finding(
+    { code: error.code ?? 'cli.COMMAND_FAILED', why: error.why, fix: error.fix, link: error.link },
+    { status: 'fail' },
+  )
+  io.ui.done({
+    jsonMode: io.args.json,
+    json: { error: { code: error.code, message: error.message, why: error.why, fix: error.fix } },
+    human: error.fix ? `${error.message}\n→ ${error.fix}` : error.message,
+  })
+  io.ui.exit(EXIT_FAIL)
 }
 
 /**

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -140,6 +140,32 @@ export const cliErrors = defineErrorCatalog('cli', {
     link: 'https://evlog.dev/cli/init',
     tags: ['init'],
   },
+  AGENTS_INVALID_SOURCE: {
+    status: 400,
+    message: ({ value }: { value: string }) =>
+      `Invalid --source "${value}" — expected an http(s) URL`,
+    why: 'The source is handed to npx, and on Windows that argument reaches a shell',
+    fix: 'Pass the origin the skills are published from, e.g. --source https://www.evlog.dev',
+    link: 'https://evlog.dev/cli/agents',
+    tags: ['agents', 'skills'],
+  },
+  AGENTS_INVALID_SKILL: {
+    status: 400,
+    message: ({ value }: { value: string }) =>
+      `Invalid --skills entry "${value}"`,
+    why: 'Skill names are lowercase and dashed, and the value is handed to npx',
+    fix: 'Run evlog agents without --skills to install every published skill',
+    link: 'https://evlog.dev/reference/agent-skills',
+    tags: ['agents', 'skills'],
+  },
+  AGENTS_UNREADABLE: {
+    status: 500,
+    message: ({ file }: { file: string }) => `Cannot read ${file}`,
+    why: 'The path exists but could not be read — it may be a directory, or permissions may deny it',
+    fix: 'Check the file and its permissions, then run the command again',
+    link: 'https://evlog.dev/cli/agents',
+    tags: ['agents'],
+  },
   MAP_BASELINE_NOT_FOUND: {
     status: 404,
     message: ({ source }: { source: string }) =>

--- a/packages/cli/src/lib/init/prompts.ts
+++ b/packages/cli/src/lib/init/prompts.ts
@@ -29,8 +29,6 @@ import {
 } from './catalog'
 import type { DrainId, EnricherId, ExtraGroup, ExtraId, OfferContext, SamplingProfile } from './catalog'
 import type { FileAction, ManualStep } from './frameworks'
-import type { PackageManager } from './pm'
-import { installCommand } from './pm'
 
 /** Every answer `init` needs, however it was obtained. */
 export interface InitAnswers {
@@ -45,6 +43,8 @@ export interface InitAnswers {
   sampling: SamplingProfile
   /** Run the package manager for a missing `evlog`. */
   install: boolean
+  /** Write the `AGENTS.md` block and install the published skills. */
+  agentGuide: boolean
 }
 
 /** Thrown when the user aborts a prompt — the command exits quietly, writing nothing. */
@@ -77,14 +77,15 @@ export interface PromptContext {
   evlogInstalled: boolean
   /** Whether `--install` is still on — `--no-install` is an answer, not a prompt. */
   installRequested: boolean
-  packageManager: PackageManager
+  /** Whether `--agents` is still on — `--no-agents` is an answer, not a prompt. */
+  agentGuideRequested: boolean
   /** Builds the offer list once the destinations are known. */
   offers: (prodDrains: DrainId[], framework: Framework) => OfferContext
 }
 
-export function openInteractive(ctx: CliContext, projectLabel: string): void {
+export function openInteractive(ctx: CliContext, command: string, projectLabel: string): void {
   const { paint } = createStyle(ctx)
-  intro(`${paint(['bold', 'cyan'], ' evlog init ')} ${paint('dim', projectLabel)}`)
+  intro(`${paint(['bold', 'cyan'], ` ${command} `)} ${paint('dim', projectLabel)}`)
 }
 
 /**
@@ -197,6 +198,15 @@ export async function askAnswers(input: PromptContext): Promise<InitAnswers> {
     }))
     : 'all'
 
+  /* Wiring evlog in and leaving the agent that writes the handlers unaware of
+     it is most of the way to nothing. */
+  const agentGuide = input.agentGuideRequested
+    ? required(await confirm({
+      message: 'Teach AI agents the evlog conventions? (AGENTS.md + skills)',
+      initialValue: true,
+    }))
+    : false
+
   // Not a question of its own: the plan lists the install and asks once.
   return {
     framework,
@@ -207,19 +217,23 @@ export async function askAnswers(input: PromptContext): Promise<InitAnswers> {
     enrichers,
     sampling,
     install: !input.evlogInstalled && input.installRequested,
+    agentGuide,
   }
 }
 
-/** Nothing lands until the user has read what is about to land. */
+/**
+ * Nothing lands until the user has read what is about to land.
+ *
+ * @param runs - Commands this run will shell out to, listed before the writes.
+ */
 export function showPlan(
   actions: FileAction[],
   already: string[],
-  installing: boolean,
-  packageManager: PackageManager,
+  runs: string[] = [],
 ): boolean {
   const lines: string[] = []
 
-  if (installing) lines.push(`run  ${installCommand(packageManager)}`)
+  for (const run of runs) lines.push(`run  ${run}`)
   for (const action of actions) {
     lines.push(`${action.kind === 'create' ? 'create' : 'update'}  ${action.relative}`)
   }
@@ -237,10 +251,9 @@ export function showPlan(
 export async function confirmPlan(
   actions: FileAction[],
   already: string[],
-  installing: boolean,
-  packageManager: PackageManager,
+  runs: string[] = [],
 ): Promise<boolean> {
-  if (!showPlan(actions, already, installing, packageManager)) return false
+  if (!showPlan(actions, already, runs)) return false
 
   return required(await confirm({ message: 'Apply?', initialValue: true }))
 }
@@ -257,6 +270,65 @@ export function noteEnvironment(prodDrains: DrainId[]): void {
   note(
     variables.map(variable => `${variable.name.padEnd(width)}  ${variable.hint}`).join('\n'),
     'Set these before anything is received',
+  )
+}
+
+/** How the agent skills ended up, for a run that is drawing its own frame. */
+export interface SkillsNote {
+  status: 'pending' | 'already' | 'installed' | 'skipped' | 'failed'
+  /** `npx skills add …`, as the user would type it. */
+  command: string
+  /** Agent directories they were found in, when they were already there. */
+  dirs?: string[]
+  error?: string
+}
+
+/**
+ * A command the reader is meant to type.
+ *
+ * Label on the left, command on the right — the shape the outro already uses
+ * for `score  evlog map`. Inline in a sentence it reads as prose and the reader
+ * never registers there is something for them to run.
+ */
+function command(ctx: CliContext, label: string, line: string): string {
+  const { paint } = createStyle(ctx)
+  return `${paint('dim', label)}  ${paint('bold', line)}`
+}
+
+/**
+ * Say what happened to the skills.
+ *
+ * The interactive flow suppresses the written report, so without this the whole
+ * step is invisible — and "already installed" looks exactly like "did nothing"
+ * to somebody watching the terminal.
+ */
+export function noteSkills(ctx: CliContext, note: SkillsNote): void {
+  const { paint } = createStyle(ctx)
+
+  switch (note.status) {
+    case 'already':
+      clackLog.success(`evlog skills already installed${note.dirs?.length ? ` · ${paint('dim', note.dirs.join(', '))}` : ''}`)
+      clackLog.message(command(ctx, 'refresh', 'npx skills update'))
+      return
+    case 'installed':
+      clackLog.success('Installed the evlog skills')
+      return
+    case 'failed':
+      clackLog.error('Skills not installed')
+      if (note.error) clackLog.message(paint('dim', note.error))
+      clackLog.message(command(ctx, 'retry  ', note.command))
+      return
+    default:
+      clackLog.warn('Skills not installed')
+      clackLog.message(command(ctx, 'install', note.command))
+  }
+}
+
+/** Said before handing the terminal to the skills CLI, so it is not a surprise. */
+export function noteSkillsStarting(ctx: CliContext, line: string): void {
+  const { paint } = createStyle(ctx)
+  clackLog.step(
+    `${command(ctx, 'running', line)}\n${paint('dim', 'the skills CLI takes over from here')}`,
   )
 }
 
@@ -291,6 +363,16 @@ export function closeInteractive(
   }
   clackLog.message(`${paint('dim', 'score')}  evlog map`)
   outro(`${FRAMEWORK_LABELS[framework]} wired · ${DOCS_URL}${docsPath}`)
+}
+
+/** Closes the `evlog agents` session — without it the run just stops mid-frame. */
+export function closeAgents(ctx: CliContext, dryRun = false): void {
+  const { paint } = createStyle(ctx)
+  if (dryRun) {
+    outro(`${paint('yellow', 'Dry run')} — nothing was written. Drop --dry-run to apply.`)
+    return
+  }
+  outro(`Your agents know evlog · ${DOCS_URL}/cli/agents`)
 }
 
 export function closeCancelled(): void {

--- a/packages/cli/src/lib/init/report.ts
+++ b/packages/cli/src/lib/init/report.ts
@@ -83,6 +83,25 @@ export function formatInitReport(ctx: CliContext, result: InitResult): string {
     lines.push(`${paint('yellow', '·')} ${paint('dim', `${id} does not apply here — skipped`)}`)
   }
 
+  const guide = result.agentGuide
+  if (guide) {
+    /* The block lands whatever happens here; saying nothing would leave the
+       author believing their agent has guidance it never received. */
+    if (guide.status === 'already') {
+      lines.push(`${paint('green', '✓')} ${paint('dim', `evlog skills already installed · ${guide.dirs.join(', ')}`)}`)
+      lines.push(`  ${paint('dim', 'refresh')}  ${paint('bold', 'npx skills update')}`)
+    } else if (guide.status === 'installed') {
+      lines.push(`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`)
+    } else if (guide.status === 'failed') {
+      lines.push(`${paint('red', '✗')} ${paint('dim', 'skills not installed')}`)
+      if (guide.error) lines.push(`   ${paint('dim', guide.error)}`)
+      lines.push(`  ${paint('dim', 'retry  ')}  ${paint('bold', guide.command)}`)
+    } else {
+      lines.push(`${paint('yellow', '·')} ${paint('dim', 'skills not installed')}`)
+      lines.push(`  ${paint('dim', 'install')}  ${paint('bold', guide.command)}`)
+    }
+  }
+
   if (result.verified) {
     const { ok, warn, fail } = result.verified
     const glyph = fail > 0 ? paint('red', '✗') : warn > 0 ? paint('yellow', '⚠') : paint('green', '✓')

--- a/packages/cli/src/lib/init/report.ts
+++ b/packages/cli/src/lib/init/report.ts
@@ -1,6 +1,7 @@
 import type { CliContext } from '../../core/context'
 import { gradientRule, HEADER_GRADIENT_WIDTH } from '../../core/brand'
 import { DOCS_URL, createStyle } from '../../core/output'
+import { skillsReportLines } from '../agents/report'
 import { findDestination, findEnricher, findExtra, findSamplingPreset } from './catalog'
 import { frameworkDocs } from './run'
 import type { InitResult } from './run'
@@ -83,23 +84,10 @@ export function formatInitReport(ctx: CliContext, result: InitResult): string {
     lines.push(`${paint('yellow', '·')} ${paint('dim', `${id} does not apply here — skipped`)}`)
   }
 
-  const guide = result.agentGuide
-  if (guide) {
-    /* The block lands whatever happens here; saying nothing would leave the
-       author believing their agent has guidance it never received. */
-    if (guide.status === 'already') {
-      lines.push(`${paint('green', '✓')} ${paint('dim', `evlog skills already installed · ${guide.dirs.join(', ')}`)}`)
-      lines.push(`  ${paint('dim', 'refresh')}  ${paint('bold', 'npx skills update')}`)
-    } else if (guide.status === 'installed') {
-      lines.push(`${paint('green', '✓')} ${paint('dim', 'installed the evlog skills')}`)
-    } else if (guide.status === 'failed') {
-      lines.push(`${paint('red', '✗')} ${paint('dim', 'skills not installed')}`)
-      if (guide.error) lines.push(`   ${paint('dim', guide.error)}`)
-      lines.push(`  ${paint('dim', 'retry  ')}  ${paint('bold', guide.command)}`)
-    } else {
-      lines.push(`${paint('yellow', '·')} ${paint('dim', 'skills not installed')}`)
-      lines.push(`  ${paint('dim', 'install')}  ${paint('bold', guide.command)}`)
-    }
+  /* The block lands whatever happens here; saying nothing would leave the
+     author believing their agent has guidance it never received. */
+  if (result.agentGuide) {
+    lines.push(...skillsReportLines(ctx, result.agentGuide))
   }
 
   if (result.verified) {

--- a/packages/cli/src/lib/init/resolve.ts
+++ b/packages/cli/src/lib/init/resolve.ts
@@ -94,6 +94,8 @@ export interface ResolveInput {
   evlogInstalled: boolean
   /** `--install` (default true); irrelevant when evlog is already there. */
   install: boolean
+  /** `--agents` (default true) — write the AGENTS.md block and install the skills. */
+  agentGuide: boolean
   devDrain?: DrainId
   prodDrains?: DrainId[]
   extras?: ExtraId[]
@@ -124,6 +126,7 @@ export function resolveAnswers(input: ResolveInput): InitAnswers {
     enrichers: extras.includes('enrichers') ? input.enrichers ?? [...DEFAULT_ENRICHERS] : [],
     sampling: extras.includes('sampling') ? input.sampling ?? 'medium' : 'all',
     install: input.evlogInstalled ? false : input.install,
+    agentGuide: input.agentGuide,
   }
 }
 

--- a/packages/cli/src/lib/init/run.ts
+++ b/packages/cli/src/lib/init/run.ts
@@ -279,12 +279,16 @@ export async function runInit(
     }, r => ({ found: r.found.length }))
   }
 
-  const installing = !evlogInstalled && answers.install && !dryRun
+  /* What the run would shell out to, `--dry-run` included: a preview that hides
+     the commands is the one thing a preview exists to show. Execution stays
+     gated on `dryRun` separately, further down. */
+  const wouldInstall = !evlogInstalled && answers.install
   /* Already-installed skills belong to `npx skills update`, not to us. */
-  const addingSkills = agentGuide !== null && agentGuide.found.length === 0 && !dryRun
+  const wouldAddSkills = agentGuide !== null && agentGuide.found.length === 0
+  const installing = wouldInstall && !dryRun
   const runs = [
-    ...(installing ? [command] : []),
-    ...(addingSkills ? [agentGuide!.command] : []),
+    ...(wouldInstall ? [command] : []),
+    ...(wouldAddSkills ? [agentGuide!.command] : []),
   ]
 
   if (interactive && dryRun) {

--- a/packages/cli/src/lib/init/run.ts
+++ b/packages/cli/src/lib/init/run.ts
@@ -2,6 +2,8 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { runDoctor } from '../../commands/doctor'
 import type { CliContext } from '../../core/context'
+import { planAgents } from '../agents/plan'
+import { findInstalledSkills, runSkills, skillsCommand } from '../agents/skills'
 import type { CliDebug } from '../debug'
 import { createNoopCliDebug } from '../debug'
 import { detectFramework } from '../map/detect'
@@ -25,6 +27,8 @@ import {
   InitCancelled,
   noteEnvironment,
   noteManual,
+  noteSkills,
+  noteSkillsStarting,
   openInteractive,
   runVerification,
 } from './prompts'
@@ -55,6 +59,8 @@ export interface InitResult {
   insight: InsightSummary | null
   /** `evlog doctor` after the writes, when it ran. */
   verified: VerifySummary | null
+  /** The agent guidelines step, when it was asked for. */
+  agentGuide: AgentGuideSummary | null
   dryRun: boolean
   /** True when the run asked questions — the report stays quiet if so. */
   interactive: boolean
@@ -76,6 +82,21 @@ export interface VerifySummary {
   fail: number
 }
 
+export type SkillsStatus = 'pending' | 'already' | 'installed' | 'failed'
+
+/** What the agent guidelines step managed to do. */
+export interface AgentGuideSummary {
+  /** Skills already on disk when the run started, in any agent's directory. */
+  found: string[]
+  /** The agent directories they were found in. */
+  dirs: string[]
+  /** `npx skills add …`, as the user would type it. */
+  command: string
+  status: SkillsStatus
+  /** Why the skills CLI did not finish, when it did not. */
+  error?: string
+}
+
 export interface InitOptions {
   framework?: Framework
   service?: string
@@ -90,6 +111,8 @@ export interface InitOptions {
   install?: boolean
   /** Skip every question and take the defaults. */
   yes?: boolean
+  /** Write the AGENTS.md block and install the skills. Default: true. */
+  agentGuide?: boolean
   /** Force non-interactive regardless of the terminal (set by `--json`). */
   nonInteractive?: boolean
 }
@@ -165,6 +188,7 @@ export async function runInit(
     defaultService: defaultService(project),
     evlogInstalled,
     install: options.install !== false,
+    agentGuide: options.agentGuide !== false,
     devDrain: options.devDrain,
     prodDrains: options.prodDrains,
     extras: options.extras,
@@ -177,7 +201,7 @@ export async function runInit(
   let answers: InitAnswers
 
   if (interactive) {
-    openInteractive(ctx, project.packageName ?? project.packageDir)
+    openInteractive(ctx, 'evlog init', project.packageName ?? project.packageDir)
     try {
       answers = await askAnswers({
         ctx,
@@ -187,7 +211,7 @@ export async function runInit(
         defaultService: base.defaultService,
         evlogInstalled,
         installRequested: base.install,
-        packageManager,
+        agentGuideRequested: base.agentGuide,
         offers,
       })
     } catch (error) {
@@ -225,19 +249,55 @@ export async function runInit(
     r => ({ writes: r.actions.length, manual: r.manual.length }),
   )
 
+  /* Merged into the same plan rather than run afterwards, so the user reads one
+     list and confirms once. The skills are a separate step: `npx skills add`
+     owns them, and it runs alongside the package-manager install below. */
+  let agentGuide: AgentGuideSummary | null = null
+  if (answers.agentGuide) {
+    agentGuide = await log.step('agentGuide', () => {
+      const found = findInstalledSkills(project.packageDir, ctx.home)
+      const guide = planAgents({
+        root: project.packageDir,
+        projectName: project.packageName ?? 'This project',
+        framework: answers.framework,
+        hasSkills: true,
+      })
+      plan.actions.push(...guide.actions)
+      plan.already.push(...guide.already)
+      /* In the plan as well as the report: a step nobody sees considered is a
+         step the reader assumes was forgotten. */
+      if (found.names.length > 0) {
+        plan.already.push(`evlog skills already installed · ${found.dirs.join(', ')}`)
+      }
+
+      return {
+        found: found.names,
+        dirs: found.dirs,
+        command: skillsCommand({ interactive }).display,
+        status: 'pending' as SkillsStatus,
+      }
+    }, r => ({ found: r.found.length }))
+  }
+
   const installing = !evlogInstalled && answers.install && !dryRun
+  /* Already-installed skills belong to `npx skills update`, not to us. */
+  const addingSkills = agentGuide !== null && agentGuide.found.length === 0 && !dryRun
+  const runs = [
+    ...(installing ? [command] : []),
+    ...(addingSkills ? [agentGuide!.command] : []),
+  ]
 
   if (interactive && dryRun) {
     /* `--dry-run` promises the plan. The confirm step is the only thing that
        renders it, and interactive runs suppress the written report — so
        without this the terminal shows the questions and then nothing. */
-    showPlan(plan.actions, plan.already, false, packageManager)
+    showPlan(plan.actions, plan.already, runs)
   }
 
   if (interactive && !dryRun) {
     let confirmed: boolean
     try {
-      confirmed = await confirmPlan(plan.actions, plan.already, installing, packageManager)
+      confirmed = await confirmPlan(plan.actions, plan.already, runs)
     } catch (error) {
       if (error instanceof InitCancelled) {
         closeCancelled()
@@ -275,6 +335,25 @@ export async function runInit(
     })
   }
 
+  if (agentGuide) {
+    if (agentGuide.found.length > 0) {
+      agentGuide.status = 'already'
+    } else if (dryRun) {
+      agentGuide.status = 'pending'
+    } else {
+      /* Runs after the writes: the block is the part we own, and it should be
+         on disk whatever a subprocess we do not control decides to do. */
+      if (interactive) noteSkillsStarting(ctx, agentGuide.command)
+      const outcome = await log.step(
+        'skills',
+        () => runSkills(skillsCommand({ interactive }), project.packageDir, interactive),
+        r => ({ installed: r.ok }),
+      )
+      agentGuide.status = outcome.ok ? 'installed' : 'failed'
+      if (!outcome.ok) agentGuide.error = outcome.error
+    }
+  }
+
   let verified: VerifySummary | null = null
   if (!dryRun) {
     const verify = async (): Promise<VerifySummary> => {
@@ -292,6 +371,7 @@ export async function runInit(
   }
 
   if (interactive) {
+    if (agentGuide) noteSkills(ctx, agentGuide)
     noteEnvironment(answers.prodDrains)
     noteManual(plan.manual)
     closeInteractive(ctx, answers.framework, frameworkDocs(answers.framework), dryRun)
@@ -316,6 +396,7 @@ export async function runInit(
       }
       : null,
     verified,
+    agentGuide,
     dryRun,
     interactive,
     cancelled: false,
@@ -344,6 +425,7 @@ function cancelledResult(input: {
     dropped: [],
     insight: null,
     verified: null,
+    agentGuide: null,
     dryRun: input.dryRun,
     /* Only an interactive run can be cancelled — there is nothing to answer
        when nobody was asked. */

--- a/packages/cli/src/lib/init/telemetry.ts
+++ b/packages/cli/src/lib/init/telemetry.ts
@@ -55,6 +55,12 @@ export function recordInitAnswers(result: InitResult): void {
     if (result.verified) fields.initDoctorFail = result.verified.fail
   }
 
+  fields.initAgentGuide = answers.agentGuide
+  if (result.agentGuide) {
+    fields.initAgentSkillsFound = result.agentGuide.found.length
+    fields.initAgentSkillsFailed = result.agentGuide.status === 'failed'
+  }
+
   /* The gap between "offered" and "taken" is what says whether an offer earns
      its place. Whether the scan found something, never what it found. */
   if (result.insight) {
@@ -81,6 +87,9 @@ export function initTelemetryFieldNames(): string[] {
     'initDoctorFail',
     'initHadRepeatedErrors',
     'initHadAuditGaps',
+    'initAgentGuide',
+    'initAgentSkillsFound',
+    'initAgentSkillsFailed',
     ...DESTINATIONS.map(destination => memberField('Prod', destination.id)),
     ...EXTRAS.map(extra => memberField('Extra', extra.id)),
     ...ENRICHERS.map(enricher => memberField('Enricher', enricher.id)),

--- a/packages/cli/test/agents.test.ts
+++ b/packages/cli/test/agents.test.ts
@@ -178,26 +178,31 @@ describe('findInstalledSkills', () => {
 
 describe('skillsCommand', () => {
   it('adds every published skill from the docs site by default', () => {
-    expect(skillsCommand({ interactive: true }).display).toBe('npx skills add https://www.evlog.dev')
+    expect(skillsCommand({ interactive: true }).display).toBe('npx --yes skills add https://www.evlog.dev')
+  })
+
+  it('shows the command it actually runs, argument for argument', () => {
+    /* The plan prints this and the report says to re-run it, so a tidied
+       version that drops npx's own --yes would not reproduce the run. */
+    const command = skillsCommand({ interactive: false })
+
+    expect(command.display).toBe(`${command.bin} ${command.args.join(' ')}`)
   })
 
   it('lets the skills CLI ask its own questions when somebody is watching', () => {
-    /* Which agents to install for is its question, not ours. */
-    expect(skillsCommand({ interactive: true }).display).not.toContain('--yes')
-    /* Non-interactively it must never block on a prompt nobody will answer. */
-    expect(skillsCommand({ interactive: false }).display).toContain('--yes')
-  })
-
-  it('always answers npx own install prompt', () => {
-    /* Distinct from the flag above: this one is npx being asked whether to
-       fetch the skills package, and it blocks even in a run we did not drive. */
-    expect(skillsCommand({ interactive: true }).args[0]).toBe('--yes')
+    /* Which agents to install for is its question, not ours — so the trailing
+       --yes, the one aimed at the skills CLI, appears only when nobody can
+       answer. The leading one is npx's and is always there. */
+    expect(skillsCommand({ interactive: true }).display)
+      .toBe('npx --yes skills add https://www.evlog.dev')
+    expect(skillsCommand({ interactive: false }).display)
+      .toBe('npx --yes skills add https://www.evlog.dev --yes')
   })
 
   it('passes the scope and the skill selection through', () => {
     const command = skillsCommand({ interactive: true, global: true, skills: ['analyze-logs'] })
 
-    expect(command.display).toBe('npx skills add https://www.evlog.dev --skill analyze-logs --global')
+    expect(command.display).toBe('npx --yes skills add https://www.evlog.dev --skill analyze-logs --global')
   })
 
   it('runs npx rather than depending on the package', () => {
@@ -205,9 +210,23 @@ describe('skillsCommand', () => {
   })
 
   it('rejects a source that is not an http(s) URL', () => {
-    /* On Windows the spawn needs a shell to find npx, so `&` in this value
-       would start a second command. Checked once, before anything is spawned. */
-    for (const source of ['https://evlog.dev && calc', 'file:///etc/passwd', 'not a url', '']) {
+    for (const source of ['file:///etc/passwd', 'not a url', '']) {
+      expect(() => skillsCommand({ interactive: true, source }), source)
+        .toThrowError(expect.objectContaining({ code: 'cli.AGENTS_INVALID_SOURCE' }))
+    }
+  })
+
+  it('rejects shell metacharacters even inside a valid URL', () => {
+    /* Being an http(s) URL is not enough: `?q=1&calc` parses, and on Windows
+       the spawn needs a shell, where `&` starts a second command. */
+    for (const source of [
+      'https://evlog.dev?q=1&calc',
+      'https://evlog.dev && calc',
+      'https://evlog.dev|calc',
+      'https://evlog.dev;calc',
+      'https://evlog.dev/%TEMP%',
+      'https://evlog.dev/$(calc)',
+    ]) {
       expect(() => skillsCommand({ interactive: true, source }), source)
         .toThrowError(expect.objectContaining({ code: 'cli.AGENTS_INVALID_SOURCE' }))
     }
@@ -222,7 +241,7 @@ describe('skillsCommand', () => {
 
   it('accepts a self-hosted origin', () => {
     expect(skillsCommand({ interactive: true, source: 'http://localhost:3000' }).display)
-      .toBe('npx skills add http://localhost:3000')
+      .toBe('npx --yes skills add http://localhost:3000')
   })
 })
 
@@ -270,7 +289,7 @@ describe('runAgents', () => {
 
     expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toContain(MARKER_START)
     expect(await readFile(join(root, 'CLAUDE.md'), 'utf8')).toBe('@AGENTS.md\n')
-    expect(result.skills).toMatchObject({ status: 'skipped', command: 'npx skills add https://www.evlog.dev --yes' })
+    expect(result.skills).toMatchObject({ status: 'skipped', command: 'npx --yes skills add https://www.evlog.dev --yes' })
   })
 
   it('is safe to run twice — the second run changes nothing', async () => {

--- a/packages/cli/test/agents.test.ts
+++ b/packages/cli/test/agents.test.ts
@@ -7,6 +7,7 @@ import { createContext } from '../src/core/context'
 import type { CliContext } from '../src/core/context'
 import { MARKER_END, MARKER_START, renderBlock, upsertBlock, upsertClaudePointer } from '../src/lib/agents/block'
 import { planAgents } from '../src/lib/agents/plan'
+import { formatAgentsReport } from '../src/lib/agents/report'
 import { agentsTelemetryFieldNames, runAgents } from '../src/lib/agents/run'
 import { EVLOG_SKILLS, findInstalledSkills, skillsCommand } from '../src/lib/agents/skills'
 
@@ -380,6 +381,17 @@ describe('runAgents', () => {
     const contents = await readFile(join(root, 'AGENTS.md'), 'utf8')
     expect(contents).not.toContain('review-logging-patterns')
     expect(contents).toContain('https://evlog.dev/learn/wide-events')
+  })
+
+  it('records the command it ran, for a run nobody watched', async () => {
+    /* Non-interactively the command never goes by on screen, so the report is
+       the only record of what was spawned — which the trust model promises. */
+    skills.spawnResult = { ok: true }
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, {})
+
+    expect(formatAgentsReport(fakeContext(root), result)).toContain(result.skills.command)
   })
 
   it('marks a successful install without spawning twice', async () => {

--- a/packages/cli/test/agents.test.ts
+++ b/packages/cli/test/agents.test.ts
@@ -1,0 +1,299 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createContext } from '../src/core/context'
+import type { CliContext } from '../src/core/context'
+import { MARKER_END, MARKER_START, renderBlock, upsertBlock, upsertClaudePointer } from '../src/lib/agents/block'
+import { planAgents } from '../src/lib/agents/plan'
+import { agentsTelemetryFieldNames, runAgents } from '../src/lib/agents/run'
+import { EVLOG_SKILLS, findInstalledSkills, skillsCommand } from '../src/lib/agents/skills'
+
+const tempDirs: string[] = []
+
+async function project(files: Record<string, string> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'evlog-cli-agents-'))
+  tempDirs.push(dir)
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(dir, path)
+    await mkdir(join(target, '..'), { recursive: true })
+    await writeFile(target, contents, 'utf8')
+  }
+  return dir
+}
+
+/**
+ * An empty home, so a run is judged on the project rather than on whatever the
+ * machine executing the suite happens to have installed globally.
+ */
+function fakeContext(cwd: string, home = join(cwd, '__home')): CliContext {
+  return createContext({ cwd, home, env: {}, nodeVersion: 'v22.0.0', tty: false, color: false, columns: 80 })
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('renderBlock', () => {
+  it('wraps the guidance in the markers', () => {
+    const block = renderBlock({ framework: 'nuxt', hasSkills: false })
+
+    expect(block.startsWith(MARKER_START)).toBe(true)
+    expect(block.trimEnd().endsWith(MARKER_END)).toBe(true)
+  })
+
+  it('names the framework-native accessor', () => {
+    expect(renderBlock({ framework: 'nuxt', hasSkills: false })).toContain('useLogger(event)')
+    expect(renderBlock({ framework: 'tanstack-start', hasSkills: false })).toContain('req.context.log')
+    expect(renderBlock({ framework: 'next', hasSkills: false })).toContain('lib/evlog.ts')
+  })
+
+  it('falls back to a generic accessor when detection found nothing', () => {
+    expect(renderBlock({ framework: null, hasSkills: false })).toContain('`useLogger()` inside a request handler')
+  })
+
+  it('names the skill but never the directory it landed in', () => {
+    /* Every agent reads a different path, so naming one would be wrong for the
+       rest — the skills CLI decides where they go. */
+    const block = renderBlock({ framework: 'nuxt', hasSkills: true })
+
+    expect(block).toContain('review-logging-patterns')
+    expect(block).not.toContain('.agents/skills')
+    expect(block).not.toContain('.claude/skills')
+  })
+})
+
+describe('upsertBlock', () => {
+  it('replaces the block and leaves everything around it alone', () => {
+    const source = `# shop\n\nOur rules.\n\n${MARKER_START}\nold\n${MARKER_END}\n\nMore rules.\n`
+
+    const next = upsertBlock(source, `${MARKER_START}\nnew\n${MARKER_END}\n`)
+
+    expect(next).toBe(`# shop\n\nOur rules.\n\n${MARKER_START}\nnew\n${MARKER_END}\n\nMore rules.\n`)
+  })
+
+  it('returns null when the block is already exactly this', () => {
+    const block = `${MARKER_START}\nsame\n${MARKER_END}\n`
+
+    expect(upsertBlock(`# shop\n\n${block.trimEnd()}\n`, block)).toBeNull()
+  })
+
+  it('appends when there are no markers yet', () => {
+    const next = upsertBlock('# shop\n\nOur rules.\n', `${MARKER_START}\nnew\n${MARKER_END}\n`)
+
+    expect(next).toBe(`# shop\n\nOur rules.\n\n${MARKER_START}\nnew\n${MARKER_END}\n`)
+  })
+})
+
+describe('upsertClaudePointer', () => {
+  it('creates the pointer when there is no file', () => {
+    expect(upsertClaudePointer(null)).toBe('@AGENTS.md\n')
+  })
+
+  it('leaves a file that already mentions AGENTS.md alone', () => {
+    expect(upsertClaudePointer('See AGENTS.md for the rules.\n')).toBeNull()
+  })
+
+  it('appends to a file that does not', () => {
+    expect(upsertClaudePointer('# rules\n')).toBe('# rules\n\n@AGENTS.md\n')
+  })
+})
+
+describe('findInstalledSkills', () => {
+  const NO_HOME = join(tmpdir(), 'evlog-cli-agents-no-home')
+
+  it('finds a skill in any agent directory', async () => {
+    const root = await project({ '.claude/skills/review-logging-patterns/SKILL.md': '# x\n' })
+
+    expect(findInstalledSkills(root, NO_HOME)).toMatchObject({
+      names: ['review-logging-patterns'],
+      dirs: ['.claude/skills'],
+    })
+  })
+
+  it('collects the same skill installed for several agents', async () => {
+    const root = await project({
+      '.claude/skills/analyze-logs/SKILL.md': '# x\n',
+      '.cursor/skills/analyze-logs/SKILL.md': '# x\n',
+    })
+
+    expect(findInstalledSkills(root, NO_HOME).dirs).toEqual(['.claude/skills', '.cursor/skills'])
+  })
+
+  it('ignores a directory that is not one of ours', async () => {
+    const root = await project({ '.claude/skills/something-else/SKILL.md': '# x\n' })
+
+    expect(findInstalledSkills(root, NO_HOME).names).toEqual([])
+  })
+
+  it('finds a globally installed skill and marks the scope', async () => {
+    /* Somebody who ran `npx skills add -g` months ago must not be told to
+       install again in every project they open. */
+    const home = await project({ '.claude/skills/analyze-logs/SKILL.md': '# x\n' })
+    const root = await project({ 'package.json': '{}' })
+
+    expect(findInstalledSkills(root, home)).toMatchObject({
+      names: ['analyze-logs'],
+      dirs: ['~/.claude/skills'],
+    })
+  })
+
+  it('knows every published skill', () => {
+    expect([...EVLOG_SKILLS].sort()).toEqual(['analyze-logs', 'build-audit-logs', 'review-logging-patterns'])
+  })
+})
+
+describe('skillsCommand', () => {
+  it('adds every published skill from the docs site by default', () => {
+    expect(skillsCommand({ interactive: true }).display).toBe('npx skills add https://www.evlog.dev')
+  })
+
+  it('lets the skills CLI ask its own questions when somebody is watching', () => {
+    /* Which agents to install for is its question, not ours. */
+    expect(skillsCommand({ interactive: true }).display).not.toContain('--yes')
+    /* Non-interactively it must never block on a prompt nobody will answer. */
+    expect(skillsCommand({ interactive: false }).display).toContain('--yes')
+  })
+
+  it('always answers npx own install prompt', () => {
+    /* Distinct from the flag above: this one is npx being asked whether to
+       fetch the skills package, and it blocks even in a run we did not drive. */
+    expect(skillsCommand({ interactive: true }).args[0]).toBe('--yes')
+  })
+
+  it('passes the scope and the skill selection through', () => {
+    const command = skillsCommand({ interactive: true, global: true, skills: ['analyze-logs'] })
+
+    expect(command.display).toBe('npx skills add https://www.evlog.dev --skill analyze-logs --global')
+  })
+
+  it('runs npx rather than depending on the package', () => {
+    expect(skillsCommand({ interactive: true }).bin).toBe('npx')
+  })
+})
+
+describe('planAgents', () => {
+  it('creates both files in a project that has neither', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const plan = planAgents({ root, projectName: 'shop', framework: 'nuxt', hasSkills: false })
+
+    expect(plan.actions.map(action => action.relative)).toEqual(['AGENTS.md', 'CLAUDE.md'])
+    expect(plan.actions.every(action => action.kind === 'create')).toBe(true)
+    expect(plan.actions[0]!.contents).toContain('# shop')
+  })
+
+  it('plans no skill files — they are not ours to write', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const plan = planAgents({ root, projectName: 'shop', framework: 'nuxt', hasSkills: true })
+
+    expect(plan.actions.every(action => !action.relative.includes('skills'))).toBe(true)
+  })
+})
+
+describe('agents telemetry fields', () => {
+  it('never names a field that could carry a path or a project name', () => {
+    for (const name of agentsTelemetryFieldNames()) {
+      expect(name).toMatch(/^agents[A-Z]/)
+      expect(name.toLowerCase()).not.toContain('name')
+      expect(name.toLowerCase()).not.toContain('path')
+    }
+  })
+
+  it('keeps the field names distinct', () => {
+    const names = agentsTelemetryFieldNames()
+
+    expect(new Set(names).size).toBe(names.length)
+  })
+})
+
+describe('runAgents', () => {
+  it('writes the block and the pointer, and delegates the skills', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, { noSkills: true })
+
+    expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toContain(MARKER_START)
+    expect(await readFile(join(root, 'CLAUDE.md'), 'utf8')).toBe('@AGENTS.md\n')
+    expect(result.skills).toMatchObject({ status: 'skipped', command: 'npx skills add https://www.evlog.dev --yes' })
+  })
+
+  it('is safe to run twice — the second run changes nothing', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    await runAgents(fakeContext(root), undefined, { noSkills: true })
+    const first = await readFile(join(root, 'AGENTS.md'), 'utf8')
+
+    const second = await runAgents(fakeContext(root), undefined, { noSkills: true })
+
+    expect(second.written).toHaveLength(0)
+    expect(second.already).toEqual(['AGENTS.md is up to date', 'CLAUDE.md already points at AGENTS.md'])
+    expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toBe(first)
+  })
+
+  it('keeps the hand-written parts of an existing AGENTS.md', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop"}',
+      'AGENTS.md': '# shop\n\nRun the tests before you push.\n',
+    })
+
+    await runAgents(fakeContext(root), undefined, { noSkills: true })
+
+    const contents = await readFile(join(root, 'AGENTS.md'), 'utf8')
+    expect(contents).toContain('Run the tests before you push.')
+    expect(contents).toContain('## Logging with evlog')
+  })
+
+  it('leaves already-installed skills to npx skills update', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop"}',
+      '.claude/skills/review-logging-patterns/SKILL.md': '# x\n',
+    })
+
+    const result = await runAgents(fakeContext(root), undefined, {})
+
+    /* Nothing was spawned: an existing install is the skills CLI's to refresh,
+       and re-adding it would be us duplicating what it already tracks. */
+    expect(result.skills).toMatchObject({
+      status: 'already',
+      found: ['review-logging-patterns'],
+      dirs: ['.claude/skills'],
+    })
+  })
+
+  it('says so in the plan when the skills are already there', async () => {
+    /* Doing nothing quietly reads as having forgotten the step — which is
+       exactly how this looked before it was reported. */
+    const root = await project({
+      'package.json': '{"name":"shop"}',
+      '.claude/skills/analyze-logs/SKILL.md': '# x\n',
+    })
+
+    const result = await runAgents(fakeContext(root), undefined, {})
+
+    expect(result.already).toContain('evlog skills already installed · .claude/skills')
+  })
+
+  it('writes nothing and runs nothing under --dry-run', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, { dryRun: true })
+
+    expect(result.written.length).toBeGreaterThan(0)
+    expect(result.skills.status).toBe('skipped')
+    expect(existsSync(join(root, 'AGENTS.md'))).toBe(false)
+  })
+
+  it('still writes the block when no framework could be detected', async () => {
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, { noSkills: true })
+
+    expect(result.framework).toBeNull()
+    expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toContain('One wide event per operation')
+  })
+})

--- a/packages/cli/test/agents.test.ts
+++ b/packages/cli/test/agents.test.ts
@@ -2,13 +2,35 @@ import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createContext } from '../src/core/context'
 import type { CliContext } from '../src/core/context'
 import { MARKER_END, MARKER_START, renderBlock, upsertBlock, upsertClaudePointer } from '../src/lib/agents/block'
 import { planAgents } from '../src/lib/agents/plan'
 import { agentsTelemetryFieldNames, runAgents } from '../src/lib/agents/run'
 import { EVLOG_SKILLS, findInstalledSkills, skillsCommand } from '../src/lib/agents/skills'
+
+/**
+ * Only the spawn is faked; everything else in the module stays real.
+ *
+ * Set `spawnResult` to drive the one branch a test cannot reach for real —
+ * actually shelling out to `npx` in a unit test is neither fast nor honest.
+ */
+const skills = vi.hoisted(() => ({
+  spawnResult: null as null | { ok: true } | { ok: false, error: string },
+  calls: 0,
+}))
+
+vi.mock('../src/lib/agents/skills', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/agents/skills')>()
+  return {
+    ...actual,
+    runSkills: (...args: Parameters<typeof actual.runSkills>) => {
+      skills.calls += 1
+      return skills.spawnResult ? Promise.resolve(skills.spawnResult) : actual.runSkills(...args)
+    },
+  }
+})
 
 const tempDirs: string[] = []
 
@@ -34,6 +56,8 @@ function fakeContext(cwd: string, home = join(cwd, '__home')): CliContext {
 afterEach(async () => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  skills.spawnResult = null
+  skills.calls = 0
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -103,7 +127,13 @@ describe('upsertClaudePointer', () => {
 })
 
 describe('findInstalledSkills', () => {
-  const NO_HOME = join(tmpdir(), 'evlog-cli-agents-no-home')
+  /* Owned by the suite rather than a fixed temp path: a stray
+     `evlog-cli-agents-no-home/.claude/skills/<name>` on the build machine would
+     otherwise silently change what these assertions mean. */
+  let NO_HOME: string
+  beforeEach(async () => {
+    NO_HOME = await project()
+  })
 
   it('finds a skill in any agent directory', async () => {
     const root = await project({ '.claude/skills/review-logging-patterns/SKILL.md': '# x\n' })
@@ -172,6 +202,27 @@ describe('skillsCommand', () => {
 
   it('runs npx rather than depending on the package', () => {
     expect(skillsCommand({ interactive: true }).bin).toBe('npx')
+  })
+
+  it('rejects a source that is not an http(s) URL', () => {
+    /* On Windows the spawn needs a shell to find npx, so `&` in this value
+       would start a second command. Checked once, before anything is spawned. */
+    for (const source of ['https://evlog.dev && calc', 'file:///etc/passwd', 'not a url', '']) {
+      expect(() => skillsCommand({ interactive: true, source }), source)
+        .toThrowError(expect.objectContaining({ code: 'cli.AGENTS_INVALID_SOURCE' }))
+    }
+  })
+
+  it('rejects a skill name that is not a plain identifier', () => {
+    for (const skill of ['analyze logs', 'a&&b', '../escape', 'UPPER']) {
+      expect(() => skillsCommand({ interactive: true, skills: [skill] }), skill)
+        .toThrowError(expect.objectContaining({ code: 'cli.AGENTS_INVALID_SKILL' }))
+    }
+  })
+
+  it('accepts a self-hosted origin', () => {
+    expect(skillsCommand({ interactive: true, source: 'http://localhost:3000' }).display)
+      .toBe('npx skills add http://localhost:3000')
   })
 })
 
@@ -286,6 +337,41 @@ describe('runAgents', () => {
     expect(result.written.length).toBeGreaterThan(0)
     expect(result.skills.status).toBe('skipped')
     expect(existsSync(join(root, 'AGENTS.md'))).toBe(false)
+  })
+
+  it('reports a failed install and keeps the block', async () => {
+    skills.spawnResult = { ok: false, error: 'npx: command not found' }
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, {})
+
+    expect(result.skills).toMatchObject({ status: 'failed', error: 'npx: command not found' })
+    /* The block never needed the network, so it stands. */
+    expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toContain('One wide event per operation')
+  })
+
+  it('does not leave the block promising a skill the failed install never wrote', async () => {
+    /* The block is written before the install so it survives a dead subprocess,
+       which means on failure it names a skill that is now known to be absent. */
+    skills.spawnResult = { ok: false, error: 'network unreachable' }
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    await runAgents(fakeContext(root), undefined, {})
+
+    const contents = await readFile(join(root, 'AGENTS.md'), 'utf8')
+    expect(contents).not.toContain('review-logging-patterns')
+    expect(contents).toContain('https://evlog.dev/learn/wide-events')
+  })
+
+  it('marks a successful install without spawning twice', async () => {
+    skills.spawnResult = { ok: true }
+    const root = await project({ 'package.json': '{"name":"shop"}' })
+
+    const result = await runAgents(fakeContext(root), undefined, {})
+
+    expect(result.skills.status).toBe('installed')
+    expect(skills.calls).toBe(1)
+    expect(await readFile(join(root, 'AGENTS.md'), 'utf8')).toContain('review-logging-patterns')
   })
 
   it('still writes the block when no framework could be detected', async () => {

--- a/packages/cli/test/init.resolve.test.ts
+++ b/packages/cli/test/init.resolve.test.ts
@@ -66,6 +66,7 @@ describe('resolveAnswers', () => {
     defaultService: 'shop',
     evlogInstalled: false,
     install: true,
+    agentGuide: false,
     offers,
   }
 
@@ -78,6 +79,7 @@ describe('resolveAnswers', () => {
       extras: [],
       enrichers: [],
       sampling: 'all',
+      agentGuide: false,
       install: true,
     })
   })

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createContext } from '../src/core/context'
 import type { CliContext } from '../src/core/context'
 import { planWiring } from '../src/lib/init/frameworks'
@@ -22,8 +22,17 @@ async function project(files: Record<string, string>): Promise<string> {
   return dir
 }
 
+/** An empty home, so globally installed skills cannot sway a run. */
 function fakeContext(cwd: string): CliContext {
-  return createContext({ cwd, env: {}, nodeVersion: 'v22.0.0', tty: false, color: false, columns: 80 })
+  return createContext({
+    cwd,
+    home: join(cwd, '__home'),
+    env: {},
+    nodeVersion: 'v22.0.0',
+    tty: false,
+    color: false,
+    columns: 80,
+  })
 }
 
 
@@ -42,6 +51,7 @@ function wiring(overrides: Partial<Parameters<typeof planWiring>[0]> = {}) {
 }
 
 afterEach(async () => {
+  vi.unstubAllGlobals()
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -168,7 +178,7 @@ describe('runInit', () => {
       'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
     })
 
-    const result = await runInit(fakeContext(cwd), undefined, { dryRun: true, yes: true })
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: false, dryRun: true, yes: true })
 
     expect(result.answers.framework).toBe('nuxt')
     /* The scope is noise once every event carries the service name. */
@@ -184,9 +194,9 @@ describe('runInit', () => {
       'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
     })
 
-    await runInit(fakeContext(cwd), undefined, { install: false, yes: true })
+    await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
     const afterFirst = await readFile(join(cwd, 'nuxt.config.ts'), 'utf8')
-    const second = await runInit(fakeContext(cwd), undefined, { install: false, yes: true })
+    const second = await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
 
     expect(second.written).toHaveLength(0)
     expect(await readFile(join(cwd, 'nuxt.config.ts'), 'utf8')).toBe(afterFirst)
@@ -198,7 +208,7 @@ describe('runInit', () => {
       'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
     })
 
-    await runInit(fakeContext(cwd), undefined, { install: false, yes: true })
+    await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
 
     const plugin = await readFile(join(cwd, 'server/plugins/evlog-drain.ts'), 'utf8')
     expect(plugin).toContain('if (!import.meta.dev) return')
@@ -211,7 +221,7 @@ describe('runInit', () => {
       'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
     })
 
-    await runInit(fakeContext(cwd), undefined, { install: false, devDrain: 'none', yes: true })
+    await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, devDrain: 'none', yes: true })
 
     expect(existsSync(join(cwd, 'server/plugins/evlog-drain.ts'))).toBe(false)
   })
@@ -223,9 +233,59 @@ describe('runInit', () => {
       'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
     })
 
-    const result = await runInit(fakeContext(cwd), undefined, { install: false, yes: true })
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
 
     expect(result.install).toMatchObject({ status: 'skipped', command: 'pnpm add evlog' })
+  })
+})
+
+describe('runInit — agent guidelines', () => {
+  async function nuxtProject(files: Record<string, string> = {}): Promise<string> {
+    return await project({
+      'package.json': '{"name":"shop","dependencies":{"nuxt":"^4.0.0"}}',
+      'nuxt.config.ts': 'export default defineNuxtConfig({})\n',
+      ...files,
+    })
+  }
+
+  it('writes the guidelines alongside the wiring, in one plan', async () => {
+    /* The skills are already there, so the run never spawns anything — the
+       block is what `init` itself is responsible for. */
+    const cwd = await nuxtProject({ '.claude/skills/review-logging-patterns/SKILL.md': '# x\n' })
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, yes: true })
+
+    expect(result.agentGuide).toMatchObject({
+      status: 'already',
+      found: ['review-logging-patterns'],
+      dirs: ['.claude/skills'],
+    })
+    /* Reported, not silent: doing nothing quietly reads as a forgotten step. */
+    expect(result.already).toContain('evlog skills already installed · .claude/skills')
+    expect(result.written.map(action => action.relative)).toEqual(
+      expect.arrayContaining(['AGENTS.md', 'CLAUDE.md']),
+    )
+    /* The wiring and the guidelines land in the same plan, not two runs. */
+    expect(await readFile(join(cwd, 'nuxt.config.ts'), 'utf8')).toContain('evlog/nuxt')
+    expect(await readFile(join(cwd, 'AGENTS.md'), 'utf8')).toContain('## Logging with evlog')
+  })
+
+  it('never writes skill files itself', async () => {
+    const cwd = await nuxtProject({ '.claude/skills/analyze-logs/SKILL.md': '# x\n' })
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, yes: true })
+
+    /* `npx skills add` owns them: a copy we wrote is one it could never update. */
+    expect(result.written.every(action => !action.relative.includes('skills'))).toBe(true)
+  })
+
+  it('does nothing at all under --no-agents', async () => {
+    const cwd = await nuxtProject()
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
+
+    expect(result.agentGuide).toBeNull()
+    expect(existsSync(join(cwd, 'AGENTS.md'))).toBe(false)
   })
 })
 

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -340,7 +340,7 @@ describe('runInit — agent guidelines', () => {
     const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, dryRun: true, yes: true })
 
     expect(result.agentGuide?.status).toBe('pending')
-    expect(result.agentGuide?.command).toContain('npx skills add')
+    expect(result.agentGuide?.command).toContain('npx --yes skills add')
     expect(skills.calls).toBe(0)
     expect(existsSync(join(cwd, 'AGENTS.md'))).toBe(false)
   })

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -9,6 +9,23 @@ import { planWiring } from '../src/lib/init/frameworks'
 import { detectPackageManager, installCommand } from '../src/lib/init/pm'
 import { runInit } from '../src/lib/init/run'
 
+/** Only the spawn is faked; the rest of the skills module stays real. */
+const skills = vi.hoisted(() => ({
+  spawnResult: null as null | { ok: true } | { ok: false, error: string },
+  calls: 0,
+}))
+
+vi.mock('../src/lib/agents/skills', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/agents/skills')>()
+  return {
+    ...actual,
+    runSkills: (...args: Parameters<typeof actual.runSkills>) => {
+      skills.calls += 1
+      return skills.spawnResult ? Promise.resolve(skills.spawnResult) : actual.runSkills(...args)
+    },
+  }
+})
+
 const tempDirs: string[] = []
 
 async function project(files: Record<string, string>): Promise<string> {
@@ -52,6 +69,8 @@ function wiring(overrides: Partial<Parameters<typeof planWiring>[0]> = {}) {
 
 afterEach(async () => {
   vi.unstubAllGlobals()
+  skills.spawnResult = null
+  skills.calls = 0
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -285,6 +304,44 @@ describe('runInit — agent guidelines', () => {
     const result = await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
 
     expect(result.agentGuide).toBeNull()
+    expect(existsSync(join(cwd, 'AGENTS.md'))).toBe(false)
+    expect(skills.calls).toBe(0)
+  })
+
+  it('installs the skills when none are on disk — the common case', async () => {
+    skills.spawnResult = { ok: true }
+    const cwd = await nuxtProject()
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, yes: true })
+
+    /* `pending` is the value the step starts at; leaving it there would mean
+       the skills execution never ran. */
+    expect(result.agentGuide).toMatchObject({ status: 'installed', found: [] })
+    expect(skills.calls).toBe(1)
+    /* The files land before the spawn, so a dead subprocess cannot cost them. */
+    expect(await readFile(join(cwd, 'AGENTS.md'), 'utf8')).toContain('## Logging with evlog')
+    expect(existsSync(join(cwd, 'CLAUDE.md'))).toBe(true)
+  })
+
+  it('keeps the wiring and the block when the skills install fails', async () => {
+    skills.spawnResult = { ok: false, error: 'npx: command not found' }
+    const cwd = await nuxtProject()
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, yes: true })
+
+    expect(result.agentGuide).toMatchObject({ status: 'failed', error: 'npx: command not found' })
+    expect(await readFile(join(cwd, 'nuxt.config.ts'), 'utf8')).toContain('evlog/nuxt')
+    expect(existsSync(join(cwd, 'AGENTS.md'))).toBe(true)
+  })
+
+  it('previews the skills command under --dry-run without running it', async () => {
+    const cwd = await nuxtProject()
+
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: true, install: false, dryRun: true, yes: true })
+
+    expect(result.agentGuide?.status).toBe('pending')
+    expect(result.agentGuide?.command).toContain('npx skills add')
+    expect(skills.calls).toBe(0)
     expect(existsSync(join(cwd, 'AGENTS.md'))).toBe(false)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- clickhouse (ClickHouse drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- loki (Grafana Loki drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `evlog agents` to generate or update `AGENTS.md` and `CLAUDE.md` guidance.
  * Added optional skill installation with project/global detection, dry-run, JSON, interactive, and non-interactive modes.
  * Integrated agent guidance setup into `evlog init`, with an option to skip it and continued execution after skill failures.
* **Documentation**
  * Added CLI usage, options, examples, and agent-skills guidance.
* **Tests**
  * Added coverage for configuration, detection, dry runs, idempotency, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->