### PR TITLE
fix(evi): mark sandbox workspaces safe for git across uid boundaries

### DIFF
--- a/apps/evi/agent/sandbox.ts
+++ b/apps/evi/agent/sandbox.ts
@@ -20,10 +20,6 @@ export default defineSandbox({
     await sandbox.run({ command: 'cd repo && corepack enable && corepack prepare --activate && pnpm install && pnpm run dev:prepare' })
     // Commits authored in the sandbox belong to the bot, on every channel.
     await sandbox.run({ command: 'git config --global user.name "evlogai[bot]" && git config --global user.email "evlogai[bot]@users.noreply.github.com"' })
-    // The template builds under a different uid than the session user; without
-    // these, every git command in a session dies on "dubious ownership" and the
-    // GitHub channel checkout fails silently.
-    await sandbox.run({ command: 'git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/repo' })
     // Browser tooling is template-scoped: Chromium and the capture CLI are
     // paid once per template build, never per session.
     await installAgentBrowser(sandbox)
@@ -31,6 +27,12 @@ export default defineSandbox({
   },
   async onSession({ use }) {
     const sandbox = await use()
+    // The template snapshot is owned by the builder uid, not the session user;
+    // without these entries every git command, this fetch included, dies on
+    // "dubious ownership" and the GitHub channel checkout fails silently.
+    // Written here rather than in bootstrap so they land in the session
+    // identity's own config whatever HOME it resolves to.
+    await sandbox.run({ command: 'git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/repo' })
     await sandbox.run({ command: 'cd repo && git fetch origin main && git checkout -B main origin/main' })
   },
 })

--- a/apps/evi/agent/sandbox.ts
+++ b/apps/evi/agent/sandbox.ts
@@ -13,13 +13,17 @@ const BEFORE_AFTER_CLI = '@vercel/before-and-after@0.0.4'
  */
 export default defineSandbox({
   backend: defaultBackend({ vercel: { resources: { vcpus: 4 } } }),
-  revalidationKey: () => `evlog-workspace-v3:${agentBrowserRevalidationKey()}:${BEFORE_AFTER_CLI}`,
+  revalidationKey: () => `evlog-workspace-v4:${agentBrowserRevalidationKey()}:${BEFORE_AFTER_CLI}`,
   async bootstrap({ use }) {
     const sandbox = await use()
     await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
     await sandbox.run({ command: 'cd repo && corepack enable && corepack prepare --activate && pnpm install && pnpm run dev:prepare' })
     // Commits authored in the sandbox belong to the bot, on every channel.
     await sandbox.run({ command: 'git config --global user.name "evlogai[bot]" && git config --global user.email "evlogai[bot]@users.noreply.github.com"' })
+    // The template builds under a different uid than the session user; without
+    // these, every git command in a session dies on "dubious ownership" and the
+    // GitHub channel checkout fails silently.
+    await sandbox.run({ command: 'git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/repo' })
     // Browser tooling is template-scoped: Chromium and the capture CLI are
     // paid once per template build, never per session.
     await installAgentBrowser(sandbox)


### PR DESCRIPTION
Production GitHub turns are currently failing their checkout on every turn, and eve swallows the failure:

```
[eve:github.defaults] GitHub checkout failed — swallowed
fatal: detected dubious ownership in repository at '/workspace'
```

The sandbox template builds under a different uid than the session user, so git's ownership protection rejects `/workspace` at `configure git remote`, the checkout dies, and the turn grinds on without the repository it believes it has. This is what turned the two `@evlogai` mentions on #427 into hours-long silent runs with no comment posted.

Bootstrap now registers `/workspace` and `/workspace/repo` as `safe.directory` in the same global git config that already sets the bot identity, and the revalidation key bumps to v3 so existing templates rebuild.

Typecheck green. No changeset: change confined to `apps/*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session Git operations when user permissions differ.
  * Updated sandbox validation to ensure refreshed environments use the latest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->