### PR TITLE
feat(evi): expose the agent over mcp for external harnesses

### DIFF
--- a/apps/evi/agent/channels/mcp.ts
+++ b/apps/evi/agent/channels/mcp.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'node:crypto'
+import { defineChannel, POST } from 'eve/channels'
+import { finalMessageFromStream, handleMcpRequest, mcpSessionAuth, verifyMcpBearer } from '../lib/mcp'
+
+/**
+ * Exposes Evi over the Model Context Protocol at POST /eve/v1/mcp, for
+ * external harnesses (Raycast AI, Claude Code, Cursor). One `evi` tool
+ * forwards the message into a real Evi session under the `mcp:hugo`
+ * principal, which agent/lib/trust.ts trusts as the maintainer only while
+ * EVI_MCP_TOKEN is configured. Protocol handling lives in agent/lib/mcp.ts.
+ *
+ * The mcp-session-id issued on initialize keys the eve continuation token,
+ * so one Raycast chat maps to one Evi conversation.
+ */
+
+// A shipping flow (checks, push, PR) runs for minutes; let the synchronous tool call wait.
+export const maxDuration = 800
+
+function unauthorized(): Response {
+  return new Response(null, {
+    status: 401,
+    headers: { 'www-authenticate': 'Bearer realm="evi-mcp"' },
+  })
+}
+
+function parseError(): Response {
+  return Response.json(
+    { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+    { status: 200, headers: { 'cache-control': 'no-store' } },
+  )
+}
+
+export default defineChannel({
+  cors: {
+    methods: ['POST'],
+    allowHeaders: ['authorization', 'content-type', 'mcp-protocol-version', 'mcp-session-id'],
+  },
+  routes: [
+    // Absolute path: custom-channel routes are not auto-prefixed, and only
+    // /eve/v1/* is the eve surface in production.
+    POST('/eve/v1/mcp', async (req, { send }) => {
+      if (!verifyMcpBearer(req.headers.get('authorization'), process.env.EVI_MCP_TOKEN?.trim())) {
+        return unauthorized()
+      }
+
+      let body: unknown
+      try {
+        body = await req.json()
+      }
+      catch {
+        return parseError()
+      }
+
+      const mcpSessionId = req.headers.get('mcp-session-id')?.trim() || randomUUID()
+      const result = await handleMcpRequest(body, async (message) => {
+        const session = await send(message, {
+          auth: mcpSessionAuth(),
+          continuationToken: `mcp:${mcpSessionId}`,
+        })
+        return await finalMessageFromStream(await session.getEventStream())
+      })
+
+      const headers: Record<string, string> = {
+        'cache-control': 'no-store',
+        'mcp-session-id': mcpSessionId,
+      }
+      if (result.body === null) return new Response(null, { status: result.status, headers })
+      return Response.json(result.body, { status: result.status, headers })
+    }),
+  ],
+})

--- a/apps/evi/agent/channels/mcp.ts
+++ b/apps/evi/agent/channels/mcp.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { defineChannel, POST } from 'eve/channels'
+import { defineChannel, GET, POST } from 'eve/channels'
 import { finalMessageFromStream, handleMcpRequest, mcpSessionAuth, verifyMcpBearer } from '../lib/mcp'
 
 /**
@@ -32,12 +32,15 @@ function parseError(): Response {
 
 export default defineChannel({
   cors: {
-    methods: ['POST'],
+    methods: ['GET', 'POST'],
     allowHeaders: ['authorization', 'content-type', 'mcp-protocol-version', 'mcp-session-id'],
   },
   routes: [
     // Absolute path: custom-channel routes are not auto-prefixed, and only
     // /eve/v1/* is the eve surface in production.
+    // Streamable HTTP: no server-initiated streams are offered, so GET is a
+    // spec-compliant 405 instead of an SSE channel.
+    GET('/eve/v1/mcp', async () => new Response(null, { status: 405, headers: { allow: 'POST' } })),
     POST('/eve/v1/mcp', async (req, { send }) => {
       if (!verifyMcpBearer(req.headers.get('authorization'), process.env.EVI_MCP_TOKEN?.trim())) {
         return unauthorized()

--- a/apps/evi/agent/lib/mcp.test.ts
+++ b/apps/evi/agent/lib/mcp.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { finalMessageFromStream, handleMcpRequest, verifyMcpBearer } from './mcp'
+
+function streamOf(events: unknown[]): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) controller.enqueue(event)
+      controller.close()
+    },
+  })
+}
+
+describe('verifyMcpBearer', () => {
+  it('accepts only the exact configured token', () => {
+    expect(verifyMcpBearer('Bearer tok-123', 'tok-123')).toBe(true)
+    expect(verifyMcpBearer('Bearer tok-124', 'tok-123')).toBe(false)
+    expect(verifyMcpBearer('Bearer ', 'tok-123')).toBe(false)
+    expect(verifyMcpBearer('Basic tok-123', 'tok-123')).toBe(false)
+    expect(verifyMcpBearer(null, 'tok-123')).toBe(false)
+  })
+
+  it('admits nobody when the token is not configured', () => {
+    expect(verifyMcpBearer('Bearer anything', undefined)).toBe(false)
+    expect(verifyMcpBearer('Bearer anything', '')).toBe(false)
+  })
+})
+
+describe('handleMcpRequest', () => {
+  const echo = async (message: string) => `echo: ${message}`
+
+  it('answers the protocol lifecycle', async () => {
+    const init = await handleMcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, echo)
+    expect(init.status).toBe(200)
+    expect((init.body as { result: { serverInfo: { name: string } } }).result.serverInfo.name).toBe('evi')
+    expect((await handleMcpRequest({ method: 'notifications/initialized' }, echo)).body).toBeNull()
+    const tools = await handleMcpRequest({ id: 2, method: 'tools/list' }, echo)
+    expect((tools.body as { result: { tools: { name: string }[] } }).result.tools.map(t => t.name)).toEqual(['evi'])
+  })
+
+  it('routes a valid tools/call and surfaces failures as isError results', async () => {
+    const call = await handleMcpRequest(
+      { id: 3, method: 'tools/call', params: { name: 'evi', arguments: { message: 'hi' } } },
+      echo,
+    )
+    expect((call.body as { result: { content: { text: string }[] } }).result.content[0]?.text).toBe('echo: hi')
+
+    const failing = await handleMcpRequest(
+      { id: 4, method: 'tools/call', params: { name: 'evi', arguments: { message: 'hi' } } },
+      async () => { throw new Error('turn died') },
+    )
+    expect((failing.body as { result: { isError: boolean, content: { text: string }[] } }).result.isError).toBe(true)
+  })
+
+  it('rejects unknown tools, empty messages, and malformed bodies', async () => {
+    const unknown = await handleMcpRequest({ id: 5, method: 'tools/call', params: { name: 'x' } }, echo)
+    expect((unknown.body as { error: { code: number } }).error.code).toBe(-32601)
+    const empty = await handleMcpRequest({ id: 6, method: 'tools/call', params: { name: 'evi', arguments: { message: ' ' } } }, echo)
+    expect((empty.body as { error: { code: number } }).error.code).toBe(-32602)
+    const bad = await handleMcpRequest('nope', echo)
+    expect((bad.body as { error: { code: number } }).error.code).toBe(-32600)
+  })
+})
+
+describe('finalMessageFromStream', () => {
+  it('returns the last completed message once the turn settles', async () => {
+    await expect(finalMessageFromStream(streamOf([
+      { type: 'turn.started' },
+      { type: 'message.completed', data: { message: 'first' } },
+      { type: 'message.completed', message: 'final' },
+      { type: 'turn.completed' },
+      { type: 'message.completed', data: { message: 'after terminal, ignored' } },
+    ]))).resolves.toBe('final')
+  })
+
+  it('throws on a failed turn and on a silent completion', async () => {
+    await expect(finalMessageFromStream(streamOf([
+      { type: 'turn.failed', data: { message: 'model exploded' } },
+    ]))).rejects.toThrow('model exploded')
+    await expect(finalMessageFromStream(streamOf([
+      { type: 'turn.completed' },
+    ]))).rejects.toThrow('without a message')
+  })
+})

--- a/apps/evi/agent/lib/mcp.ts
+++ b/apps/evi/agent/lib/mcp.ts
@@ -1,7 +1,7 @@
 import { createHash, timingSafeEqual } from 'node:crypto'
 import type { SessionAuthContext } from 'eve/context'
 
-const PROTOCOL_VERSION = '2024-11-05'
+const PROTOCOL_VERSION = '2025-03-26'
 const SERVER_INFO = { name: 'evi', version: '1.0.0' } as const
 
 /** The principal MCP bearer sessions run under; trusted as the maintainer when the token is configured. */
@@ -94,8 +94,7 @@ function err(id: number | string | null, code: number, message: string): McpRpcR
 
 /**
  * Handles one parsed MCP JSON-RPC request. Protocol problems map to JSON-RPC
- * errors; a thrown `callEvi` becomes an `isError` tool result. Ported from
- * V's proven MCP proxy shape.
+ * errors; a thrown `callEvi` becomes an `isError` tool result.
  */
 export async function handleMcpRequest(body: unknown, callEvi: CallEvi): Promise<McpRpcResult> {
   if (typeof body !== 'object' || body === null || typeof (body as { method?: unknown }).method !== 'string') {

--- a/apps/evi/agent/lib/mcp.ts
+++ b/apps/evi/agent/lib/mcp.ts
@@ -1,0 +1,140 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+import type { SessionAuthContext } from 'eve/context'
+
+const PROTOCOL_VERSION = '2024-11-05'
+const SERVER_INFO = { name: 'evi', version: '1.0.0' } as const
+
+/** The principal MCP bearer sessions run under; trusted as the maintainer when the token is configured. */
+export const MCP_PRINCIPAL = 'mcp:hugo'
+
+const EVI_TOOL = {
+  name: 'evi',
+  description: 'Talk to Evi, the evlog maintainer agent: questions about evlog, repository work (issues, PRs, shipping a change), digests, Linear planning, captures. Pass the full request as `message`; the conversation continues across calls in the same MCP session.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      message: { type: 'string', description: 'Your full request to Evi.' },
+    },
+    required: ['message'],
+  },
+}
+
+/**
+ * Constant-time bearer comparison via digests, so neither token length nor
+ * prefix leaks through timing. Absent configuration admits nobody.
+ */
+export function verifyMcpBearer(authorization: string | null, expected: string | undefined): boolean {
+  if (!expected || !authorization?.startsWith('Bearer ')) return false
+  const presented = authorization.slice('Bearer '.length).trim()
+  if (presented.length === 0) return false
+  const a = createHash('sha256').update(presented).digest()
+  const b = createHash('sha256').update(expected).digest()
+  return timingSafeEqual(a, b)
+}
+
+/** Session auth for an authenticated MCP caller: Hugo through an external harness. */
+export function mcpSessionAuth(): SessionAuthContext {
+  return {
+    attributes: {},
+    authenticator: 'mcp-bearer',
+    principalId: MCP_PRINCIPAL,
+    principalType: 'user',
+  }
+}
+
+/**
+ * Reads a session's event stream until the turn settles and returns the last
+ * completed message. Events arrive parsed; the payload is on `data` or flat
+ * depending on the producer, so both are read.
+ */
+export async function finalMessageFromStream(stream: ReadableStream<unknown>): Promise<string> {
+  const reader = stream.getReader()
+  let lastMessage: string | null = null
+  let failure: string | null = null
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const event = value as { type?: string, data?: Record<string, unknown> } & Record<string, unknown>
+      const data = (event.data ?? event) as Record<string, unknown>
+      if (event.type === 'message.completed' && typeof data.message === 'string') {
+        lastMessage = data.message
+      }
+      if (event.type === 'turn.failed' || event.type === 'session.failed') {
+        failure = typeof data.message === 'string' ? data.message : 'The turn failed.'
+        break
+      }
+      if (event.type === 'turn.completed') break
+    }
+  }
+  finally {
+    reader.releaseLock()
+  }
+  if (failure !== null) throw new Error(failure)
+  if (lastMessage === null) throw new Error('The turn completed without a message.')
+  return lastMessage
+}
+
+/** How the channel forwards a tool message into an Evi session. */
+export type CallEvi = (message: string) => Promise<string>
+
+export interface McpRpcResult {
+  /** JSON body to return, or null for a no-content (202) response. */
+  body: unknown
+  status: number
+}
+
+function ok(id: number | string | null, result: unknown): McpRpcResult {
+  return { body: { jsonrpc: '2.0', id, result }, status: 200 }
+}
+
+function err(id: number | string | null, code: number, message: string): McpRpcResult {
+  return { body: { jsonrpc: '2.0', id, error: { code, message } }, status: 200 }
+}
+
+/**
+ * Handles one parsed MCP JSON-RPC request. Protocol problems map to JSON-RPC
+ * errors; a thrown `callEvi` becomes an `isError` tool result. Ported from
+ * V's proven MCP proxy shape.
+ */
+export async function handleMcpRequest(body: unknown, callEvi: CallEvi): Promise<McpRpcResult> {
+  if (typeof body !== 'object' || body === null || typeof (body as { method?: unknown }).method !== 'string') {
+    return err(null, -32600, 'Invalid Request')
+  }
+  const request = body as { method: string, id?: number | string | null, params?: { name?: string, arguments?: { message?: string } } }
+  const id = request.id ?? null
+
+  switch (request.method) {
+    case 'initialize':
+      return ok(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      })
+    case 'notifications/initialized':
+      return { body: null, status: 202 }
+    case 'ping':
+      return ok(id, {})
+    case 'tools/list':
+      return ok(id, { tools: [EVI_TOOL] })
+    case 'tools/call': {
+      if (request.params?.name !== 'evi') {
+        return err(id, -32601, `Unknown tool: ${String(request.params?.name)}`)
+      }
+      const message = request.params.arguments?.message
+      if (typeof message !== 'string' || message.trim() === '') {
+        return err(id, -32602, 'The `evi` tool requires a non-empty `message` string.')
+      }
+      try {
+        const text = await callEvi(message)
+        return ok(id, { content: [{ type: 'text', text }] })
+      }
+      catch (error) {
+        const detail = error instanceof Error ? error.message : 'Internal error'
+        return ok(id, { content: [{ type: 'text', text: detail }], isError: true })
+      }
+    }
+    default:
+      return err(id, -32601, `Method not found: ${String(request.method)}`)
+  }
+}

