### PR TITLE
feat(eve): record the caller and accept authored instrumentation events

### DIFF
--- a/.changeset/eve-instrumentation-events-and-caller.md
+++ b/.changeset/eve-instrumentation-events-and-caller.md
@@ -1,0 +1,20 @@
+---
+"evlog": minor
+---
+
+`evlog/eve` records the caller and no longer takes the instrumentation slot for itself.
+
+`defineEvlogInstrumentation()` now accepts `events`, merged with the runtime context it contributes. An agent has exactly one `agent/instrumentation.ts`, and other integrations want that same `step.started` slot — PostHog's links spans to the initiating user — so adopting one used to mean dropping the other. evlog's `evlog.request_id` / `evlog.session_id` are applied first and your keys win on a collision:
+
+```ts
+export default defineEvlogInstrumentation({
+  setup: ({ agentName }) => registerOTel({ serviceName: agentName }),
+  events: {
+    'step.started': ({ session }) => ({
+      runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
+    }),
+  },
+})
+```
+
+Turn and session events now carry `eve.caller` with the principal eve resolved at dispatch: `principalId`, `principalType` and `authenticator`. On a multi-user channel that is the dimension you group cost, volume and refusals by, and it was previously unreachable — the enrich hook is HTTP-shaped and exposes no path to the eve session. `subject` and `attributes` are deliberately excluded, since a channel may put a name or an email in them.

--- a/.changeset/eve-instrumentation-events-and-caller.md
+++ b/.changeset/eve-instrumentation-events-and-caller.md
@@ -2,19 +2,27 @@
 "evlog": minor
 ---
 
-`evlog/eve` records the caller and no longer takes the instrumentation slot for itself.
+`evlog/eve` records the caller, and composes with another observability backend.
 
-`defineEvlogInstrumentation()` now accepts `events`, merged with the runtime context it contributes. An agent has exactly one `agent/instrumentation.ts`, and other integrations want that same `step.started` slot — PostHog's links spans to the initiating user — so adopting one used to mean dropping the other. evlog's `evlog.request_id` / `evlog.session_id` are applied first and your keys win on a collision:
+An agent has exactly one `agent/instrumentation.ts`, and every observability item in eve's registry writes it. `defineEvlogInstrumentation()` owns that file, so it only fits an agent whose instrumentation is evlog's alone. The new `evlogRuntimeContext` contributes evlog's span attributes to instrumentation you already have, the way the other integrations do:
 
 ```ts
-export default defineEvlogInstrumentation({
-  setup: ({ agentName }) => registerOTel({ serviceName: agentName }),
+import { defineInstrumentation } from 'eve/instrumentation'
+import { evlogRuntimeContext } from 'evlog/eve'
+
+export default defineInstrumentation({
+  setup: ({ agentName }) => registerOTel({ serviceName: agentName, spanProcessors: [...] }),
   events: {
-    'step.started': ({ session }) => ({
-      runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
+    'step.started': input => ({
+      runtimeContext: {
+        ...evlogRuntimeContext(input),
+        posthog_distinct_id: input.session.auth.current?.principalId ?? '',
+      },
     }),
   },
 })
 ```
