### PR TITLE
fix(evi): namespace dynamic tool names and re-resolve gates per turn

### DIFF
--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -20,13 +20,15 @@ The `@vercel/before-and-after` CLI is preinstalled in the sandbox and drives the
 
 ## 2. Capture
 
+**Frame the change, not the page.** The default capture is the viewport at scroll position zero: for anything smaller than a full-page redesign that produces two near-identical frames where the change is a needle in a haystack. Capture the changed element with a CSS selector instead, which scrolls it into view and crops to it:
+
 ```bash
-before-and-after '<before-url>' '<after-url>' --output ./screenshots
+before-and-after '<before-url>' '<after-url>' '.hero' --output ./screenshots
 ```
 
-- Target a component with a CSS selector: `before-and-after '<url1>' '<url2>' '.hero'` (or two selectors when the markup changed: `'.old' '.new'`).
+- Find the right selector first: `browser__snapshot` (or `browser__get` on styles/attributes) on the page, then pick the tightest stable container around the change — a section class or landmark, not a hashed utility class. Two selectors when the markup itself changed: `'.old' '.new'`.
+- A full-viewport capture is for page-level changes only (layout, theme, redesign); `--full` only when explicitly asked for the whole scrollable page.
 - Viewports: `--mobile` (375×812), `--tablet` (768×1024), `--size 1920x1080`. Add mobile when the change affects responsive layout.
