### PR TITLE
fix(evi): frame mcp post responses as sse when the client accepts it

### DIFF
--- a/apps/evi/agent/channels/mcp.ts
+++ b/apps/evi/agent/channels/mcp.ts
@@ -68,6 +68,15 @@ export default defineChannel({
         'mcp-session-id': mcpSessionId,
       }
       if (result.body === null) return new Response(null, { status: result.status, headers })
+      // Streamable HTTP lets the server answer POSTs as JSON or as an SSE
+      // frame; clients built against SSE-framing servers (Linear's among
+      // them) expect the frame when their Accept says so.
+      if (req.headers.get('accept')?.includes('text/event-stream')) {
+        return new Response(`event: message\ndata: ${JSON.stringify(result.body)}\n\n`, {
+          status: result.status,
+          headers: { ...headers, 'content-type': 'text/event-stream' },
+        })
+      }
       return Response.json(result.body, { status: result.status, headers })
     }),
   ],


### PR DESCRIPTION
Raycast connects but the session setup fails against plain-JSON POST responses; Linear's MCP (which Raycast handles) frames POST responses as a single SSE message event. The channel now mirrors that: when the request's Accept includes text/event-stream, the JSON-RPC response is returned as an SSE frame with content-type text/event-stream; plain JSON otherwise. GET stays a spec-compliant 405. No changeset: confined to apps/evi. Verified: tsc, 63 unit tests, eve build; curl with both Accept variants validates on the preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP POST requests requesting `text/event-stream` now receive responses in Server-Sent Events format.
  * Other requests continue to receive standard JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->