### PR TITLE
fix(evi): keep the fs drain off read-only filesystems

### DIFF
--- a/apps/evi/agent/hooks/evlog.ts
+++ b/apps/evi/agent/hooks/evlog.ts
@@ -4,12 +4,20 @@ import { createFsDrain } from 'evlog/fs'
 import { createDrainPipeline } from 'evlog/pipeline'
 import { environment } from '../lib/environment'
 
-const drain = createDrainPipeline<DrainContext>({
-  batch: { size: 5, intervalMs: 2000 },
-})(createFsDrain())
+/**
+ * The fs drain only runs where the filesystem is writable. On Vercel
+ * everything outside /tmp is read-only, so attaching it there errored on every
+ * flush and persisted nothing; hosted environments run without a drain until a
+ * hosted destination lands (EVL-256).
+ */
+const drain = process.env.VERCEL
+  ? undefined
+  : createDrainPipeline<DrainContext>({
+      batch: { size: 5, intervalMs: 2000 },
+    })(createFsDrain())
 
 export default defineEvlogHook({
   init: { env: { service: 'evi', environment: environment() } },
-  drain,
+  ...(drain ? { drain } : {}),
   sessionEvent: true,
 })


### PR DESCRIPTION
`agent/hooks/evlog.ts` attached `createFsDrain()` unconditionally. On Vercel everything outside `/tmp` is read-only, so every batch flush logged `[evlog/fs] Failed to send events: ENOENT mkdir '.evlog'` and dropped the events.

The drain now only attaches off Vercel (local dev and evals keep their file output). Hosted environments run drainless until a hosted destination lands; that and the fs adapter's repeat-error contract stay tracked in EVL-256.

No changeset: change confined to `apps/*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event logging compatibility on Vercel by disabling unsupported filesystem-based logging there.
  * Preserved batched filesystem logging behavior in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->