### PR TITLE
docs(evi): sync authorization notes with the approval-free review request

### DIFF
--- a/apps/evi/docs/authorization.md
+++ b/apps/evi/docs/authorization.md
@@ -111,7 +111,11 @@ this list keeps its approval too, for the reason below:
 `addIssueComment`, `updateIssueComment`, `addPullRequestComment`,
 `updatePullRequestComment`, `addIssueReaction`, `addCommentReaction`,
 `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`,
-`requestReviewers`, `addDiscussionComment`.
+`addDiscussionComment`.
+
+`requestReviewers` is approval-free on every kind of run, not only admin:
+requesting a review is reversible and grants nothing, and the instructions
+require it on every non-draft PR.
 
 Everything else keeps a real approval even for admin: `createIssue`, `closeIssue`,
 `deleteIssueComment`, `deletePullRequestComment`, `createPullRequest`,


### PR DESCRIPTION
Follow-up to #536: the authorization design note still listed requestReviewers among approval-gated writes; it is approval-free on every kind of run now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated approval guidance for review requests and discussion comments.
  - Clarified that review requests are reversible, do not grant permissions, and are required for every non-draft pull request.
  - Documented that discussion comments can be added without approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->