--- a/apps/evi/agent/lib/trust.test.ts
+++ b/apps/evi/agent/lib/trust.test.ts
@@ -92,6 +92,15 @@ describe('local dev grant', () => {
   })
 })
 
+describe('mcp principal', () => {
+  it('is trusted only while the mcp token is configured', async () => {
+    const withToken = await loadTrust({ EVI_MCP_TOKEN: 'tok' })
+    expect(withToken.isMaintainer(auth({ principalId: 'mcp:hugo' }))).toBe(true)
+    const without = await loadTrust({ EVI_MCP_TOKEN: undefined })
+    expect(without.isMaintainer(auth({ principalId: 'mcp:hugo' }))).toBe(false)
+  })
+})
+
 describe('isAutonomous', () => {
   it('matches only the constructed first-responder principal', async () => {
     const trust = await loadTrust({})

--- a/apps/evi/agent/lib/trust.ts
+++ b/apps/evi/agent/lib/trust.ts
@@ -18,6 +18,9 @@ const MAINTAINER_PRINCIPALS = new Set(
     MAINTAINER_GITHUB_ID && `github:${MAINTAINER_GITHUB_ID}`,
     process.env.MAINTAINER_LINEAR_ID && `linear:${process.env.MAINTAINER_LINEAR_ID}`,
     MAINTAINER_PHONE && `imessage:${MAINTAINER_PHONE}`,
+    // The MCP channel only mints this principal after verifying the bearer
+    // token, so configuring the token is what admits the external harness.
+    process.env.EVI_MCP_TOKEN && 'mcp:hugo',
   ].filter((principal): principal is string => Boolean(principal)),
 )
 

--- a/apps/evi/docs/notes.md
+++ b/apps/evi/docs/notes.md
@@ -125,6 +125,18 @@ turn and writes events nobody can read.
 for both local and eval traffic while the spend tags separate them. Both now read
 `agent/lib/environment.ts`.
 
+## MCP channel
+
+External harnesses (Raycast AI, Claude Code, Cursor) reach Evi at
+`POST /eve/v1/mcp` with `Authorization: Bearer $EVI_MCP_TOKEN`: a single `evi`
+tool that runs a real session under the `mcp:hugo` principal, trusted as the
+maintainer only while the token env is set. The `mcp-session-id` returned on
+`initialize` keys the conversation, so one Raycast chat is one Evi session.
+Setup: generate a token (`openssl rand -hex 32`), set `EVI_MCP_TOKEN` on the
+project, add an HTTP MCP server in the client pointing at the production URL
+with the Authorization header. Rotate by changing the env var. There is no
+OAuth AS on purpose: single-user surface, a static bearer is the right size.
+
 ## Open
 
 - Per-tool input-token attribution. `ai.tools[]` records name, duration and


### PR DESCRIPTION
Makes Evi reachable from MCP clients — Raycast AI first, Claude Code and Cursor for free — following the pattern of V's MCP channel.

- `POST /eve/v1/mcp`: a custom channel serving MCP JSON-RPC (initialize, tools/list, tools/call, ping). One `evi` tool forwards the message into a real Evi session via the route `send()` and collects the reply from the session event stream. `maxDuration: 800` so a shipping flow can complete within the synchronous call.
- Auth is a static bearer (`EVI_MCP_TOKEN`), compared in constant time over digests. Verified requests run under the `mcp:hugo` principal, which `trust.ts` counts as the maintainer **only while the token is configured** — full admin surface (push, captures, Linear, gateway) from the harness, revocable by rotating one env var. No OAuth AS on purpose: single-user surface.
- The `mcp-session-id` issued on initialize keys the eve continuation token: one Raycast chat, one continuous Evi conversation.
- Protocol handling, bearer verification, and the stream collector live in `agent/lib/mcp.ts` with colocated tests (10 new; 63 total).

Setup after merge: `openssl rand -hex 32` → `EVI_MCP_TOKEN` on the evi project, then add an HTTP MCP server in Raycast pointing at `https://evi.evlog.cloud/eve/v1/mcp` with the `Authorization: Bearer …` header. Documented in `docs/notes.md`.

No changeset: confined to `apps/evi`. Verified: `tsc`, 63 unit tests, `eve build`. End-to-end validates against the preview with a curl `initialize`/`tools/call` once `EVI_MCP_TOKEN` is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP-compatible HTTP endpoint for Evi interactions.
  * Supports authenticated sessions, tool discovery, tool execution, notifications, and streamed responses.
  * Returns clear protocol and tool errors for invalid or failed requests.
  * Long-running requests can run for up to 800 seconds.

* **Documentation**
  * Added setup, authentication, session handling, token rotation, and integration guidance.

* **Bug Fixes**
  * Improved handling of malformed JSON, invalid requests, failed turns, and silent completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->