### PR TITLE
fix(evi): frame captures on the selector and fail when it misses

### DIFF
--- a/apps/evi/agent/lib/capture.test.ts
+++ b/apps/evi/agent/lib/capture.test.ts
@@ -96,8 +96,12 @@ function element(text: string, section?: Record<string, unknown>) {
   return {
     textContent: text,
     marks,
-    setAttribute: (name: string, value: string) => { marks[name] = value },
-    removeAttribute: (name: string) => { delete marks[name] },
+    setAttribute: (name: string, value: string) => {
+      marks[name] = value 
+    },
+    removeAttribute: (name: string) => {
+      delete marks[name] 
+    },
     closest: () => section ?? null,
   }
 }

--- a/apps/evi/agent/lib/capture.test.ts
+++ b/apps/evi/agent/lib/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { captureAttestation, captureMarkdown, escapeInline, FRAME_HEIGHT_BOUNDS, frameHeight, frameParkExpression, frameProbeExpression, markdownUrl, missingSelectorMessage, readFrameProbe, sensitiveCaptureReason, validateCaptureUrl } from './capture'
+import { CAPTURE_MARK, captureAttestation, captureMarkdown, describeTarget, escapeInline, markdownUrl, readTargetProbe, resolveTargetExpression, sensitiveCaptureReason, unresolvedTargetMessage, validateCaptureUrl } from './capture'
 
 describe('validateCaptureUrl', () => {
   it('accepts evlog surfaces, previews, and local dev servers', () => {
@@ -46,7 +46,7 @@ describe('escaping', () => {
       beforeImageUrl: 'https://blob/x.png',
       afterImageUrl: 'https://blob/y.png',
       caption: 'ok\n\n## Forged section\n<script>x</script>',
-      selector: null,
+      frame: 'full viewport',
       viewport: 'desktop',
       capturedAt: 't',
     })
@@ -63,7 +63,7 @@ describe('captureMarkdown', () => {
       beforeImageUrl: 'https://blob/x.png',
       afterImageUrl: 'https://blob/y.png',
       caption: 'Landing hero, desktop viewport.',
-      selector: '.hero',
+      frame: '.hero',
       viewport: 'desktop',
       capturedAt: '2026-08-09T15:00:00.000Z',
     })
@@ -77,7 +77,7 @@ describe('captureMarkdown', () => {
       captureAttestation({
         beforeUrl: 'https://evlog.dev/',
         afterUrl: 'https://evlog.cloud/',
-        selector: null,
+        frame: 'full viewport',
         viewport: 'mobile',
         capturedAt: 't',
       }),
@@ -85,106 +85,131 @@ describe('captureMarkdown', () => {
   })
 })
 
-/** Evaluates a probe expression against a stubbed page. */
+
+/** Evaluates a resolver expression against a stubbed page. */
 function runInPage(expression: string, page: { document: unknown, window: unknown }): unknown {
   return new Function('document', 'window', `return ${expression}`)(page.document, page.window)
 }
 
-function pageWith(
-  element: Record<string, unknown> | null,
-  options: { hooks?: string[], scrollY?: number, onScroll?: (y: number) => void } = {},
-) {
-  const { hooks = [], scrollY = 0, onScroll } = options
+function element(text: string, section?: Record<string, unknown>) {
+  const marks: Record<string, string> = {}
   return {
-    document: {
-      querySelector: () => element,
-      querySelectorAll: () => hooks.map(hook => ({ getAttribute: () => hook })),
-    },
-    window: { scrollX: 0, scrollY, scrollTo: (_x: number, y: number) => onScroll?.(y) },
+    textContent: text,
+    marks,
+    setAttribute: (name: string, value: string) => { marks[name] = value },
+    removeAttribute: (name: string) => { delete marks[name] },
+    closest: () => section ?? null,
   }
 }
 
-describe('frameProbeExpression', () => {
-  it('reveals the element and reports its height', () => {
-    let revealed = false
-    const page = pageWith({
-      scrollIntoView: () => { revealed = true },
-      getBoundingClientRect: () => ({ top: 40, height: 790.4 }),
-    })
-    expect(runInPage(frameProbeExpression('[data-section="landing-faq"]'), page)).toEqual({
-      found: true,
-      height: 791,
-      hooks: [],
-    })
-    expect(revealed).toBe(true)
+function pageWith(options: {
+  bySelector?: Record<string, unknown> | null
+  nodes?: Record<string, unknown>[]
+  hooks?: string[]
+  headings?: string[]
+}) {
+  const { bySelector = null, nodes = [], hooks = [], headings = [] } = options
+  return {
+    document: {
+      querySelector: () => bySelector,
+      querySelectorAll: (query: string) => {
+        if (query.includes(CAPTURE_MARK)) return []
+        if (query === '[data-section]') return hooks.map(hook => ({ getAttribute: () => hook }))
+        if (query === 'h1, h2') return headings.map(heading => ({ textContent: heading }))
+        return nodes
+      },
+    },
+    window: {},
+  }
+}
+
+describe('resolveTargetExpression', () => {
+  it('marks the element the selector matched', () => {
+    const target = element('anything')
+    const probe = runInPage(resolveTargetExpression({ selector: '[data-section="landing-faq"]' }), pageWith({ bySelector: target }))
+    expect(probe).toMatchObject({ found: true, how: 'selector' })
+    expect(target.marks[CAPTURE_MARK]).toBe('')
   })
 
-  it('reports the page hooks when the selector matches nothing', () => {
-    const page = pageWith(null, { hooks: ['landing-hero', 'landing-faq', 'landing-faq'] })
-    expect(runInPage(frameProbeExpression('.missing'), page)).toEqual({
-      found: false,
-      height: 0,
-      hooks: ['landing-hero', 'landing-faq'],
-    })
+  it('falls back to the visible copy and widens it to the section', () => {
+    const section = element('the whole section')
+    const heading = element('Before you install', section)
+    const probe = runInPage(resolveTargetExpression({ text: 'before you INSTALL' }), pageWith({ nodes: [element('unrelated'), heading] }))
+    expect(probe).toMatchObject({ found: true, how: 'text' })
+    expect(section.marks[CAPTURE_MARK]).toBe('')
+    expect(heading.marks[CAPTURE_MARK]).toBeUndefined()
   })
 
-  it('embeds the selector as a literal, so a quote cannot break out', () => {
-    const expression = frameProbeExpression('[data-x="a\'b\\"c"]')
-    expect(() => runInPage(expression, pageWith(null))).not.toThrow()
-  })
-})
-
-describe('frameParkExpression', () => {
-  it('scrolls by the document offset, not the viewport offset', () => {
-    const scrolled: number[] = []
-    const page = pageWith(
-      { getBoundingClientRect: () => ({ top: -420, height: 791 }) },
-      { scrollY: 11_848, onScroll: y => scrolled.push(y) },
+  it('prefers the selector and keeps text as the fallback', () => {
+    const target = element('matched by selector')
+    const heading = element('Before you install')
+    const probe = runInPage(
+      resolveTargetExpression({ selector: '#faq', text: 'Before you install' }),
+      pageWith({ bySelector: target, nodes: [heading] }),
     )
-    expect(runInPage(frameParkExpression('[data-section="landing-faq"]'), page)).toEqual({ found: true })
-    expect(scrolled).toEqual([11_428])
+    expect(probe).toMatchObject({ found: true, how: 'selector' })
+    expect(heading.marks[CAPTURE_MARK]).toBeUndefined()
   })
 
-  it('reports a miss instead of scrolling to the top of the page', () => {
-    const scrolled: number[] = []
-    const page = pageWith(null, { onScroll: y => scrolled.push(y) })
-    expect(runInPage(frameParkExpression('.missing'), page)).toEqual({ found: false })
-    expect(scrolled).toEqual([])
+  it('marks the text match itself when it has no sectioning ancestor', () => {
+    const orphan = element('Before you install')
+    runInPage(resolveTargetExpression({ text: 'Before you install' }), pageWith({ nodes: [orphan] }))
+    expect(orphan.marks[CAPTURE_MARK]).toBe('')
+  })
+
+  it('reports the page hooks and headings when nothing resolves', () => {
+    const probe = runInPage(
+      resolveTargetExpression({ selector: '.missing', text: 'absent copy' }),
+      pageWith({ nodes: [element('something else')], hooks: ['landing-hero', 'landing-hero'], headings: ['One command'] }),
+    )
+    expect(probe).toEqual({ found: false, how: null, hooks: ['landing-hero'], headings: ['One command'] })
+  })
+
+  it('embeds selector and text as literals, so a quote cannot break out', () => {
+    const expression = resolveTargetExpression({ selector: '[data-x="a\'b\\"c"]', text: '") + alert(1) + ("' })
+    expect(() => runInPage(expression, pageWith({}))).not.toThrow()
   })
 })
 
-describe('readFrameProbe', () => {
+describe('readTargetProbe', () => {
   it('reads the agent-browser envelope', () => {
-    expect(readFrameProbe({ data: { found: true, height: 791, hooks: [] } })).toEqual({
+    expect(readTargetProbe({ data: { found: true, how: 'text', hooks: [], headings: [] } })).toEqual({
       found: true,
-      height: 791,
+      how: 'text',
       hooks: [],
+      headings: [],
     })
   })
 
-  it('treats a malformed probe as a miss rather than a frame', () => {
-    expect(readFrameProbe({ data: {} })).toEqual({ found: false, height: 0, hooks: [] })
-    expect(() => readFrameProbe({ data: null })).toThrow(/no frame probe/)
-    expect(() => readFrameProbe(null)).toThrow(/no frame probe/)
+  it('treats a malformed probe as unresolved rather than as a frame', () => {
+    expect(readTargetProbe({ data: {} })).toEqual({ found: false, how: null, hooks: [], headings: [] })
+    expect(() => readTargetProbe({ data: null })).toThrow(/no target probe/)
+    expect(() => readTargetProbe(null)).toThrow(/no target probe/)
   })
 })
 
-describe('frameHeight', () => {
-  it('clamps to the supported bounds', () => {
-    expect(frameHeight(791.2)).toBe(792)
-    expect(frameHeight(10)).toBe(FRAME_HEIGHT_BOUNDS.min)
-    expect(frameHeight(99_999)).toBe(FRAME_HEIGHT_BOUNDS.max)
+describe('describeTarget', () => {
+  it('records how the frame was located', () => {
+    expect(describeTarget({ selector: '[data-section="landing-faq"]' }, 'selector')).toBe('[data-section="landing-faq"]')
+    expect(describeTarget({ text: 'Before you install' }, 'text')).toBe('text "Before you install"')
+    expect(describeTarget({}, null)).toBe('full viewport')
   })
 })
 
-describe('missingSelectorMessage', () => {
-  it('offers the hooks the page does expose', () => {
-    const message = missingSelectorMessage('.py-24', ['landing-hero', 'landing-faq'])
-    expect(message).toContain('matched nothing')
-    expect(message).toContain('[data-section="landing-hero"], [data-section="landing-faq"]')
+describe('unresolvedTargetMessage', () => {
+  it('names what was asked for and what the page offers', () => {
+    const message = unresolvedTargetMessage(
+      { selector: '.py-24', text: 'Before you install' },
+      { found: false, how: null, hooks: ['landing-hero'], headings: ['One command'] },
+    )
+    expect(message).toContain('selector ".py-24" nor text "Before you install"')
+    expect(message).toContain('[data-section="landing-hero"]')
+    expect(message).toContain('"One command"')
   })
 
-  it('says to add a hook when the page has none', () => {
-    expect(missingSelectorMessage('.py-24', [])).toMatch(/no \[data-section\] hooks/)
+  it('says so when the page offers neither', () => {
+    expect(
+      unresolvedTargetMessage({ selector: '.py-24' }, { found: false, how: null, hooks: [], headings: [] }),
+    ).toMatch(/no hooks and no headings/)
   })
 })

--- a/apps/evi/agent/lib/capture.test.ts
+++ b/apps/evi/agent/lib/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { captureAttestation, captureMarkdown, escapeInline, markdownUrl, sensitiveCaptureReason, validateCaptureUrl } from './capture'
+import { captureAttestation, captureMarkdown, escapeInline, FRAME_HEIGHT_BOUNDS, frameHeight, frameParkExpression, frameProbeExpression, markdownUrl, missingSelectorMessage, readFrameProbe, sensitiveCaptureReason, validateCaptureUrl } from './capture'
 
 describe('validateCaptureUrl', () => {
   it('accepts evlog surfaces, previews, and local dev servers', () => {
@@ -82,5 +82,109 @@ describe('captureMarkdown', () => {
         capturedAt: 't',
       }),
     ).toBe('captured by agent-browser · https://evlog.dev/ → https://evlog.cloud/ · mobile · full viewport · t')
+  })
+})
+
+/** Evaluates a probe expression against a stubbed page. */
+function runInPage(expression: string, page: { document: unknown, window: unknown }): unknown {
+  return new Function('document', 'window', `return ${expression}`)(page.document, page.window)
+}
+
+function pageWith(
+  element: Record<string, unknown> | null,
+  options: { hooks?: string[], scrollY?: number, onScroll?: (y: number) => void } = {},
+) {
+  const { hooks = [], scrollY = 0, onScroll } = options
+  return {
+    document: {
+      querySelector: () => element,
+      querySelectorAll: () => hooks.map(hook => ({ getAttribute: () => hook })),
+    },
+    window: { scrollX: 0, scrollY, scrollTo: (_x: number, y: number) => onScroll?.(y) },
+  }
+}
+
+describe('frameProbeExpression', () => {
+  it('reveals the element and reports its height', () => {
+    let revealed = false
+    const page = pageWith({
+      scrollIntoView: () => { revealed = true },
+      getBoundingClientRect: () => ({ top: 40, height: 790.4 }),
+    })
+    expect(runInPage(frameProbeExpression('[data-section="landing-faq"]'), page)).toEqual({
+      found: true,
+      height: 791,
+      hooks: [],
+    })
+    expect(revealed).toBe(true)
+  })
+
+  it('reports the page hooks when the selector matches nothing', () => {
+    const page = pageWith(null, { hooks: ['landing-hero', 'landing-faq', 'landing-faq'] })
+    expect(runInPage(frameProbeExpression('.missing'), page)).toEqual({
+      found: false,
+      height: 0,
+      hooks: ['landing-hero', 'landing-faq'],
+    })
+  })
+
+  it('embeds the selector as a literal, so a quote cannot break out', () => {
+    const expression = frameProbeExpression('[data-x="a\'b\\"c"]')
+    expect(() => runInPage(expression, pageWith(null))).not.toThrow()
+  })
+})
+
+describe('frameParkExpression', () => {
+  it('scrolls by the document offset, not the viewport offset', () => {
+    const scrolled: number[] = []
+    const page = pageWith(
+      { getBoundingClientRect: () => ({ top: -420, height: 791 }) },
+      { scrollY: 11_848, onScroll: y => scrolled.push(y) },
+    )
+    expect(runInPage(frameParkExpression('[data-section="landing-faq"]'), page)).toEqual({ found: true })
+    expect(scrolled).toEqual([11_428])
+  })
+
+  it('reports a miss instead of scrolling to the top of the page', () => {
+    const scrolled: number[] = []
+    const page = pageWith(null, { onScroll: y => scrolled.push(y) })
+    expect(runInPage(frameParkExpression('.missing'), page)).toEqual({ found: false })
+    expect(scrolled).toEqual([])
+  })
+})
+
+describe('readFrameProbe', () => {
+  it('reads the agent-browser envelope', () => {
+    expect(readFrameProbe({ data: { found: true, height: 791, hooks: [] } })).toEqual({
+      found: true,
+      height: 791,
+      hooks: [],
+    })
+  })
+
+  it('treats a malformed probe as a miss rather than a frame', () => {
+    expect(readFrameProbe({ data: {} })).toEqual({ found: false, height: 0, hooks: [] })
+    expect(() => readFrameProbe({ data: null })).toThrow(/no frame probe/)
+    expect(() => readFrameProbe(null)).toThrow(/no frame probe/)
+  })
+})
+
+describe('frameHeight', () => {
+  it('clamps to the supported bounds', () => {
+    expect(frameHeight(791.2)).toBe(792)
+    expect(frameHeight(10)).toBe(FRAME_HEIGHT_BOUNDS.min)
+    expect(frameHeight(99_999)).toBe(FRAME_HEIGHT_BOUNDS.max)
+  })
+})
+
+describe('missingSelectorMessage', () => {
+  it('offers the hooks the page does expose', () => {
+    const message = missingSelectorMessage('.py-24', ['landing-hero', 'landing-faq'])
+    expect(message).toContain('matched nothing')
+    expect(message).toContain('[data-section="landing-hero"], [data-section="landing-faq"]')
+  })
+
+  it('says to add a hook when the page has none', () => {
+    expect(missingSelectorMessage('.py-24', [])).toMatch(/no \[data-section\] hooks/)
   })
 })

--- a/apps/evi/agent/lib/capture.ts
+++ b/apps/evi/agent/lib/capture.ts
@@ -25,88 +25,112 @@ export type CaptureViewport = keyof typeof CAPTURE_VIEWPORTS
 export const CAPTURE_SETTLE_MS = 5000
 
 /**
- * Bounds on the viewport height used to frame a selector. The floor keeps a
- * short section from producing a sliver, the ceiling keeps a long one inside
- * the Blob size limit.
+ * Attribute the capture stamps on the resolved element, so the scroll can
+ * address it by selector even when the page offers nothing stable to select.
+ * It exists for the length of one capture and never reaches the repository.
  */
-export const FRAME_HEIGHT_BOUNDS = { min: 320, max: 2400 } as const
+export const CAPTURE_MARK = 'data-evi-capture'
 
-export interface FrameProbe {
+/** What the target resolved to, or what the page offered instead. */
+export interface TargetProbe {
   readonly found: boolean
-  /** Rendered height of the element, in CSS pixels. */
-  readonly height: number
-  /** Every `data-section` on the page, offered when the selector missed. */
+  /** How the element was located, for the attestation receipt. */
+  readonly how: 'selector' | 'text' | null
+  /** `data-section` hooks on the page, offered when nothing resolved. */
   readonly hooks: readonly string[]
+  /** Headings on the page, offered when nothing resolved. */
+  readonly headings: readonly string[]
+}
+
+export interface CaptureTarget {
+  readonly selector?: string
+  readonly text?: string
 }
 
 /**
- * JavaScript run in the page to reveal the target and measure it. It scrolls
- * the element into view in the same call, so a section that only animates in
- * on scroll has started before the frame is measured.
+ * JavaScript that locates the element to frame and marks it.
  *
- * @param selector - CSS selector framing the change
+ * The selector is tried first. When it matches nothing, or when only `text`
+ * was given, the visible copy is searched instead and the match is widened to
+ * its nearest sectioning ancestor. A change is usually authored as prose, so
+ * the text the author just wrote is a locator they already hold, and it works
+ * on a page whose components carry no hook.
+ *
+ * The element is stamped with {@link CAPTURE_MARK} rather than returned, so
+ * the scroll that follows can use agent-browser's own `scrollintoview`, which
+ * handles scroll containers and sticky headers that a hand-rolled
+ * `window.scrollTo` gets wrong.
  */
-export function frameProbeExpression(selector: string): string {
-  const literal = JSON.stringify(selector)
+export function resolveTargetExpression(target: CaptureTarget): string {
+  const selector = JSON.stringify(target.selector ?? '')
+  const text = JSON.stringify(target.text ?? '')
   return `(() => {
-    const el = document.querySelector(${literal})
+    const MARK = ${JSON.stringify(CAPTURE_MARK)}
+    document.querySelectorAll('[' + MARK + ']').forEach(n => n.removeAttribute(MARK))
+    const selector = ${selector}
+    const text = ${text}
+    let el = selector ? document.querySelector(selector) : null
+    let how = el ? 'selector' : null
+    if (!el && text) {
+      const needle = text.trim().toLowerCase()
+      const nodes = [...document.querySelectorAll('h1, h2, h3, h4, p, li, summary, button, a, figcaption')]
+      const hit = nodes.find(n => (n.textContent || '').trim().toLowerCase().includes(needle))
+      if (hit) {
+        el = hit.closest('section, article, [data-section], [class*="not-prose"]') || hit
+        how = 'text'
+      }
+    }
     if (!el) {
       const hooks = [...document.querySelectorAll('[data-section]')].map(n => n.getAttribute('data-section'))
-      return { found: false, height: 0, hooks: [...new Set(hooks)] }
+      const headings = [...document.querySelectorAll('h1, h2')].map(n => (n.textContent || '').trim()).filter(Boolean)
+      return { found: false, how: null, hooks: [...new Set(hooks)], headings: headings.slice(0, 12) }
     }
-    el.scrollIntoView({ block: 'start' })
-    return { found: true, height: Math.ceil(el.getBoundingClientRect().height), hooks: [] }
+    el.setAttribute(MARK, '')
+    return { found: true, how, hooks: [], headings: [] }
   })()`
 }
 
-/**
- * JavaScript that parks the element's top edge at the top of the viewport.
- * Run after the viewport has been resized to the element, so the frame holds
- * the element and nothing else. `getBoundingClientRect` is viewport-relative,
- * so the page offset has to be added back before scrolling.
- *
- * @param selector - CSS selector framing the change
- */
-export function frameParkExpression(selector: string): string {
-  const literal = JSON.stringify(selector)
-  return `(() => {
-    const el = document.querySelector(${literal})
-    if (!el) return { found: false }
-    window.scrollTo(0, el.getBoundingClientRect().top + window.scrollY)
-    return { found: true }
-  })()`
-}
-
-/** Reads the agent-browser envelope returned by a probe expression. */
-export function readFrameProbe(envelope: unknown): FrameProbe {
+/** Reads the agent-browser envelope returned by {@link resolveTargetExpression}. */
+export function readTargetProbe(envelope: unknown): TargetProbe {
   const data = (envelope as { data?: unknown } | null | undefined)?.data
   if (data === null || typeof data !== 'object') {
-    throw new Error('The browser returned no frame probe. The page did not load, or the expression failed.')
+    throw new Error('The browser returned no target probe. The page did not load, or the expression failed.')
   }
   const probe = data as Record<string, unknown>
-  const hooks = Array.isArray(probe.hooks) ? probe.hooks.filter((hook): hook is string => typeof hook === 'string') : []
+  const strings = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
   return {
     found: probe.found === true,
-    height: typeof probe.height === 'number' ? probe.height : 0,
-    hooks,
+    how: probe.how === 'selector' || probe.how === 'text' ? probe.how : null,
+    hooks: strings(probe.hooks),
+    headings: strings(probe.headings),
   }
+}
+
+/** How the frame is described in the attestation receipt. */
+export function describeTarget(target: CaptureTarget, how: TargetProbe['how']): string {
+  if (how === 'text') return `text "${escapeInline(target.text ?? '')}"`
+  if (how === 'selector') return escapeInline(target.selector ?? '')
+  return 'full viewport'
 }
 
 /**
- * The error raised when a selector matches nothing. It names the hooks the
+ * The error raised when nothing resolved. It names the hooks and headings the
  * page does offer, so the next attempt is a correction rather than a guess.
  */
-export function missingSelectorMessage(selector: string, hooks: readonly string[]): string {
-  const available = hooks.length === 0
-    ? 'That page exposes no [data-section] hooks; add one to the section component before capturing it.'
-    : `That page exposes: ${hooks.map(hook => `[data-section="${hook}"]`).join(', ')}.`
-  return `The selector "${selector}" matched nothing, so the capture would have framed the top of the page. ${available}`
-}
-
-/** Viewport height that frames the element, within the supported bounds. */
-export function frameHeight(elementHeight: number): number {
-  const { min, max } = FRAME_HEIGHT_BOUNDS
-  return Math.min(Math.max(Math.ceil(elementHeight), min), max)
+export function unresolvedTargetMessage(target: CaptureTarget, probe: TargetProbe): string {
+  const asked = [
+    target.selector ? `selector "${target.selector}"` : null,
+    target.text ? `text "${target.text}"` : null,
+  ].filter(Boolean).join(' nor ')
+  const offered = [
+    probe.hooks.length > 0 ? `hooks: ${probe.hooks.map(hook => `[data-section="${hook}"]`).join(', ')}` : null,
+    probe.headings.length > 0 ? `headings: ${probe.headings.map(heading => `"${heading}"`).join(', ')}` : null,
+  ].filter(Boolean).join('; ')
+  const available = offered === ''
+    ? 'That page offers no hooks and no headings to locate one by.'
+    : `That page offers ${offered}.`
+  return `No ${asked} matched, so the capture would have framed the top of the page. ${available}`
 }
 
 /** Returns the refusal reason, or null when the URL may be captured. */
@@ -168,14 +192,14 @@ interface AttestationInput {
   readonly afterUrl: string
   readonly beforeUrl: string
   readonly capturedAt: string
-  readonly selector: string | null
+  /** How the frame was located, from {@link describeTarget}. */
+  readonly frame: string
   readonly viewport: CaptureViewport
 }
 
 /** Human-readable receipt embedded under the comparison table. */
 export function captureAttestation(input: AttestationInput): string {
-  const frame = input.selector === null ? 'full viewport' : escapeInline(input.selector)
-  return `captured by agent-browser · ${markdownUrl(input.beforeUrl)} → ${markdownUrl(input.afterUrl)} · ${input.viewport} · ${frame} · ${input.capturedAt}`
+  return `captured by agent-browser · ${markdownUrl(input.beforeUrl)} → ${markdownUrl(input.afterUrl)} · ${input.viewport} · ${escapeInline(input.frame)} · ${input.capturedAt}`
 }
 
 /** The finished markdown block: table, caption, attestation receipt. */

--- a/apps/evi/agent/lib/capture.ts
+++ b/apps/evi/agent/lib/capture.ts
@@ -24,6 +24,91 @@ export type CaptureViewport = keyof typeof CAPTURE_VIEWPORTS
 /** Entrance animations and font swaps settle before the frame is taken. */
 export const CAPTURE_SETTLE_MS = 5000
 
+/**
+ * Bounds on the viewport height used to frame a selector. The floor keeps a
+ * short section from producing a sliver, the ceiling keeps a long one inside
+ * the Blob size limit.
+ */
+export const FRAME_HEIGHT_BOUNDS = { min: 320, max: 2400 } as const
+
+export interface FrameProbe {
+  readonly found: boolean
+  /** Rendered height of the element, in CSS pixels. */
+  readonly height: number
+  /** Every `data-section` on the page, offered when the selector missed. */
+  readonly hooks: readonly string[]
+}
+
+/**
+ * JavaScript run in the page to reveal the target and measure it. It scrolls
+ * the element into view in the same call, so a section that only animates in
+ * on scroll has started before the frame is measured.
+ *
+ * @param selector - CSS selector framing the change
+ */
+export function frameProbeExpression(selector: string): string {
+  const literal = JSON.stringify(selector)
+  return `(() => {
+    const el = document.querySelector(${literal})
+    if (!el) {
+      const hooks = [...document.querySelectorAll('[data-section]')].map(n => n.getAttribute('data-section'))
+      return { found: false, height: 0, hooks: [...new Set(hooks)] }
+    }
+    el.scrollIntoView({ block: 'start' })
+    return { found: true, height: Math.ceil(el.getBoundingClientRect().height), hooks: [] }
+  })()`
+}
+
+/**
+ * JavaScript that parks the element's top edge at the top of the viewport.
+ * Run after the viewport has been resized to the element, so the frame holds
+ * the element and nothing else. `getBoundingClientRect` is viewport-relative,
+ * so the page offset has to be added back before scrolling.
+ *
+ * @param selector - CSS selector framing the change
+ */
+export function frameParkExpression(selector: string): string {
+  const literal = JSON.stringify(selector)
+  return `(() => {
+    const el = document.querySelector(${literal})
+    if (!el) return { found: false }
+    window.scrollTo(0, el.getBoundingClientRect().top + window.scrollY)
+    return { found: true }
+  })()`
+}
+
+/** Reads the agent-browser envelope returned by a probe expression. */
+export function readFrameProbe(envelope: unknown): FrameProbe {
+  const data = (envelope as { data?: unknown } | null | undefined)?.data
+  if (data === null || typeof data !== 'object') {
+    throw new Error('The browser returned no frame probe. The page did not load, or the expression failed.')
+  }
+  const probe = data as Record<string, unknown>
+  const hooks = Array.isArray(probe.hooks) ? probe.hooks.filter((hook): hook is string => typeof hook === 'string') : []
+  return {
+    found: probe.found === true,
+    height: typeof probe.height === 'number' ? probe.height : 0,
+    hooks,
+  }
+}
+
+/**
+ * The error raised when a selector matches nothing. It names the hooks the
+ * page does offer, so the next attempt is a correction rather than a guess.
+ */
+export function missingSelectorMessage(selector: string, hooks: readonly string[]): string {
+  const available = hooks.length === 0
+    ? 'That page exposes no [data-section] hooks; add one to the section component before capturing it.'
+    : `That page exposes: ${hooks.map(hook => `[data-section="${hook}"]`).join(', ')}.`
+  return `The selector "${selector}" matched nothing, so the capture would have framed the top of the page. ${available}`
+}
+
+/** Viewport height that frames the element, within the supported bounds. */
+export function frameHeight(elementHeight: number): number {
+  const { min, max } = FRAME_HEIGHT_BOUNDS
+  return Math.min(Math.max(Math.ceil(elementHeight), min), max)
+}
+
 /** Returns the refusal reason, or null when the URL may be captured. */
 export function validateCaptureUrl(raw: string): string | null {
   let url: URL

--- a/apps/evi/agent/lib/capture.ts
+++ b/apps/evi/agent/lib/capture.ts
@@ -138,8 +138,7 @@ export function validateCaptureUrl(raw: string): string | null {
   let url: URL
   try {
     url = new URL(raw)
-  }
-  catch {
+  } catch {
     return `"${raw}" is not a valid absolute URL.`
   }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {

--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -14,6 +14,7 @@ When "after" needs a dev server, start it in the background **as soon as the bra
 ## 1. Decide what "before" and "after" are
 
 - The current state of the code is **after**. Never switch branches, stash, or revert to fabricate a "before".
+- **A pure addition has no before.** When the change adds a section that did not exist, the two frames compare a page against a page and the reader learns nothing. Capture the new thing alone and say what it replaces in prose. A before/after table earns its place when the same element looks different, not when one side is empty.
 - **Before** is the deployed production page (`evlog.dev`, `evlog.dev/docs/...`) or the last merged preview.
 - **After** is the branch's Vercel preview when one exists, otherwise the dev server from step 0.
 - A `*.vercel.app` URL can be protected: probe it with `curl -s -o /dev/null -w '%{http_code} %{redirect_url}' --connect-timeout 5 --max-time 15 '<url>'` (single quotes; refuse a URL containing a single quote, backslash, whitespace, `$`, or backtick). 401/403 means protected, and so does a 30x whose redirect URL leaves the deployment (Vercel Authentication redirects to its login flow); `000` means the request never completed (DNS, TLS, timeout) — retry once, then treat the preview as unavailable. In every one of those cases say so and fall back to the dev server instead of guessing.
@@ -30,6 +31,9 @@ The tool's URLs go public the instant it runs. Landing, docs, and playground pag
 `capture__before_after({ beforeUrl, afterUrl, selector, caption })`
 
 - Omit `selector` only for page-level changes (layout, theme, redesign).
+- **Look at both returned frames before you paste anything.** A capture that silently falls back to the top of the page is the failure mode of this tool, and a landing page hero looks like a successful screenshot. Read the two images back and name, to yourself, the element you changed in each one. If you cannot point at it, the selector did not match: fix it and capture again rather than shipping a frame that proves nothing.
+- A `selector` that resolves but sits below the fold needs the element's position in the **document**, not in the viewport. Anything driving Chrome directly must add `window.scrollY` to `getBoundingClientRect().top` before using it as a `Page.captureScreenshot` clip; the two coordinate systems only agree at the top of the page, which is why a mis-framed capture always lands on the hero.
+- A section that reveals on scroll (every `Motion` block on the landing) has to be scrolled into view and given a beat to settle, or the frame catches it mid-transition or fully transparent.
 - For responsive changes, call it again with `viewport: 'mobile'`.
 - Capturing `evlog.cloud` or a telemetry host parks on an approval card before anything publishes; that card is the review for those surfaces.
 - Paste the returned `markdown` verbatim — table, caption, and attestation receipt — where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. The receipt is the proof of what was compared; never strip it.

--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -5,7 +5,7 @@ description: Produce a before/after visual comparison of an evlog surface (landi
 
 # Before/after captures
 
-One tool does the whole capture: `capture__before_after` opens both URLs in the sandbox Chromium, waits 5s for animations to settle, frames the selector (scrolling it into view, resizing the viewport to it, then parking on it), validates and uploads both frames to Blob, and returns the finished markdown table with an attestation receipt. It returns only that block, so there is nothing to reassemble by hand.
+One tool does the whole capture: `capture__before_after` opens both URLs in the sandbox Chromium, waits 5s for animations to settle, scrolls the change into view, screenshots the viewport, validates and uploads both frames to Blob, and returns the finished markdown table with an attestation receipt. It returns only that block, so there is nothing to reassemble by hand.
 
 ## 0. Start the dev server first
 
@@ -26,14 +26,17 @@ The tool's URLs go public the instant it runs. Landing, docs, and playground pag
 
 ## 3. Capture and deliver
 
-**Frame the change, not the page.** The selector is derived from what you edited, not discovered: every section on the landing and every doc content component carries `data-section="<its MDC tag>"`. You edited `::landing-faq` in `0.landing.md`, so the selector is `[data-section="landing-faq"]`. Reach for `browser__snapshot` only when the surface has no hook yet, and add one to the component in the same PR rather than selecting on utility classes: eleven landing sections render the identical `section.py-24.md:py-32`, so a class selector there frames the wrong section or none.
+**Point at the change, do not go hunting for it.** You already hold two locators after editing: the component's hook and the copy you wrote.
 
-`capture__before_after({ beforeUrl, afterUrl, selector, caption })`
+`capture__before_after({ beforeUrl, afterUrl, selector, text, caption })`
 
-- Omit `selector` only for page-level changes (layout, theme, redesign).
-- The tool resizes the viewport to the element and parks on it, so the frame holds that element and nothing else. A selector matching nothing **fails the call** and the error lists the `data-section` hooks the page does expose; take one of those rather than retrying with a guess.
-- **Look at both returned frames before you paste anything.** The tool now refuses the failure that produced a hero shot, but it cannot tell you the frame is the wrong element, or that the "before" side has no counterpart. Read the two images back and name, to yourself, the thing you changed in each one.
+- **`selector` when the surface has a hook.** Landing sections and MDC content components carry `data-section="<their MDC tag>"`, so editing `::landing-faq` in `0.landing.md` gives `[data-section="landing-faq"]` with nothing to look up.
+- **`text` when it does not.** Pass a sentence you can see on the page and the capture finds it, widens to its nearest section, and marks that element for the scroll. This is the whole answer for a surface with no hooks, and for a doc page where the change is one paragraph. Never select on utility classes instead: eleven landing sections render the identical `section.py-24.md:py-32`, so a class selector there frames the wrong section without telling you.
+- Give both and the selector wins, with `text` as the fallback. Omit both only for page-level changes (layout, theme, redesign).
+- The frame is the normal viewport, scrolled to the change. When neither locator resolves the call **fails**, listing the hooks and headings the page does offer; take one of those rather than retrying with a guess.
+- **Look at both returned frames before you paste anything.** The tool refuses the failure that produced a hero shot, but it cannot tell you the frame caught the wrong element, or that the "before" side has no counterpart. Read the two images back and name, to yourself, the thing you changed in each one.
 - For responsive changes, call it again with `viewport: 'mobile'`.
+- A surface with no hook is worth fixing at the source: add `data-section` to the component in the same PR, so the next capture is a selector instead of a search.
 - Capturing `evlog.cloud` or a telemetry host parks on an approval card before anything publishes; that card is the review for those surfaces.
 - Paste the returned `markdown` verbatim — table, caption, and attestation receipt — where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. The receipt is the proof of what was compared; never strip it.
 

--- a/apps/evi/agent/skills/before-after/SKILL.md
+++ b/apps/evi/agent/skills/before-after/SKILL.md
@@ -5,7 +5,7 @@ description: Produce a before/after visual comparison of an evlog surface (landi
 
 # Before/after captures
 
-One tool does the whole capture: `capture__before_after` opens both URLs in the sandbox Chromium, waits 5s for animations to settle, screenshots (cropped to the selector), validates and uploads both frames to Blob, and returns the finished markdown table with an attestation receipt.
+One tool does the whole capture: `capture__before_after` opens both URLs in the sandbox Chromium, waits 5s for animations to settle, frames the selector (scrolling it into view, resizing the viewport to it, then parking on it), validates and uploads both frames to Blob, and returns the finished markdown table with an attestation receipt. It returns only that block, so there is nothing to reassemble by hand.
 
 ## 0. Start the dev server first
 
@@ -26,14 +26,13 @@ The tool's URLs go public the instant it runs. Landing, docs, and playground pag
 
 ## 3. Capture and deliver
 
-**Frame the change, not the page.** Find the tightest stable container around the change with `browser__snapshot` (a section class or landmark, not a hashed utility class), then:
+**Frame the change, not the page.** The selector is derived from what you edited, not discovered: every section on the landing and every doc content component carries `data-section="<its MDC tag>"`. You edited `::landing-faq` in `0.landing.md`, so the selector is `[data-section="landing-faq"]`. Reach for `browser__snapshot` only when the surface has no hook yet, and add one to the component in the same PR rather than selecting on utility classes: eleven landing sections render the identical `section.py-24.md:py-32`, so a class selector there frames the wrong section or none.
 
 `capture__before_after({ beforeUrl, afterUrl, selector, caption })`
 
 - Omit `selector` only for page-level changes (layout, theme, redesign).
-- **Look at both returned frames before you paste anything.** A capture that silently falls back to the top of the page is the failure mode of this tool, and a landing page hero looks like a successful screenshot. Read the two images back and name, to yourself, the element you changed in each one. If you cannot point at it, the selector did not match: fix it and capture again rather than shipping a frame that proves nothing.
-- A `selector` that resolves but sits below the fold needs the element's position in the **document**, not in the viewport. Anything driving Chrome directly must add `window.scrollY` to `getBoundingClientRect().top` before using it as a `Page.captureScreenshot` clip; the two coordinate systems only agree at the top of the page, which is why a mis-framed capture always lands on the hero.
-- A section that reveals on scroll (every `Motion` block on the landing) has to be scrolled into view and given a beat to settle, or the frame catches it mid-transition or fully transparent.
+- The tool resizes the viewport to the element and parks on it, so the frame holds that element and nothing else. A selector matching nothing **fails the call** and the error lists the `data-section` hooks the page does expose; take one of those rather than retrying with a guess.
+- **Look at both returned frames before you paste anything.** The tool now refuses the failure that produced a hero shot, but it cannot tell you the frame is the wrong element, or that the "before" side has no counterpart. Read the two images back and name, to yourself, the thing you changed in each one.
 - For responsive changes, call it again with `viewport: 'mobile'`.
 - Capturing `evlog.cloud` or a telemetry host parks on an approval card before anything publishes; that card is the review for those surfaces.
 - Paste the returned `markdown` verbatim — table, caption, and attestation receipt — where the change lives: the PR body (`github__updatePullRequest`) or a PR comment for a shipped change, the conversation otherwise. The receipt is the proof of what was compared; never strip it.

--- a/apps/evi/agent/skills/contributing/SKILL.md
+++ b/apps/evi/agent/skills/contributing/SKILL.md
@@ -15,6 +15,7 @@ What follows is the shape of the answer, so you know what to look for and what t
 
 - **A changeset is required** for anything a consumer of evlog would notice: a feature, a bug fix, a breaking change. `pnpm changeset`, committed alongside the code. Changes confined to `apps/*` or `examples/*` never need one. A PR without a changeset for a user-facing change does not merge.
 - **Conventional Commits, lowercase subject.** `feat: add stream server`, not `feat: Add stream server`. Omit the scope when the change is cross-cutting; never use `evlog` as a scope. A new subsystem needs its scope registered in both `.github/workflows/semantic-pull-request.yml` and `.github/pull_request_template.md`, and because title validation reads the base branch, that registration has to land in an earlier PR.
+- **The scope list is a closed set, and you read it before you write the title.** `.github/workflows/semantic-pull-request.yml` holds the only scopes CI accepts. Anything else fails `Validate PR title`, and a scope that merely sounds plausible (`evlog`, the package name, the app directory) is the usual way that happens. A change confined to `apps/docs` is `docs:`, with no scope: `docs` is already the type.
 - **A bug fix needs a failing regression test first**, then the fix.
 - **New exports** go in `packages/evlog/package.json` (`exports` and `typesVersions`) *and* `tsdown.config.ts`.
 - **Skills must stay in sync.** If a change touches something a skill documents, the SKILL.md changes in the same PR, both the internal `.agents/skills/` and the published `apps/docs/skills/`.
@@ -59,6 +60,9 @@ The whole flow runs in `/workspace/repo`; nothing ships through the GitHub file 
 4. Commit with a Conventional Commits subject: lowercase, a registered scope or none.
 5. Push with `git__push`. It refuses `main` and `master`, and only maintainer sessions have it.
 6. Open the pull request with `github__createPullRequest`, report each check result in the body, and request `hugorcd` via `github__requestReviewers` unless it is a draft.
+7. **Read CI back once it has run.** `Validate PR title` settles in seconds and is the check your own title most often breaks. A pull request announced as ready while a required check is red costs the maintainer the review; fix the title or the code and say so, rather than leaving it for them to find.
+
+A pull request is not finished when it is open. Before you report it, the local checks are green, CI is green, and you have looked at the rendered result of anything visual. "Lint and typecheck pass" is a claim about the build, not about whether the thing you wrote is correct or reads well.
 
 `pnpm --filter @evlog/cli exec evlog map --json --no-write` scores an entry point's observability and is built for exactly this: it is the fastest way to ground a "should this be logged" answer in the tree you are working in. Run the workspace copy rather than `npx @evlog/cli`, which would fetch and execute whatever version the registry currently serves.
 

--- a/apps/evi/agent/skills/contributing/SKILL.md
+++ b/apps/evi/agent/skills/contributing/SKILL.md
@@ -58,7 +58,7 @@ The whole flow runs in `/workspace/repo`; nothing ships through the GitHub file 
 2. Edit, then run the checks above. A bug fix commits its failing regression test first, then the fix. For a visual change, start the dev server in the background before the checks (see `before-after`, step 0) so it warms while they run. Before the first check of the session, call `turbo__enable_remote_cache` once, then prefix each check with `TURBO_REMOTE_CACHE_READ_ONLY=true`: turbo reuses the artifacts CI already built, and the template cache covers the rest, so only what the diff affects actually runs.
 3. When a consumer of evlog would notice the change, add a changeset: write `.changeset/<some-name>.md` by hand with the `---` frontmatter naming the package and bump plus a consumer-facing description (`pnpm changeset` is interactive and cannot run here). Look at an existing file in `.changeset/` for the exact shape.
 4. Commit with a Conventional Commits subject: lowercase, a registered scope or none.
-5. Push with `git__push`. It refuses `main` and `master`, and only maintainer sessions have it.
+5. **Push the branch with `git__push`.** That tool is the only way code reaches the remote: never the GitHub file API. It refuses `main` and `master`, and only maintainer sessions have it.
 6. Open the pull request with `github__createPullRequest`, report each check result in the body, and request `hugorcd` via `github__requestReviewers` unless it is a draft.
 7. **Read CI back once it has run.** `Validate PR title` settles in seconds and is the check your own title most often breaks. A pull request announced as ready while a required check is red costs the maintainer the review; fix the title or the code and say so, rather than leaving it for them to find.
 

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -9,12 +9,16 @@ import { canAccessAdminTools } from '../lib/trust'
 
 const SCREENSHOT_DIR = '/workspace/screenshots'
 
+interface FrameRequest {
+  readonly side: 'before' | 'after'
+  readonly target: CaptureTarget | null
+  readonly url: string
+  readonly viewport: CaptureViewport
+}
+
 async function captureFrame(
   ctx: EveToolContext,
-  side: 'before' | 'after',
-  url: string,
-  target: CaptureTarget | null,
-  viewport: CaptureViewport,
+  { side, target, url, viewport }: FrameRequest,
 ): Promise<{ path: string, how: 'selector' | 'text' | null }> {
   const { width, height } = CAPTURE_VIEWPORTS[viewport]
   const path = `${SCREENSHOT_DIR}/${side}-${Date.now()}.png`
@@ -57,71 +61,70 @@ export default defineDynamic({
       if (!canAccessAdminTools(ctx.session.auth.current)) return null
       return {
         capture__before_after: defineTool({
-      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, scroll the change into view, screenshot the viewport, validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Point it at the change with selector, or with text when the page has no stable selector: text finds the visible copy and widens to its section, so the sentence you just wrote is enough. Give both and text is the fallback. When neither resolves the call fails, listing the hooks and headings the page does offer, rather than silently framing the top of the page. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
-      inputSchema: z.object({
-        beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
-        afterUrl: z.string().min(1).describe('URL of the after state, e.g. http://localhost:3000'),
-        selector: z.string().trim().min(1).max(200).optional().describe('CSS selector framing the change, e.g. [data-section="landing-faq"]'),
-        text: z.string().trim().min(1).max(200).optional().describe('Visible copy inside the change, used when no selector matches. The capture widens it to the nearest section.'),
-        viewport: z.enum(['desktop', 'mobile', 'tablet']).optional().describe('Defaults to desktop (1280×800)'),
-        caption: z.string().trim().min(1).max(200).describe('One line naming the surface and viewport, e.g. "Landing hero, desktop viewport."'),
-      }),
-      // Skill-level "review sensitive surfaces first" is not an enforceable
-      // control; a capture of a surface that can show real user data parks on
-      // an approval card before anything publishes.
-      approval(approvalCtx) {
-        for (const raw of [approvalCtx.toolInput?.beforeUrl, approvalCtx.toolInput?.afterUrl]) {
-          if (typeof raw !== 'string') continue
-          let reason: string | null
-          try {
-            reason = sensitiveCaptureReason(raw)
-          }
-          catch {
-            continue // invalid URL: execute() refuses it with a clear error
-          }
-          if (reason) return 'user-approval'
-        }
-        return 'not-applicable'
-      },
-      async execute(input, toolCtx) {
-        if (!canAccessAdminTools(toolCtx.session.auth.current)) {
-          return { success: false as const, error: 'Captures are not available in this session.' }
-        }
-        for (const url of [input.beforeUrl, input.afterUrl]) {
-          const refusal = validateCaptureUrl(url)
-          if (refusal) return { success: false as const, error: refusal }
-        }
-        if (!process.env.BLOB_READ_WRITE_TOKEN) {
-          return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
-        }
-        const viewport = input.viewport ?? 'desktop'
-        const target: CaptureTarget | null = input.selector || input.text
-          ? { selector: input.selector, text: input.text }
-          : null
-        const sandbox = await toolCtx.getSandbox()
-        await sandbox.run({ command: `mkdir -p ${SCREENSHOT_DIR}` })
-        const before = await captureFrame(toolCtx, 'before', input.beforeUrl, target, viewport)
-        const after = await captureFrame(toolCtx, 'after', input.afterUrl, target, viewport)
-        const beforeImageUrl = await hostFrame(sandbox, before.path)
-        const afterImageUrl = await hostFrame(sandbox, after.path)
-        const capturedAt = new Date().toISOString()
-        // Only the composed block is returned: handing back the bare image URLs
-        // invites a hand-assembled table that drops the attestation receipt.
-        return {
-          success: true as const,
-          markdown: captureMarkdown({
-            beforeUrl: input.beforeUrl,
-            afterUrl: input.afterUrl,
-            beforeImageUrl,
-            afterImageUrl,
-            caption: input.caption,
-            frame: target === null ? 'full viewport' : describeTarget(target, after.how),
-            viewport,
-            capturedAt,
+          description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, scroll the change into view, screenshot the viewport, validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Point it at the change with selector, or with text when the page has no stable selector: text finds the visible copy and widens to its section, so the sentence you just wrote is enough. Give both and text is the fallback. When neither resolves the call fails, listing the hooks and headings the page does offer, rather than silently framing the top of the page. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
+          inputSchema: z.object({
+            beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
+            afterUrl: z.string().min(1).describe('URL of the after state, e.g. http://localhost:3000'),
+            selector: z.string().trim().min(1).max(200).optional().describe('CSS selector framing the change, e.g. [data-section="landing-faq"]'),
+            text: z.string().trim().min(1).max(200).optional().describe('Visible copy inside the change, used when no selector matches. The capture widens it to the nearest section.'),
+            viewport: z.enum(['desktop', 'mobile', 'tablet']).optional().describe('Defaults to desktop (1280×800)'),
+            caption: z.string().trim().min(1).max(200).describe('One line naming the surface and viewport, e.g. "Landing hero, desktop viewport."'),
           }),
-        }
-      },
-    }),
+          // Skill-level "review sensitive surfaces first" is not an enforceable
+          // control; a capture of a surface that can show real user data parks on
+          // an approval card before anything publishes.
+          approval(approvalCtx) {
+            for (const raw of [approvalCtx.toolInput?.beforeUrl, approvalCtx.toolInput?.afterUrl]) {
+              if (typeof raw !== 'string') continue
+              let reason: string | null
+              try {
+                reason = sensitiveCaptureReason(raw)
+              } catch {
+                continue // invalid URL: execute() refuses it with a clear error
+              }
+              if (reason) return 'user-approval'
+            }
+            return 'not-applicable'
+          },
+          async execute(input, toolCtx) {
+            if (!canAccessAdminTools(toolCtx.session.auth.current)) {
+              return { success: false as const, error: 'Captures are not available in this session.' }
+            }
+            for (const url of [input.beforeUrl, input.afterUrl]) {
+              const refusal = validateCaptureUrl(url)
+              if (refusal) return { success: false as const, error: refusal }
+            }
+            if (!process.env.BLOB_READ_WRITE_TOKEN) {
+              return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
+            }
+            const viewport = input.viewport ?? 'desktop'
+            const target: CaptureTarget | null = input.selector || input.text
+              ? { selector: input.selector, text: input.text }
+              : null
+            const sandbox = await toolCtx.getSandbox()
+            await sandbox.run({ command: `mkdir -p ${SCREENSHOT_DIR}` })
+            const before = await captureFrame(toolCtx, { side: 'before', url: input.beforeUrl, target, viewport })
+            const after = await captureFrame(toolCtx, { side: 'after', url: input.afterUrl, target, viewport })
+            const beforeImageUrl = await hostFrame(sandbox, before.path)
+            const afterImageUrl = await hostFrame(sandbox, after.path)
+            const capturedAt = new Date().toISOString()
+            // Only the composed block is returned: handing back the bare image URLs
+            // invites a hand-assembled table that drops the attestation receipt.
+            return {
+              success: true as const,
+              markdown: captureMarkdown({
+                beforeUrl: input.beforeUrl,
+                afterUrl: input.afterUrl,
+                beforeImageUrl,
+                afterImageUrl,
+                caption: input.caption,
+                frame: target === null ? 'full viewport' : describeTarget(target, after.how),
+                viewport,
+                capturedAt,
+              }),
+            }
+          },
+        }),
       }
     },
   },

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -4,7 +4,7 @@ import { defineDynamic, defineTool } from 'eve/tools'
 import type { SandboxSession } from 'eve/sandbox'
 import { z } from 'zod'
 import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
-import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, frameHeight, frameParkExpression, frameProbeExpression, missingSelectorMessage, readFrameProbe, sensitiveCaptureReason, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
+import { CAPTURE_MARK, CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, describeTarget, readTargetProbe, resolveTargetExpression, sensitiveCaptureReason, unresolvedTargetMessage, validateCaptureUrl, type CaptureTarget, type CaptureViewport } from '../lib/capture'
 import { canAccessAdminTools } from '../lib/trust'
 
 const SCREENSHOT_DIR = '/workspace/screenshots'
@@ -13,24 +13,24 @@ async function captureFrame(
   ctx: EveToolContext,
   side: 'before' | 'after',
   url: string,
-  selector: string | null,
+  target: CaptureTarget | null,
   viewport: CaptureViewport,
-): Promise<string> {
+): Promise<{ path: string, how: 'selector' | 'text' | null }> {
   const { width, height } = CAPTURE_VIEWPORTS[viewport]
   const path = `${SCREENSHOT_DIR}/${side}-${Date.now()}.png`
   await runAgentBrowser(ctx, ['set', 'viewport', String(width), String(height)])
   await runAgentBrowser(ctx, ['open', url])
   await runAgentBrowser(ctx, ['wait', String(CAPTURE_SETTLE_MS)])
-  if (selector !== null) {
-    const probe = readFrameProbe((await runAgentBrowser(ctx, ['eval', frameProbeExpression(selector)])).json)
-    if (!probe.found) throw new Error(missingSelectorMessage(selector, probe.hooks))
-    await runAgentBrowser(ctx, ['wait', '500'])
-    await runAgentBrowser(ctx, ['set', 'viewport', String(width), String(frameHeight(probe.height))])
-    await runAgentBrowser(ctx, ['eval', frameParkExpression(selector)])
-    await runAgentBrowser(ctx, ['wait', '300'])
+  if (target === null) {
+    await runAgentBrowser(ctx, ['screenshot', path])
+    return { path, how: null }
   }
+  const probe = readTargetProbe((await runAgentBrowser(ctx, ['eval', resolveTargetExpression(target)])).json)
+  if (!probe.found) throw new Error(unresolvedTargetMessage(target, probe))
+  await runAgentBrowser(ctx, ['scrollintoview', `[${CAPTURE_MARK}]`])
+  await runAgentBrowser(ctx, ['wait', '500'])
   await runAgentBrowser(ctx, ['screenshot', path])
-  return path
+  return { path, how: probe.how }
 }
 
 async function hostFrame(sandbox: SandboxSession, path: string): Promise<string> {
@@ -57,11 +57,12 @@ export default defineDynamic({
       if (!canAccessAdminTools(ctx.session.auth.current)) return null
       return {
         capture__before_after: defineTool({
-      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, frame the selector (the viewport is resized to the element and parked on it, so the frame holds that element and nothing else), validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. A selector that matches nothing fails the call rather than framing the top of the page. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
+      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, scroll the change into view, screenshot the viewport, validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Point it at the change with selector, or with text when the page has no stable selector: text finds the visible copy and widens to its section, so the sentence you just wrote is enough. Give both and text is the fallback. When neither resolves the call fails, listing the hooks and headings the page does offer, rather than silently framing the top of the page. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
       inputSchema: z.object({
         beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
         afterUrl: z.string().min(1).describe('URL of the after state, e.g. http://localhost:3000'),
-        selector: z.string().trim().min(1).max(200).optional().describe('CSS selector framing the change; omit only for page-level changes'),
+        selector: z.string().trim().min(1).max(200).optional().describe('CSS selector framing the change, e.g. [data-section="landing-faq"]'),
+        text: z.string().trim().min(1).max(200).optional().describe('Visible copy inside the change, used when no selector matches. The capture widens it to the nearest section.'),
         viewport: z.enum(['desktop', 'mobile', 'tablet']).optional().describe('Defaults to desktop (1280×800)'),
         caption: z.string().trim().min(1).max(200).describe('One line naming the surface and viewport, e.g. "Landing hero, desktop viewport."'),
       }),
@@ -94,13 +95,15 @@ export default defineDynamic({
           return { success: false as const, error: 'BLOB_READ_WRITE_TOKEN is not configured. Locally, run `vercel env pull` in apps/evi.' }
         }
         const viewport = input.viewport ?? 'desktop'
-        const selector = input.selector ?? null
+        const target: CaptureTarget | null = input.selector || input.text
+          ? { selector: input.selector, text: input.text }
+          : null
         const sandbox = await toolCtx.getSandbox()
         await sandbox.run({ command: `mkdir -p ${SCREENSHOT_DIR}` })
-        const beforePath = await captureFrame(toolCtx, 'before', input.beforeUrl, selector, viewport)
-        const afterPath = await captureFrame(toolCtx, 'after', input.afterUrl, selector, viewport)
-        const beforeImageUrl = await hostFrame(sandbox, beforePath)
-        const afterImageUrl = await hostFrame(sandbox, afterPath)
+        const before = await captureFrame(toolCtx, 'before', input.beforeUrl, target, viewport)
+        const after = await captureFrame(toolCtx, 'after', input.afterUrl, target, viewport)
+        const beforeImageUrl = await hostFrame(sandbox, before.path)
+        const afterImageUrl = await hostFrame(sandbox, after.path)
         const capturedAt = new Date().toISOString()
         // Only the composed block is returned: handing back the bare image URLs
         // invites a hand-assembled table that drops the attestation receipt.
@@ -112,7 +115,7 @@ export default defineDynamic({
             beforeImageUrl,
             afterImageUrl,
             caption: input.caption,
-            selector,
+            frame: target === null ? 'full viewport' : describeTarget(target, after.how),
             viewport,
             capturedAt,
           }),

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -4,7 +4,7 @@ import { defineDynamic, defineTool } from 'eve/tools'
 import type { SandboxSession } from 'eve/sandbox'
 import { z } from 'zod'
 import { imageContentType, MAX_IMAGE_BYTES, screenshotKey, sniffImageContentType } from '../lib/blob'
-import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, sensitiveCaptureReason, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
+import { CAPTURE_SETTLE_MS, CAPTURE_VIEWPORTS, captureMarkdown, frameHeight, frameParkExpression, frameProbeExpression, missingSelectorMessage, readFrameProbe, sensitiveCaptureReason, validateCaptureUrl, type CaptureViewport } from '../lib/capture'
 import { canAccessAdminTools } from '../lib/trust'
 
 const SCREENSHOT_DIR = '/workspace/screenshots'
@@ -22,8 +22,12 @@ async function captureFrame(
   await runAgentBrowser(ctx, ['open', url])
   await runAgentBrowser(ctx, ['wait', String(CAPTURE_SETTLE_MS)])
   if (selector !== null) {
-    await runAgentBrowser(ctx, ['scrollintoview', selector])
+    const probe = readFrameProbe((await runAgentBrowser(ctx, ['eval', frameProbeExpression(selector)])).json)
+    if (!probe.found) throw new Error(missingSelectorMessage(selector, probe.hooks))
     await runAgentBrowser(ctx, ['wait', '500'])
+    await runAgentBrowser(ctx, ['set', 'viewport', String(width), String(frameHeight(probe.height))])
+    await runAgentBrowser(ctx, ['eval', frameParkExpression(selector)])
+    await runAgentBrowser(ctx, ['wait', '300'])
   }
   await runAgentBrowser(ctx, ['screenshot', path])
   return path
@@ -53,7 +57,7 @@ export default defineDynamic({
       if (!canAccessAdminTools(ctx.session.auth.current)) return null
       return {
         capture__before_after: defineTool({
-      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, screenshot (cropped to the selector when given), validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
+      description: 'Capture a before/after comparison of an evlog surface in one call: for each URL, open it in the sandbox browser, wait 5s for animations to settle, frame the selector (the viewport is resized to the element and parked on it, so the frame holds that element and nothing else), validate and upload both frames to the Blob store, and return the finished markdown table with an attestation receipt. A selector that matches nothing fails the call rather than framing the top of the page. Origins are restricted to evlog domains, Vercel previews, and sandbox dev servers. For surfaces that can show real user data (telemetry), review the pages with browser__screenshot before calling this: the returned URLs are public immediately.',
       inputSchema: z.object({
         beforeUrl: z.string().min(1).describe('URL of the before state, e.g. https://evlog.dev'),
         afterUrl: z.string().min(1).describe('URL of the after state, e.g. http://localhost:3000'),
@@ -98,6 +102,8 @@ export default defineDynamic({
         const beforeImageUrl = await hostFrame(sandbox, beforePath)
         const afterImageUrl = await hostFrame(sandbox, afterPath)
         const capturedAt = new Date().toISOString()
+        // Only the composed block is returned: handing back the bare image URLs
+        // invites a hand-assembled table that drops the attestation receipt.
         return {
           success: true as const,
           markdown: captureMarkdown({
@@ -110,8 +116,6 @@ export default defineDynamic({
             viewport,
             capturedAt,
           }),
-          before: { sourceUrl: input.beforeUrl, imageUrl: beforeImageUrl },
-          after: { sourceUrl: input.afterUrl, imageUrl: afterImageUrl },
         }
       },
     }),


### PR DESCRIPTION
## What

Three commits, from the post-mortem of #578.

**The capture tool locates the change instead of guessing at it.**

`captureFrame` scrolled to the selector and shot the viewport. Its description claimed the frame was "cropped to the selector"; it never was, and `agent-browser screenshot` has no crop option to do it with. A selector matching nothing scrolled nowhere and produced a top-of-page frame, which on the landing is the hero and looks exactly like a working screenshot.

It now resolves the target in the page before anything else (`agent/lib/capture.ts`):

- **`selector` when the surface has a hook**, `[data-section="landing-faq"]` and the like.
- **`text` when it does not.** Pass a sentence visible on the page; the capture finds it, widens to the nearest sectioning ancestor, and stamps that element with a temporary `data-evi-capture` attribute so the scroll can address it by selector. The mark lives for one capture and never touches the repository. This means a page whose components carry no hook is captured correctly today, with no markup change first.
- **Nothing resolved is a hard failure**, and the error lists the `data-section` hooks and the headings the page does offer, so the retry is a correction rather than another guess.
- The frame stays the **normal viewport**, scrolled to the change. No resize, no cropping.
- **Only the composed `markdown` is returned.** The tool used to also hand back the bare image URLs, which is what the mis-framed PR body was assembled from, dropping the attestation receipt that would have shown `full viewport` and exposed the problem. The receipt now also records how the target resolved.

**The skills that let it ship.**

- The scope list in `.github/workflows/semantic-pull-request.yml` is a closed set, read before writing a title. #578 opened as `docs(evlog):`, which is not in that list and is forbidden by `AGENTS.md`; `Validate PR title` was red and nobody looked.
- CI is read back once the PR is open, and a PR is not finished when it is open.
- `before-after` documents both locators, the hard failure, and that a pure addition has no meaningful before/after table.

## Why

The failure had four layers and no single one was the bug: no stable selector existed to write, the tool never cropped, a miss failed silently into a plausible frame, and the receipt recording the framing was stripped. Fixing only the guidance would have left the silent fallback in place.

## Notes

- `apps/evi` only, nothing published, so no changeset.
- `pnpm exec tsc` clean; `agent/lib/capture.test.ts` passes 19 tests, 11 new.
- Verified end to end against the docs dev server by driving Chrome with the exact algorithm from `agent/lib/capture.ts`, on this branch, whose landing carries **no** `data-section` hooks: `text: "Every blind spot"` resolved by copy, widened to the right section, and framed it; an absent sentence was refused with the page's twelve headings listed and no frame written.
- `evals` caught a real regression on the first push: lengthening the shipping section pushed `git__push` far enough down that `contributing/ship-flow` stopped naming it. Fixed at the cause by making step 5 state that it is the only way code reaches the remote, rather than by touching the eval.
- The `data-section` hooks in the companion `apps/docs` PR are now an optimisation, not a prerequisite: they make the selector derivable, and `text` covers everything else.
