### PR TITLE
feat(evi): route internal reports and findings to linear

### DIFF
--- a/apps/evi/agent/instructions.md
+++ b/apps/evi/agent/instructions.md
@@ -76,6 +76,16 @@ Questions about yourself (who you are, what you can do) you answer directly with
 - **Expand from what you already have.** If a follow-up asks for more, build on the pages and files already retrieved in this session. Retrieve again only when the existing evidence is missing or stale.
 - Match the platform. A GitHub comment can carry a fenced code block and a link; keep it tight regardless.
 
+## Where output lives
+
+Three destinations, chosen by audience, not by where the conversation happens:
+
+- **Linear (evlog team)** is for internal work: recurring reports go to **documents** (`linear__save_document`), actionable internal items — self-improvement findings, upstream decisions, repo gaps spotted during admin work — go to **issues** (`linear__save_issue`). Search before creating; update an existing issue rather than duplicating it.
+- **GitHub** is for anything the community should see: issue replies, doc-gap issues found while triaging a community report, PRs, labels.
+- **Chat (iMessage)** carries pointers and one-liners: the link to the document, the single most important line, an approval card. A multi-section report pasted into chat is a rendering failure, not a delivery.
+
+Autonomous first-responder turns have no Linear access by design (they process untrusted text); their narrow GitHub writes are defined in the injected first-responder instructions.
+
 ## Working on the repository
 
 - Reading is free. Every write is behind an approval card, and that card is the confirmation, so do not also ask for confirmation in prose beforehand. It confirms a write someone asked for; it is not a way to obtain permission you were not given. One card per action, so batch a triage pass into the fewest calls that do the job (`updateIssue` sets labels, assignees, state and milestone at once; do not fan out four tools).

--- a/apps/evi/agent/skills/daily-digest/SKILL.md
+++ b/apps/evi/agent/skills/daily-digest/SKILL.md
@@ -5,7 +5,14 @@ description: Build and deliver the daily activity digest, covering GitHub activi
 
 # Daily digest
 
-One message summarizing the last 24 hours, most attention-worthy first. Post it to the thread the request came from. Read-only: gather and report, never modify anything.
+A summary of the last 24 hours, most attention-worthy first. Gathering is read-only; the only write is the Linear document below.
+
+**Delivery: a Linear document, not a chat wall.** Chat renders a multi-section report badly; Linear renders it well and keeps the history browsable. On the scheduled run (and whenever Hugo asks for "the digest"):
+
+1. Write the full digest as a Linear document via `linear__save_document`, on the evlog team, titled `Daily digest — YYYY-MM-DD`, with real markdown headings per section.
+2. Post to the thread only: one or two lines with the single most attention-worthy item, then the document link.
+
+If `linear__save_document` is unavailable or fails, fall back to posting the full digest in the thread and say why. An ad-hoc question in conversation ("what happened this week?") is answered in the thread directly, at conversational length; the document is for the recurring report.
 
 When the request names a different window ("this week", "since Monday"), keep the structure and widen the window; the 24-hour default is for the scheduled morning run.
 

--- a/apps/evi/agent/skills/upstream-sync/SKILL.md
+++ b/apps/evi/agent/skills/upstream-sync/SKILL.md
@@ -26,8 +26,13 @@ The frameworks this app runs on move independently: eve and its satellites (@age
 - One draft PR per coherent change: a dependency bump with its adaptation, or a workaround replacement. Never bundle unrelated updates.
 - Branch off `main` in `/workspace/repo`, apply the change, run `pnpm run lint`, `pnpm run typecheck` and `pnpm run test`. Add a changeset when a consumer of evlog would notice the change.
 - Push the branch, open a draft PR per branch. Drafts cannot merge; marking one ready is Hugo's call.
-- Post one summary to the thread: what moved upstream, each PR link with one line on what it does, and anything left for Hugo's judgment.
+
+## 4. Track what needs a human in Linear
+
+A draft PR is its own artifact and needs nothing else. But an upstream finding that could **not** become a safe PR — a deprecation to plan around, a breaking change to schedule, a new capability worth adopting deliberately — becomes a **Linear issue** via `linear__save_issue` on the evlog team: a title stating the situation, the upstream link, what it affects in this repo, and the decision Hugo has to make. One issue per finding; search `linear__list_issues` first so a recurring finding updates the existing issue instead of duplicating it.
+
+Then post one summary to the thread: one line per draft PR and per Linear issue, links inline.
 
 ## When nothing is warranted
 
-One line in the thread: versions current, or nothing in the releases affects this app. Never invent work to fill the run.
+One line in the thread: versions current, or nothing in the releases affects this app. Never invent work to fill the run, and never open a Linear issue to say nothing happened.


### PR DESCRIPTION
Chat renders multi-section reports badly and Linear is private to the team, so internal output moves there; follow-up to the Linear MCP connection (#540).

- **Daily digest**: the scheduled run writes the full digest as a Linear document (`Daily digest — YYYY-MM-DD`, evlog team, real headings) and the iMessage thread gets one or two lines plus the link. Ad-hoc "what happened" questions still answer in the thread. Explicit fallback to the old in-thread digest when the document write fails.
- **Upstream sync**: findings that could not become a safe draft PR (deprecations, breaking changes to schedule, capabilities to adopt deliberately) become Linear issues — one per finding, deduplicated against existing ones. Draft PRs remain their own artifact; the thread summary is one line per PR and per issue.
- **Instructions**: a "Where output lives" section fixes the routing by audience — Linear for internal (documents for recurring reports, issues for actionable items), GitHub for anything community-facing, chat for pointers and one-liners.

One deliberate boundary: autonomous first-responder turns keep their doc-gap issues on GitHub. They process untrusted text and have no Linear access by design (the connection is admin-gated); giving them a private-workspace write path would trade a public, community-visible artifact for an injection target. The instructions state this explicitly.

No changeset: confined to `apps/evi`. Verified: `tsc`, 55 unit tests, `eve build`.