### PR TITLE
feat(core): expose durationMs as a number on the wide event

### DIFF
--- a/.changeset/wide-event-duration-ms.md
+++ b/.changeset/wide-event-duration-ms.md
@@ -1,0 +1,15 @@
+---
+"evlog": minor
+---
+
+feat(core): expose `durationMs` as a number on the wide event
+
+Request loggers now write `durationMs` (a number, in milliseconds) next to the existing `duration` string. `duration` keeps its current shape — `"12ms"`, `"1.20s"` — and is still what the pretty terminal renders; `durationMs` is the one to query. Backends stop needing a parse step: ClickHouse can `avg()` and `quantile(0.95)()` on a real column, LogQL can do `| json | durationMs > 1000`, and facet-based UIs get a numeric field instead of a string.
+
+The ClickHouse adapter's default `toClickHouseRow()` maps it to a new `duration_ms` column. Add it to an existing table before upgrading:
+
+```sql
+ALTER TABLE evlog_events ADD COLUMN duration_ms Nullable(UInt32) AFTER duration;
+```
+
+`BaseWideEvent` now declares both fields, so `event.durationMs` is typed `number | undefined` in enrichers and drains. Code that read `event.duration` as a number was already wrong at runtime and will now fail to type-check — switch it to `event.durationMs`.

--- a/.changeset/wide-event-duration-ms.md
+++ b/.changeset/wide-event-duration-ms.md
@@ -12,4 +12,6 @@ The ClickHouse adapter's default `toClickHouseRow()` maps it to a new `duration_
 ALTER TABLE evlog_events ADD COLUMN duration_ms Nullable(UInt32) AFTER duration;
 ```
 
+Durations are measured with a clamped elapsed helper, so a backward wall-clock step (NTP, manual change) during a request can no longer surface a negative `durationMs`, `duration`, or tail-sampling duration.
+
 `BaseWideEvent` now declares both fields, so `event.durationMs` is typed `number | undefined` in enrichers and drains. Code that read `event.duration` as a number was already wrong at runtime and will now fail to type-check — switch it to `event.durationMs`.

--- a/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
@@ -189,8 +189,8 @@ evlog sends structured wide events that are perfect for Axiom's APL query langua
 ```apl [Axiom APL queries]
 // Find slow requests
 ['your-dataset']
-| where duration > 1000
-| project timestamp, path, duration, status
+| where durationMs > 1000
+| project timestamp, path, durationMs, status
 
 // Error rate by endpoint
 ['your-dataset']

--- a/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
@@ -261,7 +261,7 @@ Filter by label, then reach into the wide event with `| json`:
 
 ```logql
 # Slow requests on one route
-{service="checkout"} | json | path="/api/orders" | duration_ms > 1000
+{service="checkout"} | json | path="/api/orders" | durationMs > 1000
 ```
 
 ```logql

--- a/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
@@ -294,7 +294,7 @@ GROUP BY service;
 -- Slowest routes
 SELECT path, count() AS hits, avg(duration_ms) AS avg_ms, quantile(0.95)(duration_ms) AS p95_ms
 FROM evlog_events
-WHERE timestamp > now() - INTERVAL 1 DAY AND method = 'GET'
+WHERE timestamp > now() - INTERVAL 1 DAY AND method = 'GET' AND duration_ms IS NOT NULL
 GROUP BY path
 ORDER BY avg_ms DESC
 LIMIT 20;

--- a/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS evlog_events
   path          String,
   status        Nullable(UInt16),
   duration      String,
+  duration_ms   Nullable(UInt32),
   error_name    String,
   error_message String,
   data          String
@@ -291,7 +292,7 @@ GROUP BY service;
 
 ```sql
 -- Slowest routes
-SELECT path, count() AS hits, avg(JSONExtractFloat(data, 'durationMs')) AS avg_ms
+SELECT path, count() AS hits, avg(duration_ms) AS avg_ms, quantile(0.95)(duration_ms) AS p95_ms
 FROM evlog_events
 WHERE timestamp > now() - INTERVAL 1 DAY AND method = 'GET'
 GROUP BY path

