### PR TITLE
fix(evi): smooth the interactive run frictions

### DIFF
--- a/apps/evi/agent/channels/photon.ts
+++ b/apps/evi/agent/channels/photon.ts
@@ -43,6 +43,7 @@ export default photonIMessageChannel({
           const options = request.options ?? []
           if (options.length > 0) {
             lines.push('', ...options.map((option) => `· ${option.label}: reply "${option.id}"`))
+            lines.push('Or answer in your own words.')
           }
 
           return lines.join('\n')

--- a/apps/evi/agent/extensions/github.ts
+++ b/apps/evi/agent/extensions/github.ts
@@ -99,9 +99,11 @@ export default githubExtension({
   context: { owner: 'HugoRCD', repo: 'evlog' },
   include: [...TOOLS],
   // Omitted write tools keep the default always(): closeIssue, deleteIssueComment,
-  // deletePullRequestComment, createPullRequestReview, requestReviewers, deleteLabel.
+  // deletePullRequestComment, createPullRequestReview, deleteLabel.
   // Connect scopes are derived from `include` (createLabel → issues:write) in sdk ≥ 1.11.1.
   requireApproval: {
+    // Reversible and harmless on every kind of run; a card here only slows the PR flow down.
+    requestReviewers: (): ApprovalStatus => 'not-applicable',
     createPullRequest: policy,
     updatePullRequest: policy,
     createIssue: autonomousWrite,

--- a/apps/evi/agent/instructions.md
+++ b/apps/evi/agent/instructions.md
@@ -72,6 +72,7 @@ Questions about yourself (who you are, what you can do) you answer directly with
 - **Short by default.** Lead with the answer. A simple question gets the conclusion and the single most useful supporting fact or link, then stops.
 - **Structure longer answers.** When the request has multiple parts, or covers a tradeoff, comparison, or migration, lead with the conclusion and then use short paragraphs and one-level bullets. Sections mirror the request, not the sources you consulted.
 - **An explicit request wins.** If someone asks for detail, or asks you to be brief, follow it.
+- **Long work announces itself.** On a chat channel, when a task will take more than a minute or two (checks, captures, a PR to build), send one line first saying what you are starting; the next message is the result. A silent stretch reads as a hang, not as work.
 - **Expand from what you already have.** If a follow-up asks for more, build on the pages and files already retrieved in this session. Retrieve again only when the existing evidence is missing or stale.
 - Match the platform. A GitHub comment can carry a fenced code block and a link; keep it tight regardless.
 


### PR DESCRIPTION
Three frictions surfaced by the latest end-to-end run.

- `github__requestReviewers` sat in the omitted-tools list and kept the default `always()` approval, while the instructions require requesting a review on every non-draft PR — so every PR flow produced an approval card for a reversible, harmless action. It is now `not-applicable` on every kind of run.
- Long silent stretches: iMessage has no typing indicator, so the minutes between an answer and the finished PR read as a hang. Instructions now require a one-line announcement before starting work that will take more than a minute or two on a chat channel.
- Input-request prompts listed only the option-id replies; free-form answers were always accepted but nothing said so. The photon prompt now ends with "Or answer in your own words."

No changeset: confined to `apps/evi`. Verified: `tsc`, 53 unit tests, `eve build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool-approval prompts now let you respond in your own words when options are provided.
  * Longer-running chat tasks now include an announcement before work begins, followed by a result update.
  * Review requests can be sent without an additional approval prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->