### PR TITLE
feat(evi): linear mcp connection

### DIFF
--- a/apps/evi/agent/connections/linear.ts
+++ b/apps/evi/agent/connections/linear.ts
@@ -1,0 +1,14 @@
+import { defineMcpClientConnection } from 'eve/connections'
+import { adminOnlyAppConnection } from '../lib/connect'
+
+/**
+ * Linear's hosted MCP, on its read-only endpoint: writes are impossible
+ * server-side, so no client allowlist is needed. The bearer token comes from
+ * a dedicated Connect connector; Linear accepts it directly in the
+ * Authorization header, no interactive OAuth hop.
+ */
+export default defineMcpClientConnection({
+  url: 'https://mcp.linear.app/mcp/readonly',
+  description: "Hugo's Linear workspace, read-only (admin only): issues, projects, initiatives, milestones, cycles, documents, status updates. The authority on what is planned, in progress, or decided in Linear. Use it to answer questions about planning state or to ground a digest; interacting with Linear (creating or updating issues) happens on the Linear channel, not here.",
+  auth: adminOnlyAppConnection('scl_D48zMshnOiQncJ3eFn2mRA'),
+})

--- a/apps/evi/agent/connections/linear.ts
+++ b/apps/evi/agent/connections/linear.ts
@@ -2,13 +2,50 @@ import { defineMcpClientConnection } from 'eve/connections'
 import { adminOnlyAppConnection } from '../lib/connect'
 
 /**
- * Linear's hosted MCP, on its read-only endpoint: writes are impossible
- * server-side, so no client allowlist is needed. The bearer token comes from
- * a dedicated Connect connector; Linear accepts it directly in the
- * Authorization header, no interactive OAuth hop.
+ * The full read surface plus the three writes Evi's workflows need: issues,
+ * comments, and documents (`save_*` creates and updates). Deletes, diffs,
+ * attachments, and structural writes (projects, initiatives, releases) stay
+ * excluded. One list, maintained here.
+ */
+const ALLOWED_TOOLS: string[] = [
+  // Reads
+  'get_document',
+  'get_initiative',
+  'get_issue',
+  'get_issue_status',
+  'get_milestone',
+  'get_project',
+  'get_team',
+  'get_user',
+  'get_workspace',
+  'list_comments',
+  'list_cycles',
+  'list_documents',
+  'list_initiative_labels',
+  'list_initiatives',
+  'list_issue_labels',
+  'list_issue_statuses',
+  'list_issues',
+  'list_milestones',
+  'list_project_labels',
+  'list_projects',
+  'list_teams',
+  'list_users',
+  'search_documentation',
+  // Writes
+  'save_comment',
+  'save_document',
+  'save_issue',
+]
+
+/**
+ * Linear's hosted MCP. The bearer token comes from a dedicated Connect
+ * connector; Linear accepts it directly in the Authorization header, no
+ * interactive OAuth hop.
  */
 export default defineMcpClientConnection({
-  url: 'https://mcp.linear.app/mcp/readonly',
-  description: "Hugo's Linear workspace, read-only (admin only): issues, projects, initiatives, milestones, cycles, documents, status updates. The authority on what is planned, in progress, or decided in Linear. Use it to answer questions about planning state or to ground a digest; interacting with Linear (creating or updating issues) happens on the Linear channel, not here.",
+  url: 'https://mcp.linear.app/mcp',
+  description: "Hugo's Linear workspace (admin only): the authority on what is planned, in progress, or decided. Read issues, projects, initiatives, milestones, cycles, documents, and status updates; write via save_issue (create or update an issue), save_comment, and save_document — documents are the home for recurring reports like weekly digests, where formatting beats a chat message. No deletes and no structural writes.",
+  tools: { allow: ALLOWED_TOOLS },
   auth: adminOnlyAppConnection('linear/mcp'),
 })