--- a/apps/docs/content/4.integrate/adapters/self-hosted/01.fs.md
+++ b/apps/docs/content/4.integrate/adapters/self-hosted/01.fs.md
@@ -209,8 +209,8 @@ tail -f .evlog/logs/2026-03-14.jsonl
 # Find errors
 cat .evlog/logs/2026-03-14.jsonl | jq 'select(.level == "error")'
 
-# Slow requests (duration is a formatted string like "706ms" or "1.23s")
-cat .evlog/logs/2026-03-14.jsonl | jq 'select(.duration | test("^[0-9.]+s"))'
+# Slow requests (over 1s)
+cat .evlog/logs/2026-03-14.jsonl | jq 'select(.durationMs > 1000)'
 
 # Requests by path
 cat .evlog/logs/2026-03-14.jsonl | jq 'select(.path == "/api/checkout")'

--- a/apps/docs/content/4.integrate/adapters/self-hosted/03.memory.md
+++ b/apps/docs/content/4.integrate/adapters/self-hosted/03.memory.md
@@ -203,7 +203,7 @@ const recent = readMemoryLogs({
 
 // Custom predicate
 const slow = readMemoryLogs({
-  filter: e => typeof e.duration === 'string' && e.duration.endsWith('s'),
+  filter: e => (e.durationMs ?? 0) > 1000,
 })
 
 // Most recent 50 events

--- a/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
@@ -118,6 +118,7 @@ Your wide event now includes:
   "path": "/api/chat",
   "status": 200,
   "duration": "4.5s",
+  "durationMs": 4512,
   "ai": {
     "calls": 1,
     "model": "claude-sonnet-4.6",

--- a/apps/docs/content/5.use-cases/3.better-auth/05.performance.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/05.performance.md
@@ -69,6 +69,7 @@ When you also use [`evlog/ai`](/use-cases/ai-sdk/overview), your wide events inc
   "path": "/api/chat",
   "status": 200,
   "duration": "4.5s",
+  "durationMs": 4512,
   "userId": "QBX9tPjJQExWawAbNll75",
   "user": {
     "id": "QBX9tPjJQExWawAbNll75",

--- a/apps/docs/content/5.use-cases/4.audit/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.audit/01.overview.md
@@ -202,6 +202,7 @@ audit({
   "path": "/api/invoices/inv_889/refund",
   "status": 200,
   "duration": "84ms",
+  "durationMs": 84,
   "requestId": "a566ef91-7765-4f59-b6f0-b9f40ce71599",
   "audit": {
     "action": "invoice.refund",

--- a/apps/docs/content/5.use-cases/4.audit/03.recording.md
+++ b/apps/docs/content/5.use-cases/4.audit/03.recording.md
@@ -62,6 +62,7 @@ if (!user.canRefund(invoice)) {
   "path": "/api/invoices/inv_889/refund",
   "status": 403,
   "duration": "12ms",
+  "durationMs": 12,
   "requestId": "9c3f7d12-8a45-4e60-b8a9-1f0d4c5e6e7d",
   "audit": {
     "action": "invoice.refund",

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -129,6 +129,7 @@ Each completed turn emits one event:
   "path": "/sessions/sess_abc/turns/turn_0",
   "status": 200,
   "duration": "7.9s",
+  "durationMs": 7903,
   "service": "clearbill-support-agent",
   "eve": {
     "sessionId": "sess_abc",

--- a/apps/docs/content/6.extend/3.consumer-recipes.md
+++ b/apps/docs/content/6.extend/3.consumer-recipes.md
@@ -177,7 +177,7 @@ curl -sN "$URL" | jq -c 'select(.type == "event" and .data.level == "error") | .
 curl -sN "$URL" | jq -c 'select(.type == "event" and .data.service == "checkout") | .data'
 
 # Slow requests
-curl -sN "$URL" | jq -c 'select(.type == "event" and .data.duration > 500) | .data'
+curl -sN "$URL" | jq -c 'select(.type == "event" and .data.durationMs > 500) | .data'
 ```
 
 `-N` keeps `curl` in streaming mode (no buffering). `-s` is silent.
@@ -253,7 +253,7 @@ Keep the server dumb — every consumer picks what it cares about:
 const errors = events.filter(e => e.level === 'error')
 
 // Slow requests
-const slowReqs = events.filter(e => typeof e.duration === 'number' && e.duration > 500)
+const slowReqs = events.filter(e => (e.durationMs ?? 0) > 500)
 
 // Group by service
 const byService = Object.groupBy(events, e => e.service)

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -124,11 +124,11 @@ export const requestMetricsPlugin = definePlugin({
   },
 
   enrich({ event }) {
-    event.tier = event.duration && event.duration > 1000 ? 'slow' : 'fast'
+    event.tier = event.durationMs && event.durationMs > 1000 ? 'slow' : 'fast'
   },
 
   drain({ event }) {
-    statsd.timing('http.request', event.duration as number, { path: event.path as string })
+    statsd.timing('http.request', event.durationMs!, { path: event.path as string })
   },
 
   onRequestStart({ logger, request }) {

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -124,11 +124,13 @@ export const requestMetricsPlugin = definePlugin({
   },
 
   enrich({ event }) {
-    event.tier = event.durationMs && event.durationMs > 1000 ? 'slow' : 'fast'
+    if (event.durationMs !== undefined) event.tier = event.durationMs > 1000 ? 'slow' : 'fast'
   },
 
   drain({ event }) {
-    statsd.timing('http.request', event.durationMs!, { path: event.path as string })
+    if (event.durationMs !== undefined) {
+      statsd.timing('http.request', event.durationMs, { path: event.path as string })
+    }
   },
 
   onRequestStart({ logger, request }) {

--- a/apps/docs/content/6.extend/5.custom-enrichers.md
+++ b/apps/docs/content/6.extend/5.custom-enrichers.md
@@ -254,11 +254,11 @@ export const performanceTier = defineEnricher<string>({
   name: 'performance-tier',
   field: 'performanceTier',
   compute: ({ event }) => {
-    const duration = event.duration as number | undefined
-    if (duration === undefined) return undefined
-    if (duration < 100) return 'fast'
-    if (duration < 500) return 'normal'
-    if (duration < 2000) return 'slow'
+    const durationMs = event.durationMs
+    if (durationMs === undefined) return undefined
+    if (durationMs < 100) return 'fast'
+    if (durationMs < 500) return 'normal'
+    if (durationMs < 2000) return 'slow'
     return 'critical'
   },
 })

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -208,7 +208,7 @@ encode: (events, cfg) => {
   const payload = filtered.map(e => ({
     ts: new Date(e.timestamp).getTime(),
     severity: e.level.toUpperCase(),
-    attributes: { method: e.method, path: e.path, status: e.status, duration: e.duration },
+    attributes: { method: e.method, path: e.path, status: e.status, durationMs: e.durationMs },
   }))
 
   return {

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -61,6 +61,7 @@ Output:
   "method": "POST",
   "path": "/api/checkout",
   "duration": "1.2s",
+  "durationMs": 1204,
   "user": { "id": "123", "plan": "premium" },
   "cart": { "items": 3, "total": 9999 },
   "error": { "message": "Card declined", "step": "payment" }
@@ -167,6 +168,7 @@ The wide event emitted at the end contains **everything**:
   "method": "POST",
   "path": "/api/checkout",
   "duration": "1.2s",
+  "durationMs": 1204,
   "user": { "id": "user_123", "plan": "premium" },
   "cart": { "items": 3, "total": 9999 },
   "payment": { "id": "pay_xyz", "method": "card" },
@@ -270,6 +272,7 @@ Output when the export completes:
   "method": "POST",
   "path": "/api/documents/doc_123/export",
   "duration": "2.4s",
+  "durationMs": 2412,
   "document": { "id": "doc_123", "title": "Q4 Report", "pages": 24 },
   "export": { "format": "pdf", "size": 1240000, "pages": 24 },
   "status": 200

--- a/packages/evlog/src/adapters/clickhouse.ts
+++ b/packages/evlog/src/adapters/clickhouse.ts
@@ -66,6 +66,19 @@ function readString(event: WideEvent, key: string): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
+const UINT32_MAX = 4_294_967_295
+
+/**
+ * Coerce a value to what `Nullable(UInt32)` accepts, or `null`.
+ *
+ * ClickHouse rejects the whole `JSONEachRow` batch on an out-of-range value, so
+ * one odd event would drop every event sent with it.
+ */
+function readUInt32(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return null
+  return value >= 0 && value <= UINT32_MAX ? value : null
+}
+
 /**
  * Convert an ISO timestamp to ClickHouse's `DateTime64(3)` text format
  * (`YYYY-MM-DD HH:MM:SS.mmm`, UTC).
@@ -100,7 +113,7 @@ export function toClickHouseRow(event: WideEvent): Record<string, unknown> {
     path: readString(event, 'path') ?? '',
     status: typeof status === 'number' ? status : null,
     duration: readString(event, 'duration') ?? '',
-    duration_ms: typeof durationMs === 'number' ? durationMs : null,
+    duration_ms: readUInt32(durationMs),
     error_name: typeof errorRecord?.name === 'string' ? errorRecord.name : '',
     error_message: typeof errorRecord?.message === 'string' ? errorRecord.message : '',
     data: JSON.stringify(event),

--- a/packages/evlog/src/adapters/clickhouse.ts
+++ b/packages/evlog/src/adapters/clickhouse.ts
@@ -85,7 +85,7 @@ export function toClickHouseDateTime(timestamp: string): string {
  * target a different schema.
  */
 export function toClickHouseRow(event: WideEvent): Record<string, unknown> {
-  const { error, status } = event as Record<string, unknown>
+  const { durationMs, error, status } = event as Record<string, unknown>
   const errorRecord = typeof error === 'object' && error !== null ? error as Record<string, unknown> : undefined
 
   return {
@@ -100,6 +100,7 @@ export function toClickHouseRow(event: WideEvent): Record<string, unknown> {
     path: readString(event, 'path') ?? '',
     status: typeof status === 'number' ? status : null,
     duration: readString(event, 'duration') ?? '',
+    duration_ms: typeof durationMs === 'number' ? durationMs : null,
     error_name: typeof errorRecord?.name === 'string' ? errorRecord.name : '',
     error_message: typeof errorRecord?.message === 'string' ? errorRecord.message : '',
     data: JSON.stringify(event),

--- a/packages/evlog/src/eve/index.ts
+++ b/packages/evlog/src/eve/index.ts
@@ -107,6 +107,7 @@ const TURN_ONLY_KEYS = new Set([
   'path',
   'status',
   'duration',
+  'durationMs',
   'level',
   'error',
   'agent',

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -641,6 +641,7 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
     }
     delete rest.duration
   }
+  delete rest.durationMs
 
   writeLine(parts.join(''), ...styles)
 
@@ -973,6 +974,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
           if (key !== '_forceKeep') context[key] = obj[key]
         }
       }
+      context.durationMs = durationMs
       context.duration = formatDuration(durationMs)
 
       const wide = emitWideEvent(level, context, { deferDrain, ownsEvent: true, waitUntil })

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -8,7 +8,7 @@ import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER } f
 import { resolveDevTerminal } from './shared/dev-terminal'
 import { globalConfig } from './shared/globalRegistry'
 import { EvlogError } from './error'
-import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, isoNow, matchesPattern } from './utils'
+import { colors, cssColors, detectEnvironment, elapsedMs, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, isoNow, matchesPattern } from './utils'
 
 const nativeStdoutWrite =
   typeof process !== 'undefined' && typeof process.stdout?.write === 'function'
@@ -942,7 +942,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
         return null
       }
 
-      const durationMs = Date.now() - startTime
+      const durationMs = elapsedMs(startTime)
       const level: LogLevel = manualLevel ?? (hasError ? 'error' : hasWarn ? 'warn' : 'info')
 
       let forceKeep = false

--- a/packages/evlog/src/nitro-v3/plugin.ts
+++ b/packages/evlog/src/nitro-v3/plugin.ts
@@ -11,7 +11,7 @@ import { extendDeferredDrain } from '../nitro/deferred-drain'
 import { normalizeRedactConfig } from '../redact'
 import { resolveEvlogConfigForNitroPlugin, setActiveNitroRuntime } from '../shared/nitroConfigBridge'
 import type { EnrichContext, RequestLogger, TailSamplingContext, WideEvent } from '../types'
-import { filterSafeHeaders } from '../utils'
+import { elapsedMs, filterSafeHeaders } from '../utils'
 
 // Nitro v3 doesn't fully export hook types yet
 // https://github.com/nitrojs/nitro/blob/8882bc9e1dbf2d342e73097f22a2156f70f50575/src/types/runtime/nitro.ts#L48-L53
@@ -249,7 +249,7 @@ export default definePlugin(async (nitroApp) => {
       log.set({ status: responseStatus })
 
       const startTime = ctx._evlogStartTime as number | undefined
-      const durationMs = startTime ? Date.now() - startTime : undefined
+      const durationMs = startTime ? elapsedMs(startTime) : undefined
 
       const { pathname } = parseURL(event.req.url)
 
@@ -302,7 +302,7 @@ export default definePlugin(async (nitroApp) => {
 
       const { pathname } = parseURL(e.req.url)
       const startTime = ctx._evlogStartTime as number | undefined
-      const durationMs = startTime ? Date.now() - startTime : undefined
+      const durationMs = startTime ? elapsedMs(startTime) : undefined
 
       const tailCtx: TailSamplingContext = {
         status: errorStatus,

--- a/packages/evlog/src/nitro/plugin.ts
+++ b/packages/evlog/src/nitro/plugin.ts
@@ -14,7 +14,7 @@ import { resolveEvlogConfigForNitroPlugin, setActiveNitroRuntime } from '../shar
 import { bindStreamingResponseLifecycle, shouldDeferEmitForResponse } from '../shared/streamResponse'
 import { startStreamServer, type StreamServerOptions } from '../stream'
 import type { RequestLogger, ServerEvent, TailSamplingContext } from '../types'
-import { filterSafeHeaders } from '../utils'
+import { elapsedMs, filterSafeHeaders } from '../utils'
 import { callEnrichAndDrain } from './enrich-drain'
 
 function getSafeHeaders(event: ServerEvent): Record<string, string> {
@@ -146,7 +146,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       requestLog.set({ status: errorStatus })
 
       const startTime = e.context._evlogStartTime as number | undefined
-      const durationMs = startTime ? Date.now() - startTime : undefined
+      const durationMs = startTime ? elapsedMs(startTime) : undefined
 
       const tailCtx: TailSamplingContext = {
         status: errorStatus,
@@ -185,7 +185,7 @@ export default defineNitroPlugin(async (nitroApp) => {
       requestLog.set({ status })
 
       const startTime = e.context._evlogStartTime as number | undefined
-      const durationMs = startTime ? Date.now() - startTime : undefined
+      const durationMs = startTime ? elapsedMs(startTime) : undefined
 
       const tailCtx: TailSamplingContext = {
         status,

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -2,6 +2,7 @@ import type { DrainContext, EnrichContext, RedactConfig, RequestLogger, RouteCon
 import type { AuditableLogger } from '../audit'
 import { createRequestLogger, getGlobalDrain, getGlobalPluginRunner, isEnabled, markWideEventDrainStarted, shouldKeep } from '../logger'
 import { isGloballyRedacted, redactEvent, resolveRedactConfig } from '../redact'
+import { elapsedMs } from '../utils'
 import { extractErrorStatus } from './errors'
 import type { EvlogPlugin, PluginRunner } from './plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './plugin'
@@ -293,7 +294,7 @@ export function createMiddlewareLogger(options: MiddlewareLoggerOptions): Middle
       requestLogger.set({ status })
     }
 
-    const durationMs = Date.now() - startTime
+    const durationMs = elapsedMs(startTime)
 
     const resolvedStatus = error
       ? extractErrorStatus(error)

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -638,6 +638,10 @@ export interface BaseWideEvent {
   version?: string
   commitHash?: string
   region?: string
+  /** Request duration, human-formatted (`"12ms"`, `"1.2s"`). Set by request loggers on emit. */
+  duration?: string
+  /** Request duration in milliseconds. Query this one — `duration` is for humans. */
+  durationMs?: number
   audit?: AuditFields
 }
 

--- a/packages/evlog/src/utils.ts
+++ b/packages/evlog/src/utils.ts
@@ -1,5 +1,16 @@
 import type { EnvironmentContext, LogLevel } from './types'
 
+/**
+ * Milliseconds elapsed since `startTime`, never negative.
+ *
+ * `Date.now()` is wall-clock: an NTP step or a manual clock change during a
+ * request can move it backwards. Clamping keeps the duration a valid
+ * non-negative measurement rather than leaking a negative number to drains.
+ */
+export function elapsedMs(startTime: number): number {
+  return Math.max(0, Date.now() - startTime)
+}
+
 export function formatDuration(ms: number): string {
   if (ms < 1000) {
     return `${Math.round(ms)}ms`

--- a/packages/evlog/test/adapters/clickhouse.test.ts
+++ b/packages/evlog/test/adapters/clickhouse.test.ts
@@ -98,8 +98,12 @@ describe('clickhouse adapter', () => {
     })
 
     it('nulls a duration_ms that Nullable(UInt32) would reject', () => {
+      const event = createTestEvent()
       for (const durationMs of [-1, 1.5, 4_294_967_296, Number.NaN, '12', null]) {
-        expect(toClickHouseRow(createTestEvent({ durationMs })).duration_ms, String(durationMs)).toBeNull()
+        expect(
+          toClickHouseRow({ ...event, durationMs } as unknown as WideEvent).duration_ms,
+          String(durationMs),
+        ).toBeNull()
       }
 
       expect(toClickHouseRow(createTestEvent({ durationMs: 0 })).duration_ms).toBe(0)

--- a/packages/evlog/test/adapters/clickhouse.test.ts
+++ b/packages/evlog/test/adapters/clickhouse.test.ts
@@ -97,6 +97,15 @@ describe('clickhouse adapter', () => {
       expect(row.duration_ms).toBeNull()
     })
 
+    it('nulls a duration_ms that Nullable(UInt32) would reject', () => {
+      for (const durationMs of [-1, 1.5, 4_294_967_296, Number.NaN, '12', null]) {
+        expect(toClickHouseRow(createTestEvent({ durationMs })).duration_ms, String(durationMs)).toBeNull()
+      }
+
+      expect(toClickHouseRow(createTestEvent({ durationMs: 0 })).duration_ms).toBe(0)
+      expect(toClickHouseRow(createTestEvent({ durationMs: 4_294_967_295 })).duration_ms).toBe(4_294_967_295)
+    })
+
     it('ignores a non-numeric status', () => {
       expect(toClickHouseRow(createTestEvent({ status: 'ok' })).status).toBeNull()
     })

--- a/packages/evlog/test/adapters/clickhouse.test.ts
+++ b/packages/evlog/test/adapters/clickhouse.test.ts
@@ -58,6 +58,7 @@ describe('clickhouse adapter', () => {
         path: '/api/users',
         status: 200,
         duration: '12ms',
+        durationMs: 12,
       }))
       expect(row).toMatchObject({
         timestamp: '2024-01-01 12:00:00.000',
@@ -69,6 +70,7 @@ describe('clickhouse adapter', () => {
         path: '/api/users',
         status: 200,
         duration: '12ms',
+        duration_ms: 12,
       })
     })
 
@@ -92,6 +94,7 @@ describe('clickhouse adapter', () => {
       expect(row.method).toBe('')
       expect(row.error_name).toBe('')
       expect(row.status).toBeNull()
+      expect(row.duration_ms).toBeNull()
     })
 
     it('ignores a non-numeric status', () => {

--- a/packages/evlog/test/core/logger-browser.test.ts
+++ b/packages/evlog/test/core/logger-browser.test.ts
@@ -93,6 +93,15 @@ describe('browser pretty printing', () => {
     expect(styles.some((s: string) => s.includes('#6b7280'))).toBe(true)
   })
 
+  it('does not render durationMs as a tree field', () => {
+    const logger = createRequestLogger({ method: 'GET', path: '/api/test' })
+    logger.emit()
+
+    for (const call of logSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('durationMs')
+    }
+  })
+
   it('escapes % in dynamic values to prevent format string injection', () => {
     log.info('test', '100% complete %c injected %s')
 

--- a/packages/evlog/test/core/logger-request-logger.test.ts
+++ b/packages/evlog/test/core/logger-request-logger.test.ts
@@ -456,6 +456,19 @@ describe('createRequestLogger', () => {
     })
   })
 
+  it('never reports a negative duration when the clock steps backwards', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValue(10_000)
+    const logger = createRequestLogger({})
+
+    // NTP step or manual clock change mid-request.
+    now.mockReturnValue(9_000)
+    const event = logger.emit()
+
+    expect(event?.durationMs).toBe(0)
+    expect(event?.duration).toBe('0ms')
+  })
+
   it('allows overrides on emit()', () => {
     const logger = createRequestLogger({})
     logger.set({ original: true })

--- a/packages/evlog/test/core/logger-request-logger.test.ts
+++ b/packages/evlog/test/core/logger-request-logger.test.ts
@@ -445,6 +445,17 @@ describe('createRequestLogger', () => {
     })
   })
 
+  it('includes durationMs as a number alongside the formatted duration', async () => {
+    await withFakeTimers(() => {
+      const logger = createRequestLogger({})
+      vi.advanceTimersByTime(1500)
+      const event = logger.emit()
+
+      expect(event?.durationMs).toBe(1500)
+      expect(event?.duration).toBe('1.50s')
+    })
+  })
+
   it('allows overrides on emit()', () => {
     const logger = createRequestLogger({})
     logger.set({ original: true })

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -205,6 +205,7 @@ describe('createMiddlewareLogger', () => {
 
     expect(event.duration).toBeDefined()
     expect(typeof event.duration).toBe('string')
+    expect(typeof event.durationMs).toBe('number')
   })
 
   it('finish() with warn level when logger has warnings', async () => {

--- a/packages/evlog/test/core/utils.test.ts
+++ b/packages/evlog/test/core/utils.test.ts
@@ -1,6 +1,26 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { colors, formatDuration, getLevelColor, isBrowser, isClient, isDev, isLevelEnabled, isServer, isoNow, matchesPattern } from '../../src/utils'
+import { colors, elapsedMs, formatDuration, getLevelColor, isBrowser, isClient, isDev, isLevelEnabled, isServer, isoNow, matchesPattern } from '../../src/utils'
 import { shouldLog } from '../../src/shared/routes'
+
+describe('elapsedMs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('measures elapsed milliseconds', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValue(5_000)
+
+    expect(elapsedMs(3_500)).toBe(1_500)
+  })
+
+  it('clamps a backward clock step to zero', () => {
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValue(1_000)
+
+    expect(elapsedMs(4_000)).toBe(0)
+  })
+})
 
 describe('formatDuration', () => {
   it('formats milliseconds for duration < 1s', () => {

--- a/packages/evlog/test/e2e/clickhouse-init.sql
+++ b/packages/evlog/test/e2e/clickhouse-init.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS evlog_events
   path          String,
   status        Nullable(UInt16),
   duration      String,
+  duration_ms   Nullable(UInt32),
   error_name    String,
   error_message String,
   data          String


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- clickhouse (ClickHouse drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- loki (Grafana Loki drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added numeric `durationMs` request timing alongside the existing human-readable duration.
  - ClickHouse exports now include a nullable `duration_ms` column for numeric analysis.
  - Pretty-printed logs avoid displaying `durationMs` as an extra event field.

- **Bug Fixes**
  - Request durations are clamped to zero when system clocks move backward.

- **Documentation**
  - Updated integration, querying, filtering, and usage examples to use numeric millisecond durations.
  - Added guidance for ClickHouse schema migration and performance queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->