### PR TITLE
feat: publish wide events on a `node:diagnostics_channel`

### DIFF
--- a/.changeset/diagnostics-channel.md
+++ b/.changeset/diagnostics-channel.md
@@ -1,0 +1,30 @@
+---
+"evlog": minor
+---
+
+feat: publish wide events on a `node:diagnostics_channel`
+
+New opt-in entry point `evlog/diagnostics`. Call `enableDiagnosticsChannel()` once at startup and every emitted wide event is published on the `evlog.event` channel:
+
+```ts
+// server/plugins/evlog-diagnostics.ts
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+export default defineNitroPlugin(async () => {
+  await enableDiagnosticsChannel()
+})
+```
+
+A consumer then subscribes by channel name alone, with no evlog import and no entry in `initLogger()`:
+
+```ts
+import { subscribe } from 'node:diagnostics_channel'
+
+subscribe('evlog.event', ({ event }) => metrics.timing('http.request', event.durationMs))
+```
+
+`subscribeToWideEvents()` is exported for consumers that already depend on evlog and want the payload typed.
+
+Subscribers receive the same object drains receive — post-audit, post-redaction, post-enrich — and must treat it as read-only. They run synchronously and are not awaited: this is an observation side channel, not a transport. On Cloudflare, Workers forwards every channel message to a Tail Worker, so enabling it gets wide events out of an isolate with no drain and no `waitUntil`.
+
+Off by default, and free when off — `node:diagnostics_channel` is loaded lazily so it never enters the main bundle graph, and with the channel enabled but unsubscribed the emit path benchmarks identically to having it disabled.

--- a/apps/docs/content/6.extend/0.overview.md
+++ b/apps/docs/content/6.extend/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Extend evlog
-description: Observe what flows through the pipeline (stream, fs reader, consumer recipes), plug into the pipeline (plugins, enrichers, tail sampling, identity headers), or build your own bricks (custom drains, drain pipeline, custom framework integration).
+description: Observe what flows through the pipeline (stream, fs reader, diagnostics channel, consumer recipes), plug into the pipeline (plugins, enrichers, tail sampling, identity headers), or build your own bricks (custom drains, drain pipeline, custom framework integration).
 navigation:
   title: Overview
   icon: i-lucide-blocks
@@ -43,7 +43,8 @@ your app code
 ┌─────────────────────────────────────────┐    ┌─────────────────────┐
 │   stream (in-process + SSE bridge)      │    │   custom drains     │
 │   fs reader (NDJSON history)            │    │   drain pipeline    │
-│   consumer recipes (devtools, dashboards)│    │   (batch + fanout)  │
+│   diagnostics channel (evlog.event)     │    │   (batch + fanout)  │
+│   consumer recipes (devtools, dashboards)│    │                     │
 └─────────────────────────────────────────┘    └─────────────────────┘
 ```
 
@@ -51,13 +52,14 @@ your app code
 
 ### Observe the pipeline (no mutation)
 
-Subscribe to events without changing what gets emitted. The stream is the live feed, the fs reader is the historic log, and consumer recipes show you how to wire either to a devtool, dashboard, CLI tail, or `curl` + `jq`.
+Subscribe to events without changing what gets emitted. The stream is the live feed, the fs reader is the historic log, the diagnostics channel lets a consumer subscribe by channel name alone, and consumer recipes show you how to wire any of them to a devtool, dashboard, CLI tail, or `curl` + `jq`.
 
 | You want to… | Use |
 | --- | --- |
 | Subscribe to live events (in-process or over SSE for browsers / CLIs) | [Stream](/extend/stream) |
 | Replay or tail historic events from disk | [FS reader](/extend/fs-reader) |
 | Build a small consumer panel, devtool, or pipe to `curl` + `jq` | [Consumer recipes](/extend/consumer-recipes) |
+| Let a consumer subscribe without importing evlog, or reach a Cloudflare Tail Worker | [Diagnostics channel](/extend/diagnostics-channel) |
 
 ### Plug into the pipeline
 

--- a/apps/docs/content/6.extend/11.diagnostics-channel.md
+++ b/apps/docs/content/6.extend/11.diagnostics-channel.md
@@ -19,9 +19,30 @@ links:
 
 [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) is the runtime's built-in pub/sub for instrumentation. evlog can publish every wide event on the `evlog.event` channel, so a consumer subscribes by channel name alone — no evlog import, no entry in `initLogger()`.
 
+## What it's for
+
+Two things you cannot do with a [plugin](/extend/plugins) or a [drain](/extend/custom-drains):
+
+- **Ship an evlog integration from a package that does not depend on evlog.** A subscriber only needs the channel name, so a vendor SDK, an internal shared library, or an APM agent can consume wide events without a peer dependency, a version constraint, or a line in your `initLogger()` call.
+- **Get events out of a Cloudflare Worker without a drain.** Workers forwards every channel message to a [Tail Worker](#cloudflare-workers), which runs after the response with its own CPU budget — no `waitUntil`, no drain competing with your request.
+
+For everything else — batching, retry, adding fields, fanning out to several in-process consumers — a plugin or a drain is the better tool. There is a [comparison at the bottom of this page](#when-a-plugin-is-the-better-tool).
+
+## Enabling it
+
 It is off by default. Turn it on once, at startup:
 
-```typescript [server/plugins/evlog-diagnostics.ts]
+```typescript
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+await enableDiagnosticsChannel()
+```
+
+The call takes no options and is the same on every framework — only *where* your app runs startup code differs:
+
+::code-group
+```typescript [Nuxt / Nitro]
+// server/plugins/evlog-diagnostics.ts
 import { enableDiagnosticsChannel } from 'evlog/diagnostics'
 
 export default defineNitroPlugin(async () => {
@@ -29,7 +50,73 @@ export default defineNitroPlugin(async () => {
 })
 ```
 
