### PR TITLE
feat: fix the derivable content findings with content:lint --fix

### DIFF
--- a/.agents/skills/write-evlog-content/SKILL.md
+++ b/.agents/skills/write-evlog-content/SKILL.md
@@ -73,6 +73,8 @@ pnpm content:lint --url https://example.com/post --as blog   # a page outside th
 cat draft.md | pnpm content:lint --stdin                     # prose that is not a file yet
 ```
 
+Some findings are fixed before anyone reads them. `pnpm content:lint <paths> --fix` applies the rules whose corrected text follows from the rule itself: a retired entry point, a term with one replacement, a link with a redirect behind it, a dash pair around a parenthetical. It re-scans and reverts anything that scored worse. Run it before reviewing, so a review spends its attention on what a codemod cannot decide.
+
 Rates are compared per surface. A reference page and a skill file have different natural rhythms, and one median over both flatters whichever is looser. A `--url` scan drops every evlog-specific check: someone else's entry points, links, and vocabulary are theirs, so what comes back is how the page reads.
 
 Every scan returns two lists. The findings are what tripped a counter. `modelChecks` is what no counter reached on that page, chosen for its surface and its shape: whether the claims carry a mechanism, whether the opening states a situation, whether a skill's `description` would route to it, whether the code runs. Answer all of them. A review that only works the findings reviews only what was measurable, and a page can satisfy every count while answering nothing.

--- a/scripts/content-lint/README.md
+++ b/scripts/content-lint/README.md
@@ -17,6 +17,24 @@ pnpm content:lint --url https://… --as blog    # a page that is not in the rep
 cat draft.md | pnpm content:lint --stdin       # prose that is not a file yet
 ```
 
+## Fixing what is derivable
+
+```bash
+pnpm content:lint <paths…> --fix             # rewrite in place, report every change
+pnpm content:lint <paths…> --fix --dry-run   # print what it would do, write nothing
+```
+
+A rule reaches `lib/fix.mjs` only when the corrected text follows from the rule rather than from taste:
+
+| Rule | Fixed | Left to a reader |
+| --- | --- | --- |
+| `T-15` | `evlog/shared` → `evlog/toolkit`, `evlog/browser` → `evlog/http` | a page documenting the deprecation, which is skipped |
+| `U-15` | `sink` → `drain`, `error registry` → `error catalog` | `child logger`, which does not slot into the same sentence |
+| `U-16` | a link with a redirect behind it | a link with no destination |
+| `U-14` | `A — B — C` → `A, B, C` | the single elaborating dash, which wants a comma here and a colon there |
+
+After writing, each file is re-scanned. If the score dropped or a new finding id appeared, the file is reverted and reported as unfixed — that check is the whole argument for running this before a reviewer sees the file. `--fix` refuses to run without explicit paths: a corpus-wide rewrite is a maintainer's decision.
+
 `--url` fetches, drops nav, header, footer, and aside, prefers `<main>` then `<article>`, and turns what is left back into markdown so every check downstream is the one that runs on a docs page. A script-rendered page yields nothing and says so rather than reporting clean. An external scan drops the evlog-specific checks (`T-15`, `U-12`, `U-15`, link resolution): someone else's entry points, links, and vocabulary are theirs.
 
 The baseline is always the whole corpus, never the selection: a single-file run returns what a full sweep would say about that file. Rates are compared within a surface, so a reference page is not measured against a blog post.

--- a/scripts/content-lint/index.mjs
+++ b/scripts/content-lint/index.mjs
@@ -21,7 +21,7 @@
  * half: what no threshold reached on this page, which the reviewer owes.
  */
 
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseMarkdown } from './lib/mdc.mjs'
@@ -32,6 +32,7 @@ import { SURFACES, corpusFiles, surfaceOf } from './lib/surfaces.mjs'
 import { modelChecks } from './lib/model-checks.mjs'
 import { extract } from './lib/extract.mjs'
 import { fetchPublic } from './lib/net.mjs'