--- a/apps/evi/agent/connections/linear.ts
+++ b/apps/evi/agent/connections/linear.ts
@@ -45,7 +45,7 @@ const ALLOWED_TOOLS: string[] = [
  */
 export default defineMcpClientConnection({
   url: 'https://mcp.linear.app/mcp',
-  description: "Hugo's Linear workspace (admin only): the authority on what is planned, in progress, or decided. Read issues, projects, initiatives, milestones, cycles, documents, and status updates; write via save_issue (create or update an issue), save_comment, and save_document — documents are the home for recurring reports like weekly digests, where formatting beats a chat message. No deletes and no structural writes.",
+  description: 'Hugo\'s Linear workspace (admin only): the authority on what is planned, in progress, or decided. Read issues, projects, initiatives, milestones, cycles, documents, and status updates; write via save_issue (create or update an issue), save_comment, and save_document — documents are the home for recurring reports like weekly digests, where formatting beats a chat message. No deletes and no structural writes.',
   tools: { allow: ALLOWED_TOOLS },
   auth: adminOnlyAppConnection('linear/mcp'),
 })

--- a/apps/evi/agent/connections/linear.ts
+++ b/apps/evi/agent/connections/linear.ts
@@ -10,5 +10,5 @@ import { adminOnlyAppConnection } from '../lib/connect'
 export default defineMcpClientConnection({
   url: 'https://mcp.linear.app/mcp/readonly',
   description: "Hugo's Linear workspace, read-only (admin only): issues, projects, initiatives, milestones, cycles, documents, status updates. The authority on what is planned, in progress, or decided in Linear. Use it to answer questions about planning state or to ground a digest; interacting with Linear (creating or updating issues) happens on the Linear channel, not here.",
-  auth: adminOnlyAppConnection('scl_D48zMshnOiQncJ3eFn2mRA'),
+  auth: adminOnlyAppConnection('linear/mcp'),
 })

--- a/apps/evi/agent/connections/vercel.ts
+++ b/apps/evi/agent/connections/vercel.ts
@@ -1,7 +1,7 @@
 import { defineMcpClientConnection } from 'eve/connections'
 import { adminOnlyAppConnection } from '../lib/connect'
 
-const VERCEL_TEAM_ID = process.env.VERCEL_TEAM_ID
+const { VERCEL_TEAM_ID } = process.env
 
 const ALLOWED_TOOLS: string[] = [
   'search_vercel_documentation',
@@ -25,9 +25,9 @@ const VERCEL_MCP_INSTRUCTIONS = [
   '**Vercel MCP connection (vercel__*, admin only): read-only, use judiciously.**',
   '',
   '- Discover exact schemas via `connection_search`, then call `vercel__<tool>`.',
-  '- The connection is scoped to the evlog team (' + TEAM_ID + ") but NOT to a single project: evlog runs several Vercel projects, and Evi may need logs, deployments, or agent runs from any of them. Pass the team id to `list_deployments`, `get_deployment`, `get_deployment_build_logs`, `get_runtime_logs`, `get_runtime_errors`, `get_project`, `get_web_analytics`, and use `list_projects` to enumerate the team's projects when you need an id or slug.",
-  "- Evi's own Agent Runs (`list_agent_runs`) live in the eve service's own project, not the app project. Call `list_agent_run_projects` first to discover it. Still NOT tokens/cost. Use `ai_gateway__*` for that. No per-run trace access: this connection only exposes run-level metadata, never raw conversation content.",
-  "- `get_web_analytics` (production only, requires Web Analytics enabled on the project): `mode: 'count'` (default) returns one total, e.g. visitors this week; `mode: 'aggregate'` groups by up to two `by` dimensions (hour/day/week/month/year, country, route, requestPath, referrerHostname, deviceType, browserName, eventName, ...) and requires `since`+`until`. `dataset: 'visits'` (default) for pageviews, `'events'` for custom track() events. `filter` is OData, e.g. `requestPath eq '/docs'`.",
+  `- The connection is scoped to the evlog team (${ TEAM_ID }) but NOT to a single project: evlog runs several Vercel projects, and Evi may need logs, deployments, or agent runs from any of them. Pass the team id to \`list_deployments\`, \`get_deployment\`, \`get_deployment_build_logs\`, \`get_runtime_logs\`, \`get_runtime_errors\`, \`get_project\`, \`get_web_analytics\`, and use \`list_projects\` to enumerate the team's projects when you need an id or slug.`,
+  '- Evi\'s own Agent Runs (`list_agent_runs`) live in the eve service\'s own project, not the app project. Call `list_agent_run_projects` first to discover it. Still NOT tokens/cost. Use `ai_gateway__*` for that. No per-run trace access: this connection only exposes run-level metadata, never raw conversation content.',
+  '- `get_web_analytics` (production only, requires Web Analytics enabled on the project): `mode: \'count\'` (default) returns one total, e.g. visitors this week; `mode: \'aggregate\'` groups by up to two `by` dimensions (hour/day/week/month/year, country, route, requestPath, referrerHostname, deviceType, browserName, eventName, ...) and requires `since`+`until`. `dataset: \'visits\'` (default) for pageviews, `\'events\'` for custom track() events. `filter` is OData, e.g. `requestPath eq \'/docs\'`.',
   '- `search_vercel_documentation` needs no ids: general Vercel platform docs search.',
 ].join(String.fromCharCode(10))
 

--- a/apps/evi/agent/connections/vercel.ts
+++ b/apps/evi/agent/connections/vercel.ts
@@ -1,7 +1,5 @@
-import { connect } from '@vercel/connect/eve'
 import { defineMcpClientConnection } from 'eve/connections'
-import type { SessionContext } from 'eve/context'
-import { canAccessAdminTools } from '../lib/trust'
+import { adminOnlyAppConnection } from '../lib/connect'
 
 const VERCEL_TEAM_ID = process.env.VERCEL_TEAM_ID
 
@@ -18,26 +16,6 @@ const ALLOWED_TOOLS: string[] = [
   'list_agent_runs',
   'list_projects',
 ]
-
-/**
- * Read-only Vercel platform access, gated to maintainer and app-principal
- * sessions. A blocked caller gets a terminal error instead of a silent
- * authorization challenge, matching the notes in docs/notes.md on app-scoped
- * Connect auth.
- */
-function adminOnlyVercelAuth() {
-  return (ctx: SessionContext) => {
-    if (!canAccessAdminTools(ctx.session.auth.current)) {
-      return {
-        principalType: 'app' as const,
-        async getToken(): Promise<never> {
-          throw new Error('This tool is not available in the current session.')
-        },
-      }
-    }
-    return connect({ connector: 'vercel/mcp', principalType: 'app', autoProvision: false })
-  }
-}
 
 // The description must stay non-empty at build time, when VERCEL_TEAM_ID is
 // absent; it is only interpolated here, never gated on.
@@ -57,5 +35,5 @@ export default defineMcpClientConnection({
   url: 'https://mcp.vercel.com',
   description: VERCEL_MCP_INSTRUCTIONS,
   tools: { allow: ALLOWED_TOOLS },
-  auth: adminOnlyVercelAuth(),
+  auth: adminOnlyAppConnection('vercel/mcp'),
 })

--- a/apps/evi/agent/lib/connect.ts
+++ b/apps/evi/agent/lib/connect.ts
@@ -1,0 +1,22 @@
+import { connect } from '@vercel/connect/eve'
+import type { SessionContext } from 'eve/context'
+import { canAccessAdminTools } from './trust'
+
+/**
+ * App-scoped Connect auth for admin-gated MCP connections: maintainer and
+ * schedule sessions get the connector's token; anyone else gets a terminal
+ * error instead of a silent authorization challenge.
+ */
+export function adminOnlyAppConnection(connector: string) {
+  return (ctx: SessionContext) => {
+    if (!canAccessAdminTools(ctx.session.auth.current)) {
+      return {
+        principalType: 'app' as const,
+        async getToken(): Promise<never> {
+          throw new Error('This tool is not available in the current session.')
+        },
+      }
+    }
+    return connect({ connector, principalType: 'app', autoProvision: false })
+  }
+}


### PR DESCRIPTION
Adds Linear planning state to Evi's admin surface, the same way the Vercel MCP is wired: `defineMcpClientConnection` with app-scoped Connect bearer auth instead of the interactive OAuth flow.

- Endpoint is Linear's dedicated read-only MCP (`mcp.linear.app/mcp/readonly`): writes are impossible server-side, so no client allowlist. Interacting with Linear stays on the Linear channel.
- Bearer-direct auth validated empirically against the endpoint (initialize + tools/list return the full read suite: issues, projects, initiatives, cycles, milestones, documents, status updates).
- Token comes from a dedicated Connect connector (`scl_D48zMshnOiQncJ3eFn2mRA`), gated to maintainer and schedule sessions like the Vercel MCP; blocked callers get a terminal error instead of a silent authorization challenge.
- The admin-gated Connect auth helper now lives in `agent/lib/connect.ts`, shared by both MCP connections.

No changeset: confined to `apps/evi`. Verified: `tsc`, 53 unit tests, `eve build`. The Connect-token path end-to-end validates on the preview deployment; if the fresh connector's app grant is not provisioned yet, the first call will say so explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only Linear connection for administrative access.
  - Administrative sessions can now connect to Linear using secure bearer-token authentication.

- **Security & Access**
  - Standardized administrative access controls for supported app connections.
  - Restricted Linear and Vercel integrations to authorized administrators.
  - Unauthorized access attempts are blocked with a terminal authorization error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->