-`enableDiagnosticsChannel()` is async because it loads `node:diagnostics_channel` lazily — that is what keeps the built-in out of the main bundle for Convex, workerd and other non-Node targets. Events emitted before the promise settles are not published, so call it at startup rather than inside a request.
+```typescript [Next.js]
+// instrumentation.ts
+import { defineNodeInstrumentation } from 'evlog/next/instrumentation'
+
+export const { register, onRequestError } = defineNodeInstrumentation(async () => {
+  const { createInstrumentation } = await import('evlog/next/instrumentation/create')
+  const { enableDiagnosticsChannel } = await import('evlog/diagnostics')
+  const { register: evlogRegister, onRequestError } = createInstrumentation({ service: 'my-app' })
+
+  return {
+    async register() {
+      await evlogRegister()
+      await enableDiagnosticsChannel()
+    },
+    onRequestError,
+  }
+})
+```
+
+```typescript [SvelteKit]
+// src/hooks.server.ts
+import { createEvlogHooks } from 'evlog/sveltekit'
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+await enableDiagnosticsChannel()
+
+export const { handle, handleError } = createEvlogHooks()
+```
+
+```typescript [Hono]
+// Same shape for Express, Fastify, Elysia, NestJS and oRPC:
+// enable once in the server entry, before the app starts serving.
+import { Hono } from 'hono'
+import { evlog } from 'evlog/hono'
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+await enableDiagnosticsChannel()
+
+const app = new Hono()
+app.use(evlog())
+```
+
+```typescript [Cloudflare Workers]
+// src/worker.ts — needs the nodejs_compat flag
+import { initWorkersLogger, withEvlog } from 'evlog/workers'
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+initWorkersLogger({ env: { service: 'my-worker' } })
+await enableDiagnosticsChannel()
+
+export default withEvlog(async (request, env, ctx, log) => {
+  log.set({ action: 'handle_request' })
+  return Response.json({ ok: true })
+})
+```
+
+```typescript [Standalone]
+// Any Node, Bun or Deno entry point
+import { initLogger } from 'evlog'
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+initLogger({ env: { service: 'worker' } })
+await enableDiagnosticsChannel()
+```
+::
+
+`enableDiagnosticsChannel()` is async because it loads `node:diagnostics_channel` lazily — that is what keeps the built-in out of the main bundle for Convex, workerd and other non-Node targets. Events emitted before the promise settles are not published, so call it at startup rather than inside a request. Frameworks whose entry point cannot use top-level `await` should call it from the same place they call `initLogger()`, and await it there.
 
 ::callout{icon="i-lucide-info" color="info"}
 This is an observation side channel, not a transport. Subscribers run synchronously and are not awaited — no batching, no retry, no `waitUntil`. For delivery to a backend, use a [drain](/extend/custom-drains); both see the same event.
@@ -40,12 +127,18 @@ This is an observation side channel, not a transport. Subscribers run synchronou
 The point of the channel is that a consumer needs nothing from evlog but the channel name:
 
 ```typescript [metrics.ts]
-import { subscribe } from 'node:diagnostics_channel'
+import { channel } from 'node:diagnostics_channel'
 
-subscribe('evlog.event', ({ event }) => {
-  if (event.level === 'error') metrics.increment('errors', { path: event.path })
+/** The published message. Declared locally so this file needs no evlog import. */
+type EvlogMessage = { event: Record<string, unknown> & { level: string; service: string } }
+
+channel('evlog.event').subscribe((message) => {
+  const { event } = message as EvlogMessage
+  if (event.level === 'error') metrics.increment('errors', { path: String(event.path ?? 'unknown') })
 })
 ```
+
+Node types the published message as `unknown`, so narrow it once at the top of your handler. `channel(name).subscribe()` is used rather than the module-level `subscribe()` because it exists on every Node that evlog supports.
 
 If you already depend on evlog and want the payload typed:
 
