### PR TITLE
docs: give every section a data-section capture hook

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -14,3 +14,11 @@ MDC animation components (e.g. `EnricherChain`, `DrainFanOut`, `StreamBus`) foll
 - **Compact by default**: `text-[10px]` for body, `text-[9px]` for footers/labels, `leading-tight` or `leading-snug`, `py-1.5` / `py-2` headers/footers, `space-y-0.5` or none, `gap-1.5` or smaller. The doc page width (sidebar + TOC) is narrow; aim for a final height under ~280px.
 - Use `<div>` (not `<ol>/<li>`) for repeating slots — list elements collide with grid layout in Docus.
 - **No viewport-dependent layout shift.** Stick to a single column at any width or use `sm:` for the optional split — never `lg:` (the doc content area never reaches the `lg:` breakpoint).
+
+## Capture hooks (`data-section`)
+
+Every landing section and every MDC content component carries `data-section="<its MDC tag>"` on its root element: `LandingHero.vue` renders `data-section="landing-hero"`, `DrainFanOut.vue` renders `data-section="drain-fan-out"`.
+
+- **A new section component adds its hook in the same commit.** The value is the kebab-case MDC tag the markdown already uses, so the two never have to be reconciled.
+- **The hook exists because utility classes cannot identify a section.** Eleven landing sections render the identical `section.py-24.md:py-32`; a screenshot tool handed that selector frames the wrong one, or silently frames the top of the page.
+- **It is a tooling hook, not an anchor.** Add an `id` when a section deserves a real URL fragment. Keep the two separate: an `id` gets renamed for reader-facing reasons, `data-section` follows the component.

--- a/apps/docs/app/components/LandingCta.vue
+++ b/apps/docs/app/components/LandingCta.vue
@@ -29,7 +29,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="relative overflow-hidden flex flex-col">
+  <section class="relative overflow-hidden flex flex-col" data-section="landing-cta">
     <div
       class="absolute inset-x-0 top-0 h-24 z-[1] pointer-events-none"
       style="background: linear-gradient(180deg, #09090b 0%, transparent 100%)"

--- a/apps/docs/app/components/LandingFeatures.vue
+++ b/apps/docs/app/components/LandingFeatures.vue
@@ -1,5 +1,5 @@
 <template>
-  <UPageSection :ui="{ root: 'py-0', container: 'gap-0 lg:gap-0' }">
+  <UPageSection data-section="landing-features" :ui="{ root: 'py-0', container: 'gap-0 lg:gap-0' }">
     <slot name="body" />
   </UPageSection>
 </template>

