### PR TITLE
feat(evi): move the digest prompt into a reusable daily-digest skill

### DIFF
--- a/apps/evi/agent/schedules/digest.ts
+++ b/apps/evi/agent/schedules/digest.ts
@@ -13,8 +13,7 @@ export default defineSchedule({
     }
     waitUntil(
       receive(photon, {
-        message:
-          'Post the morning digest to this thread: GitHub issues, pull requests and CI failures from the last 24 hours, most attention-worthy first, at most 10 lines. Then AI Gateway spend for the last 24 hours (ai_gateway__report). Then visitor counts for the last 24 hours for the docs site and the other evlog projects (vercel__get_web_analytics, mode count, dataset visits). Then 2-3 short items of news or updates worth reading today. Read-only: do not modify anything.',
+        message: 'Load the daily-digest skill and follow it for the last 24 hours.',
         // Spectrum direct-chat guid: `any;-;<address>`, so the thread is
         // derived from the phone number instead of a captured thread id.
         target: { adapterName: 'imessage', threadId: `imessage:any;-;${MAINTAINER_PHONE}` },

--- a/apps/evi/agent/skills/daily-digest/SKILL.md
+++ b/apps/evi/agent/skills/daily-digest/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: daily-digest
+description: Build and deliver the daily activity digest, covering GitHub activity, AI Gateway spend, visitor counts, and a short news section. Load this when the morning digest schedule fires, or when someone asks for a digest, a daily recap, or "what happened" over a recent period, on any channel.
+---
+
+# Daily digest
+
+One message summarizing the last 24 hours, most attention-worthy first. Post it to the thread the request came from. Read-only: gather and report, never modify anything.
+
+When the request names a different window ("this week", "since Monday"), keep the structure and widen the window; the 24-hour default is for the scheduled morning run.
+
+## Sections, in order
+
+1. **GitHub (last 24h).** New and updated issues, merged and open pull requests, CI state on `main` (`getCiFailureContext` when red). Lead with whatever needs attention: a red build, a stalled community PR, an issue with activity. Skip empty categories with one word, never with an apology.
+2. **AI Gateway spend (last 24h).** `ai_gateway__report` totals, with a one-line callout only when spend is unusual against recent days.
+3. **Visitors (last 24h).** `vercel__get_web_analytics` (`mode: 'count'`, `dataset: 'visits'`) for the docs site and the other evlog projects.
+4. **Worth reading.** 2 or 3 short items of AI or ecosystem news worth Hugo's time today, each with a link and a date.
+
+## Form
+
+- At most 10 lines for the GitHub section; the whole digest stays scannable in one screen.
+- Plain sentences and short bullets. Links inline. No preamble, no sign-off.
+- A section whose tools are unavailable is reported in one line naming the failing tool, and the rest of the digest still ships.


### PR DESCRIPTION
The digest procedure lived as a one-shot prompt inside `agent/schedules/digest.ts`, so it only existed for the cron. It is now an authored skill, `agent/skills/daily-digest/SKILL.md`, and the schedule's message shrinks to "Load the daily-digest skill and follow it for the last 24 hours."

What this buys:

- The same digest works from any conversation on any channel: asking Evi for "a digest" or "what happened this week" loads the same skill, with the window widened per the request.
- The procedure is versioned and reviewable as prose instead of a string literal, and the next schedules (Monday stand-up, weekly self-review) can follow the same pattern: schedules name a skill, skills own the procedure.
- Section behavior is specified once, including the failure rule that an unavailable tool costs one line, not the digest.

Verified: `typecheck` green, production build discovers the skill (no authored-skill frontmatter diagnostics), schedule message references it.

No changeset: change confined to `apps/*`.