### PR TITLE
fix(evi): inline dynamic tool executes so resumed sessions keep their tools

### DIFF
--- a/apps/evi/agent/extensions/github.ts
+++ b/apps/evi/agent/extensions/github.ts
@@ -2,7 +2,7 @@ import githubExtension from '@github-tools/eve-extension'
 import type { ApprovalContext, ApprovalStatus } from 'eve/tools'
 import { GITHUB_CONNECTOR } from '../lib/github/credentials'
 import { createLabelPolicy, writePolicy } from '../lib/github/label-approval'
-import { isAutonomous, MAINTAINER_GITHUB_LOGIN } from '../lib/trust'
+import { isAutonomous, isScheduleAppAuth, MAINTAINER_GITHUB_LOGIN } from '../lib/trust'
 
 const TOOLS = [
   // Repository and code
@@ -104,7 +104,15 @@ export default githubExtension({
   requireApproval: {
     // Reversible and harmless on every kind of run; a card here only slows the PR flow down.
     requestReviewers: (): ApprovalStatus => 'not-applicable',
-    createPullRequest: policy,
+    createPullRequest: (ctx: ApprovalContext): ApprovalStatus => {
+      // A draft cannot merge: a schedule run delivering its PRs skips the
+      // card, and marking one ready stays a human act. Anything non-draft
+      // keeps the usual policy.
+      if (isScheduleAppAuth(ctx.session.auth.current) && (ctx.toolInput as { draft?: unknown } | undefined)?.draft === true) {
+        return 'not-applicable'
+      }
+      return policy(ctx)
+    },
     updatePullRequest: policy,
     createIssue: autonomousWrite,
     updateIssue: policy,

--- a/apps/evi/agent/schedules/digest.ts
+++ b/apps/evi/agent/schedules/digest.ts
@@ -13,7 +13,7 @@ export default defineSchedule({
     }
     waitUntil(
       receive(photon, {
-        message: 'Load the daily-digest skill and follow it for the last 24 hours.',
+        message: 'Load the daily-digest skill and follow it for the last 24 hours. This scheduled turn resumes a long-lived thread: ignore earlier conversation topics and stale pending requests, and do only this task.',
         // Spectrum direct-chat guid: `any;-;<address>`, so the thread is
         // derived from the phone number instead of a captured thread id.
         target: { adapterName: 'imessage', threadId: `imessage:any;-;${MAINTAINER_PHONE}` },

--- a/apps/evi/agent/schedules/upstream-sync.ts
+++ b/apps/evi/agent/schedules/upstream-sync.ts
@@ -14,7 +14,7 @@ export default defineSchedule({
     waitUntil(
       receive(photon, {
         message:
-          'Load the upstream-sync skill and check the eve and Vercel Connect ecosystem for updates. Open draft PRs for anything warranted.',
+          'Load the upstream-sync skill and check the eve and Vercel Connect ecosystem for updates. Open draft PRs for anything warranted. This scheduled turn resumes a long-lived thread: ignore earlier conversation topics and stale pending requests, and do only this task.',
         // Spectrum direct-chat guid: `any;-;<address>`, so the thread is
         // derived from the phone number instead of a captured thread id.
         target: { adapterName: 'imessage', threadId: `imessage:any;-;${MAINTAINER_PHONE}` },

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -76,10 +76,19 @@ function filterReportByApiKeyName(payload: unknown, apiKeyName: string): {
   }
 }
 
-function aiGatewayTools() {
-  // Dynamic map keys are bare tool names (no file-slug prefix), so the
-  // namespace is spelled out here to match every ai_gateway__* reference.
-  return {
+/**
+ * Admin-only spend observability. Resolved at turn.started with the tools
+ * defined inline: eve's bundler registers each `execute` as a step function
+ * only when it sits inline in the handler body, and a factory-built map
+ * breaks tool execution on resumed sessions. Keys are bare tool names (no
+ * file-slug prefix), so the namespace is spelled out to match every
+ * ai_gateway__* reference.
+ */
+export default defineDynamic({
+  events: {
+    'turn.started': (_event, ctx) => {
+      if (!canAccessAdminTools(ctx.session.auth.current)) return null
+      return {
     ai_gateway__credits: defineTool({
       description: 'Admin: AI Gateway credit balance and lifetime spend for the entire team account (not Evi-scoped). Prefer ai_gateway__report for Evi digests.',
       inputSchema: z.object({}),
@@ -170,20 +179,7 @@ function aiGatewayTools() {
         return await gatewayFetch('/generation', { id: input.id })
       },
     }),
-  }
-}
-
-// Re-resolved every turn so the gate follows the turn's actual caller and
-// survives a session resumed on a fresh deployment.
-export default defineDynamic({
-  events: {
-    'session.started': async (_event, ctx) => {
-      if (!canAccessAdminTools(ctx.session.auth.current)) return null
-      return aiGatewayTools()
-    },
-    'turn.started': async (_event, ctx) => {
-      if (!canAccessAdminTools(ctx.session.auth.current)) return null
-      return aiGatewayTools()
+      }
     },
   },
 })

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -76,14 +76,8 @@ function filterReportByApiKeyName(payload: unknown, apiKeyName: string): {
   }
 }
 
-/**
- * Admin-only spend observability. Resolved at turn.started with the tools
- * defined inline: eve's bundler registers each `execute` as a step function
- * only when it sits inline in the handler body, and a factory-built map
- * breaks tool execution on resumed sessions. Keys are bare tool names (no
- * file-slug prefix), so the namespace is spelled out to match every
- * ai_gateway__* reference.
- */
+// Admin-only spend observability. Executes sit inline in the resolver on
+// purpose (docs/notes.md); keys carry the ai_gateway__ namespace themselves.
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -86,7 +86,10 @@ export default defineDynamic({
     ai_gateway__credits: defineTool({
       description: 'Admin: AI Gateway credit balance and lifetime spend for the entire team account (not Evi-scoped). Prefer ai_gateway__report for Evi digests.',
       inputSchema: z.object({}),
-      async execute() {
+      async execute(_input, toolCtx) {
+        if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+          return { success: false as const, error: 'AI Gateway reporting is not available in this session.' }
+        }
         return await gatewayFetch('/credits')
       },
     }),
@@ -107,7 +110,10 @@ export default defineDynamic({
         message: 'startDate must not be later than endDate',
         path: ['startDate'],
       }),
-      async execute(input) {
+      async execute(input, toolCtx) {
+        if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+          return { success: false as const, error: 'AI Gateway reporting is not available in this session.' }
+        }
         const configuredKeyName = reportApiKeyName()
         // Key-name scope covers historical untagged traffic on a dedicated Evi
         // key, but it spends the single `group_by` slot on `api_key_name` to do
@@ -169,7 +175,10 @@ export default defineDynamic({
       inputSchema: z.object({
         id: z.string().min(1).describe('Generation id, e.g. gen_01ARZ3NDEKTSV4RRFFQ69G5FAV'),
       }),
-      async execute(input) {
+      async execute(input, toolCtx) {
+        if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+          return { success: false as const, error: 'AI Gateway reporting is not available in this session.' }
+        }
         return await gatewayFetch('/generation', { id: input.id })
       },
     }),

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -76,8 +76,8 @@ function filterReportByApiKeyName(payload: unknown, apiKeyName: string): {
   }
 }
 
-// Admin-only spend observability. Executes sit inline in the resolver on
-// purpose (docs/notes.md); keys carry the ai_gateway__ namespace themselves.
+// Admin-only spend observability. Keep executes inline in the resolver
+// (docs/notes.md); keys carry the ai_gateway__ namespace themselves.
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -17,6 +17,9 @@ export default defineDynamic({
             path: z.string().min(1).describe('Sandbox path of the image, e.g. /workspace/screenshots/after.png'),
           }),
           async execute(input, toolCtx) {
+            if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+              return { success: false as const, error: 'Image upload is not available in this session.' }
+            }
             const contentType = imageContentType(input.path)
             if (!contentType) {
               return { success: false as const, error: `"${input.path}" is not a supported image (png/jpg/webp/gif).` }

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -4,55 +4,53 @@ import { z } from 'zod'
 import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
 import { canAccessAdminTools } from '../lib/trust'
 
-function blobTools() {
-  // Dynamic map keys are bare tool names (no file-slug prefix), so the
-  // namespace is spelled out here to match every blob__upload_image reference.
-  return {
-    blob__upload_image: defineTool({
-      description: 'Upload an image file from the sandbox to the evlog Vercel Blob store and return its public URL. Use it to share screenshots (before/after comparisons, visual evidence) in pull requests and conversations. png/jpg/webp/gif, 8 MB max. The URL is public: upload only captures of evlog surfaces.',
-      inputSchema: z.object({
-        path: z.string().min(1).describe('Sandbox path of the image, e.g. /workspace/screenshots/after.png'),
-      }),
-      async execute(input, ctx) {
-        const contentType = imageContentType(input.path)
-        if (!contentType) {
-          return { success: false as const, error: `"${input.path}" is not a supported image (png/jpg/webp/gif).` }
-        }
-        if (!process.env.BLOB_READ_WRITE_TOKEN) {
-          return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
-        }
-        const sandbox = await ctx.getSandbox()
-        const bytes = await sandbox.readBinaryFile({ path: input.path })
-        if (bytes === null) {
-          return { success: false as const, error: `No file at "${input.path}".` }
-        }
-        if (bytes.byteLength > MAX_IMAGE_BYTES) {
-          return { success: false as const, error: `Image is ${bytes.byteLength} bytes; the limit is ${MAX_IMAGE_BYTES}.` }
-        }
-        // The upload is public: the bytes must actually be the image the
-        // extension claims, not arbitrary data renamed to .png.
-        if (sniffImageContentType(bytes) !== contentType) {
-          return { success: false as const, error: `The content of "${input.path}" does not match its extension; only real image files are uploaded.` }
-        }
-        const blob = await put(screenshotKey(input.path), Buffer.from(bytes), {
-          access: 'public',
-          addRandomSuffix: true,
-          contentType,
-        })
-        return { success: true as const, url: blob.url, bytes: bytes.byteLength }
-      },
-    }),
-  }
-}
-
 /**
  * The URL is public the instant it exists, so autonomous turns never see this
- * tool. Re-resolved every turn so the gate follows the turn's actual caller
- * and survives a session resumed on a fresh deployment.
+ * tool. Resolved at turn.started with the tool defined inline: eve's bundler
+ * registers `execute` as a step function only when it sits inline in the
+ * handler body, and a factory-built map breaks tool execution on resumed
+ * sessions.
  */
 export default defineDynamic({
   events: {
-    'session.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? blobTools() : null),
-    'turn.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? blobTools() : null),
+    'turn.started': (_event, ctx) => {
+      if (!canAccessAdminTools(ctx.session.auth.current)) return null
+      return {
+        blob__upload_image: defineTool({
+          description: 'Upload an image file from the sandbox to the evlog Vercel Blob store and return its public URL. Use it to share screenshots (before/after comparisons, visual evidence) in pull requests and conversations. png/jpg/webp/gif, 8 MB max. The URL is public: upload only captures of evlog surfaces.',
+          inputSchema: z.object({
+            path: z.string().min(1).describe('Sandbox path of the image, e.g. /workspace/screenshots/after.png'),
+          }),
+          async execute(input, toolCtx) {
+            const contentType = imageContentType(input.path)
+            if (!contentType) {
+              return { success: false as const, error: `"${input.path}" is not a supported image (png/jpg/webp/gif).` }
+            }
+            if (!process.env.BLOB_READ_WRITE_TOKEN) {
+              return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
+            }
+            const sandbox = await toolCtx.getSandbox()
+            const bytes = await sandbox.readBinaryFile({ path: input.path })
+            if (bytes === null) {
+              return { success: false as const, error: `No file at "${input.path}".` }
+            }
+            if (bytes.byteLength > MAX_IMAGE_BYTES) {
+              return { success: false as const, error: `Image is ${bytes.byteLength} bytes; the limit is ${MAX_IMAGE_BYTES}.` }
+            }
+            // The upload is public: the bytes must actually be the image the
+            // extension claims, not arbitrary data renamed to .png.
+            if (sniffImageContentType(bytes) !== contentType) {
+              return { success: false as const, error: `The content of "${input.path}" does not match its extension; only real image files are uploaded.` }
+            }
+            const blob = await put(screenshotKey(input.path), Buffer.from(bytes), {
+              access: 'public',
+              addRandomSuffix: true,
+              contentType,
+            })
+            return { success: true as const, url: blob.url, bytes: bytes.byteLength }
+          },
+        }),
+      }
+    },
   },
 })

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -5,7 +5,7 @@ import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType
 import { canAccessAdminTools } from '../lib/trust'
 
 // Public URLs the instant they exist: autonomous turns never see this tool.
-// Executes sit inline in the resolver on purpose (docs/notes.md).
+// Keep executes inline in the resolver (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -4,13 +4,8 @@ import { z } from 'zod'
 import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
 import { canAccessAdminTools } from '../lib/trust'
 
-/**
- * The URL is public the instant it exists, so autonomous turns never see this
- * tool. Resolved at turn.started with the tool defined inline: eve's bundler
- * registers `execute` as a step function only when it sits inline in the
- * handler body, and a factory-built map breaks tool execution on resumed
- * sessions.
- */
+// Public URLs the instant they exist: autonomous turns never see this tool.
+// Executes sit inline in the resolver on purpose (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -45,9 +45,19 @@ async function hostFrame(sandbox: SandboxSession, path: string): Promise<string>
   return blob.url
 }
 
-function captureTools() {
-  return {
-    capture__before_after: defineTool({
+/**
+ * The frames publish to public URLs the moment the tool runs, so autonomous
+ * turns never see it. Resolved at turn.started with the tool defined inline:
+ * eve's bundler registers `execute` as a step function only when it sits
+ * inline in the handler body, and a factory-built map breaks tool execution
+ * on resumed sessions.
+ */
+export default defineDynamic({
+  events: {
+    'turn.started': (_event, ctx) => {
+      if (!canAccessAdminTools(ctx.session.auth.current)) return null
+      return {
+        capture__before_after: defineTool({
       description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, screenshot (cropped to the selector when given), validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
       inputSchema: z.object({
         beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
@@ -59,8 +69,8 @@ function captureTools() {
       // Skill-level "review sensitive surfaces first" is not an enforceable
       // control; a capture of a surface that can show real user data parks on
       // an approval card before anything publishes.
-      approval(ctx) {
-        for (const raw of [ctx.toolInput?.beforeUrl, ctx.toolInput?.afterUrl]) {
+      approval(approvalCtx) {
+        for (const raw of [approvalCtx.toolInput?.beforeUrl, approvalCtx.toolInput?.afterUrl]) {
           if (typeof raw !== 'string') continue
           let reason: string | null
           try {
@@ -73,8 +83,8 @@ function captureTools() {
         }
         return 'not-applicable'
       },
-      async execute(input, ctx) {
-        if (!canAccessAdminTools(ctx.session.auth.current)) {
+      async execute(input, toolCtx) {
+        if (!canAccessAdminTools(toolCtx.session.auth.current)) {
           return { success: false as const, error: 'Captures are not available in this session.' }
         }
         for (const url of [input.beforeUrl, input.afterUrl]) {
@@ -86,10 +96,10 @@ function captureTools() {
         }
         const viewport = input.viewport ?? 'desktop'
         const selector = input.selector ?? null
-        const sandbox = await ctx.getSandbox()
+        const sandbox = await toolCtx.getSandbox()
         await sandbox.run({ command: `mkdir -p ${SCREENSHOT_DIR}` })
-        const beforePath = await captureFrame(ctx, 'before', input.beforeUrl, selector, viewport)
-        const afterPath = await captureFrame(ctx, 'after', input.afterUrl, selector, viewport)
+        const beforePath = await captureFrame(toolCtx, 'before', input.beforeUrl, selector, viewport)
+        const afterPath = await captureFrame(toolCtx, 'after', input.afterUrl, selector, viewport)
         const beforeImageUrl = await hostFrame(sandbox, beforePath)
         const afterImageUrl = await hostFrame(sandbox, afterPath)
         const capturedAt = new Date().toISOString()
@@ -110,17 +120,7 @@ function captureTools() {
         }
       },
     }),
-  }
-}
-
-/**
- * The frames publish to public URLs the moment the tool runs, so autonomous
- * turns never see it. Re-resolved every turn so the gate follows the turn's
- * actual caller and survives a session resumed on a fresh deployment.
- */
-export default defineDynamic({
-  events: {
-    'session.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? captureTools() : null),
-    'turn.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? captureTools() : null),
+      }
+    },
   },
 })

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -45,13 +45,8 @@ async function hostFrame(sandbox: SandboxSession, path: string): Promise<string>
   return blob.url
 }
 
-/**
- * The frames publish to public URLs the moment the tool runs, so autonomous
- * turns never see it. Resolved at turn.started with the tool defined inline:
- * eve's bundler registers `execute` as a step function only when it sits
- * inline in the handler body, and a factory-built map breaks tool execution
- * on resumed sessions.
- */
+// Frames publish to public URLs the moment the tool runs: autonomous turns
+// never see it. Executes sit inline in the resolver on purpose (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -46,7 +46,7 @@ async function hostFrame(sandbox: SandboxSession, path: string): Promise<string>
 }
 
 // Frames publish to public URLs the moment the tool runs: autonomous turns
-// never see it. Executes sit inline in the resolver on purpose (docs/notes.md).
+// never see it. Keep executes inline in the resolver (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -15,8 +15,7 @@ const REPO_DIR = '/workspace/repo'
 const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
 
 // Maintainer and schedule-app turns only; the push is inert (feature
-// branches only). Executes sit inline in the resolver on purpose: a
-// factory-built map loses its step functions on resumed sessions (docs/notes.md).
+// branches only). Executes sit inline in the resolver on purpose (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -14,15 +14,9 @@ const REPO_DIR = '/workspace/repo'
  */
 const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
 
-/**
- * Visible to maintainer sessions and to schedule-app turns (the upstream-sync
- * run pushes its feature branches); community and autonomous turns never see a
- * push surface. The push itself is inert: it only ever creates a feature
- * branch. Resolved at turn.started with the tools defined inline: eve's
- * bundler registers each `execute` as a step function only when it sits
- * inline in the handler body, and a factory-built map breaks tool execution
- * on resumed sessions.
- */
+// Maintainer and schedule-app turns only; the push is inert (feature
+// branches only). Executes sit inline in the resolver on purpose: a
+// factory-built map loses its step functions on resumed sessions (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -15,7 +15,7 @@ const REPO_DIR = '/workspace/repo'
 const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
 
 // Maintainer and schedule-app turns only; the push is inert (feature
-// branches only). Executes sit inline in the resolver on purpose (docs/notes.md).
+// branches only). Keep executes inline in the resolver (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -14,65 +14,59 @@ const REPO_DIR = '/workspace/repo'
  */
 const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
 
-function gitTools() {
-  // Dynamic map keys are bare tool names (no file-slug prefix), so the
-  // namespace is spelled out here to match every git__push reference.
-  return {
-    git__push: defineTool({
-      description: `Push a local branch of the ${REPO_DIR} checkout to origin (HugoRCD/evlog). The branch must already exist there with the work committed and the checks run; main and master are refused. The credential is brokered at the sandbox firewall and never enters the sandbox. After a successful push, open the pull request with github__createPullRequest.`,
-      inputSchema: z.object({
-        branch: z.string().min(1).describe('Branch name in /workspace/repo to push, e.g. fix/pipeline-flush'),
-      }),
-      async execute(input, ctx) {
-        if (!isMaintainer(ctx.session.auth.current) && !isScheduleAppAuth(ctx.session.auth.current)) {
-          return { success: false as const, error: 'Only maintainer and schedule-app sessions may push.' }
-        }
-        const refusal = validatePushBranch(input.branch)
-        if (refusal) return { success: false as const, error: refusal }
-        const sandbox = await ctx.getSandbox()
-        const token = await mintInstallationToken(githubCredentials)
-        await sandbox.setNetworkPolicy(pushBrokerPolicy(token))
-        try {
-          const push = await sandbox.run({
-            command: `git -C ${REPO_DIR} push ${PUSH_URL} 'refs/heads/${input.branch}:refs/heads/${input.branch}'`,
-          })
-          if (push.exitCode !== 0) {
-            return {
-              success: false as const,
-              error: `git push exited ${push.exitCode}: ${String(push.stderr || push.stdout).trim()}`,
-            }
-          }
-          const head = await sandbox.run({ command: `git -C ${REPO_DIR} rev-parse '${input.branch}'` })
-          return {
-            success: true as const,
-            branch: input.branch,
-            sha: String(head.stdout).trim(),
-            repository: 'HugoRCD/evlog',
-          }
-        }
-        finally {
-          // Drop the brokered credential; the channel checkout re-brokers its own when it needs to fetch.
-          await sandbox.setNetworkPolicy('allow-all')
-        }
-      },
-    }),
-  }
-}
-
 /**
  * Visible to maintainer sessions and to schedule-app turns (the upstream-sync
  * run pushes its feature branches); community and autonomous turns never see a
  * push surface. The push itself is inert: it only ever creates a feature
- * branch, and the PR that references it carries the approval card. Re-resolved
- * every turn so the gate follows the turn's actual caller and survives a
- * session resumed on a fresh deployment, where session.started never fires
- * again.
+ * branch. Resolved at turn.started with the tools defined inline: eve's
+ * bundler registers each `execute` as a step function only when it sits
+ * inline in the handler body, and a factory-built map breaks tool execution
+ * on resumed sessions.
  */
 export default defineDynamic({
   events: {
-    'session.started': (_event, ctx) =>
-      (isMaintainer(ctx.session.auth.current) || isScheduleAppAuth(ctx.session.auth.current) ? gitTools() : null),
-    'turn.started': (_event, ctx) =>
-      (isMaintainer(ctx.session.auth.current) || isScheduleAppAuth(ctx.session.auth.current) ? gitTools() : null),
+    'turn.started': (_event, ctx) => {
+      if (!isMaintainer(ctx.session.auth.current) && !isScheduleAppAuth(ctx.session.auth.current)) return null
+      return {
+        git__push: defineTool({
+          description: `Push a local branch of the ${REPO_DIR} checkout to origin (HugoRCD/evlog). The branch must already exist there with the work committed and the checks run; main and master are refused. The credential is brokered at the sandbox firewall and never enters the sandbox. After a successful push, open the pull request with github__createPullRequest.`,
+          inputSchema: z.object({
+            branch: z.string().min(1).describe('Branch name in /workspace/repo to push, e.g. fix/pipeline-flush'),
+          }),
+          async execute(input, toolCtx) {
+            if (!isMaintainer(toolCtx.session.auth.current) && !isScheduleAppAuth(toolCtx.session.auth.current)) {
+              return { success: false as const, error: 'Only maintainer and schedule-app sessions may push.' }
+            }
+            const refusal = validatePushBranch(input.branch)
+            if (refusal) return { success: false as const, error: refusal }
+            const sandbox = await toolCtx.getSandbox()
+            const token = await mintInstallationToken(githubCredentials)
+            await sandbox.setNetworkPolicy(pushBrokerPolicy(token))
+            try {
+              const push = await sandbox.run({
+                command: `git -C ${REPO_DIR} push ${PUSH_URL} 'refs/heads/${input.branch}:refs/heads/${input.branch}'`,
+              })
+              if (push.exitCode !== 0) {
+                return {
+                  success: false as const,
+                  error: `git push exited ${push.exitCode}: ${String(push.stderr || push.stdout).trim()}`,
+                }
+              }
+              const head = await sandbox.run({ command: `git -C ${REPO_DIR} rev-parse '${input.branch}'` })
+              return {
+                success: true as const,
+                branch: input.branch,
+                sha: String(head.stdout).trim(),
+                repository: 'HugoRCD/evlog',
+              }
+            }
+            finally {
+              // Drop the brokered credential; the channel checkout re-brokers its own when it needs to fetch.
+              await sandbox.setNetworkPolicy('allow-all')
+            }
+          },
+        }),
+      }
+    },
   },
 })

--- a/apps/evi/agent/tools/turbo.ts
+++ b/apps/evi/agent/tools/turbo.ts
@@ -5,7 +5,7 @@ import { canAccessAdminTools } from '../lib/trust'
 import { exchangeTurboToken, turboConfigCommand } from '../lib/turbo'
 
 // The token only touches the remote cache, but never unattended: autonomous
-// turns don't see this tool. Executes sit inline in the resolver on purpose (docs/notes.md).
+// turns don't see this tool. Keep executes inline in the resolver (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/turbo.ts
+++ b/apps/evi/agent/tools/turbo.ts
@@ -31,7 +31,13 @@ export default defineDynamic({
             catch (error) {
               return { success: false as const, error: `No Vercel OIDC token available: ${error instanceof Error ? error.message : String(error)}` }
             }
-            const token = await exchangeTurboToken(oidc, teamSlug)
+            let token: string
+        try {
+          token = await exchangeTurboToken(oidc, teamSlug)
+        }
+        catch {
+          return { success: false as const, error: 'Turborepo token exchange failed; remote caching is unavailable for this run.' }
+        }
             const sandbox = await toolCtx.getSandbox()
             const write = await sandbox.run({ command: turboConfigCommand(token, teamId, teamSlug) })
             if (write.exitCode !== 0) {

--- a/apps/evi/agent/tools/turbo.ts
+++ b/apps/evi/agent/tools/turbo.ts
@@ -4,14 +4,8 @@ import { z } from 'zod'
 import { canAccessAdminTools } from '../lib/trust'
 import { exchangeTurboToken, turboConfigCommand } from '../lib/turbo'
 
-/**
- * The token can only touch the remote cache, but a sandbox that runs untrusted
- * repro code must not hold it unattended: autonomous turns never see this
- * tool. Resolved at turn.started with the tool defined inline: eve's bundler
- * registers `execute` as a step function only when it sits inline in the
- * handler body, and a factory-built map breaks tool execution on resumed
- * sessions.
- */
+// The token only touches the remote cache, but never unattended: autonomous
+// turns don't see this tool. Executes sit inline in the resolver on purpose (docs/notes.md).
 export default defineDynamic({
   events: {
     'turn.started': (_event, ctx) => {

--- a/apps/evi/agent/tools/turbo.ts
+++ b/apps/evi/agent/tools/turbo.ts
@@ -4,52 +4,53 @@ import { z } from 'zod'
 import { canAccessAdminTools } from '../lib/trust'
 import { exchangeTurboToken, turboConfigCommand } from '../lib/turbo'
 
-function turboTools() {
-  return {
-    turbo__enable_remote_cache: defineTool({
-      description: "Connect the sandbox checkout to the team's Turborepo Remote Cache for this session. Call it once before running the checks: turbo then reuses artifacts CI already built instead of running every task cold. The short-lived token is written to turbo's own config files, never into a command. Run the checks with TURBO_REMOTE_CACHE_READ_ONLY=true so the sandbox never writes to the shared cache.",
-      inputSchema: z.object({}),
-      async execute(_input, ctx) {
-        if (!canAccessAdminTools(ctx.session.auth.current)) {
-          return { success: false as const, error: 'Remote cache access is not available in this session.' }
-        }
-        const teamSlug = process.env.TURBO_TEAM
-        const teamId = process.env.VERCEL_TEAM_ID
-        if (!teamSlug || !teamId) {
-          return { success: false as const, error: 'TURBO_TEAM and VERCEL_TEAM_ID must be configured for remote caching.' }
-        }
-        // Fetched per call: the env token is minted at boot and expires on a warm instance.
-        let oidc: string
-        try {
-          oidc = await getVercelOidcToken()
-        }
-        catch (error) {
-          return { success: false as const, error: `No Vercel OIDC token available: ${error instanceof Error ? error.message : String(error)}` }
-        }
-        const token = await exchangeTurboToken(oidc, teamSlug)
-        const sandbox = await ctx.getSandbox()
-        const write = await sandbox.run({ command: turboConfigCommand(token, teamId, teamSlug) })
-        if (write.exitCode !== 0) {
-          return { success: false as const, error: `Writing the turbo config failed: ${String(write.stderr || write.stdout).trim()}` }
-        }
-        return {
-          success: true as const,
-          team: teamSlug,
-          note: 'Remote cache connected for this session (token is short-lived). Prefix check commands with TURBO_REMOTE_CACHE_READ_ONLY=true.',
-        }
-      },
-    }),
-  }
-}
-
 /**
  * The token can only touch the remote cache, but a sandbox that runs untrusted
  * repro code must not hold it unattended: autonomous turns never see this
- * tool. Re-resolved every turn so the gate follows the turn's actual caller.
+ * tool. Resolved at turn.started with the tool defined inline: eve's bundler
+ * registers `execute` as a step function only when it sits inline in the
+ * handler body, and a factory-built map breaks tool execution on resumed
+ * sessions.
  */
 export default defineDynamic({
   events: {
-    'session.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? turboTools() : null),
-    'turn.started': (_event, ctx) => (canAccessAdminTools(ctx.session.auth.current) ? turboTools() : null),
+    'turn.started': (_event, ctx) => {
+      if (!canAccessAdminTools(ctx.session.auth.current)) return null
+      return {
+        turbo__enable_remote_cache: defineTool({
+          description: "Connect the sandbox checkout to the team's Turborepo Remote Cache for this session. Call it once before running the checks: turbo then reuses artifacts CI already built instead of running every task cold. The short-lived token is written to turbo's own config files, never into a command. Run the checks with TURBO_REMOTE_CACHE_READ_ONLY=true so the sandbox never writes to the shared cache.",
+          inputSchema: z.object({}),
+          async execute(_input, toolCtx) {
+            if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+              return { success: false as const, error: 'Remote cache access is not available in this session.' }
+            }
+            const teamSlug = process.env.TURBO_TEAM
+            const teamId = process.env.VERCEL_TEAM_ID
+            if (!teamSlug || !teamId) {
+              return { success: false as const, error: 'TURBO_TEAM and VERCEL_TEAM_ID must be configured for remote caching.' }
+            }
+            // Fetched per call: the env token is minted at boot and expires on a warm instance.
+            let oidc: string
+            try {
+              oidc = await getVercelOidcToken()
+            }
+            catch (error) {
+              return { success: false as const, error: `No Vercel OIDC token available: ${error instanceof Error ? error.message : String(error)}` }
+            }
+            const token = await exchangeTurboToken(oidc, teamSlug)
+            const sandbox = await toolCtx.getSandbox()
+            const write = await sandbox.run({ command: turboConfigCommand(token, teamId, teamSlug) })
+            if (write.exitCode !== 0) {
+              return { success: false as const, error: `Writing the turbo config failed: ${String(write.stderr || write.stdout).trim()}` }
+            }
+            return {
+              success: true as const,
+              team: teamSlug,
+              note: 'Remote cache connected for this session (token is short-lived). Prefix check commands with TURBO_REMOTE_CACHE_READ_ONLY=true.',
+            }
+          },
+        }),
+      }
+    },
   },
 })

--- a/apps/evi/docs/notes.md
+++ b/apps/evi/docs/notes.md
@@ -38,6 +38,15 @@ work grows every run and obscures real failures in the output.
 **`sessionEvent` has never been observed firing.** It emits on session
 completion, which the eval runner never reaches.
 
+### Dynamic tools: executes stay inline
+
+eve's bundler transform registers a dynamic tool's `execute` as a durable step
+function only when the function sits inline in the resolver body. A tool map
+built by a factory (`return myTools()`) type-checks and works on a fresh
+session, then fails on any resumed session with `references step function
+"..." which is not registered`. Every `agent/tools/*.ts` dynamic file
+therefore defines its tools inline in a single `turn.started` resolver.
+
 ## Schedules
 
 **Chat-sdk channels target a provider-native `threadId` from a schedule.**


### PR DESCRIPTION
Production logs from this morning's scheduled runs show the failure eve's docs warn about:

```
[eve:dynamic-tools] Dynamic tool "ai_gateway__credits" references step function
"eve:framework-dynamic:ai-gateway:ai_gateway__credits" which is not registered
```

All five dynamic tool files built their tool maps through factory functions; eve's bundler transform only registers `execute` step functions it finds inline in the resolver body, so on a resumed session (the long-lived iMessage thread permanently is one) the tools stopped executing and the model degraded to answering around them.

- `ai-gateway`, `git`, `blob`, `capture`, `turbo`: the tool maps now sit inline in a single `turn.started` resolver (which also covers what `session.started` did, once per turn instead of once per session).
- `createPullRequest` policy: a schedule-app turn creating a **draft** PR no longer parks on an approval card — a draft cannot merge, and marking one ready stays a human act. Non-draft keeps the card. This matches the original upstream-sync contract ("one or more draft PRs, nothing auto-applicable").
- Both schedule prompts now tell the turn to ignore earlier conversation topics and stale pending requests: scheduled turns resume the shared thread session, and this morning's runs showed the context bleed.

No changeset: confined to `apps/evi`. Verified: `tsc`, 63 unit tests, `eve build`. The step-registration warning disappearing from production logs after deploy is the end-to-end check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled draft pull requests now correctly bypass approval when authorized by scheduled automation.
  * Daily digest and upstream synchronization tasks no longer carry over stale requests or unrelated conversation topics.
  * Administrative tools now remain available only in authorized sessions, with access checks enforced during use.

* **Security**
  * Git, blob upload, capture, Turbo cache, and administrative tools now apply more consistent access controls.

* **Documentation**
  * Added guidance for reliable tool behavior in resumed sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->