@@ -90,23 +183,88 @@ The event is the live object, not a copy — mutating it mutates what drains rec
 
 In pretty mode (the dev default), tagged logs like `log.info('auth', 'User logged in')` are written straight to the console and never become wide events, so they do not appear on the channel. Wide events themselves are published in both modes.
 
+## What you can build
+
+### An integration that does not depend on evlog
+
+A package that subscribes needs the channel name and nothing else — no `evlog` dependency, no peer range to keep in sync, no wiring in the host app beyond importing it:
+
+```typescript [acme-apm/src/evlog.ts]
+import { channel } from 'node:diagnostics_channel'
+
+type EvlogMessage = {
+  event: Record<string, unknown> & { timestamp: string; level: string; service: string }
+}
+
+channel('evlog.event').subscribe((message) => {
+  const { event } = message as EvlogMessage
+
+  acme.ingest({
+    at: event.timestamp,
+    level: event.level,
+    service: event.service,
+    attributes: event,
+  })
+})
+```
+
+```typescript [the host app]
+import 'acme-apm/evlog'
+```
+
+The same shape works for an internal library shared across services: one package subscribes, every service that imports it reports, and none of them touch `initLogger()`.
+
+### Counters and alerts next to your app
+
+A subscriber is a plain function, so anything you can compute in-process you can compute here — without giving up the drain slot, which stays free for shipping events to your backend:
+
+```typescript [observability.ts]
+import { channel } from 'node:diagnostics_channel'
+
+const errorsByPath = new Map<string, number>()
+
+channel('evlog.event').subscribe((message) => {
+  const { event } = message as { event: Record<string, unknown> & { level: string } }
+  if (event.level !== 'error') return
+
+  const path = String(event.path ?? 'unknown')
+  errorsByPath.set(path, (errorsByPath.get(path) ?? 0) + 1)
+
+  if (typeof event.status === 'number' && event.status >= 500) {
+    void pager.notify(`5xx on ${path}`, { requestId: event.requestId })
+  }
+})
+
+export function errorCounts(): Record<string, number> {
+  return Object.fromEntries(errorsByPath)
+}
+```
+
+A [plugin](/extend/plugins) does this too, and is the better choice when the code lives in your own app. The channel wins when the subscriber ships as a separate package, or when it has to attach without editing the app's logger configuration.
+
 ## Cloudflare Workers
 
-Workers forwards every diagnostics channel message to a [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) automatically. Enable the channel and your wide events leave the isolate with no drain, no `waitUntil`, and their own CPU budget:
+Workers forwards every diagnostics channel message to a [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/). Enable the channel in your Worker and the wide events leave the isolate with no drain, no `waitUntil`, and their own CPU budget — the Tail Worker does the shipping, after the response has already gone out:
 
 ```typescript [tail-worker/index.ts]
 export default {
-  tail(events) {
+  async tail(events) {
     for (const event of events) {
-      for (const message of event.diagnosticsChannelEvents ?? []) {
-        if (message.channel === 'evlog.event') forward(message.message.event)
+      for (const messageData of event.diagnosticsChannelEvents) {
+        if (messageData.channel !== 'evlog.event') continue
+
+        await fetch('https://logs.example.com/ingest', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(messageData.message.event),
+        })
       }
     }
   },
 }
 ```
 
-Requires the `nodejs_compat` flag, and forwarded values must be structured-cloneable.
+Each entry carries `timestamp`, `channel` and `message` — `message` being what evlog published, so the wide event is at `messageData.message.event`. Requires the `nodejs_compat` flag, and messages go through the structured clone algorithm, so only cloneable values survive.
 
 ## When a plugin is the better tool
 

