### PR TITLE
feat(evi): attested one-call before/after capture tool

### DIFF
--- a/apps/evi/agent/extensions/browser.ts
+++ b/apps/evi/agent/extensions/browser.ts
@@ -1,18 +1,18 @@
 import browser from '@agent-browser/eve'
+import { ALLOWED_BROWSER_DOMAINS } from '../lib/capture'
 
 /**
- * Browser bounded to evlog's own surfaces. The agent-browser matcher accepts
- * exact hosts and `*.suffix` wildcards only (verified against the CLI), so
- * `*.vercel.app` is the narrowest bound that keeps hash-named preview
- * deployments reachable; a protected preview's redirect to vercel.com falls
- * outside the list and is blocked. Loopback is allowed because the sandbox
- * runs no listener Evi did not start herself. The extension exposes no
- * cookie/storage/auth-state commands, so session state is never readable
- * through the tool surface; pages can still set runtime cookies while a
- * session lives.
+ * Browser bounded to evlog's own surfaces (list shared with the capture
+ * tool's own gate). `*.vercel.app` is the narrowest bound that keeps
+ * hash-named preview deployments reachable; a protected preview's redirect to
+ * vercel.com falls outside the list and is blocked. Loopback is allowed
+ * because the sandbox runs no listener Evi did not start herself. The
+ * extension exposes no cookie/storage/auth-state commands, so session state
+ * is never readable through the tool surface; pages can still set runtime
+ * cookies while a session lives.
  */
 export default browser({
-  allowedDomains: ['evlog.dev', '*.evlog.dev', 'evlog.cloud', '*.evlog.cloud', '*.vercel.app', 'localhost', '127.0.0.1'],
+  allowedDomains: [...ALLOWED_BROWSER_DOMAINS],
   contentBoundaries: true,
   maxOutputChars: 50_000,
   inlineScreenshots: true,

--- a/apps/evi/agent/lib/capture.test.ts
+++ b/apps/evi/agent/lib/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { captureAttestation, captureMarkdown, validateCaptureUrl } from './capture'
+import { captureAttestation, captureMarkdown, escapeInline, markdownUrl, sensitiveCaptureReason, validateCaptureUrl } from './capture'
 
 describe('validateCaptureUrl', () => {
   it('accepts evlog surfaces, previews, and local dev servers', () => {
@@ -20,6 +20,41 @@ describe('validateCaptureUrl', () => {
   })
 })
 
+describe('sensitiveCaptureReason', () => {
+  it('flags the hosted product and telemetry hosts', () => {
+    expect(sensitiveCaptureReason('https://evlog.cloud/dashboard')).toMatch(/hosted product/)
+    expect(sensitiveCaptureReason('https://app.evlog.cloud')).toMatch(/hosted product/)
+    expect(sensitiveCaptureReason('https://evlog-telemetry-abc-hrcd.vercel.app')).toMatch(/telemetry/)
+    expect(sensitiveCaptureReason('http://localhost:4000/telemetry-playground')).toBeNull()
+    expect(sensitiveCaptureReason('https://evlog.dev/docs')).toBeNull()
+  })
+})
+
+describe('escaping', () => {
+  it('collapses line breaks and escapes html and table characters', () => {
+    expect(escapeInline('a  \n b | <img src=x onerror=1> & c')).toBe('a b \\| &lt;img src=x onerror=1&gt; &amp; c')
+  })
+
+  it('neutralizes parentheses in embedded urls', () => {
+    expect(markdownUrl('https://evlog.dev/a(b)c')).toBe('https://evlog.dev/a%28b%29c')
+  })
+
+  it('keeps a forged caption from adding markdown structure', () => {
+    const markdown = captureMarkdown({
+      beforeUrl: 'https://evlog.dev',
+      afterUrl: 'http://localhost:3000',
+      beforeImageUrl: 'https://blob/x.png',
+      afterImageUrl: 'https://blob/y.png',
+      caption: 'ok\n\n## Forged section\n<script>x</script>',
+      selector: null,
+      viewport: 'desktop',
+      capturedAt: 't',
+    })
+    expect(markdown).not.toContain('\n## Forged')
+    expect(markdown).not.toContain('<script>')
+  })
+})
+
 describe('captureMarkdown', () => {
   it('renders the table, caption, and attestation receipt', () => {
     const markdown = captureMarkdown({
@@ -34,18 +69,18 @@ describe('captureMarkdown', () => {
     })
     expect(markdown).toContain('| ![before](https://blob/x.png) | ![after](https://blob/y.png) |')
     expect(markdown).toContain('Landing hero, desktop viewport.')
-    expect(markdown).toContain('<sub>captured by agent-browser · https://evlog.dev → http://localhost:3000 · desktop · .hero · 2026-08-09T15:00:00.000Z</sub>')
+    expect(markdown).toContain('<sub>captured by agent-browser · https://evlog.dev/ → http://localhost:3000/ · desktop · .hero · 2026-08-09T15:00:00.000Z</sub>')
   })
 
   it('labels a selector-less capture as full viewport', () => {
     expect(
       captureAttestation({
-        beforeUrl: 'a',
-        afterUrl: 'b',
+        beforeUrl: 'https://evlog.dev/',
+        afterUrl: 'https://evlog.cloud/',
         selector: null,
         viewport: 'mobile',
         capturedAt: 't',
       }),
-    ).toBe('captured by agent-browser · a → b · mobile · full viewport · t')
+    ).toBe('captured by agent-browser · https://evlog.dev/ → https://evlog.cloud/ · mobile · full viewport · t')
   })
 })

--- a/apps/evi/agent/lib/capture.test.ts
+++ b/apps/evi/agent/lib/capture.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { captureAttestation, captureMarkdown, validateCaptureUrl } from './capture'
+
+describe('validateCaptureUrl', () => {
+  it('accepts evlog surfaces, previews, and local dev servers', () => {
+    expect(validateCaptureUrl('https://evlog.dev')).toBeNull()
+    expect(validateCaptureUrl('https://www.evlog.dev/docs')).toBeNull()
+    expect(validateCaptureUrl('https://evlog.cloud')).toBeNull()
+    expect(validateCaptureUrl('https://evi-abc123-hrcd.vercel.app')).toBeNull()
+    expect(validateCaptureUrl('http://localhost:3000/docs')).toBeNull()
+    expect(validateCaptureUrl('http://127.0.0.1:4000')).toBeNull()
+  })
+
+  it('refuses foreign origins, raw IPs, and non-http schemes', () => {
+    expect(validateCaptureUrl('https://example.com')).toMatch(/outside the allowed/)
+    expect(validateCaptureUrl('http://169.254.169.254/latest')).toMatch(/outside the allowed/)
+    expect(validateCaptureUrl('https://vercel.app')).toMatch(/outside the allowed/)
+    expect(validateCaptureUrl('file:///etc/passwd')).toMatch(/must use http/)
+    expect(validateCaptureUrl('not a url')).toMatch(/not a valid absolute URL/)
+  })
+})
+
+describe('captureMarkdown', () => {
+  it('renders the table, caption, and attestation receipt', () => {
+    const markdown = captureMarkdown({
+      beforeUrl: 'https://evlog.dev',
+      afterUrl: 'http://localhost:3000',
+      beforeImageUrl: 'https://blob/x.png',
+      afterImageUrl: 'https://blob/y.png',
+      caption: 'Landing hero, desktop viewport.',
+      selector: '.hero',
+      viewport: 'desktop',
+      capturedAt: '2026-08-09T15:00:00.000Z',
+    })
+    expect(markdown).toContain('| ![before](https://blob/x.png) | ![after](https://blob/y.png) |')
+    expect(markdown).toContain('Landing hero, desktop viewport.')
+    expect(markdown).toContain('<sub>captured by agent-browser · https://evlog.dev → http://localhost:3000 · desktop · .hero · 2026-08-09T15:00:00.000Z</sub>')
+  })
+
+  it('labels a selector-less capture as full viewport', () => {
+    expect(
+      captureAttestation({
+        beforeUrl: 'a',
+        afterUrl: 'b',
+        selector: null,
+        viewport: 'mobile',
+        capturedAt: 't',
+      }),
+    ).toBe('captured by agent-browser · a → b · mobile · full viewport · t')
+  })
+})

--- a/apps/evi/agent/lib/capture.ts
+++ b/apps/evi/agent/lib/capture.ts
@@ -43,6 +43,42 @@ export function validateCaptureUrl(raw: string): string | null {
   return allowed ? null : `"${host}" is outside the allowed capture origins.`
 }
 
+/**
+ * Surfaces that can show real user data: captures of these publish only after
+ * an explicit approval, whatever the skill says. evlog.cloud is the hosted
+ * product and any telemetry host shows live dashboards.
+ */
+export function sensitiveCaptureReason(raw: string): string | null {
+  const host = new URL(raw).hostname.toLowerCase()
+  if (host === 'evlog.cloud' || host.endsWith('.evlog.cloud')) {
+    return `${host} is the hosted product and can show real user data.`
+  }
+  if (host.includes('telemetry')) {
+    return `${host} serves telemetry dashboards and can show real user data.`
+  }
+  return null
+}
+
+/**
+ * One-line text safe inside the Markdown table and the <sub> receipt: line
+ * breaks collapse, and the characters that could open HTML or break the
+ * table are escaped.
+ */
+export function escapeInline(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('|', '\\|')
+}
+
+/** Normalized URL for Markdown embedding; parentheses would end the link early. */
+export function markdownUrl(raw: string): string {
+  return new URL(raw).toString().replaceAll('(', '%28').replaceAll(')', '%29')
+}
+
 interface AttestationInput {
   readonly afterUrl: string
   readonly beforeUrl: string
@@ -53,8 +89,8 @@ interface AttestationInput {
 
 /** Human-readable receipt embedded under the comparison table. */
 export function captureAttestation(input: AttestationInput): string {
-  const frame = input.selector ?? 'full viewport'
-  return `captured by agent-browser · ${input.beforeUrl} → ${input.afterUrl} · ${input.viewport} · ${frame} · ${input.capturedAt}`
+  const frame = input.selector === null ? 'full viewport' : escapeInline(input.selector)
+  return `captured by agent-browser · ${markdownUrl(input.beforeUrl)} → ${markdownUrl(input.afterUrl)} · ${input.viewport} · ${frame} · ${input.capturedAt}`
 }
 
 /** The finished markdown block: table, caption, attestation receipt. */
@@ -66,9 +102,9 @@ export function captureMarkdown(input: AttestationInput & {
   return [
     '| Before | After |',
     '| --- | --- |',
-    `| ![before](${input.beforeImageUrl}) | ![after](${input.afterImageUrl}) |`,
+    `| ![before](${markdownUrl(input.beforeImageUrl)}) | ![after](${markdownUrl(input.afterImageUrl)}) |`,
     '',
-    `${input.caption}`,
+    escapeInline(input.caption),
     '',
     `<sub>${captureAttestation(input)}</sub>`,
   ].join('\n')

--- a/apps/evi/agent/lib/capture.ts
+++ b/apps/evi/agent/lib/capture.ts
@@ -1,0 +1,75 @@
+/**
+ * Single source of truth for where the browser — and any capture — may go:
+ * evlog's own surfaces, Vercel previews, and sandbox-local dev servers. The
+ * agent-browser matcher accepts exact hosts and `*.suffix` wildcards only.
+ */
+export const ALLOWED_BROWSER_DOMAINS = [
+  'evlog.dev',
+  '*.evlog.dev',
+  'evlog.cloud',
+  '*.evlog.cloud',
+  '*.vercel.app',
+  'localhost',
+  '127.0.0.1',
+] as const
+
+export const CAPTURE_VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 375, height: 812 },
+  tablet: { width: 768, height: 1024 },
+} as const
+
+export type CaptureViewport = keyof typeof CAPTURE_VIEWPORTS
+
+/** Entrance animations and font swaps settle before the frame is taken. */
+export const CAPTURE_SETTLE_MS = 5000
+
+/** Returns the refusal reason, or null when the URL may be captured. */
+export function validateCaptureUrl(raw: string): string | null {
+  let url: URL
+  try {
+    url = new URL(raw)
+  }
+  catch {
+    return `"${raw}" is not a valid absolute URL.`
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return `"${raw}" must use http(s).`
+  }
+  const host = url.hostname.toLowerCase()
+  const allowed = ALLOWED_BROWSER_DOMAINS.some(pattern =>
+    pattern.startsWith('*.') ? host.endsWith(pattern.slice(1)) : host === pattern,
+  )
+  return allowed ? null : `"${host}" is outside the allowed capture origins.`
+}
+
+interface AttestationInput {
+  readonly afterUrl: string
+  readonly beforeUrl: string
+  readonly capturedAt: string
+  readonly selector: string | null
+  readonly viewport: CaptureViewport
+}
+
+/** Human-readable receipt embedded under the comparison table. */
+export function captureAttestation(input: AttestationInput): string {
+  const frame = input.selector ?? 'full viewport'
+  return `captured by agent-browser · ${input.beforeUrl} → ${input.afterUrl} · ${input.viewport} · ${frame} · ${input.capturedAt}`
+}
+
+/** The finished markdown block: table, caption, attestation receipt. */
+export function captureMarkdown(input: AttestationInput & {
+  readonly afterImageUrl: string
+  readonly beforeImageUrl: string
+  readonly caption: string
+}): string {
+  return [
+    '| Before | After |',
+    '| --- | --- |',
+    `| ![before](${input.beforeImageUrl}) | ![after](${input.afterImageUrl}) |`,
+    '',
+    `${input.caption}`,
+    '',
+    `<sub>${captureAttestation(input)}</sub>`,
+  ].join('\n')
+}

--- a/apps/evi/agent/sandbox.ts
+++ b/apps/evi/agent/sandbox.ts
@@ -2,6 +2,13 @@ import { agentBrowserRevalidationKey, installAgentBrowser } from '@agent-browser
 import { defaultBackend, defineSandbox } from 'eve/sandbox'
 
 /**
+ * Kept for its diff engine (pixel and DOM comparison from existing images),
+ * not for capture: capture__before_after owns capture and hosting. Pinned so
+ * template reuse invalidates when it moves.
+ */
+const BEFORE_AFTER_CLI = '@vercel/before-and-after@0.0.4'
+
+/**
  * The sandbox template carries a ready-to-work evlog checkout so sessions can
  * run lint, typecheck, and tests instead of shipping unverified changes.
  * Bootstrap is template-scoped: the clone and install are paid once per
@@ -10,7 +17,7 @@ import { defaultBackend, defineSandbox } from 'eve/sandbox'
  */
 export default defineSandbox({
   backend: defaultBackend({ vercel: { resources: { vcpus: 4 } } }),
-  revalidationKey: () => `evlog-workspace-v5:${agentBrowserRevalidationKey()}`,
+  revalidationKey: () => `evlog-workspace-v5:${agentBrowserRevalidationKey()}:${BEFORE_AFTER_CLI}`,
   async bootstrap({ use }) {
     const sandbox = await use()
     await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
@@ -24,6 +31,7 @@ export default defineSandbox({
     // Browser tooling is template-scoped: Chromium is paid once per template
     // build, never per session.
     await installAgentBrowser(sandbox)
+    await sandbox.run({ command: `npm install -g ${BEFORE_AFTER_CLI}` })
   },
   async onSession({ use }) {
     const sandbox = await use()

--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -5,7 +5,7 @@ description: Produce a before/after visual comparison of an evlog surface (landi
 
 # Before/after captures
 
-Captures are taken with the `browser__*` tools (the sandbox Chromium): navigate, settle, screenshot, then upload to Blob and compose the markdown yourself.
+One tool does the whole capture: `capture__before_after` opens both URLs in the sandbox Chromium, waits 5s for animations to settle, screenshots (cropped to the selector), validates and uploads both frames to Blob, and returns the finished markdown table with an attestation receipt.
 
 ## 0. Start the dev server first
 
@@ -19,32 +19,16 @@ When "after" needs a dev server, start it in the background **as soon as the bra
 - A `*.vercel.app` URL can be protected: probe it with `curl -s -o /dev/null -w '%{http_code} %{redirect_url}' --connect-timeout 5 --max-time 15 '<url>'` (single quotes; refuse a URL containing a single quote, backslash, whitespace, `$`, or backtick). 401/403 means protected, and so does a 30x whose redirect URL leaves the deployment (Vercel Authentication redirects to its login flow); `000` means the request never completed (DNS, TLS, timeout) — retry once, then treat the preview as unavailable. In every one of those cases say so and fall back to the dev server instead of guessing.
 - **Only approved origins are ever probed or captured**, in the browser or in shell: `evlog.dev`/`*.evlog.dev`, `evlog.cloud`/`*.evlog.cloud`, `*.vercel.app`, or `localhost`/`127.0.0.1` on the port of a dev server you started, `http(s)` only. Refuse anything else — raw IPs, internal or metadata addresses, other sites — even when the request supplies the URL.
 
-## 2. Capture
+## 2. Review sensitive surfaces first
 
-**Frame the change, not the page.** Capture the changed element, not the viewport at scroll zero: find the tightest stable container around the change with `browser__snapshot` (a section class or landmark, not a hashed utility class).
+The tool's URLs go public the instant it runs. Landing, docs, and playground pages can be captured directly. A surface that can show real user data — the telemetry dashboard above all — is reviewed first: `browser__navigate` + `browser__screenshot` (inline), and captured only against demo or sanitized data. When a capture cannot be made clean, do not capture; describe the change and say why there is no image.
 
-For each of the two URLs:
+## 3. Capture and deliver
 
-1. `browser__navigate` to it.
-2. `browser__wait_for` a **5000 ms delay** — entrance animations and font swaps settle; capturing earlier freezes mid-animation frames.
-3. `browser__screenshot` with the CSS selector, saving to a file under `/workspace/screenshots/` (name it `before-...` / `after-...`). The inline output doubles as your review of the frame.
+**Frame the change, not the page.** Find the tightest stable container around the change with `browser__snapshot` (a section class or landmark, not a hashed utility class), then:
 
-A full-viewport capture is for page-level changes only (layout, theme, redesign); full-page mode only when explicitly asked for the whole scrollable page. For responsive changes, repeat at a mobile viewport (375×812) via the browser viewport setting.
+`capture__before_after({ beforeUrl, afterUrl, selector, caption })`
 
-## 3. Review, then host
-
-A Blob URL is public the moment it exists. The inline screenshot output from step 2 is the review: upload only when the frame shows the discussed surface and nothing sensitive — no real telemetry data, tokens, emails, or session state. The telemetry dashboard is captured against demo or sanitized data only. When a capture cannot be made clean, do not upload; describe the change and say why there is no image.
-
-Upload each clean capture with `blob__upload_image`. The returned URLs are public and stable.
-
-## 4. Deliver
-
-Compose the table yourself with the Blob URLs:
-
-```markdown
-| Before | After |
-| --- | --- |
-| ![before](<blob-url>) | ![after](<blob-url>) |
-```
-
-Put it where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. One table per surface; caption it with the page and viewport when several are captured.
+- Omit `selector` only for page-level changes (layout, theme, redesign).
+- For responsive changes, call it again with `viewport: 'mobile'`.
+- Paste the returned `markdown` verbatim — table, caption, and attestation receipt — where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. The receipt is the proof of what was compared; never strip it.

--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -31,4 +31,9 @@ The tool's URLs go public the instant it runs. Landing, docs, and playground pag
 
 - Omit `selector` only for page-level changes (layout, theme, redesign).
 - For responsive changes, call it again with `viewport: 'mobile'`.
+- Capturing `evlog.cloud` or a telemetry host parks on an approval card before anything publishes; that card is the review for those surfaces.
 - Paste the returned `markdown` verbatim — table, caption, and attestation receipt — where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. The receipt is the proof of what was compared; never strip it.
+
+## 4. Precise checks, when they earn their keep
+
+The `before-and-after` CLI is installed in the sandbox as a diff engine for the frames the tool already saved under `/workspace/screenshots/`: `before-and-after '<before.png>' '<after.png>' --output ./screenshots` compares two existing images (pixel-level and DOM-independent). Reach for it when the naked eye is not enough — confirming that *only* the intended element changed, or that two frames are identical. Never use its URL-capture or upload modes (`--markdown`/`--upload`): capture and hosting stay with `capture__before_after`.

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -1,0 +1,109 @@
+import { runAgentBrowser, type EveToolContext } from '@agent-browser/eve/sandbox'
+import { put } from '@vercel/blob'
+import { defineDynamic, defineTool } from 'eve/tools'
+import type { SandboxSession } from 'eve/sandbox'
+import { z } from 'zod'
+import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
+import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
+import { canAccessAdminTools } from '../lib/trust'
+
+const SCREENSHOT_DIR = '/workspace/screenshots'
+
+async function captureFrame(
+  ctx: EveToolContext,
+  side: 'before' | 'after',
+  url: string,
+  selector: string | null,
+  viewport: CaptureViewport,
+): Promise<string> {
+  const { width, height } = CAPTURE_VIEWPORTS[viewport]
+  const path = `${SCREENSHOT_DIR}/${side}-${Date.now()}.png`
+  await runAgentBrowser(ctx, ['set', 'viewport', String(width), String(height)])
+  await runAgentBrowser(ctx, ['open', url])
+  await runAgentBrowser(ctx, ['wait', String(CAPTURE_SETTLE_MS)])
+  if (selector !== null) {
+    await runAgentBrowser(ctx, ['scrollintoview', selector])
+    await runAgentBrowser(ctx, ['wait', '500'])
+  }
+  await runAgentBrowser(ctx, ['screenshot', path])
+  return path
+}
+
+async function hostFrame(sandbox: SandboxSession, path: string): Promise<string> {
+  const bytes = await sandbox.readBinaryFile({ path })
+  if (bytes === null) throw new Error(`The capture at "${path}" was not written.`)
+  if (bytes.byteLength > MAX_IMAGE_BYTES) throw new Error(`Capture is ${bytes.byteLength} bytes; the limit is ${MAX_IMAGE_BYTES}.`)
+  const contentType = sniffImageContentType(bytes)
+  if (contentType === null || contentType !== imageContentType(path)) {
+    throw new Error(`The capture at "${path}" is not a valid image.`)
+  }
+  const blob = await put(screenshotKey(path), Buffer.from(bytes), {
+    access: 'public',
+    addRandomSuffix: true,
+    contentType,
+  })
+  return blob.url
+}
+
+function captureTools() {
+  return {
+    capture__before_after: defineTool({
+      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, screenshot (cropped to the selector when given), validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
+      inputSchema: z.object({
+        beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
+        afterUrl: z.string().min(1).describe('URL of the after state, e.g. http://localhost:3000'),
+        selector: z.string().trim().min(1).max(200).optional().describe('CSS selector framing the change; omit only for page-level changes'),
+        viewport: z.enum(['desktop', 'mobile', 'tablet']).optional().describe('Defaults to desktop (1280×800)'),
+        caption: z.string().trim().min(1).max(200).describe('One line naming the surface and viewport, e.g. "Landing hero, desktop viewport."'),
+      }),
+      async execute(input, ctx) {
+        if (!canAccessAdminTools(ctx.session.auth.current)) {
+          return { success: false as const, error: 'Captures are not available in this session.' }
+        }
+        for (const url of [input.beforeUrl, input.afterUrl]) {
+          const refusal = validateCaptureUrl(url)
+          if (refusal) return { success: false as const, error: refusal }
+        }
+        if (!process.env.BLOB_READ_WRITE_TOKEN) {
+          return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
+        }
+        const viewport = input.viewport ?? 'desktop'
+        const selector = input.selector ?? null
+        const sandbox = await ctx.getSandbox()
+        await sandbox.run({ command: `mkdir -p ${SCREENSHOT_DIR}` })
+        const beforePath = await captureFrame(ctx, 'before', input.beforeUrl, selector, viewport)
+        const afterPath = await captureFrame(ctx, 'after', input.afterUrl, selector, viewport)
+        const beforeImageUrl = await hostFrame(sandbox, beforePath)
+        const afterImageUrl = await hostFrame(sandbox, afterPath)
+        const capturedAt = new Date().toISOString()
+        return {
+          success: true as const,
+          markdown: captureMarkdown({
+            beforeUrl: input.beforeUrl,
+            afterUrl: input.afterUrl,
+            beforeImageUrl,
+            afterImageUrl,
+            caption: input.caption,
+            selector,
+            viewport,
+            capturedAt,
+          }),
+          before: { sourceUrl: input.beforeUrl, imageUrl: beforeImageUrl },
+          after: { sourceUrl: input.afterUrl, imageUrl: afterImageUrl },
+        }
+      },
+    }),
+  }
+}
+
+/**
+ * The frames publish to public URLs the moment the tool runs, so autonomous
+ * turns never see it. Re-resolved every turn so the gate follows the turn's
+ * actual caller and survives a session resumed on a fresh deployment.
+ */
+export default defineDynamic({
+  events: {
+    'session.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? captureTools() : null),
+    'turn.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? captureTools() : null),
+  },
+})

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -4,7 +4,7 @@ import { defineDynamic, defineTool } from 'eve/tools'
 import type { SandboxSession } from 'eve/sandbox'
 import { z } from 'zod'
 import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
-import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
+import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, sensitiveCaptureReason, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
 import { canAccessAdminTools } from '../lib/trust'
 
 const SCREENSHOT_DIR = '/workspace/screenshots'
@@ -56,6 +56,23 @@ function captureTools() {
         viewport: z.enum(['desktop', 'mobile', 'tablet']).optional().describe('Defaults to desktop (1280×800)'),
         caption: z.string().trim().min(1).max(200).describe('One line naming the surface and viewport, e.g. "Landing hero, desktop viewport."'),
       }),
+      // Skill-level "review sensitive surfaces first" is not an enforceable
+      // control; a capture of a surface that can show real user data parks on
+      // an approval card before anything publishes.
+      approval(ctx) {
+        for (const raw of [ctx.toolInput?.beforeUrl, ctx.toolInput?.afterUrl]) {
+          if (typeof raw !== 'string') continue
+          let reason: string | null
+          try {
+            reason = sensitiveCaptureReason(raw)
+          }
+          catch {
+            continue // invalid URL: execute() refuses it with a clear error
+          }
+          if (reason) return 'user-approval'
+        }
+        return 'not-applicable'
+      },
       async execute(input, ctx) {
         if (!canAccessAdminTools(ctx.session.auth.current)) {
           return { success: false as const, error: 'Captures are not available in this session.' }

--- a/apps/evi/evals/contributing/visual-evidence.eval.ts
+++ b/apps/evi/evals/contributing/visual-evidence.eval.ts
@@ -1,0 +1,13 @@
+import { defineEval } from 'eve/evals'
+
+export default defineEval({
+  // Visual evidence flows through the attested capture tool, never through
+  // hand-assembled screenshots or third-party hosts.
+  description: 'Asked to prove a landing change visually, the answer names capture__before_after and the attested markdown it returns.',
+  tags: ['fast'],
+  async test(t) {
+    await t.send('You just changed the landing hero on a branch. How would you show me, in the PR, exactly what changed visually?')
+    t.succeeded()
+    t.judge.autoevals.closedQA('names the capture__before_after tool (or the before-after skill flow) producing a before/after table with hosted screenshots').atLeast(0.5)
+  },
+})

--- a/apps/evi/evals/contributing/visual-evidence.eval.ts
+++ b/apps/evi/evals/contributing/visual-evidence.eval.ts
@@ -8,6 +8,6 @@ export default defineEval({
   async test(t) {
     await t.send('You just changed the landing hero on a branch. How would you show me, in the PR, exactly what changed visually?')
     t.succeeded()
-    t.judge.autoevals.closedQA('names the capture__before_after tool (or the before-after skill flow) producing a before/after table with hosted screenshots').atLeast(0.5)
+    t.judge.autoevals.closedQA('names the capture__before_after tool (or the before-after skill flow) producing a before/after table with hosted screenshots and an attestation receipt').atLeast(0.5)
   },
 })


### PR DESCRIPTION
Stacked on #533. Collapses the multi-step capture flow into one authored tool and makes the visual evidence unfakeable.

## capture__before_after
One call per comparison: opens both URLs in the sandbox Chromium (via `runAgentBrowser`), waits the 5s settle, screenshots cropped to the selector, validates the bytes (magic numbers + trailers, shared with `blob__upload_image`), uploads both frames to the Blob store, and returns the finished markdown — table, caption, and an attestation receipt naming the compared URLs, viewport, frame, and timestamp.

Trust properties:
- A working Blob URL can only be minted by the runtime (token never in the sandbox, bytes validated), so its presence in a PR proves the pipeline ran.
- The receipt says exactly what was compared; the tool call and its result are in the session stream, auditable after the fact.
- Origins are gated by the same allowlist as the browser extension, now shared from `agent/lib/capture.ts` (single source). Gated to maintainer/schedule sessions, re-resolved per turn.

## Skill
`before-after` shrinks to: start the dev server early, review sensitive surfaces first (public-the-instant-it-runs caveat), find the selector, one tool call, paste the returned markdown verbatim — the receipt is never stripped.

## Eval
`contributing/visual-evidence` pins that visual proof flows through the tool.

Latency: replaces ~8 sequential model round-trips with one tool call.

No changeset: confined to `apps/evi`. Verified: `tsc`, 44 unit tests, `eve build`. End-to-end capture validates on the preview deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorized before-and-after webpage captures with selectable viewport sizes and optional element targeting.
  * Added URL validation, screenshot hosting, capture metadata, attestation receipts, and ready-to-use Markdown output.
  * Added shared domain restrictions between browser navigation and capture tools.
  * Added guidance for reviewing sensitive content and using sanitized demonstration data.

* **Bug Fixes**
  * Standardized capture timing and validation to improve reliable visual comparisons.

* **Tests**
  * Added coverage for URL validation, Markdown rendering, metadata, and attestation formatting.
  * Added evaluation coverage for visual evidence workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->