-- `--full` only when explicitly asked for the full scrollable page.
 - **Never use `--markdown` or `--upload`**: their default upload target is a public third-party host. Hosting goes through Blob, below.
 
 ## 3. Review, then host

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -77,15 +77,17 @@ function filterReportByApiKeyName(payload: unknown, apiKeyName: string): {
 }
 
 function aiGatewayTools() {
+  // Dynamic map keys are bare tool names (no file-slug prefix), so the
+  // namespace is spelled out here to match every ai_gateway__* reference.
   return {
-    credits: defineTool({
+    ai_gateway__credits: defineTool({
       description: 'Admin: AI Gateway credit balance and lifetime spend for the entire team account (not Evi-scoped). Prefer ai_gateway__report for Evi digests.',
       inputSchema: z.object({}),
       async execute() {
         return await gatewayFetch('/credits')
       },
     }),
-    report: defineTool({
+    ai_gateway__report: defineTool({
       description: `Admin: Evi-scoped AI Gateway spend/tokens over a date range. Scopes via AI_GATEWAY_REPORT_API_KEY_NAME (preferred for historical) and/or tags (default ${defaultReportTag()}). Never returns unscoped account totals.`,
       inputSchema: z.object({
         startDate: dateSchema.describe('Start date (UTC, inclusive), YYYY-MM-DD'),
@@ -159,7 +161,7 @@ function aiGatewayTools() {
         }
       },
     }),
-    generation: defineTool({
+    ai_gateway__generation: defineTool({
       description: 'Admin: cost, latency, and token usage for a single AI Gateway generation id.',
       inputSchema: z.object({
         id: z.string().min(1).describe('Generation id, e.g. gen_01ARZ3NDEKTSV4RRFFQ69G5FAV'),
@@ -171,9 +173,15 @@ function aiGatewayTools() {
   }
 }
 
+// Re-resolved every turn so the gate follows the turn's actual caller and
+// survives a session resumed on a fresh deployment.
 export default defineDynamic({
   events: {
     'session.started': async (_event, ctx) => {
+      if (!canAccessAdminTools(ctx.session.auth.current)) return null
+      return aiGatewayTools()
+    },
+    'turn.started': async (_event, ctx) => {
       if (!canAccessAdminTools(ctx.session.auth.current)) return null
       return aiGatewayTools()
     },

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -5,8 +5,10 @@ import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType
 import { canAccessAdminTools } from '../lib/trust'
 
 function blobTools() {
+  // Dynamic map keys are bare tool names (no file-slug prefix), so the
+  // namespace is spelled out here to match every blob__upload_image reference.
   return {
-    upload_image: defineTool({
+    blob__upload_image: defineTool({
       description: 'Upload an image file from the sandbox to the evlog Vercel Blob store and return its public URL. Use it to share screenshots (before/after comparisons, visual evidence) in pull requests and conversations. png/jpg/webp/gif, 8 MB max. The URL is public: upload only captures of evlog surfaces.',
       inputSchema: z.object({
         path: z.string().min(1).describe('Sandbox path of the image, e.g. /workspace/screenshots/after.png'),
@@ -43,9 +45,14 @@ function blobTools() {
   }
 }
 
-/** The URL is public the instant it exists, so autonomous turns never see this tool. */
+/**
+ * The URL is public the instant it exists, so autonomous turns never see this
+ * tool. Re-resolved every turn so the gate follows the turn's actual caller
+ * and survives a session resumed on a fresh deployment.
+ */
 export default defineDynamic({
   events: {
     'session.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? blobTools() : null),
+    'turn.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? blobTools() : null),
   },
 })

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -15,8 +15,10 @@ const REPO_DIR = '/workspace/repo'
 const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
 
 function gitTools() {
+  // Dynamic map keys are bare tool names (no file-slug prefix), so the
+  // namespace is spelled out here to match every git__push reference.
   return {
-    push: defineTool({
+    git__push: defineTool({
       description: `Push a local branch of the ${REPO_DIR} checkout to origin (HugoRCD/evlog). The branch must already exist there with the work committed and the checks run; main and master are refused. The credential is brokered at the sandbox firewall and never enters the sandbox. After a successful push, open the pull request with github__createPullRequest.`,
       inputSchema: z.object({
         branch: z.string().min(1).describe('Branch name in /workspace/repo to push, e.g. fix/pipeline-flush'),
@@ -57,9 +59,15 @@ function gitTools() {
   }
 }
 
-/** Visible only to maintainer sessions; community and autonomous turns never see a push surface. */
+/**
+ * Visible only when the current caller is the maintainer; community and
+ * autonomous turns never see a push surface. Re-resolved every turn so the
+ * gate follows the turn's actual caller and survives a session resumed on a
+ * fresh deployment, where session.started never fires again.
+ */
 export default defineDynamic({
   events: {
     'session.started': (_event, ctx) => (isMaintainer(ctx.session.auth.current) ? gitTools() : null),
+    'turn.started': (_event, ctx) => (isMaintainer(ctx.session.auth.current) ? gitTools() : null),
   },
 })


### PR DESCRIPTION
Two defects surfaced by the first end-to-end before/after run from iMessage, plus a capture-quality follow-up.

## Dynamic tool names
Dynamic map keys are bare tool names; there is no file-slug prefix. `agent/tools/git.ts` therefore registered `push` (not `git__push`), `blob.ts` registered `upload_image`, and `ai-gateway.ts` registered `credits`/`report`/`generation`, while every instruction, skill, and eval references the namespaced names. The keys now spell the namespace out (`git__push`, `blob__upload_image`, `ai_gateway__*`), matching the docs' manual-namespacing guidance.

## Gates re-resolved per turn
The three gated tool files resolved only at `session.started`, which fires once per session. A durable session resumed on a fresh deployment never re-fires it, which is how a maintainer iMessage session lost the push tool mid-conversation right after a production redeploy. Each file now also re-resolves at `turn.started`, so the gate follows the turn's actual caller and survives redeploys.

## Capture framing
The before-after skill now leads with element capture: pick the tightest stable selector (via `browser__snapshot`) so the frames crop to the change instead of showing the viewport at scroll zero; full-viewport capture is reserved for page-level changes.

No changeset: confined to `apps/evi`. Verified: `tsc`, 40 unit tests, `eve build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture workflows now support targeted element captures using stable selectors, including separate selectors for responsive or differing layouts.
  * Full-page captures can be requested explicitly when needed.
  * Capture guidance now includes selector discovery and responsive viewport recommendations.

* **Bug Fixes**
  * Tool availability and authorization are refreshed when sessions resume or new turns begin, ensuring access reflects current permissions.
  * Tool names are now consistently grouped by their function for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->