+import { applyFixes, isSafeFix, loadRedirects } from './lib/fix.mjs'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const CONTENT_ROOT = resolve(REPO_ROOT, 'apps/docs/content')
@@ -45,6 +46,8 @@ const argv = process.argv.slice(2)
 const options = {
   json: argv.includes('--json'),
   stdin: argv.includes('--stdin'),
+  fix: argv.includes('--fix'),
+  dryRun: argv.includes('--dry-run'),
   top: numberFlag('--top', { min: 1, integer: true }),
   minScore: numberFlag('--min-score', { min: 0, max: 100 }),
   surface: surfaceFlag('--surface'),
@@ -57,10 +60,14 @@ if (options.url !== null && options.stdin) fail('--url and --stdin read differen
 if (options.url !== null && !/^https?:\/\//i.test(options.url)) {
   fail('--url takes an http or https address.')
 }
+if (options.fix && (options.url !== null || options.stdin)) fail('--fix writes files, so it takes paths.')
+// A corpus-wide rewrite is a maintainer's decision, not a default.
+if (options.fix && options.targets.length === 0) fail('--fix needs the files to fix. It never sweeps the corpus on its own.')
 
 const REDIRECTS_FILE = resolve(REPO_ROOT, 'apps/docs/config/redirects.ts')
 const api = loadApiSurface(REPO_ROOT)
 const routes = loadRoutes(CONTENT_ROOT, REDIRECTS_FILE)
+const redirects = loadRedirects(REDIRECTS_FILE)
 
 // A docs page links by route, a skill links by path. Only the second can be
 // resolved on disk, and resolving a route there would report every link.
@@ -106,15 +113,20 @@ const files = loose || options.targets.length > 0
 
 if (files.length === 0 && loose === null) fail('no markdown files matched')
 
-const scanned = [...files.map(scan), ...(loose ? [loose] : [])]
-
 // The baseline is the corpus, never the selection: a single-page run has to
 // return the same verdict it would inside a full sweep. Reuse the scan already
 // done only when the selection *is* the corpus, by identity. A count would let
 // a repeated path or an unrelated directory of the right size redefine the
-// house rhythm, which is the one number a page cannot argue with.
-const selectionIsCorpus = isSameSet(files, corpus)
-const baseline = buildBaseline(selectionIsCorpus ? files.map((_file, index) => scanned[index]) : corpus.map(file => scan(file)))
+// house rhythm, which is the one number a page cannot argue with. Built at most
+// once, since --fix needs it before the reported scan happens.
+let corpusRates = null
+const corpusBaseline = () => (corpusRates ??= buildBaseline(corpus.map(file => scan(file))))
+
+const fixes = options.fix ? files.map(fixFile) : []
+
+const scanned = [...files.map(scan), ...(loose ? [loose] : [])]
+
+const baseline = corpusRates ?? (isSameSet(files, corpus) ? buildBaseline(scanned) : corpusBaseline())
 const pages = scanned
   .map(page => ({ ...page, ...evaluate(page, baseline) }))
   .map(page => ({ ...page, modelChecks: modelChecks(page) }))
@@ -124,7 +136,9 @@ const pages = scanned
 const selected = options.top ? pages.slice(0, options.top) : pages
 
 if (options.json) {
-  process.stdout.write(`${JSON.stringify({ baseline, pages: selected }, null, 2)}\n`)
+  process.stdout.write(`${JSON.stringify({ baseline, fixed: fixes, pages: selected }, null, 2)}\n`)
+} else if (options.fix) {
+  process.stdout.write(renderFixes(fixes))
 } else if (selected.length === 1) {
   process.stdout.write(renderPage(selected[0], baseline))
 } else {
@@ -135,6 +149,34 @@ const worst = pages.at(0)
 if (options.minScore !== null && worst && worst.score < options.minScore) {
   process.stderr.write(`content-lint: ${worst.path} scored ${worst.score}, below --min-score ${options.minScore}\n`)
   process.exit(1)
+}
+
+/**
+ * Apply the derivable fixes to one file, then prove they helped.
+ *
+ * The proof is the point. A rewrite that trades one finding for another, or
+ * lowers the score on its way to removing a dash, is reverted and reported as
+ * unfixed. That is what makes this safe to run before a reviewer ever sees the
+ * file, and it costs one extra scan.
+ *
+ * @param {string} file Absolute path.
+ */
+function fixFile(file) {
+  const path = relative(REPO_ROOT, file)
+  const before = readFileSync(file, 'utf8')
+  const { source, applied } = applyFixes(before, { redirects })
+
+  if (applied.length === 0) return { path, applied: [], written: false }
+
+  const rate = text => evaluate({ path, surface: surfaceOf(path), ...scanSource(text) }, corpusBaseline())
+  const was = rate(before)
+  const now = rate(source)
+  const verdict = isSafeFix(was, now)
+
+  if (!verdict.safe) return { path, applied: [], written: false, reverted: verdict.why }
+
+  if (!options.dryRun) writeFileSync(file, source)
+  return { path, applied, written: !options.dryRun, score: { before: was.score, after: now.score } }
 }
 
 /**
@@ -217,6 +259,34 @@ function isSameSet(a, b) {
 function fail(message) {
   process.stderr.write(`content-lint: ${message}\n`)
   process.exit(2)
+}
+
+/**
+ * @param {object[]} results
+ * @returns {string}
+ */
+function renderFixes(results) {
+  const changed = results.filter(result => result.applied.length > 0)
+  const reverted = results.filter(result => result.reverted)
+  const lines = [
+    `content-lint --fix · ${results.length} file${results.length === 1 ? '' : 's'} · ${changed.length} changed${options.dryRun ? ' (dry run, nothing written)' : ''}`,
+    '',
+  ]
+
+  for (const result of changed) {
+    lines.push(`  ${result.path}  ${result.score.before} → ${result.score.after}`)
+    for (const entry of result.applied) {
+      lines.push(`    [${entry.id}] ${result.path}:${entry.line}`)
+      lines.push(`      - ${entry.before}`)
+      lines.push(`      + ${entry.after}`)
+    }
+  }
+
+  for (const result of reverted) lines.push(`  ${result.path} reverted: ${result.reverted}`)
+
+  if (changed.length === 0 && reverted.length === 0) lines.push('  nothing derivable to fix')
+  lines.push('', '  What is left needs a reader. Run without --fix for the findings.', '')
+  return lines.join('\n')
 }
 
 /**

--- a/scripts/content-lint/lib/fix.mjs
+++ b/scripts/content-lint/lib/fix.mjs
@@ -1,0 +1,236 @@
+/**
+ * The fixes with a derivable answer.
+ *
+ * A rule belongs here only when the corrected text follows from the rule
+ * itself, never from taste. `evlog/shared` has exactly one replacement.
+ * `sink` has exactly one. A single elaborating em dash does not: it wants a
+ * comma here and a colon there, and picking wrong makes a comma splice, so it
+ * stays a finding for someone who can read the sentence.
+ *
+ * Everything works on raw text, line by line, because formatting has to survive
+ * exactly and a round trip through `parseMarkdown` would not preserve it. Code
+ * and prose are separated by hand for the same reason: `T-15` fixes an import
+ * and must reach inside a fence, `U-15` fixes a word and must not.
+ */
+
+import { readFileSync } from 'node:fs'
+import { ALTERNATIVES } from './corpus.mjs'
+
+const FENCE = /^\s*(`{3,}|~{3,})/
+const DOCUMENTING_A_DEPRECATION = /\b(deprecat\w*|removed|retired|renamed|legacy|instead of|prefer|migrat\w*|never|not\b)/i
+const REDIRECT_ENTRY = /['"](\/[^'"]*)['"]\s*:\s*r\(\s*['"]([^'"]*)['"]\s*\)/g
+
+/** Retired entry points and the ones that replaced them (`T-15`). */
+const ENTRY_POINTS = {
+  'evlog/shared': 'evlog/toolkit',
+  'evlog/browser': 'evlog/http',
+}
+
+/**
+ * Terms with one replacement and no grammatical consequence (`U-15`).
+ *
+ * `child logger` is deliberately absent: `log.fork()` does not slot into the
+ * same sentence, and half the corpus uses the phrase to explain what fork does.
+ */
+const TERMS = [
+  { from: 'sinks', to: 'drains' },
+  { from: 'sink', to: 'drain' },
+  { from: 'error registry', to: 'error catalog' },
+  { from: 'error registries', to: 'error catalogs' },
+]
+
+/**
+ * A parenthetical wrapped in dashes, which becomes a pair of commas without
+ * touching the clause structure (`U-14`). The single dash is not here.
+ */
+const PAIRED_DASH = /(\S) [—–] ([^—–]+?) [—–] (?=\S)/g
+
+/**
+ * Old path to new, from the docs redirect table. A dead link with a redirect
+ * behind it has one correct destination, which makes it a fix rather than a
+ * finding.
+ *
+ * @param {string} file
+ * @returns {Map<string, string>}
+ */
+export function loadRedirects(file) {
+  const map = new Map()
+  let source = ''
+  try {
+    source = readFileSync(file, 'utf8')
+  } catch {
+    return map
+  }
+  for (const match of source.matchAll(REDIRECT_ENTRY)) map.set(match[1].replace(/\/$/, ''), match[2])
+  return map
+}
+
+/**
+ * Whether a fixed file may be written, given how it scored before and after.
+ *
+ * Not "the finding cleared": `U-14` and `U-15` are reported once per page, so
+ * removing one of four dashes leaves the finding standing and still helped.
+ * What has to hold is that nothing got worse and nothing new appeared. This is
+ * the whole safety argument for running the codemod unattended.
+ *
+ * @param {{ score: number, findings: { id: string }[] }} was
+ * @param {{ score: number, findings: { id: string }[] }} now
+ * @returns {{ safe: true } | { safe: false, why: string }}
+ */
+export function isSafeFix(was, now) {
+  const count = (findings, id) => findings.filter(finding => finding.id === id).length
+  const appeared = [...new Set(now.findings.map(finding => finding.id))]
+    .filter(id => count(now.findings, id) > count(was.findings, id))
+    .sort()
+
+  if (appeared.length > 0) return { safe: false, why: `introduced ${appeared.join(', ')}` }
+  if (now.score < was.score) return { safe: false, why: `score ${was.score} to ${now.score}` }
+  return { safe: true }
+}
+
+/**
+ * @typedef {{ id: string, line: number, before: string, after: string }} AppliedFix
+ */
+
+/**
+ * @param {string} source
+ * @param {{ redirects?: Map<string, string> }} [context]
+ * @returns {{ source: string, applied: AppliedFix[] }}
+ */
+export function applyFixes(source, context = {}) {
+  const redirects = context.redirects ?? new Map()
+  const lines = source.split('\n')
+  const applied = []
+
+  let fence = null
+  let frontmatter = lines[0]?.trim() === '---'
+
+  const fixed = lines.map((line, index) => {
+    const number = index + 1
+
+    if (frontmatter) {
+      if (number > 1 && line.trim() === '---') frontmatter = false
+      return line
+    }
+
+    const opener = FENCE.exec(line)
+    if (fence === null && opener) {
+      fence = opener[1]
+      return line
+    }
+    if (fence !== null) {
+      if (line.trimStart().startsWith(fence)) fence = null
+      else return record(line, fixCode(line), 'T-15')
+    }
+    if (fence !== null || opener) return line
+
+    return record(line, fixProse(line, redirects), null)
+
+    /**
+     * @param {string} original
+     * @param {{ text: string, ids: string[] }} result
+     * @param {string | null} forcedId
+     */
+    function record(original, result, forcedId) {
+      if (result.text === original) return original
+      for (const id of forcedId ? [forcedId] : result.ids) {
+        applied.push({ id, line: number, before: original.trim(), after: result.text.trim() })
+      }
+      return result.text
+    }
+  })
+
+  return { source: fixed.join('\n'), applied }
+}
+
+/**
+ * Inside a fence: entry points only.
+ *
+ * @param {string} line
+ * @returns {{ text: string, ids: string[] }}
+ */
+function fixCode(line) {
+  if (DOCUMENTING_A_DEPRECATION.test(line)) return { text: line, ids: [] }
+
+  let text = line
+  for (const [retired, current] of Object.entries(ENTRY_POINTS)) {
+    text = text.replaceAll(retired, current)
+  }
+  return { text, ids: text === line ? [] : ['T-15'] }
+}
+
+/**
+ * Outside a fence: entry points inside backticks, everything else outside them.
+ * A term in backticks is a symbol, and a symbol is not prose.
+ *
+ * @param {string} line
+ * @param {Map<string, string>} redirects
+ * @returns {{ text: string, ids: string[] }}
+ */
+function fixProse(line, redirects) {
+  const ids = new Set()
+  const documenting = DOCUMENTING_A_DEPRECATION.test(line)
+
+  // Odd segments are inline code, because splitting on a backtick alternates.
+  const text = line
+    .split('`')
+    .map((segment, index) => {
+      if (index % 2 === 1) {
+        if (documenting) return segment
+        const swapped = fixCode(segment)
+        if (swapped.ids.length > 0) ids.add('T-15')
+        return swapped.text
+      }
+      return prose(segment, redirects, ids)
+    })
+    .join('`')
+
+  return { text, ids: [...ids] }
+}
+
+/**
+ * @param {string} segment
+ * @param {Map<string, string>} redirects
+ * @param {Set<string>} ids
+ * @returns {string}
+ */
+function prose(segment, redirects, ids) {
+  let text = segment
+
+  const relinked = text.replace(/\]\((\/[^)#?]*)([#?][^)]*)?\)/g, (match, path, suffix) => {
+    const to = redirects.get(path.replace(/\/$/, ''))
+    return to === undefined ? match : `](${to}${suffix ?? ''})`
+  })
+  if (relinked !== text) {
+    ids.add('U-16')
+    text = relinked
+  }
+
+  const undashed = text.replace(PAIRED_DASH, '$1, $2, ')
+  if (undashed !== text) {
+    ids.add('U-14')
+    text = undashed
+  }
+
+  // A sentence naming another logger is allowed to use that logger's words.
+  if (!ALTERNATIVES.some(name => new RegExp(`\\b${name}\\b`, 'i').test(text))) {
+    for (const term of TERMS) {
+      const renamed = text.replace(new RegExp(`\\b${term.from}\\b`, 'gi'), match => matchCase(match, term.to))
+      if (renamed !== text) {
+        ids.add('U-15')
+        text = renamed
+      }
+    }
+  }
+
+  return text
+}
+
+/**
+ * @param {string} original
+ * @param {string} replacement
+ * @returns {string}
+ */
+function matchCase(original, replacement) {
+  return /^[A-Z]/.test(original) ? replacement[0].toUpperCase() + replacement.slice(1) : replacement
+}

--- a/scripts/content-lint/lib/fix.test.mjs
+++ b/scripts/content-lint/lib/fix.test.mjs
@@ -1,0 +1,129 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { applyFixes, isSafeFix, loadRedirects } from './fix.mjs'
+
+const fix = (source, redirects) => applyFixes(source, { redirects: new Map(Object.entries(redirects ?? {})) })
+
+describe('T-15 retired entry points', () => {
+  it('renames the import inside a fence', () => {
+    const { source, applied } = fix('```ts\nimport { createLogger } from \'evlog/shared\'\n```')
+
+    expect(source).toContain('evlog/toolkit')
+    expect(applied).toEqual([expect.objectContaining({ id: 'T-15', line: 2 })])
+  })
+
+  it('renames a symbol in backticks', () => {
+    expect(fix('Pull the helper from `evlog/browser` in your entry.').source)
+      .toBe('Pull the helper from `evlog/http` in your entry.')
+  })
+
+  it('leaves the page that documents the deprecation alone', () => {
+    const source = 'The `evlog/browser` path is deprecated and re-exports `evlog/http`.'
+
+    expect(fix(source).source).toBe(source)
+  })
+})
+
+describe('U-15 terminology', () => {
+  it('renames a term with one replacement, keeping its case', () => {
+    expect(fix('Register the sink. Sinks receive every event.').source)
+      .toBe('Register the drain. Drains receive every event.')
+  })
+
+  it('leaves a sentence that is describing another tool', () => {
+    const source = 'pino writes through a transport, and its sink runs in a worker.'
+
+    expect(fix(source).source).toBe(source)
+  })
+
+  it('leaves a term in backticks, because a symbol is not prose', () => {
+    expect(fix('The `sink` option takes a sink.').source).toBe('The `sink` option takes a drain.')
+  })
+})
+
+describe('U-14 dashes', () => {
+  it('replaces a parenthetical pair with commas', () => {
+    expect(fix('The drain batches — then retries with backoff — before it gives up.').source)
+      .toBe('The drain batches, then retries with backoff, before it gives up.')
+  })
+
+  it('leaves a single dash for someone who can read the sentence', () => {
+    const source = 'evlog is built for the day-zero choice — pick it once.'
+
+    expect(fix(source).source).toBe(source)
+  })
+})
+
+describe('U-16 links', () => {
+  it('follows a redirect to the page that exists now', () => {
+    const { source, applied } = fix('See [the guide](/logging/overview) for more.', { '/logging/overview': '/learn/overview' })
+
+    expect(source).toBe('See [the guide](/learn/overview) for more.')
+    expect(applied[0].id).toBe('U-16')
+  })
+
+  it('keeps the fragment', () => {
+    expect(fix('See [it](/logging#drains).', { '/logging': '/learn/overview' }).source)
+      .toBe('See [it](/learn/overview#drains).')
+  })
+
+  it('leaves a link with no redirect behind it', () => {
+    const source = 'See [it](/nowhere).'
+
+    expect(fix(source).source).toBe(source)
+  })
+})
+
+describe('what it never touches', () => {
+  it('leaves frontmatter alone', () => {
+    const source = '---\ntitle: The sink\n---\n\nRegister the sink.'
+
+    expect(fix(source).source).toBe('---\ntitle: The sink\n---\n\nRegister the drain.')
+  })
+
+  it('leaves prose words inside a fence alone', () => {
+    const source = '```bash\n# write to a sink\nevlog tail\n```'
+
+    expect(fix(source).source).toBe(source)
+  })
+
+  it('reports nothing when there is nothing to do', () => {
+    expect(fix('The drain batches events, then retries.').applied).toEqual([])
+  })
+})
+
+describe('isSafeFix', () => {
+  const rated = (score, ids) => ({ score, findings: ids.map(id => ({ id })) })
+
+  it('accepts a fix that cleared something', () => {
+    expect(isSafeFix(rated(85, ['U-14', 'U-15']), rated(90, ['U-14']))).toEqual({ safe: true })
+  })
+
+  it('accepts a partial fix that left the page-level finding standing', () => {
+    // Four dashes, one of them paired: the count drops, the finding does not.
+    expect(isSafeFix(rated(90, ['U-14']), rated(90, ['U-14']))).toEqual({ safe: true })
+  })
+
+  it('rejects a fix that traded one finding for another', () => {
+    const verdict = isSafeFix(rated(90, ['U-14']), rated(90, ['T-03']))
+
+    expect(verdict).toMatchObject({ safe: false })
+    expect(verdict.why).toContain('T-03')
+  })
+
+  it('rejects a fix that lowered the score', () => {
+    expect(isSafeFix(rated(90, ['U-14']), rated(85, []))).toMatchObject({ safe: false })
+  })
+})
+
+describe('loadRedirects', () => {
+  it('reads the docs redirect table', () => {
+    const map = loadRedirects(join(import.meta.dirname, '../../../apps/docs/config/redirects.ts'))
+
+    expect(map.get('/logging')).toBe('/learn/overview')
+  })
+
+  it('returns an empty map rather than throwing on a missing file', () => {
+    expect(loadRedirects('/nowhere/redirects.ts').size).toBe(0)
+  })
+})


### PR DESCRIPTION
Stacked on #585.

Some content findings have exactly one correct fix. This applies those, so a reviewer never spends a dispatch on an em dash.

```bash
pnpm content:lint <paths…> --fix             # rewrite in place, report every change
pnpm content:lint <paths…> --fix --dry-run   # print what it would do, write nothing
```

## What is derivable, and what is not

A rule reaches `lib/fix.mjs` only when the corrected text follows from the rule rather than from taste.

| Rule | Fixed | Left to a reader |
| --- | --- | --- |
| `T-15` | `evlog/shared` → `evlog/toolkit`, `evlog/browser` → `evlog/http` | a page documenting the deprecation, which is skipped |
| `U-15` | `sink` → `drain`, `error registry` → `error catalog` | `child logger`, which does not slot into the same sentence |
| `U-16` | a link with a redirect behind it | a link with no destination |
| `U-14` | `A — B — C` → `A, B, C` | the single elaborating dash, which wants a comma here and a colon there |

`T-13` is absent on purpose: deleting "Here's a breakdown of" leaves "what makes it special:".

On the corpus as it stands that is 51 fixes across 26 files. The two `evlog/browser` occurrences in the docs are both documenting the deprecation, and both are skipped.

## Why it is safe to run unattended

Every file is re-scanned after writing. If the score dropped or a new finding id appeared, the file is reverted and reported as unfixed.

The check is deliberately not "the finding cleared": `U-14` and `U-15` are reported once per page, so removing one of four dashes leaves the finding standing and still helped. What must hold is that nothing got worse and nothing new appeared. That logic is `isSafeFix`, tested on its own.

`--fix` refuses to run without explicit paths. A corpus-wide rewrite is a maintainer's decision.

## Checks

20 new tests, 87 total in `content:lint:test`. No changeset: `scripts/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional automatic-fix mode to the content linter.
  - Applies safe corrections for redirects, terminology, punctuation, and retired entry-point references.
  - Supports previewing changes with dry-run mode and reports applied fixes in JSON.
  - Automatically rescans results and reverts changes that reduce content quality.

- **Documentation**
  - Added guidance for using automatic fixes, preview mode, supported corrections, and cases requiring manual review.

- **Tests**
  - Expanded coverage for correction safety, protected content, redirects, and no-op scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->