--- a/apps/docs/app/components/LandingHero.vue
+++ b/apps/docs/app/components/LandingHero.vue
@@ -11,7 +11,7 @@ async function copyCommand() {
 </script>
 
 <template>
-  <section class="relative overflow-hidden bg-default">
+  <section class="relative overflow-hidden bg-default" data-section="landing-hero">
     <div class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[300px] rounded-full blur-3xl pointer-events-none" />
     <div class="relative z-10 flex flex-col items-center text-center max-w-4xl mx-auto pt-28 lg:pt-32 pb-4 px-6">
       <button

--- a/apps/docs/app/components/LandingLogos.vue
+++ b/apps/docs/app/components/LandingLogos.vue
@@ -19,6 +19,7 @@ const logos: LogoItem[] = [
 <template>
   <section
     class="relative -mt-4 pt-4"
+    data-section="landing-logos"
     aria-label="Companies using evlog"
   >
     <div

--- a/apps/docs/app/components/content/AiSdkWideEvent.vue
+++ b/apps/docs/app/components/content/AiSdkWideEvent.vue
@@ -139,7 +139,7 @@ const estimatedCost = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="ai-sdk-wide-event">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-sparkles" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/AuditCompositionFlow.vue
+++ b/apps/docs/app/components/content/AuditCompositionFlow.vue
@@ -147,7 +147,7 @@ const fanOutReached = computed(() => phase.value === 'fan-out' || phase.value ==
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="audit-composition-flow">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/AuditDualSink.vue
+++ b/apps/docs/app/components/content/AuditDualSink.vue
@@ -155,7 +155,7 @@ const recentAudit = computed(() =>
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="audit-dual-sink">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-git-fork" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/AuditForceKeep.vue
+++ b/apps/docs/app/components/content/AuditForceKeep.vue
@@ -136,7 +136,7 @@ const stats = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="audit-force-keep">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-filter" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/BenchBarRace.vue
+++ b/apps/docs/app/components/content/BenchBarRace.vue
@@ -145,7 +145,7 @@ const collapsed = computed(() => phase.value === 'collapsed' || phase.value === 
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="bench-bar-race">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/BetterAuthIdentify.vue
+++ b/apps/docs/app/components/content/BetterAuthIdentify.vue
@@ -168,7 +168,7 @@ function valueColor(value: string) {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="better-auth-identify">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/ClientServerBeacon.vue
+++ b/apps/docs/app/components/content/ClientServerBeacon.vue
@@ -152,7 +152,7 @@ const isReceived = computed(() => phase.value === 'received' || phase.value === 
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="client-server-beacon">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-radio-tower" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/DrainFanOut.vue
+++ b/apps/docs/app/components/content/DrainFanOut.vue
@@ -186,7 +186,7 @@ function statusLabel(adapter: Adapter, s: AdapterState) {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="drain-fan-out">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-3">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/DrainPipelineBatching.vue
+++ b/apps/docs/app/components/content/DrainPipelineBatching.vue
@@ -223,7 +223,7 @@ const fillPct = computed(() => Math.min(100, (buffer.value.length / BATCH_SIZE) 
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="drain-pipeline-batching">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/EnricherChain.vue
+++ b/apps/docs/app/components/content/EnricherChain.vue
@@ -152,7 +152,7 @@ const totalEnrichedFields = computed(() =>
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="enricher-chain">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-sparkles" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/HashChainTamper.vue
+++ b/apps/docs/app/components/content/HashChainTamper.vue
@@ -228,7 +228,7 @@ function outcomeClass(outcome: 'success' | 'denied' | 'failure') {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="hash-chain-tamper">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-link-2" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/HeadSamplingPlinko.vue
+++ b/apps/docs/app/components/content/HeadSamplingPlinko.vue
@@ -171,7 +171,7 @@ const allDone = computed(() => phase.value === 'done')
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="head-sampling-plinko">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/LifecycleFlow.vue
+++ b/apps/docs/app/components/content/LifecycleFlow.vue
@@ -178,7 +178,7 @@ const isDone = computed(() => phase.value >= stages.length - 1)
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="lifecycle-flow">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/MapPrGate.vue
+++ b/apps/docs/app/components/content/MapPrGate.vue
@@ -140,7 +140,7 @@ const gateLine = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="map-pr-gate">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-git-pull-request" class="size-3 text-primary shrink-0" />

--- a/apps/docs/app/components/content/MapRulesMatrix.vue
+++ b/apps/docs/app/components/content/MapRulesMatrix.vue
@@ -134,7 +134,7 @@ const failingReqs = computed(() =>
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="map-rules-matrix">
     <div ref="wrapperRef" class="w-full min-h-[248px] overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-list-checks" class="size-3 text-primary shrink-0" />

--- a/apps/docs/app/components/content/MapScanFlow.vue
+++ b/apps/docs/app/components/content/MapScanFlow.vue
@@ -165,7 +165,7 @@ const status = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="map-scan-flow">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radar" class="size-3 text-primary shrink-0" />

--- a/apps/docs/app/components/content/MapScoreClimb.vue
+++ b/apps/docs/app/components/content/MapScoreClimb.vue
@@ -137,7 +137,7 @@ function accentClass(line: Line) {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="map-score-climb">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-gauge" class="size-3 text-primary shrink-0" />

--- a/apps/docs/app/components/content/NdjsonTail.vue
+++ b/apps/docs/app/components/content/NdjsonTail.vue
@@ -124,7 +124,7 @@ const progress = computed(() => cursor.value < 0 ? 0 : ((cursor.value + 1) / lin
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="ndjson-tail">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-1.5">
         <UIcon name="i-lucide-folder-search" class="size-3 text-primary" />

--- a/apps/docs/app/components/content/RedactionStream.vue
+++ b/apps/docs/app/components/content/RedactionStream.vue
@@ -116,7 +116,7 @@ function display(field: Field, idx: number) {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="redaction-stream">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-3">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/SseWire.vue
+++ b/apps/docs/app/components/content/SseWire.vue
@@ -106,7 +106,7 @@ const replayCount = computed(() => visible.value.filter((v, i) => v && frames[i]
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="sse-wire">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radio" class="size-3 text-primary" />

--- a/apps/docs/app/components/content/StreamBus.vue
+++ b/apps/docs/app/components/content/StreamBus.vue
@@ -162,7 +162,7 @@ const stage = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="stream-bus">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-3 py-2">
         <UIcon name="i-lucide-radio-tower" class="size-3 text-primary" />

--- a/apps/docs/app/components/content/StructuredErrorBranching.vue
+++ b/apps/docs/app/components/content/StructuredErrorBranching.vue
@@ -187,7 +187,7 @@ function statusClass() {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="structured-error-branching">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/StructuredErrorContext.vue
+++ b/apps/docs/app/components/content/StructuredErrorContext.vue
@@ -124,7 +124,7 @@ const reachedRendered = computed(() => phase.value === 'rendered')
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="structured-error-context">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-shield-alert" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/TailSampleDecision.vue
+++ b/apps/docs/app/components/content/TailSampleDecision.vue
@@ -185,7 +185,7 @@ const stats = computed(() => {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="tail-sample-decision">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-funnel" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/content/TypedFieldsIntellisense.vue
+++ b/apps/docs/app/components/content/TypedFieldsIntellisense.vue
@@ -216,7 +216,7 @@ function statusClass() {
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="typed-fields-intellisense">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/ViteStripBuild.vue
+++ b/apps/docs/app/components/content/ViteStripBuild.vue
@@ -133,7 +133,7 @@ const injectCount = computed(() => sourceLines.filter(l => l.kind === 'info-obj'
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="vite-strip-build">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2">
         <div class="flex gap-1.5">

--- a/apps/docs/app/components/content/WideEventCollapse.vue
+++ b/apps/docs/app/components/content/WideEventCollapse.vue
@@ -151,7 +151,7 @@ const collapsedCount = computed(() => lineCollapsed.value.filter(Boolean).length
 </script>
 
 <template>
-  <div class="not-prose my-8">
+  <div class="not-prose my-8" data-section="wide-event-collapse">
     <div ref="wrapperRef" class="overflow-hidden border border-muted bg-default">
       <div class="flex items-center gap-2 border-b border-muted px-4 py-2.5">
         <UIcon name="i-lucide-shrink" class="size-3.5 text-primary" />

--- a/apps/docs/app/components/features/FeatureAdapters.vue
+++ b/apps/docs/app/components/features/FeatureAdapters.vue
@@ -252,7 +252,7 @@ function setupCanvas() {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-adapters">
     <div class="grid gap-6 lg:grid-cols-2 *:min-w-0">
       <div class="flex flex-col gap-8">
         <Motion

--- a/apps/docs/app/components/features/FeatureAgentReady.vue
+++ b/apps/docs/app/components/features/FeatureAgentReady.vue
@@ -84,7 +84,7 @@ function startAnimation() {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-agent-ready">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"

--- a/apps/docs/app/components/features/FeatureAiSdk.vue
+++ b/apps/docs/app/components/features/FeatureAiSdk.vue
@@ -77,7 +77,7 @@ function setView(view: 'without' | 'with') {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-ai-sdk">
     <div class="grid gap-6 lg:grid-cols-2 *:min-w-0">
       <div class="flex flex-col gap-6">
         <Motion

--- a/apps/docs/app/components/features/FeatureAudit.vue
+++ b/apps/docs/app/components/features/FeatureAudit.vue
@@ -40,7 +40,7 @@ const benefits = [
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-audit">
     <div class="grid gap-6 lg:grid-cols-2 *:min-w-0">
       <div class="flex flex-col gap-6">
         <Motion

--- a/apps/docs/app/components/features/FeatureCliMap.vue
+++ b/apps/docs/app/components/features/FeatureCliMap.vue
@@ -139,7 +139,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-cli-map">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"

--- a/apps/docs/app/components/features/FeatureClientDrain.vue
+++ b/apps/docs/app/components/features/FeatureClientDrain.vue
@@ -14,7 +14,7 @@ const pills = [
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-client-drain">
     <div class="grid gap-6 lg:grid-cols-2 *:min-w-0">
       <div class="flex flex-col gap-8">
         <Motion

--- a/apps/docs/app/components/features/FeatureFrameworks.vue
+++ b/apps/docs/app/components/features/FeatureFrameworks.vue
@@ -34,7 +34,7 @@ const frameworkRows = [
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-frameworks">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"

--- a/apps/docs/app/components/features/FeaturePerformance.vue
+++ b/apps/docs/app/components/features/FeaturePerformance.vue
@@ -88,7 +88,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-performance">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"

--- a/apps/docs/app/components/features/FeatureSampling.vue
+++ b/apps/docs/app/components/features/FeatureSampling.vue
@@ -95,7 +95,7 @@ function getLevelColor(level: string): string {
 </script>
 
 <template>
-  <section class="py-24 md:py-32">
+  <section class="py-24 md:py-32" data-section="features-feature-sampling">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"

--- a/apps/docs/app/components/features/FeatureSimpleApi.vue
+++ b/apps/docs/app/components/features/FeatureSimpleApi.vue
@@ -52,7 +52,7 @@ function setOutput(type: 'success' | 'error') {
 </script>
 
 <template>
-  <section class="pt-16 md:pt-20 pb-24 md:pb-32">
+  <section class="pt-16 md:pt-20 pb-24 md:pb-32" data-section="features-feature-simple-api">
     <Motion
       :initial="false"
       :while-in-view="{ opacity: 1, y: 0 }"


### PR DESCRIPTION
## What

Adds `data-section="<its MDC tag>"` to the root element of every landing section and every MDC content component. `LandingHero.vue` renders `data-section="landing-hero"`, `DrainFanOut.vue` renders `data-section="drain-fan-out"`.

41 components in total: 4 landing sections, 10 feature sections, 27 doc content components. `FeatureStructuredErrors.vue` is skipped because no page references it (worth deleting separately).

## Why

Eleven landing sections render the byte-identical `<section class="py-24 md:py-32">`. There is no selector that targets one of them, so any tool asked to frame a section either matches the wrong one or matches nothing and falls back to the top of the page. That is what produced the mis-framed screenshots on #578: two captures of the hero presented as a before/after of a section 11,400px further down.

The hook makes the selector **derivable rather than discovered**. A change to `::landing-faq` in `0.landing.md` is captured with `[data-section="landing-faq"]`, computed from the diff, with no page inspection and no judgment call.

It is deliberately not an `id`. IDs are a reader-facing namespace (URL fragments, `aria-labelledby`) and get renamed for reader-facing reasons; the tooling hook has to follow the component instead. `apps/docs/AGENTS.md` records the convention and that split.

## Notes

- Changes are confined to `apps/docs`, so no changeset.
- `pnpm --filter evlog-docs run lint` and `pnpm --filter evlog-docs run typecheck` exit 0.
- Every derived hook was cross-checked against the MDC tags actually used in `content/`: 27 declared, 27 referenced, no orphans.
- Verified in the rendered DOM, not just the source: the landing serves all 14 hooks, each exactly once, and `/learn/wide-events` serves `wide-event-collapse`.
- Consumed by the framing fix in the companion Evi PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring documentation sections and content components to expose consistent `data-section` identifiers.
* **Enhancements**
  * Added section identifiers across landing page sections, feature showcases, and interactive documentation content.
  * Improved consistency for locating and identifying documentation sections without changing reader-facing URL anchors or page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->