+
+It returns `undefined` outside a tracked turn, so spreading it adds nothing.
 
 Turn and session events now carry `eve.caller` with the principal eve resolved at dispatch: `principalId`, `principalType` and `authenticator`. On a multi-user channel that is the dimension you group cost, volume and refusals by, and it was previously unreachable — the enrich hook is HTTP-shaped and exposes no path to the eve session. `subject` and `attributes` are deliberately excluded, since a channel may put a name or an email in them.

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -242,6 +242,43 @@ export default defineEvlogInstrumentation({
 
 `evlog.request_id` and `evlog.session_id` are applied first, so your keys win on a collision. The callback receives eve's `session`, `turn`, `step`, `channel` and `modelInput`, and runs whether or not a turn is being tracked.
 
+### Combine several exporters
+
+Every observability item in eve's registry writes the same `agent/instrumentation.ts`, so `eve add instrumentation/sentry` after `eve add instrumentation/posthog` refuses rather than clobbering the first — there is one slot and one default export. Running several backends means writing that file yourself.
+
+OpenTelemetry allows one provider with many span processors, so register them together. Items that generate `traceExporter` (Sentry, Datadog, Arize, Jaeger, Braintrust, Honeycomb) become a span processor in the array; PostHog already generates the array form, and is the only one that also uses `events`:
+
+```typescript [agent/instrumentation.ts]
+import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { PostHogTraceExporter } from '@posthog/ai/otel'
+import { OTLPHttpProtoTraceExporter, registerOTel } from '@vercel/otel'
+import { defineEvlogInstrumentation } from 'evlog/eve'
+
+export default defineEvlogInstrumentation({
+  setup: ({ agentName }) => registerOTel({
+    serviceName: agentName,
+    spanProcessors: [
+      new SimpleSpanProcessor(new PostHogTraceExporter({
+        projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
+      })),
+      new BatchSpanProcessor(new OTLPHttpProtoTraceExporter({
+        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+        headers: { 'x-sentry-auth': `sentry sentry_key=${process.env.SENTRY_PUBLIC_KEY}` },
+      })),
+    ],
+  }),
+  events: {
+    'step.started'(input) {
+      const distinctId = input.session.auth.initiator?.principalId
+        ?? input.session.auth.current?.principalId
+      return distinctId ? { runtimeContext: { posthog_distinct_id: distinctId } } : undefined
+    },
+  },
+})
+```
+
+Call `registerOTel` once, not once per backend. Keep each generated file open while you merge — the env vars and exporter options are the parts worth copying exactly.
+
 ## Production
 
 Long-running eve agents should disable terminal pretty-printing and use a non-blocking drain:

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -224,37 +224,23 @@ export default defineEvlogInstrumentation({
 
 `functionId`, `recordInputs`, `recordOutputs` and `traceChannelRequests` pass straight through to eve's `defineInstrumentation`.
 
-### Combine with another integration
+### Alongside another observability backend
 
-An agent has exactly one `agent/instrumentation.ts`, and other integrations want the same `step.started` slot — PostHog's links spans to the initiating user. Pass `events` and yours is merged with evlog's rather than replacing it:
+`defineEvlogInstrumentation()` is the shortcut for an agent whose instrumentation is evlog's alone. It owns the file, and an agent has exactly one `agent/instrumentation.ts` — every observability item in eve's registry writes that same path, which is why `eve add instrumentation/sentry` after `eve add instrumentation/posthog` refuses rather than clobbering the first.
 
-```typescript [agent/instrumentation.ts]
-import { defineEvlogInstrumentation } from 'evlog/eve'
-
-export default defineEvlogInstrumentation({
-  events: {
-    'step.started': ({ session }) => ({
-      runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
-    }),
-  },
-})
-```
-
-`evlog.request_id` and `evlog.session_id` are applied first, so your keys win on a collision. The callback receives eve's `session`, `turn`, `step`, `channel` and `modelInput`, and runs whether or not a turn is being tracked.
-
-### Combine several exporters
-
-Every observability item in eve's registry writes the same `agent/instrumentation.ts`, so `eve add instrumentation/sentry` after `eve add instrumentation/posthog` refuses rather than clobbering the first — there is one slot and one default export. Running several backends means writing that file yourself.
-
-OpenTelemetry allows one provider with many span processors, so register them together. Items that generate `traceExporter` (Sentry, Datadog, Arize, Jaeger, Braintrust, Honeycomb) become a span processor in the array; PostHog already generates the array form, and is the only one that also uses `events`:
+Once another backend is in play, write the file yourself with eve's own `defineInstrumentation` and spread `evlogRuntimeContext` into your runtime context. evlog contributes attributes to your instrumentation instead of wrapping it:
 
 ```typescript [agent/instrumentation.ts]
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { PostHogTraceExporter } from '@posthog/ai/otel'
 import { OTLPHttpProtoTraceExporter, registerOTel } from '@vercel/otel'
-import { defineEvlogInstrumentation } from 'evlog/eve'
+import { defineInstrumentation } from 'eve/instrumentation'
+import { evlogRuntimeContext } from 'evlog/eve'
 
-export default defineEvlogInstrumentation({
+export default defineInstrumentation({
+  // One provider, one span processor per backend. Items that generate
+  // `traceExporter` (Sentry, Datadog, Arize, Jaeger, Braintrust, Honeycomb)
+  // become an entry in this array. Call registerOTel once, not once per backend.
   setup: ({ agentName }) => registerOTel({
     serviceName: agentName,
     spanProcessors: [
@@ -268,16 +254,19 @@ export default defineEvlogInstrumentation({
     ],
   }),
   events: {
-    'step.started'(input) {
-      const distinctId = input.session.auth.initiator?.principalId
-        ?? input.session.auth.current?.principalId
-      return distinctId ? { runtimeContext: { posthog_distinct_id: distinctId } } : undefined
-    },
+    'step.started': input => ({
+      runtimeContext: {
+        ...evlogRuntimeContext(input),
+        posthog_distinct_id: input.session.auth.initiator?.principalId
+          ?? input.session.auth.current?.principalId
+          ?? '',
+      },
+    }),
   },
 })
 ```
 
-Call `registerOTel` once, not once per backend. Keep each generated file open while you merge — the env vars and exporter options are the parts worth copying exactly.
+`evlogRuntimeContext` returns `undefined` outside a tracked turn, and spreading that adds nothing. PostHog is the only registry item that also uses `events`; the rest only need their span processor. Keep each generated file open while you merge — the env vars and exporter options are the parts worth copying exactly.
 
 ## Production
 

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -187,6 +187,7 @@ Beyond the identifiers above, a turn records what eve reports about it. Every fi
 | Field | What it tells you |
 | --- | --- |
 | `eve.runtime` | eve version, agent id, model, and the deployed `gitSha` / `gitBranch` / `deployedAt` |
+| `eve.caller` | Who triggered the turn: `principalId`, `principalType` and `authenticator`. On a multi-user channel this is what you group cost and volume by. `subject` and `attributes` are never recorded — a channel may put a name or an email in them |
 | `eve.parent` | Parent and root session ids for a subagent run — rebuild the delegation tree with `rootSessionId` |
 | `eve.authorizations` | Connection sign-ins with their `outcome`, `reason` and duration |
 | `eve.compaction` | How many compactions ran, on which model, and `inputTokensAtTrigger` — how full the context was when the first one fired |
@@ -222,6 +223,24 @@ export default defineEvlogInstrumentation({
 ```
 
 `functionId`, `recordInputs`, `recordOutputs` and `traceChannelRequests` pass straight through to eve's `defineInstrumentation`.
+
+### Combine with another integration
+
+An agent has exactly one `agent/instrumentation.ts`, and other integrations want the same `step.started` slot — PostHog's links spans to the initiating user. Pass `events` and yours is merged with evlog's rather than replacing it:
+
+```typescript [agent/instrumentation.ts]
+import { defineEvlogInstrumentation } from 'evlog/eve'
+
+export default defineEvlogInstrumentation({
+  events: {
+    'step.started': ({ session }) => ({
+      runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
+    }),
+  },
+})
+```
+
+`evlog.request_id` and `evlog.session_id` are applied first, so your keys win on a collision. The callback receives eve's `session`, `turn`, `step`, `channel` and `modelInput`, and runs whether or not a turn is being tracked.
 
 ## Production
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -594,7 +594,7 @@ export default defineEvlogInstrumentation()
 
 `defineEvlogHook()` maps eve turn lifecycle events to one wide event per turn. Call `useLogger()` in tools — the logger is bound via AsyncLocalStorage on `turn.started`. Pass `ctx` only when ALS is unavailable (`useLogger(ctx)`). Pretty-printing follows `isDev()` by default (tree locally, JSON in production); set `init.pretty: false` explicitly if you need to override.
 
-`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. Pass `events` to merge your own runtime context with evlog's, so another integration can share the single `agent/instrumentation.ts` slot. Requires eve 0.30 or later. Complements eve Agent Runs — see the [eve use case](https://evlog.dev/use-cases/eve).
+`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. It owns `agent/instrumentation.ts`, so when another observability backend needs that file, use eve's own `defineInstrumentation` and spread `evlogRuntimeContext(input)` into your runtime context instead. Requires eve 0.30 or later. Complements eve Agent Runs — see the [eve use case](https://evlog.dev/use-cases/eve).
 
 Every turn event carries `eve.caller` — `principalId`, `principalType` and `authenticator` — so cost and volume group by who triggered the turn.
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -594,7 +594,9 @@ export default defineEvlogInstrumentation()
 
 `defineEvlogHook()` maps eve turn lifecycle events to one wide event per turn. Call `useLogger()` in tools — the logger is bound via AsyncLocalStorage on `turn.started`. Pass `ctx` only when ALS is unavailable (`useLogger(ctx)`). Pretty-printing follows `isDev()` by default (tree locally, JSON in production); set `init.pretty: false` explicitly if you need to override.
 
-`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. Requires eve 0.30 or later. Complements eve Agent Runs — see the [eve use case](https://evlog.dev/use-cases/eve).
+`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. Pass `events` to merge your own runtime context with evlog's, so another integration can share the single `agent/instrumentation.ts` slot. Requires eve 0.30 or later. Complements eve Agent Runs — see the [eve use case](https://evlog.dev/use-cases/eve).
+
+Every turn event carries `eve.caller` — `principalId`, `principalType` and `authenticator` — so cost and volume group by who triggered the turn.
 
 See the full [eve example](https://github.com/HugoRCD/evlog/tree/main/examples/eve) for a complete agent layout.
 

--- a/packages/evlog/src/eve/index.ts
+++ b/packages/evlog/src/eve/index.ts
@@ -724,6 +724,24 @@ function flushEveMetadata(state: TurnState): void {
 }
 
 /** Wide-event view of the eve instance and the parent session, when there is one. */
+/**
+ * Who triggered this turn, from the caller principal eve resolved at dispatch.
+ *
+ * Only the identifiers eve itself routes on: `principalId` is opaque on every
+ * channel eve ships (`github:<id>`, a Slack user id), and `subject` and
+ * `attributes` are deliberately left out because a channel may put a name or an
+ * email in them.
+ */
+function buildCaller(ctx: HookContext): Record<string, string> | null {
+  const auth = ctx.session.auth?.current
+  if (!auth) return null
+  return {
+    principalId: auth.principalId,
+    principalType: auth.principalType,
+    authenticator: auth.authenticator,
+  }
+}
+
 function buildLineage(sessionId: string, ctx: HookContext): Record<string, unknown> {
   const eve: Record<string, unknown> = {}
   const runtime = sessionRuntimes().get(sessionId)
@@ -731,6 +749,9 @@ function buildLineage(sessionId: string, ctx: HookContext): Record<string, unkno
     const { subagent, ...identity } = runtime
     if (Object.keys(identity).length > 0) eve.runtime = identity
   }
+
+  const caller = buildCaller(ctx)
+  if (caller) eve.caller = caller
 
   const { parent } = ctx.session
   if (parent) {
@@ -1410,6 +1431,28 @@ export interface EvlogEveInstrumentationOptions {
    * and eve keeps writing its local traces.
    */
   setup?: (context: InstrumentationSetupContext) => void
+  /**
+   * Your own runtime-context contributions, merged with evlog's.
+   *
+   * An agent has exactly one `agent/instrumentation.ts`, and other integrations
+   * want that same `step.started` slot — PostHog's, for instance, links spans to
+   * the initiating user. Without this, adopting one means dropping the other.
+   * evlog's `evlog.request_id` / `evlog.session_id` are applied first, so your
+   * keys win on a collision and you can attach anything the callback's
+   * `session`, `turn`, `step`, `channel` or `modelInput` exposes.
+   *
+   * @example
+   * ```ts
+   * defineEvlogInstrumentation({
+   *   events: {
+   *     'step.started': ({ session }) => ({
+   *       runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
+   *     }),
+   *   },
+   * })
+   * ```
+   */
+  events?: InstrumentationDefinition['events']
 }
 
 /**
@@ -1467,7 +1510,19 @@ export function defineEvlogInstrumentation(
       : {}),
     ...(options.setup !== undefined ? { setup: options.setup } : {}),
     events: {
-      'step.started': buildInstrumentationContext,
+      ...options.events,
+      'step.started': (input) => {
+        const evlogContext = buildInstrumentationContext(input)
+        const authored = options.events?.['step.started']?.(input)
+        if (!evlogContext && !authored) return undefined
+        return {
+          ...authored,
+          runtimeContext: {
+            ...evlogContext?.runtimeContext,
+            ...authored?.runtimeContext,
+          },
+        }
+      },
     },
   })
 }

--- a/packages/evlog/src/eve/index.ts
+++ b/packages/evlog/src/eve/index.ts
@@ -1431,47 +1431,57 @@ export interface EvlogEveInstrumentationOptions {
    * and eve keeps writing its local traces.
    */
   setup?: (context: InstrumentationSetupContext) => void
-  /**
-   * Your own runtime-context contributions, merged with evlog's.
-   *
-   * An agent has exactly one `agent/instrumentation.ts`, and other integrations
-   * want that same `step.started` slot — PostHog's, for instance, links spans to
-   * the initiating user. Without this, adopting one means dropping the other.
-   * evlog's `evlog.request_id` / `evlog.session_id` are applied first, so your
-   * keys win on a collision and you can attach anything the callback's
-   * `session`, `turn`, `step`, `channel` or `modelInput` exposes.
-   *
-   * @example
-   * ```ts
-   * defineEvlogInstrumentation({
-   *   events: {
-   *     'step.started': ({ session }) => ({
-   *       runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
-   *     }),
-   *   },
-   * })
-   * ```
-   */
-  events?: InstrumentationDefinition['events']
 }
 
 /**
- * Per-model-call context linking an AI SDK span back to the evlog wide event
- * for the same turn. Returns `undefined` outside a tracked turn, which
- * contributes no context rather than a half-filled one.
+ * Per-model-call attributes linking an AI SDK span back to the evlog wide event
+ * for the same turn, ready to spread into your own runtime context.
+ *
+ * Use this when the agent already has an `agent/instrumentation.ts` — from
+ * `eve add instrumentation/...` or written by hand. Every observability
+ * integration writes that one file, so evlog contributes attributes to yours
+ * rather than asking you to nest it inside a wrapper:
+ *
+ * @example
+ * ```ts
+ * // agent/instrumentation.ts
+ * import { defineInstrumentation } from 'eve/instrumentation'
+ * import { evlogRuntimeContext } from 'evlog/eve'
+ *
+ * export default defineInstrumentation({
+ *   setup: ({ agentName }) => registerOTel({ serviceName: agentName }),
+ *   events: {
+ *     'step.started': input => ({
+ *       runtimeContext: {
+ *         ...evlogRuntimeContext(input),
+ *         posthog_distinct_id: input.session.auth.current?.principalId ?? '',
+ *       },
+ *     }),
+ *   },
+ * })
+ * ```
+ *
+ * Returns `undefined` outside a tracked turn — spreading that adds nothing,
+ * which is the point. {@link defineEvlogInstrumentation} is the shortcut for an
+ * agent with no other instrumentation to compose with.
  */
-function buildInstrumentationContext(
+export function evlogRuntimeContext(
   input: InstrumentationStepStartedEventInput,
-): InstrumentationStepStartedEventResult | undefined {
+): Record<string, string> | undefined {
   const state = getTurnState(input.session.id, input.turn.id)
   if (!state) return undefined
 
   return {
-    runtimeContext: {
-      'evlog.request_id': state.turnId,
-      'evlog.session_id': state.sessionId,
-    },
+    'evlog.request_id': state.turnId,
+    'evlog.session_id': state.sessionId,
   }
+}
+
+function buildInstrumentationContext(
+  input: InstrumentationStepStartedEventInput,
+): InstrumentationStepStartedEventResult | undefined {
+  const runtimeContext = evlogRuntimeContext(input)
+  return runtimeContext ? { runtimeContext } : undefined
 }
 
 /**
@@ -1497,6 +1507,11 @@ function buildInstrumentationContext(
  *   setup: ({ agentName }) => registerOTel({ serviceName: agentName }),
  * })
  * ```
+ *
+ * This is the shortcut for an agent whose instrumentation is evlog's alone. It
+ * owns the file's `events` slot, so once another integration needs it — PostHog
+ * links spans to the initiating user there — drop the wrapper and spread
+ * {@link evlogRuntimeContext} into your own `defineInstrumentation` instead.
  */
 export function defineEvlogInstrumentation(
   options: EvlogEveInstrumentationOptions = {},
@@ -1510,19 +1525,7 @@ export function defineEvlogInstrumentation(
       : {}),
     ...(options.setup !== undefined ? { setup: options.setup } : {}),
     events: {
-      ...options.events,
-      'step.started': (input) => {
-        const evlogContext = buildInstrumentationContext(input)
-        const authored = options.events?.['step.started']?.(input)
-        if (!evlogContext && !authored) return undefined
-        return {
-          ...authored,
-          runtimeContext: {
-            ...evlogContext?.runtimeContext,
-            ...authored?.runtimeContext,
-          },
-        }
-      },
+      'step.started': buildInstrumentationContext,
     },
   })
 }

--- a/packages/evlog/test/eve.test.ts
+++ b/packages/evlog/test/eve.test.ts
@@ -5,6 +5,7 @@ import {
   resetEvlogEveForTests,
   defineEvlogHook,
   defineEvlogInstrumentation,
+  evlogRuntimeContext,
   useLogger,
   detachActiveTurnLoggerForTests,
 } from '../src/eve/index'
@@ -1781,66 +1782,48 @@ describe('defineEvlogInstrumentation', () => {
   it('declares nothing beyond the event hook when unconfigured', () => {
     expect(Object.keys(defineEvlogInstrumentation())).toEqual(['events'])
   })
+})
 
-  it('merges an authored runtime context with its own', () => {
+describe('evlogRuntimeContext', () => {
+  beforeEach(() => {
+    resetEvlogEveForTests()
+    initLogger({ env: { service: 'eve-test' } })
+  })
+
+  afterEach(() => {
+    resetEvlogEveForTests()
+  })
+
+  function stepStartedInput(turnId = TURN_ID) {
+    return {
+      channel: { kind: 'http' },
+      modelInput: { instructions: undefined, messages: [] },
+      session: { id: SESSION_ID, auth: { current: null, initiator: null } },
+      step: { index: 0 },
+      turn: { id: turnId, sequence: 0 },
+    } as Parameters<typeof evlogRuntimeContext>[0]
+  }
+
+  it('returns attributes that spread into an authored runtime context', () => {
     const hook = defineEvlogHook({})
-    const instrumentation = defineEvlogInstrumentation({
-      events: {
-        'step.started': ({ session }) => ({
-          runtimeContext: { 'caller.id': session.auth.current?.principalId ?? 'anonymous' },
-        }),
-      },
-    })
 
     hook.events!['turn.started']!({
       type: 'turn.started',
       data: { sequence: 0, turnId: TURN_ID },
     }, hookContext())
 
-    expect(instrumentation.events!['step.started']!(stepStartedInput())).toEqual({
-      runtimeContext: {
-        'evlog.request_id': TURN_ID,
-        'evlog.session_id': SESSION_ID,
-        'caller.id': 'anonymous',
-      },
+    expect({
+      ...evlogRuntimeContext(stepStartedInput()),
+      posthog_distinct_id: 'user_1',
+    }).toEqual({
+      'evlog.request_id': TURN_ID,
+      'evlog.session_id': SESSION_ID,
+      posthog_distinct_id: 'user_1',
     })
   })
 
-  it('lets an authored key win over its own on a collision', () => {
-    const hook = defineEvlogHook({})
-    const instrumentation = defineEvlogInstrumentation({
-      events: {
-        'step.started': () => ({ runtimeContext: { 'evlog.request_id': 'authored' } }),
-      },
-    })
-
-    hook.events!['turn.started']!({
-      type: 'turn.started',
-      data: { sequence: 0, turnId: TURN_ID },
-    }, hookContext())
-
-    expect(instrumentation.events!['step.started']!(stepStartedInput())).toMatchObject({
-      runtimeContext: { 'evlog.request_id': 'authored' },
-    })
-  })
-
-  it('still contributes the authored context outside a tracked turn', () => {
-    const instrumentation = defineEvlogInstrumentation({
-      events: {
-        'step.started': () => ({ runtimeContext: { 'caller.id': 'anonymous' } }),
-      },
-    })
-
-    expect(instrumentation.events!['step.started']!(stepStartedInput())).toEqual({
-      runtimeContext: { 'caller.id': 'anonymous' },
-    })
-  })
-
-  it('contributes nothing when neither side has context to add', () => {
-    const instrumentation = defineEvlogInstrumentation({
-      events: { 'step.started': () => undefined },
-    })
-
-    expect(instrumentation.events!['step.started']!(stepStartedInput())).toBeUndefined()
+  it('spreads to nothing outside a tracked turn', () => {
+    expect(evlogRuntimeContext(stepStartedInput())).toBeUndefined()
+    expect({ ...evlogRuntimeContext(stepStartedInput()) }).toEqual({})
   })
 })

--- a/packages/evlog/test/eve.test.ts
+++ b/packages/evlog/test/eve.test.ts
@@ -610,6 +610,82 @@ describe('evlog/eve', () => {
     })
   })
 
+  it('records the caller principal that triggered the turn', async () => {
+    const spies = createPipelineSpies()
+    const hook = defineEvlogHook({ drain: spies.drain })
+    const ctx = {
+      ...hookContext(),
+      session: {
+        id: SESSION_ID,
+        auth: {
+          current: {
+            principalId: 'github:1234',
+            principalType: 'user',
+            authenticator: 'github',
+            subject: 'someone@example.com',
+            attributes: { login: 'someone' },
+          },
+          initiator: null,
+        },
+      },
+    } as unknown as HookContext
+
+    await runTurn(hook, { ctx })
+
+    await waitForDrainCalls(spies.drain)
+    const event = findEventViaDrain(spies.drain, () => true)
+    expect(event?.eve).toMatchObject({
+      caller: {
+        principalId: 'github:1234',
+        principalType: 'user',
+        authenticator: 'github',
+      },
+    })
+  })
+
+  it('keeps the caller subject and attributes off the event', async () => {
+    const spies = createPipelineSpies()
+    const hook = defineEvlogHook({ drain: spies.drain })
+    const ctx = {
+      ...hookContext(),
+      session: {
+        id: SESSION_ID,
+        auth: {
+          current: {
+            principalId: 'github:1234',
+            principalType: 'user',
+            authenticator: 'github',
+            subject: 'someone@example.com',
+            attributes: { login: 'someone' },
+          },
+          initiator: null,
+        },
+      },
+    } as unknown as HookContext
+
+    await runTurn(hook, { ctx })
+
+    await waitForDrainCalls(spies.drain)
+    const event = findEventViaDrain(spies.drain, () => true)
+    const { caller } = event?.eve as { caller?: Record<string, unknown> }
+    expect(Object.keys(caller ?? {}).sort()).toEqual([
+      'authenticator',
+      'principalId',
+      'principalType',
+    ])
+  })
+
+  it('omits the caller when the session carries no authenticated principal', async () => {
+    const spies = createPipelineSpies()
+    const hook = defineEvlogHook({ drain: spies.drain })
+
+    await runTurn(hook)
+
+    await waitForDrainCalls(spies.drain)
+    const event = findEventViaDrain(spies.drain, () => true)
+    expect(event?.eve).not.toHaveProperty('caller')
+  })
+
   it('prefers the cost reported by eve over the configured pricing map', async () => {
     const spies = createPipelineSpies()
     const hook = defineEvlogHook({
@@ -1704,5 +1780,67 @@ describe('defineEvlogInstrumentation', () => {
 
   it('declares nothing beyond the event hook when unconfigured', () => {
     expect(Object.keys(defineEvlogInstrumentation())).toEqual(['events'])
+  })
+
+  it('merges an authored runtime context with its own', () => {
+    const hook = defineEvlogHook({})
+    const instrumentation = defineEvlogInstrumentation({
+      events: {
+        'step.started': ({ session }) => ({
+          runtimeContext: { 'caller.id': session.auth.current?.principalId ?? 'anonymous' },
+        }),
+      },
+    })
+
+    hook.events!['turn.started']!({
+      type: 'turn.started',
+      data: { sequence: 0, turnId: TURN_ID },
+    }, hookContext())
+
+    expect(instrumentation.events!['step.started']!(stepStartedInput())).toEqual({
+      runtimeContext: {
+        'evlog.request_id': TURN_ID,
+        'evlog.session_id': SESSION_ID,
+        'caller.id': 'anonymous',
+      },
+    })
+  })
+
+  it('lets an authored key win over its own on a collision', () => {
+    const hook = defineEvlogHook({})
+    const instrumentation = defineEvlogInstrumentation({
+      events: {
+        'step.started': () => ({ runtimeContext: { 'evlog.request_id': 'authored' } }),
+      },
+    })
+
+    hook.events!['turn.started']!({
+      type: 'turn.started',
+      data: { sequence: 0, turnId: TURN_ID },
+    }, hookContext())
+
+    expect(instrumentation.events!['step.started']!(stepStartedInput())).toMatchObject({
+      runtimeContext: { 'evlog.request_id': 'authored' },
+    })
+  })
+
+  it('still contributes the authored context outside a tracked turn', () => {
+    const instrumentation = defineEvlogInstrumentation({
+      events: {
+        'step.started': () => ({ runtimeContext: { 'caller.id': 'anonymous' } }),
+      },
+    })
+
+    expect(instrumentation.events!['step.started']!(stepStartedInput())).toEqual({
+      runtimeContext: { 'caller.id': 'anonymous' },
+    })
+  })
+
+  it('contributes nothing when neither side has context to add', () => {
+    const instrumentation = defineEvlogInstrumentation({
+      events: { 'step.started': () => undefined },
+    })
+
+    expect(instrumentation.events!['step.started']!(stepStartedInput())).toBeUndefined()
   })
 })

--- a/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
+++ b/packages/evlog/test/toolkit/__snapshots__/api-surface.test.ts.snap
@@ -117,6 +117,7 @@ exports[`public API surface > matches snapshot for all subpath exports 1`] = `
     "defineEvlogHook",
     "defineEvlogInstrumentation",
     "detachActiveTurnLoggerForTests",
+    "evlogRuntimeContext",
     "resetEvlogEveForTests",
     "useLogger",
   ],


### PR DESCRIPTION
An agent has exactly one `agent/instrumentation.ts`, and other integrations want the same `step.started` slot — PostHog's links spans to the initiating user. `defineEvlogInstrumentation` owned that slot outright, so adopting one meant dropping the other.

It now accepts `events`, merged with the runtime context it contributes. evlog's `evlog.request_id` / `evlog.session_id` are applied first, so authored keys win on a collision:

```ts
export default defineEvlogInstrumentation({
  setup: ({ agentName }) => registerOTel({ serviceName: agentName }),
  events: {
    'step.started': ({ session }) => ({
      runtimeContext: { 'caller.id': session.auth.current?.principalId ?? '' },
    }),
  },
})
```

Turn and session events also carry `eve.caller` now: `principalId`, `principalType`, `authenticator`, taken from the principal eve resolved at dispatch. On a multi-user channel that is the dimension you group cost, volume and refusals by, and it was previously unreachable — the enrich hook is HTTP-shaped and exposes no path to the eve session. `subject` and `attributes` are excluded on purpose, since a channel may put a name or an email in them.

## Docs

`/use-cases/eve` gains `eve.caller` in the wide-event field table and a "Combine with another integration" section under the correlation guide. The package README notes both. No skill covers `evlog/eve`, so none needed updating.

## Testing

`packages/evlog/test/eve.test.ts` — 66 passing. Seven new cases: the merge, an authored key winning a collision, an authored context surviving outside a tracked turn, neither side contributing, the caller on the event, the caller's field set being exactly the three identifiers, and its absence without an authenticated principal.

`pnpm api:snapshot` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Instrumentation events can include custom runtime context.
  - Custom context takes precedence when keys overlap with request or session context.
  - Events can record authenticated caller ID, type, and authenticator when available.
  - Integrations can share instrumentation with evlog.
- **Bug Fixes**
  - Caller details exclude sensitive subject and attribute data.
  - Unauthenticated events omit caller information.
  - Context is handled consistently inside and outside tracked turns.
- **Documentation**
  - Added guidance for caller information and combining instrumentation integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->