### PR TITLE
fix(evi): grant schedule sessions the admin observability tools

### DIFF
--- a/apps/evi/agent/lib/trust.ts
+++ b/apps/evi/agent/lib/trust.ts
@@ -42,5 +42,13 @@ export function isAutonomous(auth: SessionAuthContext | null): boolean {
  * which carry no user identity. The weekly self-review runs from a schedule.
  */
 export function canAccessAdminTools(auth: SessionAuthContext | null): boolean {
-  return isMaintainer(auth) || auth?.principalType === 'app'
+  return isMaintainer(auth) || isScheduleAppAuth(auth)
+}
+
+/** The app principal eve stamps on schedule-dispatched turns (eve `channel/schedule-auth`). */
+function isScheduleAppAuth(auth: SessionAuthContext | null): boolean {
+  return auth !== null
+    && auth.authenticator === 'app'
+    && auth.principalId === 'eve:app'
+    && auth.principalType === 'runtime'
 }


### PR DESCRIPTION
`canAccessAdminTools` tested `principalType === 'app'`, but the principal eve stamps on schedule-dispatched turns is `{ authenticator: 'app', principalId: 'eve:app', principalType: 'runtime' }` (eve `channel/schedule-auth`). The predicate never matched, so the morning digest session was denied both admin surfaces: the `ai_gateway__*` tools were absent and the `vercel` connection threw "This tool is not available in the current session", exactly as the 2026-08-09 digest reported.

Match the documented triple instead. No changeset: change confined to `apps/*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted administrative tool access to maintainers and authenticated, authorized application schedule sessions.
  * Prevented other application-principal sessions from receiving administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->