### PR TITLE
fix(evi): trust local eve dev sessions as the maintainer

### DIFF
--- a/apps/evi/agent/lib/github/label-approval.test.ts
+++ b/apps/evi/agent/lib/github/label-approval.test.ts
@@ -15,6 +15,7 @@ async function load(env: Record<string, string | undefined> = {}) {
   vi.resetModules()
   // Tests model deployed behavior; the local dev grant would trust every caller.
   vi.stubEnv('VERCEL_ENV', 'production')
+  vi.stubEnv('EVE_RUN_MODE', undefined)
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) vi.stubEnv(key, '')
     else vi.stubEnv(key, value)

--- a/apps/evi/agent/lib/github/label-approval.test.ts
+++ b/apps/evi/agent/lib/github/label-approval.test.ts
@@ -13,6 +13,8 @@ function auth(overrides: Partial<SessionAuthContext>): SessionAuthContext {
 
 async function load(env: Record<string, string | undefined> = {}) {
   vi.resetModules()
+  // Tests model deployed behavior; the local dev grant would trust every caller.
+  vi.stubEnv('VERCEL_ENV', 'production')
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) vi.stubEnv(key, '')
     else vi.stubEnv(key, value)

--- a/apps/evi/agent/lib/trust.test.ts
+++ b/apps/evi/agent/lib/trust.test.ts
@@ -15,6 +15,7 @@ async function loadTrust(env: Record<string, string | undefined>) {
   vi.resetModules()
   // Tests model deployed behavior unless a case opts into the local grant.
   vi.stubEnv('VERCEL_ENV', 'production')
+  vi.stubEnv('EVE_RUN_MODE', undefined)
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) vi.stubEnv(key, undefined)
     else vi.stubEnv(key, value)
@@ -53,13 +54,40 @@ describe('isMaintainer', () => {
 })
 
 describe('local dev grant', () => {
-  it('trusts any caller when running locally, but never in eval or deployed runs', async () => {
-    const local = await loadTrust({ VERCEL_ENV: undefined })
-    expect(local.isMaintainer(null)).toBe(true)
-    expect(local.canAccessAdminTools(auth({ principalId: 'anon' }))).toBe(true)
-    const evalRun = await loadTrust({ VERCEL_ENV: undefined, EVE_RUN_MODE: 'eval' })
+  const oidc = (claims: Record<string, unknown>) =>
+    `h.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.s`
+
+  it('requires local environment and a decodable team OIDC token together', async () => {
+    const granted = await loadTrust({
+      VERCEL_ENV: undefined,
+      VERCEL_OIDC_TOKEN: oidc({ owner_id: 'team_x' }),
+      VERCEL_TEAM_ID: 'team_x',
+    })
+    expect(granted.isMaintainer(null)).toBe(true)
+    expect(granted.canAccessAdminTools(auth({ principalId: 'anon' }))).toBe(true)
+
+    const noToken = await loadTrust({ VERCEL_ENV: undefined, VERCEL_OIDC_TOKEN: undefined })
+    expect(noToken.isMaintainer(null)).toBe(false)
+
+    const wrongTeam = await loadTrust({
+      VERCEL_ENV: undefined,
+      VERCEL_OIDC_TOKEN: oidc({ owner_id: 'team_other' }),
+      VERCEL_TEAM_ID: 'team_x',
+    })
+    expect(wrongTeam.isMaintainer(null)).toBe(false)
+
+    const garbage = await loadTrust({ VERCEL_ENV: undefined, VERCEL_OIDC_TOKEN: 'not-a-jwt' })
+    expect(garbage.isMaintainer(null)).toBe(false)
+  })
+
+  it('never applies in eval or deployed runs, token or not', async () => {
+    const evalRun = await loadTrust({
+      VERCEL_ENV: undefined,
+      EVE_RUN_MODE: 'eval',
+      VERCEL_OIDC_TOKEN: oidc({ owner_id: 'team_x' }),
+    })
     expect(evalRun.isMaintainer(null)).toBe(false)
-    const deployed = await loadTrust({})
+    const deployed = await loadTrust({ VERCEL_OIDC_TOKEN: oidc({ owner_id: 'team_x' }) })
     expect(deployed.isMaintainer(auth({ principalId: 'anon' }))).toBe(false)
   })
 })

--- a/apps/evi/agent/lib/trust.test.ts
+++ b/apps/evi/agent/lib/trust.test.ts
@@ -13,8 +13,10 @@ function auth(overrides: Partial<SessionAuthContext>): SessionAuthContext {
 
 async function loadTrust(env: Record<string, string | undefined>) {
   vi.resetModules()
+  // Tests model deployed behavior unless a case opts into the local grant.
+  vi.stubEnv('VERCEL_ENV', 'production')
   for (const [key, value] of Object.entries(env)) {
-    if (value === undefined) vi.stubEnv(key, '')
+    if (value === undefined) vi.stubEnv(key, undefined)
     else vi.stubEnv(key, value)
   }
   return await import('./trust')
@@ -47,6 +49,18 @@ describe('isMaintainer', () => {
     expect(trust.isMaintainer(auth({ principalId: 'github:12345' }))).toBe(true)
     expect(trust.isMaintainer(auth({ principalId: 'linear:abc-def' }))).toBe(false)
     expect(trust.isMaintainer(auth({ principalId: 'imessage:+33600000000' }))).toBe(false)
+  })
+})
+
+describe('local dev grant', () => {
+  it('trusts any caller when running locally, but never in eval or deployed runs', async () => {
+    const local = await loadTrust({ VERCEL_ENV: undefined })
+    expect(local.isMaintainer(null)).toBe(true)
+    expect(local.canAccessAdminTools(auth({ principalId: 'anon' }))).toBe(true)
+    const evalRun = await loadTrust({ VERCEL_ENV: undefined, EVE_RUN_MODE: 'eval' })
+    expect(evalRun.isMaintainer(null)).toBe(false)
+    const deployed = await loadTrust({})
+    expect(deployed.isMaintainer(auth({ principalId: 'anon' }))).toBe(false)
   })
 })
 

--- a/apps/evi/agent/lib/trust.ts
+++ b/apps/evi/agent/lib/trust.ts
@@ -1,4 +1,5 @@
 import type { SessionAuthContext } from 'eve/context'
+import { environment } from './environment'
 
 /**
  * Hugo's identity on each channel, read from the environment so the public
@@ -21,6 +22,9 @@ const MAINTAINER_PRINCIPALS = new Set(
 )
 
 export function isMaintainer(auth: SessionAuthContext | null): boolean {
+  // An `eve dev` session runs on the maintainer's own machine; its REPL
+  // caller is him. Deployments and eval runs never resolve to `local`.
+  if (environment() === 'local') return true
   return auth !== null && MAINTAINER_PRINCIPALS.has(auth.principalId)
 }
 

--- a/apps/evi/agent/lib/trust.ts
+++ b/apps/evi/agent/lib/trust.ts
@@ -21,10 +21,37 @@ const MAINTAINER_PRINCIPALS = new Set(
   ].filter((principal): principal is string => Boolean(principal)),
 )
 
+function decodeJwtClaims(token: string): Record<string, unknown> | null {
+  const payload = token.split('.')[1]
+  if (payload === undefined) return null
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString()) as Record<string, unknown>
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * A local `eve dev` session counts as the maintainer only when the process
+ * also holds a Vercel OIDC token for this project's team: the repo is public,
+ * but that token only lands in `.env.local` through `vercel env pull` under
+ * an authorized Vercel login. Claims are decoded, not signature-verified, and
+ * expiry is ignored on purpose: possession is the signal, not freshness.
+ * Deployments and eval runs never resolve to `local`.
+ */
+function isTrustedLocalDev(): boolean {
+  if (environment() !== 'local') return false
+  const token = process.env.VERCEL_OIDC_TOKEN
+  if (!token) return false
+  const claims = decodeJwtClaims(token)
+  if (claims === null) return false
+  const team = process.env.VERCEL_TEAM_ID
+  return team === undefined || claims.owner_id === team
+}
+
 export function isMaintainer(auth: SessionAuthContext | null): boolean {
-  // An `eve dev` session runs on the maintainer's own machine; its REPL
-  // caller is him. Deployments and eval runs never resolve to `local`.
-  if (environment() === 'local') return true
+  if (isTrustedLocalDev()) return true
   return auth !== null && MAINTAINER_PRINCIPALS.has(auth.principalId)
 }
 


### PR DESCRIPTION
Asking the local `eve dev` REPL anything admin-gated (Vercel MCP, the new Linear MCP, ai-gateway, captures, push) failed with "This tool is not available in the current session": the REPL caller is neither a maintainer principal nor the schedule app principal, so every gate refused it — which made the admin surface untestable from the machine it runs on.

`isMaintainer` now returns true when `environment()` resolves to `local`: an `eve dev` session runs on the maintainer's own machine. Deployments resolve to their `VERCEL_ENV` and eval runs to `eval`, so nothing changes there — covered by a dedicated test, and the existing trust/label tests now pin `VERCEL_ENV=production` explicitly so they keep modeling deployed behavior.

No changeset: confined to `apps/evi`. Verified: `tsc`, 54 unit tests, `eve build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local development sessions are now automatically trusted.
  * Deployed and evaluation environments continue to enforce configured maintainer access.
  * Improved handling of unset environment configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->