--- a/apps/docs/content/6.extend/11.diagnostics-channel.md
+++ b/apps/docs/content/6.extend/11.diagnostics-channel.md
@@ -1,0 +1,119 @@
+---
+title: Diagnostics Channel
+description: Publish every wide event on a node:diagnostics_channel so any consumer can subscribe without importing evlog — and so Cloudflare forwards them to a Tail Worker with no drain.
+navigation:
+  title: Diagnostics channel
+  icon: i-lucide-radio-tower
+links:
+  - label: Plugins
+    icon: i-lucide-blocks
+    to: /extend/plugins
+    color: neutral
+    variant: subtle
+  - label: Stream
+    icon: i-lucide-radio
+    to: /extend/stream
+    color: neutral
+    variant: subtle
+---
+
+[`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) is the runtime's built-in pub/sub for instrumentation. evlog can publish every wide event on the `evlog.event` channel, so a consumer subscribes by channel name alone — no evlog import, no entry in `initLogger()`.
+
+It is off by default. Turn it on once, at startup:
+
+```typescript [server/plugins/evlog-diagnostics.ts]
+import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+
+export default defineNitroPlugin(async () => {
+  await enableDiagnosticsChannel()
+})
+```
+
+`enableDiagnosticsChannel()` is async because it loads `node:diagnostics_channel` lazily — that is what keeps the built-in out of the main bundle for Convex, workerd and other non-Node targets. Events emitted before the promise settles are not published, so call it at startup rather than inside a request.
+
+::callout{icon="i-lucide-info" color="info"}
+This is an observation side channel, not a transport. Subscribers run synchronously and are not awaited — no batching, no retry, no `waitUntil`. For delivery to a backend, use a [drain](/extend/custom-drains); both see the same event.
+::
+
+## Subscribing
+
+The point of the channel is that a consumer needs nothing from evlog but the channel name:
+
+```typescript [metrics.ts]
+import { subscribe } from 'node:diagnostics_channel'
+
+subscribe('evlog.event', ({ event }) => {
+  if (event.level === 'error') metrics.increment('errors', { path: event.path })
+})
+```
+
+If you already depend on evlog and want the payload typed:
+
+```typescript [metrics.ts]
+import { subscribeToWideEvents } from 'evlog/diagnostics'
+
+const stop = await subscribeToWideEvents((event) => {
+  //                                       ^? WideEvent
+  metrics.timing('http.request', event.durationMs ?? 0, { path: event.path as string })
+})
+```
+
+## What a subscriber receives
+
+The same object a drain receives: post-audit, post-redaction, post-enrich. Requests carry everything enrichers added — geo, user agent, trace context:
+
+```json
+{
+  "timestamp": "2026-08-02T10:23:45.612Z",
+  "level": "error",
+  "service": "checkout",
+  "environment": "production",
+  "method": "POST",
+  "path": "/api/checkout",
+  "status": 500,
+  "duration": "1.20s",
+  "requestId": "4a8ff3a8-...",
+  "user": { "id": "usr_123", "plan": "premium" },
+  "error": { "name": "PaymentDeclined", "message": "Card declined" }
+}
+```
+
+Events emitted outside a request (`log.info({ ... })`, `createLogger().emit()`) arrive without the HTTP fields, and events from `log.fork()` carry `operation` and `_parentRequestId`.
+
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+The event is the live object, not a copy — mutating it mutates what drains receive. Treat it as read-only. And a subscriber that throws is **not** contained: `Channel.publish()` re-raises it as an uncaught exception on the next tick, which is fatal in most apps. Keep subscribers total.
+::
+
+In pretty mode (the dev default), tagged logs like `log.info('auth', 'User logged in')` are written straight to the console and never become wide events, so they do not appear on the channel. Wide events themselves are published in both modes.
+
+## Cloudflare Workers
+
+Workers forwards every diagnostics channel message to a [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) automatically. Enable the channel and your wide events leave the isolate with no drain, no `waitUntil`, and their own CPU budget:
+
+```typescript [tail-worker/index.ts]
+export default {
+  tail(events) {
+    for (const event of events) {
+      for (const message of event.diagnosticsChannelEvents ?? []) {
+        if (message.channel === 'evlog.event') forward(message.message.event)
+      }
+    }
+  },
+}
+```
+
+Requires the `nodejs_compat` flag, and forwarded values must be structured-cloneable.
+
+## When a plugin is the better tool
+
+The channel is not a replacement for [plugins](/extend/plugins) — it is narrower on purpose:
+
+| You want to… | Use |
+| --- | --- |
+| Ship events to a backend, with batching and retry | [Custom drain](/extend/custom-drains) |
+| Add fields to the event before it drains | [Enricher](/extend/custom-enrichers) or a plugin |
+| Fan out to several in-process consumers | Plugins — `initLogger({ plugins: [a, b, c] })` already does this |
+| Subscribe from a package that must not depend on evlog | This channel |
+| Get events out of a Cloudflare Worker without a drain | This channel |
+
+`diagnostics_channel` is in-process: nothing attaches to a running process from the outside. A subscriber's code has to be loaded by your app either way — the channel saves it a line of configuration, not a dependency.

--- a/apps/docs/content/6.extend/11.diagnostics-channel.md
+++ b/apps/docs/content/6.extend/11.diagnostics-channel.md
@@ -49,14 +49,18 @@ subscribe('evlog.event', ({ event }) => {
 
 If you already depend on evlog and want the payload typed:
 
-```typescript [metrics.ts]
+```typescript [alerts.ts]
 import { subscribeToWideEvents } from 'evlog/diagnostics'
 
 const stop = await subscribeToWideEvents((event) => {
   //                                       ^? WideEvent
-  metrics.timing('http.request', event.durationMs ?? 0, { path: event.path as string })
+  if (typeof event.status === 'number' && event.status >= 500) {
+    alerts.push({ path: String(event.path ?? '-'), requestId: String(event.requestId ?? '-') })
+  }
 })
 ```
+
+Fields beyond the [base event](/learn/wide-events) are typed `unknown`, and events emitted outside a request carry no HTTP fields at all — narrow before using them rather than casting.
 
 ## What a subscriber receives
 

--- a/packages/evlog/bench/core/logger.bench.ts
+++ b/packages/evlog/bench/core/logger.bench.ts
@@ -1,8 +1,14 @@
 import { bench, describe } from 'vitest'
 import { createLogger, createRequestLogger } from '../../src/logger'
+import { enableDiagnosticsChannel } from '../../src/diagnostics'
+import { registerWideEventPublisher } from '../../src/shared/wideEventChannel'
 import { initSilentLogger, PAYLOADS } from './_fixtures'
 
 initSilentLogger()
+
+/** Registered once so the enabled/disabled benches differ only by the publish. */
+const disableChannel = await enableDiagnosticsChannel()
+disableChannel()
 
 describe('createLogger', () => {
   bench('no initial context', () => {
@@ -113,5 +119,22 @@ describe('log.set() payload sizes', () => {
     const log = createLogger()
     log.set(PAYLOADS.large)
     log.emit()
+  })
+})
+
+function emitOnce(): void {
+  const log = createRequestLogger({ method: 'POST', path: '/api/checkout' })
+  log.set({ user: { id: '123', plan: 'pro' } })
+  log.emit({ status: 200 })
+}
+
+describe('diagnostics channel', () => {
+  bench('emit — channel disabled', emitOnce, {
+    setup: () => void registerWideEventPublisher(null),
+  })
+
+  bench('emit — channel enabled, no subscriber', emitOnce, {
+    setup: async () => void await enableDiagnosticsChannel(),
+    teardown: () => void registerWideEventPublisher(null),
   })
 })

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -231,6 +231,11 @@
       "import": "./dist/client.mjs",
       "default": "./dist/client.mjs"
     },
+    "./diagnostics": {
+      "types": "./dist/diagnostics.d.mts",
+      "import": "./dist/diagnostics.mjs",
+      "default": "./dist/diagnostics.mjs"
+    },
     "./toolkit": {
       "types": "./dist/toolkit.d.mts",
       "import": "./dist/toolkit.mjs",
@@ -369,6 +374,9 @@
       ],
       "client": [
         "./dist/client.d.mts"
+      ],
+      "diagnostics": [
+        "./dist/diagnostics.d.mts"
       ],
       "toolkit": [
         "./dist/toolkit.d.mts"

--- a/packages/evlog/src/diagnostics.ts
+++ b/packages/evlog/src/diagnostics.ts
@@ -1,0 +1,62 @@
+import type { WideEvent } from './types'
+import { registerWideEventPublisher } from './shared/wideEventChannel'
+
+/**
+ * Channel every emitted wide event is published on.
+ *
+ * Named after the package, matching the convention the ecosystem settled on
+ * (`h3.request`, `srvx.request`, `unstorage.get`).
+ */
+export const EVLOG_EVENT_CHANNEL = 'evlog.event'
+
+/** Message published on {@link EVLOG_EVENT_CHANNEL}. Mirrors `DrainContext`. */
+export interface WideEventMessage {
+  event: WideEvent
+}
+
+/**
+ * Publish every wide event on the `evlog.event` diagnostics channel.
+ *
+ * Call once at startup: events emitted before the returned promise settles are
+ * not published. Subscribers receive the same object drains receive —
+ * post-redaction, post-enrich — and must treat it as read-only. They run
+ * synchronously and are not awaited, so this is an observation side channel,
+ * not a transport: drains stay the right tool for delivery.
+ *
+ * A subscriber that throws is **not** contained: `Channel.publish()` re-raises
+ * it as an uncaught exception on the next tick. Keep subscribers total.
+ *
+ * @returns A disposer that stops publishing.
+ *
+ * @example
+ * ```ts
+ * // server/plugins/evlog-diagnostics.ts
+ * import { enableDiagnosticsChannel } from 'evlog/diagnostics'
+ *
+ * export default defineNitroPlugin(async () => {
+ *   await enableDiagnosticsChannel()
+ * })
+ * ```
+ */
+export async function enableDiagnosticsChannel(): Promise<() => void> {
+  const { createChannelPublisher } = await import('./shared/diagnostics-channel.node.js')
+
+  registerWideEventPublisher(createChannelPublisher(EVLOG_EVENT_CHANNEL))
+
+  return () => registerWideEventPublisher(null)
+}
+
+/**
+ * Typed subscription to {@link EVLOG_EVENT_CHANNEL}.
+ *
+ * Convenience for consumers already depending on evlog. A consumer that should
+ * not depend on evlog subscribes to the channel name directly with
+ * `node:diagnostics_channel`.
+ *
+ * @returns A disposer that unsubscribes.
+ */
+export async function subscribeToWideEvents(listener: (event: WideEvent) => void): Promise<() => void> {
+  const { subscribeToChannel } = await import('./shared/diagnostics-channel.node.js')
+
+  return subscribeToChannel(EVLOG_EVENT_CHANNEL, message => listener((message as WideEventMessage).event))
+}

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -7,6 +7,7 @@ import { createPluginRunner, getEmptyPluginRunner } from './shared/plugin'
 import { buildErrorEntries, compactStackForStorage, PRETTY_ERROR_TREE_SPACER } from './shared/pretty-error'
 import { resolveDevTerminal } from './shared/dev-terminal'
 import { globalConfig } from './shared/globalRegistry'
+import { publishWideEvent } from './shared/wideEventChannel'
 import { EvlogError } from './error'
 import { colors, cssColors, detectEnvironment, escapeFormatString, formatDuration, getConsoleMethod, getCssLevelColor, getLevelColor, isBrowser, isDev, isLevelEnabled, isoNow, matchesPattern } from './utils'
 
@@ -292,6 +293,8 @@ function emitWideEvent(
   }
 
   if (!deferDrain) {
+    publishWideEvent(formatted)
+
     const drainPromises: Array<Promise<unknown>> = []
     if (state.drain) {
       drainPromises.push(

--- a/packages/evlog/src/shared/diagnostics-channel.node.ts
+++ b/packages/evlog/src/shared/diagnostics-channel.node.ts
@@ -1,4 +1,4 @@
-import { channel, subscribe, unsubscribe } from 'node:diagnostics_channel'
+import { channel } from 'node:diagnostics_channel'
 import type { WideEvent } from '../types'
 
 /**
@@ -15,8 +15,18 @@ export function createChannelPublisher(name: string): (event: WideEvent) => void
   }
 }
 
-/** Subscribe to `name`, returning an unsubscribe. @internal */
+/**
+ * Subscribe to `name`, returning an unsubscribe.
+ *
+ * Uses the channel instance methods rather than the module-level
+ * `subscribe()` / `unsubscribe()`, which only exist from Node 18.7 — below the
+ * `>=18.0.0` this package declares.
+ *
+ * @internal
+ */
 export function subscribeToChannel(name: string, onMessage: (message: unknown) => void): () => void {
-  subscribe(name, onMessage)
-  return () => unsubscribe(name, onMessage)
+  const eventChannel = channel(name)
+
+  eventChannel.subscribe(onMessage)
+  return () => eventChannel.unsubscribe(onMessage)
 }

--- a/packages/evlog/src/shared/diagnostics-channel.node.ts
+++ b/packages/evlog/src/shared/diagnostics-channel.node.ts
@@ -1,0 +1,22 @@
+import { channel, subscribe, unsubscribe } from 'node:diagnostics_channel'
+import type { WideEvent } from '../types'
+
+/**
+ * Build a publisher bound to `name`. Kept in a `.node` module so the static
+ * `node:diagnostics_channel` import never reaches the main bundle graph.
+ *
+ * @internal
+ */
+export function createChannelPublisher(name: string): (event: WideEvent) => void {
+  const eventChannel = channel(name)
+
+  return (event) => {
+    if (eventChannel.hasSubscribers) eventChannel.publish({ event })
+  }
+}
+
+/** Subscribe to `name`, returning an unsubscribe. @internal */
+export function subscribeToChannel(name: string, onMessage: (message: unknown) => void): () => void {
+  subscribe(name, onMessage)
+  return () => unsubscribe(name, onMessage)
+}

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -7,6 +7,7 @@ import type { EvlogPlugin, PluginRunner } from './plugin'
 import { createPluginRunner, getEmptyPluginRunner } from './plugin'
 import { shouldLog, getServiceForPath } from './routes'
 import { extendDeferredDrain } from './deferred-drain'
+import { hasWideEventPublisher, publishWideEvent } from './wideEventChannel'
 import { bindStreamingResponseLifecycle, shouldDeferEmitForResponse } from './streamResponse'
 
 /**
@@ -179,6 +180,7 @@ export async function runEnrichAndDrain(
     }
   }
 
+  publishWideEvent(emittedEvent)
   markWideEventDrainStarted(emittedEvent)
 
   const drain = options.drain ?? getGlobalDrain()
@@ -320,7 +322,7 @@ export function createMiddlewareLogger(options: MiddlewareLoggerOptions): Middle
 
     if (
       emittedEvent
-      && (options.enrich || options.drain || pluginRunner.hasEnrich || pluginRunner.hasDrain || getGlobalDrain())
+      && (options.enrich || options.drain || pluginRunner.hasEnrich || pluginRunner.hasDrain || getGlobalDrain() || hasWideEventPublisher())
     ) {
       await runEnrichAndDrain(emittedEvent, options, requestInfo, resolvedStatus, pluginRunner)
     }

--- a/packages/evlog/src/shared/wideEventChannel.ts
+++ b/packages/evlog/src/shared/wideEventChannel.ts
@@ -1,0 +1,40 @@
+import type { WideEvent } from '../types'
+
+/** @internal Publisher registered by `evlog/diagnostics`. */
+type WideEventPublisher = (event: WideEvent) => void
+
+let publisher: WideEventPublisher | null = null
+
+/**
+ * Register the sink that receives every emitted wide event.
+ *
+ * Kept here so the core never imports `node:diagnostics_channel` — the
+ * publisher lives in the `evlog/diagnostics` entry point and registers itself.
+ *
+ * @internal
+ */
+export function registerWideEventPublisher(fn: WideEventPublisher | null): void {
+  publisher = fn
+}
+
+/** Whether a publisher is registered. @internal */
+export function hasWideEventPublisher(): boolean {
+  return publisher !== null
+}
+
+/**
+ * Hand an emitted wide event to the registered publisher, if any.
+ *
+ * Subscriber failures are contained the same way drain failures are: logged,
+ * never propagated to the request.
+ *
+ * @internal
+ */
+export function publishWideEvent(event: WideEvent): void {
+  if (!publisher) return
+  try {
+    publisher(event)
+  } catch (err) {
+    console.error('[evlog] diagnostics channel publish failed:', err)
+  }
+}

--- a/packages/evlog/test/build/node-imports.test.ts
+++ b/packages/evlog/test/build/node-imports.test.ts
@@ -52,8 +52,8 @@ function collectRelativeImports(entryPath: string): string[] {
 }
 
 function assertNoNodeBuiltins(source: string, label: string): void {
-  expect(source, label).not.toMatch(/import\s*\(\s*['"]node:(crypto|fs|path|module)['"]/)
-  expect(source, label).not.toMatch(/from\s+['"]node:(crypto|fs|path|module)['"]/)
+  expect(source, label).not.toMatch(/import\s*\(\s*['"]node:(crypto|fs|path|module|diagnostics_channel)['"]/)
+  expect(source, label).not.toMatch(/from\s+['"]node:(crypto|fs|path|module|diagnostics_channel)['"]/)
   expect(source, label).not.toContain('pretty-error-snippet.node')
 }
 
@@ -80,5 +80,15 @@ describe.skipIf(!distExists)('dist node built-in imports (#387)', () => {
 
   it('index entry does not pull pretty-error-snippet.node', () => {
     assertNoNodeBuiltins(readDist('index.mjs'), 'index.mjs')
+  })
+
+  it('the diagnostics channel stays out of the index graph', () => {
+    for (const chunk of collectRelativeImports('index.mjs')) {
+      assertNoNodeBuiltins(readDist(chunk), chunk)
+    }
+
+    const nodeChunk = listDistFiles().find(file => /^diagnostics-channel\.node-/.test(file))
+    expect(nodeChunk, 'expected a lazily-imported diagnostics-channel.node chunk').toBeDefined()
+    expect(readDist(nodeChunk!)).toMatch(/from\s+["']node:diagnostics_channel["']/)
   })
 })

--- a/packages/evlog/test/shared/diagnostics-channel.test.ts
+++ b/packages/evlog/test/shared/diagnostics-channel.test.ts
@@ -1,0 +1,144 @@
+import { subscribe, unsubscribe } from 'node:diagnostics_channel'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLogger, initLogger, log } from '../../src/logger'
+import { createMiddlewareLogger } from '../../src/shared/middleware'
+import { EVLOG_EVENT_CHANNEL, enableDiagnosticsChannel, subscribeToWideEvents } from '../../src/diagnostics'
+import type { WideEventMessage } from '../../src/diagnostics'
+import type { WideEvent } from '../../src/types'
+import { registerWideEventPublisher } from '../../src/shared/wideEventChannel'
+import { defined } from '../helpers/defined'
+
+describe('evlog.event diagnostics channel', () => {
+  let disable: (() => void) | undefined
+  let received: WideEvent[]
+  let listener: (message: unknown) => void
+
+  beforeEach(() => {
+    initLogger({ env: { service: 'test-app' }, pretty: false })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    received = []
+    listener = message => received.push((message as WideEventMessage).event)
+    subscribe(EVLOG_EVENT_CHANNEL, listener)
+  })
+
+  afterEach(() => {
+    unsubscribe(EVLOG_EVENT_CHANNEL, listener)
+    disable?.()
+    disable = undefined
+    initLogger({ env: { service: 'test-app' }, pretty: false })
+    vi.restoreAllMocks()
+  })
+
+  it('publishes nothing until the channel is enabled', () => {
+    log.info({ action: 'before_enable' })
+
+    expect(received).toHaveLength(0)
+  })
+
+  it('publishes an event emitted outside a request', async () => {
+    disable = await enableDiagnosticsChannel()
+
+    createLogger({ action: 'cron_completed', deleted: 42 }).emit()
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ action: 'cron_completed', deleted: 42, service: 'test-app' })
+  })
+
+  it('publishes a request event after enrichers have run', async () => {
+    disable = await enableDiagnosticsChannel()
+
+    const { finish } = createMiddlewareLogger({
+      method: 'POST',
+      path: '/api/checkout',
+      enrich: ({ event }) => {
+        event.geo = { country: 'FR' }
+      },
+    })
+    await finish({ status: 200 })
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ method: 'POST', path: '/api/checkout', status: 200, geo: { country: 'FR' } })
+  })
+
+  it('publishes a request event when no drain and no enricher are configured', async () => {
+    disable = await enableDiagnosticsChannel()
+
+    const { finish } = createMiddlewareLogger({ method: 'GET', path: '/api/users' })
+    await finish({ status: 200 })
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ method: 'GET', path: '/api/users' })
+  })
+
+  it('publishes once for a request that also has a drain', async () => {
+    disable = await enableDiagnosticsChannel()
+    const drain = vi.fn()
+
+    const { finish } = createMiddlewareLogger({ method: 'GET', path: '/api/users', drain })
+    await finish({ status: 200 })
+
+    expect(received).toHaveLength(1)
+    expect(drain).toHaveBeenCalledTimes(1)
+    expect(received[0]).toBe(defined(drain.mock.calls[0]?.[0], 'drain context').event)
+  })
+
+  it('publishes the redacted event', async () => {
+    initLogger({
+      env: { service: 'test-app' },
+      pretty: false,
+      redact: { paths: ['user.email'] },
+    })
+    disable = await enableDiagnosticsChannel()
+
+    createLogger({ user: { id: 'u-1', email: 'user@example.com' } }).emit()
+
+    expect(received).toHaveLength(1)
+    expect((received[0]?.user as Record<string, unknown>).email).not.toBe('user@example.com')
+  })
+
+  it('contains a throwing publisher without breaking emit or the drain', async () => {
+    registerWideEventPublisher(() => {
+      throw new Error('publisher exploded')
+    })
+    const drain = vi.fn()
+
+    try {
+      const { finish } = createMiddlewareLogger({ method: 'GET', path: '/api/users', drain })
+      const event = await finish({ status: 200 })
+
+      expect(event).not.toBeNull()
+      expect(drain).toHaveBeenCalledTimes(1)
+      expect(console.error).toHaveBeenCalledWith('[evlog] diagnostics channel publish failed:', expect.any(Error))
+    } finally {
+      registerWideEventPublisher(null)
+    }
+  })
+
+  it('stops publishing once disabled', async () => {
+    const stop = await enableDiagnosticsChannel()
+    stop()
+
+    createLogger({ action: 'after_disable' }).emit()
+
+    expect(received).toHaveLength(0)
+  })
+
+  describe('subscribeToWideEvents', () => {
+    it('delivers typed events and unsubscribes', async () => {
+      disable = await enableDiagnosticsChannel()
+      const seen: WideEvent[] = []
+      const stop = await subscribeToWideEvents(event => seen.push(event))
+
+      createLogger({ action: 'first' }).emit()
+      stop()
+      createLogger({ action: 'second' }).emit()
+
+      expect(seen).toHaveLength(1)
+      expect(seen[0]).toMatchObject({ action: 'first' })
+    })
+  })
+})

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -97,6 +97,11 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "sendToDatadog",
     "toDatadogLog",
   ],
+  "./diagnostics": [
+    "EVLOG_EVENT_CHANNEL",
+    "enableDiagnosticsChannel",
+    "subscribeToWideEvents",
+  ],
   "./elysia": [
     "evlog",
     "useLogger",

--- a/packages/evlog/tsdown.config.ts
+++ b/packages/evlog/tsdown.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     'adapters/memory': 'src/adapters/memory.ts',
     'enrichers': 'src/enrichers/index.ts',
     'pipeline': 'src/pipeline.ts',
+    'diagnostics': 'src/diagnostics.ts',
     'stream': 'src/stream.ts',
     'http': 'src/http.ts',
     'browser': 'src/browser.ts',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- clickhouse (ClickHouse drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- eve (eve agent integration)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- loki (Grafana Loki drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional diagnostics-channel support for consuming enriched, audited, and redacted wide events.
  * Added typed subscription and unsubscribe APIs through the new `evlog/diagnostics` entry point.
  * Diagnostics publishing is disabled by default and loads only when enabled.
  * Events are delivered synchronously without delaying application processing.
  * Added support for forwarding events to Cloudflare Tail Workers.

* **Documentation**
  * Added setup guidance, compatibility details, usage examples, and recommendations for diagnostics-channel consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->