### PR TITLE
fix: declare the stryker vitest-runner plugin explicitly

### DIFF
--- a/packages/evlog/stryker.config.json
+++ b/packages/evlog/stryker.config.json
@@ -2,6 +2,8 @@
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "_": "Mutation testing for evlog core. Slow (~minutes) — do not run in default CI; see .github/workflows/mutation.yml for the weekly cron.",
   "_mutate_scope": "Only core modules listed in `mutate` are mutated (logger, pipeline, redact, error, catalog, audit, utils, shared/{routes,headers,middleware}). Framework integrations (express, hono, fastify, ...) and adapters (axiom, posthog, ...) are intentionally excluded — Stryker would re-boot each framework's runtime per mutant which is prohibitively expensive, and those modules are already covered by integration tests in test/frameworks/ and test/adapters/.",
+  "_plugins": "Explicit because the default @stryker-mutator/* discovery globs relative to core's own install dir, which under pnpm's isolated layout never contains the runner.",
+  "plugins": ["@stryker-mutator/vitest-runner"],
   "packageManager": "pnpm",
   "testRunner": "vitest",
   "vitest": {


### PR DESCRIPTION
The weekly mutation workflow has failed on every run since it was added: Stryker's default `@stryker-mutator/*` plugin discovery globs the `node_modules` directory five levels above `@stryker-mutator/core`, which under pnpm's isolated layout is core's own `.pnpm` install dir — it only ever contains core's dependencies (api, util, instrumenter, all ignored by the loader), never the vitest runner. No TestRunner plugin loads and the run dies before the first mutant.

Declaring `plugins: ["@stryker-mutator/vitest-runner"]` explicitly makes Stryker import it as a bare specifier, which resolves through pnpm's hoisted fallback.

Verified locally: dry run passes (1264 tests via the vitest runner) and the full mutation run completes with a score of 59.15 against the break threshold of 50.

Internal tooling only, no changeset.