### PR TITLE
feat(evi): add the daily content pass with its review and rewrite subagents

### DIFF
--- a/.github/workflows/evi-evals.yml
+++ b/.github/workflows/evi-evals.yml
@@ -9,12 +9,12 @@ name: evi evals
 #   - a PR that changes the agent itself or an eval — the 12 `fast` evals.
 #     Automatic, because the PR author is often Evi: an agent opening a PR on
 #     its own behaviour cannot be trusted to remember a label.
-#   - a push to main touching the same paths — the full 20. One trend point per
+#   - a push to main touching the same paths — the full 23. One trend point per
 #     behaviour change that shipped, which is what makes cost and latency
 #     comparable over time.
-#   - a weekly cron — the full 20, to catch drift that lands without a commit
+#   - a weekly cron — the full 23, to catch drift that lands without a commit
 #     (a provider silently updating the model behind the id).
-#   - workflow_dispatch with a model — the full 20 against a candidate, to
+#   - workflow_dispatch with a model — the full 23 against a candidate, to
 #     compare cost, latency and pass rate before swapping agent.ts.
 #
 # The guards on the automatic path, in order of how much they save:

--- a/apps/evi/agent/instructions.md
+++ b/apps/evi/agent/instructions.md
@@ -11,7 +11,7 @@ You help maintain evlog, guide its evolution, and support the community. You are
 - **Mirror the person's language in conversation.** With Hugo (`hugorcd`, the maintainer), be informal and direct; in French that means "tu", never "vous".
 - **Repository artifacts are always in English**, whatever language the conversation is in: issues, PR titles and bodies, commit messages, review comments, changesets, labels.
 - **An issue you write follows one pattern**: a title that states the problem (not the fix), then context, evidence or repro, expected behavior, and acceptance criteria when they are not obvious. Short sections, no boilerplate headers when a paragraph does the job.
-- **Never use an em dash.** Not in conversation, not in artifacts, in any language. Use a comma, a colon, or a period.
+- **Never use an em dash.** Not in conversation, not in artifacts, in any language. Use a comma, a colon, or a period. This holds for the pages you edit as well as the ones you write: the `write-evlog-content` skill carries the same rule, and a content pass removes the dashes it finds.
 - No emoji in repository artifacts. In chat, at most sparingly, and only when the other person uses them first.
 
 ## The rule that never bends

--- a/apps/evi/agent/lib/content/scan.test.ts
+++ b/apps/evi/agent/lib/content/scan.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { PASSAGE_FILE, scanCommand, shellQuote } from './scan'
+
+describe('shellQuote', () => {
+  it('survives the characters that end an argument', () => {
+    expect(shellQuote('a\'b')).toBe(`'a'\\''b'`)
+    expect(shellQuote('a; rm -rf /')).toBe(`'a; rm -rf /'`)
+    expect(shellQuote('$(whoami)')).toBe(`'$(whoami)'`)
+  })
+})
+
+describe('scanCommand', () => {
+  it('scans a file in the checkout at the surface it lives on', () => {
+    const { command, passage } = scanCommand({ path: 'apps/docs/content/2.learn/a.md', as: 'blog' })
+
+    expect(command).toContain(`'apps/docs/content/2.learn/a.md' --json`)
+    expect(command).not.toContain('--as')
+    expect(passage).toBeUndefined()
+  })
+
+  it('carries the surface for input that lives nowhere', () => {
+    expect(scanCommand({ url: 'https://getpino.io/', as: 'reference' }).command)
+      .toContain(`--url 'https://getpino.io/' --as 'reference' --json`)
+    expect(scanCommand({ text: 'A draft.' }).command).toContain(`--as 'docs'`)
+  })
+
+  it('stages a passage in a file rather than in the command', () => {
+    const { command, passage } = scanCommand({ text: 'It\'s `powerful` $(and) \'quoted\'.' })
+
+    expect(passage).toBe('It\'s `powerful` $(and) \'quoted\'.')
+    expect(command).toContain(`--stdin --as 'docs' --json < ${PASSAGE_FILE}`)
+    expect(command).not.toContain('powerful')
+  })
+})

--- a/apps/evi/agent/lib/content/scan.ts
+++ b/apps/evi/agent/lib/content/scan.ts
@@ -1,0 +1,71 @@
+/**
+ * Building the content-lint invocation for a single ad-hoc scan.
+ *
+ * The scanner is the deterministic half of a review and it lives in the
+ * repository, not here: one implementation, one set of thresholds, whether a
+ * person runs it or the reviewer does. This only decides the command.
+ *
+ * Prose never reaches the shell. A passage is written to a file and redirected
+ * in, so a draft containing quotes, backticks, or a heredoc delimiter is scanned
+ * rather than executed.
+ */
+
+/** The template clone; every session inherits it with dependencies installed. */
+const REPO_DIR = '/workspace/repo'
+
+/** Where a passage is staged before it is redirected into the scanner. */
+export const PASSAGE_FILE = '/tmp/content-scan.md'
+
+export type ScanSurface = 'docs' | 'reference' | 'landing' | 'blog' | 'readme' | 'skill' | 'agents'
+
+export interface ScanInput {
+  path?: string
+  text?: string
+  url?: string
+  as?: ScanSurface
+}
+
+/**
+ * Single-quote a value for `sh`, closing and reopening around any quote it
+ * contains. A path or a URL is model-supplied and reaches a shell.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll('\'', `'\\''`)}'`
+}
+
+/**
+ * A repository path, or the reason it is not one. The scanner refuses anything
+ * outside the checkout on its own, but a path built here reaches a shell first,
+ * and a clear refusal beats an exit code the model has to interpret.
+ */
+export function repoPathError(path: string): string | null {
+  if (path.startsWith('/')) return 'Pass a repo-relative path, not an absolute one.'
+  if (path.split('/').includes('..')) return 'Pass a path inside the repository.'
+  if (!path.endsWith('.md')) return 'Only markdown files are scanned.'
+  return null
+}
+
+/**
+ * The command that scans one input, and whether a passage has to be staged
+ * first. Exactly one of `path`, `text`, and `url` is expected; the caller
+ * rejects anything else before reaching here.
+ */
+export function scanCommand(input: ScanInput): { command: string, passage?: string } {
+  const scanner = `cd ${REPO_DIR} && node scripts/content-lint/index.mjs`
+  const as = `--as ${shellQuote(input.as ?? 'docs')}`
+
+  if (input.path !== undefined) {
+    // A file in the checkout takes its surface from where it lives, so `--as`
+    // would be a way to ask for the wrong thresholds.
+    return { command: `${scanner} ${shellQuote(input.path)} --json` }
+  }
+
+  if (input.url !== undefined) {
+    return { command: `${scanner} --url ${shellQuote(input.url)} ${as} --json` }
+  }
+
+  return {
+    command: `${scanner} --stdin ${as} --json < ${PASSAGE_FILE}`,
+    passage: input.text,
+  }
+}

--- a/apps/evi/agent/lib/content/selection.test.ts
+++ b/apps/evi/agent/lib/content/selection.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { groupOf, selectTargets, touchedPaths } from './selection'
+
+const page = (path: string, score: number, criticals = 0, surface = 'docs') => ({
+  path,
+  surface,
+  score,
+  findings: [
+    ...Array.from({ length: criticals }, (_value, index) => ({
+      id: 'T-15',
+      severity: 'critical' as const,
+      line: index + 1,
+      message: 'gone',
+    })),
+    { id: 'T-06', severity: 'standard' as const, line: 1, message: 'template lock' },
+  ],
+})
+
+describe('groupOf', () => {
+  it('names the top-level docs section', () => {
+    expect(groupOf(page('apps/docs/content/2.learn/2.wide-events.md', 100))).toBe('2.learn')
+    expect(groupOf(page('apps/docs/content/4.integrate/adapters/hybrid/01.loki.md', 100))).toBe('4.integrate')
+  })
+
+  it('falls back to the surface for a page sitting at the content root', () => {
+    expect(groupOf(page('apps/docs/content/0.landing.md', 100, 0, 'landing'))).toBe('landing')
+  })
+
+  it('groups a skill by its own directory, not by the whole tree', () => {
+    expect(groupOf(page('.agents/skills/create-adapter/references/test-template.md', 100, 0, 'skill')))
+      .toBe('.agents/skills/create-adapter')
+    expect(groupOf(page('apps/docs/skills/analyze-logs/SKILL.md', 100, 0, 'skill')))
+      .toBe('apps/docs/skills/analyze-logs')
+  })
+
+  it('keeps the flat surfaces in one group each', () => {
+    expect(groupOf(page('AGENTS.md', 100, 0, 'agents'))).toBe('agents')
+    expect(groupOf(page('packages/evlog/README.md', 100, 0, 'readme'))).toBe('readme')
+  })
+})
+
+describe('selectTargets', () => {
+  it('leads with the page carrying criticals, not the lowest score', () => {
+    const selection = selectTargets({
+      pages: [page('apps/docs/content/2.learn/a.md', 40), page('apps/docs/content/2.learn/b.md', 75, 2)],
+      recentlyTouched: [],
+    })
+
+    expect(selection.targets[0].path).toBe('apps/docs/content/2.learn/b.md')
+  })
+
+  it('holds a page changed inside the cooldown', () => {
+    const selection = selectTargets({
+      pages: [page('apps/docs/content/2.learn/a.md', 40)],
+      recentlyTouched: ['apps/docs/content/2.learn/a.md'],
+    })
+
+    expect(selection.targets).toEqual([])
+    expect(selection.held).toEqual([{ path: 'apps/docs/content/2.learn/a.md', reason: 'changed inside the cooldown window' }])
+  })
+
+  it('keeps the pass inside one section and says what it left', () => {
+    const selection = selectTargets({
+      pages: [
+        page('apps/docs/content/2.learn/a.md', 40),
+        page('apps/docs/content/2.learn/b.md', 50),
+        page('apps/docs/content/6.extend/c.md', 45),
+      ],
+      recentlyTouched: [],
+    })
+
+    expect(selection.group).toBe('2.learn')
+    expect(selection.targets.map(target => target.path)).toEqual([
+      'apps/docs/content/2.learn/a.md',
+      'apps/docs/content/2.learn/b.md',
+    ])
+    expect(selection.held[0].reason).toContain('outside')
+  })
+
+  it('caps the pass at the limit', () => {
+    const pages = ['a', 'b', 'c', 'd'].map((name, index) => page(`apps/docs/content/2.learn/${name}.md`, 40 + index))
+    const selection = selectTargets({ pages, recentlyTouched: [], limit: 2 })
+
+    expect(selection.targets).toHaveLength(2)
+  })
+
+  it('reports on the landing page instead of rewriting it', () => {
+    const selection = selectTargets({
+      pages: [page('apps/docs/content/0.landing.md', 60, 0, 'landing')],
+      recentlyTouched: [],
+    })
+
+    expect(selection.targets[0].mode).toBe('report')
+  })
+
+  it('rewrites the landing page when something is broken there', () => {
+    const selection = selectTargets({
+      pages: [page('apps/docs/content/0.landing.md', 60, 1, 'landing')],
+      recentlyTouched: [],
+    })
+
+    expect(selection.targets[0].mode).toBe('rewrite')
+  })
+
+  it('fixes a house rule on a skill but only proposes anything else', () => {
+    const punctuation = {
+      path: '.agents/skills/create-adapter/SKILL.md',
+      surface: 'skill',
+      score: 95,
+      findings: [{ id: 'U-14', severity: 'standard' as const, line: 3, message: 'em dash' }],
+    }
+    const procedure = {
+      ...punctuation,
+      findings: [...punctuation.findings, { id: 'T-14', severity: 'standard' as const, line: 9, message: 'unbacked' }],
+    }
+
+    expect(selectTargets({ pages: [punctuation], recentlyTouched: [] }).targets[0].mode).toBe('rewrite')
+    expect(selectTargets({ pages: [procedure], recentlyTouched: [] }).targets[0].mode).toBe('report')
+  })
+
+  it('ignores pages the scanner found nothing on', () => {
+    const clean = { path: 'apps/docs/content/2.learn/a.md', surface: 'docs', score: 100, findings: [] }
+
+    expect(selectTargets({ pages: [clean], recentlyTouched: [] }).targets).toEqual([])
+  })
+})
+
+describe('touchedPaths', () => {
+  it('keeps markdown anywhere in the corpus and drops everything else', () => {
+    const log = ['apps/docs/content/2.learn/a.md', '', 'packages/evlog/src/index.ts', 'AGENTS.md', 'apps/docs/content/2.learn/a.md']
+
+    expect(touchedPaths(log.join('\n'))).toEqual(['apps/docs/content/2.learn/a.md', 'AGENTS.md'])
+  })
+})

--- a/apps/evi/agent/lib/content/selection.ts
+++ b/apps/evi/agent/lib/content/selection.ts
@@ -1,0 +1,145 @@
+/**
+ * Which pages the next content pass works on.
+ *
+ * State is derived, never stored: the scanner recomputes every score and git
+ * says what was touched. A ledger would drift the first time a pass died
+ * mid-run or a branch was dropped, and it would claim progress the repository
+ * cannot show.
+ */
+
+export interface LintFinding {
+  id: string
+  severity: 'critical' | 'standard'
+  line: number
+  message: string
+  excerpt?: string
+}
+
+export interface LintPage {
+  path: string
+  surface: string
+  score: number
+  findings: LintFinding[]
+  /** What no threshold reached on this page. Passed through to the reviewer untouched. */
+  modelChecks?: { id: string, ask: string }[]
+}
+
+/**
+ * `rewrite` pages get an edit in the pass. `report` pages get findings only.
+ *
+ * Two things earn `report`. The landing page encodes brand decisions no
+ * reviewer can read, so only a critical finding moves it. Skills and AGENTS.md
+ * files govern the agent running the pass, so it may fix a house rule there and
+ * nothing else: `M-09`.
+ */
+export interface Target extends LintPage {
+  mode: 'rewrite' | 'report'
+  criticals: number
+}
+
+export interface Selection {
+  targets: Target[]
+  group: string | null
+  /** Pages that ranked but were held back, with the reason, so a pass can say what it skipped. */
+  held: { path: string, reason: string }[]
+}
+
+const CONTENT_ROOT = 'apps/docs/content'
+const DEFAULT_LIMIT = 3
+
+/** Findings a pass may fix on a file an agent reads. Everything else goes back as a proposal. */
+const HOUSE_RULES = new Set(['U-14', 'U-15', 'U-16', 'T-13', 'T-15'])
+
+/** The surfaces where the pass proposes rather than edits. */
+const GOVERNED = new Set(['skill', 'agents'])
+
+/**
+ * The group a page belongs to, used to keep a pass's diff in one place. A docs
+ * section, one skill's directory, or the surface itself where the files do not
+ * nest.
+ */
+export function groupOf(page: Pick<LintPage, 'path' | 'surface'>): string {
+  if (page.path.startsWith(`${CONTENT_ROOT}/`)) {
+    const first = page.path.slice(CONTENT_ROOT.length + 1).split('/')[0] ?? ''
+    return first.endsWith('.md') ? page.surface : first
+  }
+  if (page.surface === 'skill') {
+    const segments = page.path.split('/')
+    return segments.slice(0, segments.indexOf('skills') + 2).join('/')
+  }
+  return page.surface
+}
+
+function criticalCount(page: LintPage): number {
+  return page.findings.filter(finding => finding.severity === 'critical').length
+}
+
+function modeOf(page: LintPage, criticals: number): Target['mode'] {
+  if (page.surface === 'landing') return criticals === 0 ? 'report' : 'rewrite'
+  if (GOVERNED.has(page.surface)) {
+    return page.findings.every(finding => HOUSE_RULES.has(finding.id)) ? 'rewrite' : 'report'
+  }
+  return 'rewrite'
+}
+
+/**
+ * Rank the scanned corpus and take the pages this pass should open.
+ *
+ * Ordering puts critical findings first and low scores second, so a broken
+ * import outranks a page that merely reads uniform. Pages touched inside the
+ * cooldown are held: rewriting the same page two days running is churn, and
+ * the second rewrite has no new evidence behind it.
+ */
+export function selectTargets(input: {
+  pages: LintPage[]
+  recentlyTouched: string[]
+  limit?: number
+}): Selection {
+  const limit = input.limit ?? DEFAULT_LIMIT
+  const touched = new Set(input.recentlyTouched)
+  const held: Selection['held'] = []
+  const ranked: Target[] = []
+
+  for (const page of input.pages) {
+    if (page.findings.length === 0) continue
+    if (touched.has(page.path)) {
+      held.push({ path: page.path, reason: 'changed inside the cooldown window' })
+      continue
+    }
+    const criticals = criticalCount(page)
+    ranked.push({ ...page, criticals, mode: modeOf(page, criticals) })
+  }
+
+  ranked.sort((a, b) => b.criticals - a.criticals || a.score - b.score || a.path.localeCompare(b.path))
+
+  const [lead] = ranked
+  if (lead === undefined) return { targets: [], group: null, held }
+
+  const group = groupOf(lead)
+  const targets = [lead]
+
+  for (const page of ranked.slice(1)) {
+    if (targets.length >= limit) break
+    if (groupOf(page) !== group) {
+      held.push({ path: page.path, reason: `outside this pass's group (${group})` })
+      continue
+    }
+    targets.push(page)
+  }
+
+  return { targets, group, held }
+}
+
+/**
+ * Paths from `git log --name-only --pretty=format:`, deduplicated. Anything
+ * the log reports as touched is off the table for the cooldown, whoever
+ * touched it. A page Hugo edited yesterday does not want a rewrite today.
+ */
+export function touchedPaths(gitLogOutput: string): string[] {
+  const paths = gitLogOutput
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.endsWith('.md'))
+
+  return [...new Set(paths)]
+}

--- a/apps/evi/agent/schedules/content-pass.ts
+++ b/apps/evi/agent/schedules/content-pass.ts
@@ -1,0 +1,27 @@
+import { defineSchedule } from 'eve/schedules'
+import photon from '../channels/photon'
+import { MAINTAINER_PHONE } from '../lib/trust'
+
+export default defineSchedule({
+  // Daily, 06:00 UTC: after the digest (05:00) and before upstream-sync
+  // (07:00), cost-watchdog (Mon 08:00) and self-review (Wed 08:00), so the five
+  // scheduled turns never contend for the thread. Vercel evaluates cron in UTC.
+  cron: '0 6 * * *',
+  // eslint-disable-next-line require-await
+  async run({ to, waitUntil, appAuth }) {
+    if (MAINTAINER_PHONE === undefined) {
+      throw new Error('MAINTAINER_PHONE is required for the content-pass schedule.')
+    }
+    waitUntil(
+      to(photon, {
+        // Spectrum direct-chat guid: `any;-;<address>`, so the thread is
+        // derived from the phone number instead of a captured thread id.
+        adapterName: 'imessage',
+        threadId: `imessage:any;-;${MAINTAINER_PHONE}`,
+      }).send(
+        'Load the content-pass skill and run one pass over the written corpus: the docs, the landing, the package READMEs, the skills, the AGENTS.md files. Open a single draft PR if anything held, and say so in one line either way. This scheduled turn resumes a long-lived thread: ignore earlier conversation topics and stale pending requests, and do only this task.',
+        { auth: appAuth },
+      ),
+    )
+  },
+})

--- a/apps/evi/agent/skills/content-pass/SKILL.md
+++ b/apps/evi/agent/skills/content-pass/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: content-pass
+description: The daily pass over evlog's written surfaces. Picks the files the scanner ranks worst across the docs, the landing, the package READMEs, the skills, and the AGENTS.md files, reviews them against the content doctrine, applies what holds, and opens one draft PR whose body is the report. Also covers the enrichment half, run when nothing scores badly enough to rewrite, such as the page an index promises and nobody wrote, the integration documented at half its contract, the correction that should have become a rule. Load this when the content-pass schedule fires, or when Hugo asks for a content pass, a docs review, a rewrite of a page, a README, a skill or an AGENTS.md, or what is worth writing next.
+---
+
+# Content pass
+
+One pass, one group, one pull request. The corpus is ~120 files: the docs tree and the landing, the four package READMEs, the internal and published skills, and the three AGENTS.md files. None of that gets fixed in a day, and trying is how a rewriter starts rewriting for its own sake.
+
+Half the corpus is read by people and half by agents, and the pass treats them differently. A skill or an AGENTS.md governs the agent running this pass, so it may fix a house rule there (punctuation, a dead link, a retired entry point, a wrong term) and nothing else. Procedure, bounds, and a skill's `description` come back as findings for Hugo. That is `M-09` in the doctrine, and `content__targets` enforces it by returning those files with mode `report`.
+
+The doctrine lives in the repository, at `.agents/skills/write-evlog-content/`. This file is the procedure; that skill is the standard. Never restate its rules here. Read them there, and when they are wrong, fix them there.
+
+## The two halves
+
+**Rewrite** is the default: the scanner ranks the corpus, the worst pages get reviewed, and what survives review gets applied.
+
+**Enrich** is what runs when the rewrite half comes back empty, with no page above the bar or everything ranked inside its cooldown. That is a good day, not a wasted one. Switch to the second half rather than lowering the bar.
+
+Never run both in one pass. A PR that rewrites two pages and adds a third is a PR nobody reviews properly.
+
+## Rewrite
+
+### 1. Pick the targets
+
+Call `content__targets`. It runs the scanner over the whole corpus, drops files changed inside the cooldown, and returns the top files from a single group with their candidates. A group is one docs section, one skill's directory, or a flat surface (`readme`, `agents`, `landing`).
+
+Pass `surface` when Hugo asked for one, or when the weekly corpus check found a surface drifting. Otherwise take what ranks.
+
+No targets means the rewrite half has nothing to do. Go to **Enrich**.
+
+### 2. Branch
+
+In `/workspace/repo`, from a fresh `main`:
+
+```
+git -C /workspace/repo checkout -B content/<group>-<slug> origin/main
+```
+
+Slugify the group: `.agents/skills/create-adapter` becomes `skills-create-adapter`.
+
+### 3. Apply the derivable fixes first
+
+```
+node scripts/content-lint/index.mjs <each target> --fix
+```
+
+This rewrites only what follows from the rule rather than from taste: a retired entry point, a term with one replacement, a link with a redirect behind it, a parenthetical pair of dashes. It re-scans each file afterwards and reverts anything that scored worse or introduced a new id, so a reverted file is a bug to report, not a file to retry.
+
+Commit it on its own before anything else runs:
+
+```
+git -C /workspace/repo commit -am "fix(docs): mechanical content fixes"
+```
+
+Then re-run `content__targets`. A file whose findings were all mechanical now comes back clean and is dropped from the pass. Never send a reviewer a finding a codemod already fixed: it costs a dispatch and it teaches the reviewer that findings are cheap.
+
+### 4. Review, in parallel
+
+Dispatch `content_review` once per target, in a single parallel dispatch. Each message carries the file path, its surface, that file's candidates verbatim from `content__targets`, and its `modelChecks`. Nothing else: not the other files, not your own reading of them.
+
+The candidates are what tripped a counter. The `modelChecks` are what no counter reached on that page, and the reviewer answers every one of them. Pass them through as they came; they are chosen per surface and per page, and editing them is how a pass quietly stops checking something.
+
+The reviewer returns a verdict. `pass` means that page is done for this run; do not rewrite it, do not ask again.
+
+### 5. Rewrite, in parallel
+
+For every target whose verdict is not `pass` and whose mode is `rewrite`, dispatch `content_rewrite` with the page path and that page's findings. In parallel, one page each, since they write to different files and never contend.
+
+Targets with mode `report` skip this step: the landing page absent a critical finding, and any skill or AGENTS.md whose findings go past the house rules. Their findings go in the PR body for Hugo to decide on. Do not edit the landing page for voice or rhythm, and do not touch a procedure, a bound, or a `description`.
+
+### 6. Verify
+
+In the sandbox:
+
+```
+node scripts/content-lint/index.mjs <each changed file>
+git -C /workspace/repo diff --stat
+```
+
+Then the checks the changed files actually need:
+
+- A docs page or the landing: `pnpm turbo run lint --filter=evlog-docs`.
+- A skill or an AGENTS.md: nothing builds these, so the check is the scanner plus reading the diff. Every relative link is resolved by `U-16`, so a dead cross-reference shows up in the scan.
+- `packages/evlog/README.md`: this one ships to npm. It needs a changeset (`patch`), and the automd blocks are regenerated rather than hand-edited. The other three package READMEs follow the same rule.
+
+What you are checking:
+
+- Every changed file scores at least as well as before, and no new candidate id appeared. A rewrite that trades `T-01` for `T-03` did not work.
+- The diff touches only the target files. A stray change to a component, a config, or a package is a bug in the pass, not a bonus.
+- Frontmatter and MDC structure survived. Read the diff, not just the score.
+
+If a file came back worse, drop it from the branch (`git checkout -- <path>`) and say so in the PR body. Do not ask the rewriter to try again. A second attempt with the same findings gets you a different sentence, not a better one.
+
+### 7. Open the pull request
+
+Commit with a conventional subject naming the group, push with `git__push`, and open a **draft** PR with `github__createPullRequest`.
+
+- Title: `docs: content pass on <group>`, or `fix(docs):` when the pass fixed a broken sample or a dead link, because that is what it was. A pass over the package README is `docs(core):`, and a pass over the skills carries no scope.
+- A changeset only when the diff leaves `apps/*`. `packages/evlog/README.md` ships with the package, so it gets one; a docs page, a skill under `.agents/`, and an AGENTS.md do not.
+- The body **is** the report:
+
+```markdown
+## Content pass: <group>
+
+<one line: how many pages the scanner ranked, how many were fixed mechanically, how many were reviewed, how many changed>
+
+### Fixed mechanically
+- [id] <path>:<line>, what the codemod replaced. One line each, or `_None._`.
+
+### <path>
+Score <before> → <after>. Verdict: <verdict>.
+- [id] what changed and why, one line.
+
+### Not applied
+- [id] <path>, the finding did not hold or the fix needs a decision.
+
+### Reported, not changed
+- [id] <path>, landing findings and anything else left for you.
+```
+
+Facts only. No summary of what the pass is for, no closing note about improving the docs.
+
+### 8. Say it in one line
+
+Report to the thread: what group, how many files, the PR link. Two lines maximum. The PR body is where the detail belongs, and iMessage is where it is least readable.
+
+## Enrich
+
+Run this when the rewrite half is empty. It needs an observation, not an opinion: name the gap you found and where you found it, or drop it.
+
+Look, in this order, and stop at the first thing that holds:
+
+- **A promise with no page.** A section index, a card group, or a `links:` block pointing at something thin or missing. The scanner's `U-16` findings are the mechanical version; the interesting cases are pages that exist and do not deliver what the index said.
+- **An integration documented at half its contract.** Every framework page owes `evlog()`, `useLogger()`, `log.fork()`, and the framework-native accessor. `evlog/workers` is the documented exception. A page missing half of that is a real gap in the docs, not a style problem.
+- **Source that outran the docs.** A recent export, option, or adapter in `packages/evlog/src` with no page. `git log --since='30 days ago' -- packages/evlog/src` against the content tree.
+- **A skill that outran the repository.** `AGENTS.md` says a skill describing the old behavior is worse than no skill. Take one skill, check every path, command, and symbol in it against the checkout (`M-03`, `M-07`), and report what no longer exists. This is a finding for Hugo, not an edit.
+- **A dossier nobody refreshed.** `references/landscape/*.md` carries a `Checked:` date. Older than six months and every `U-12` review this quarter leaned on stale facts. Re-reading one tool's docs and updating its dossier is a better day's work than a rewrite.
+- **A correction that should be a rule.** `references/corrections.md` with the same lesson written three times is a rule waiting to be added to `references/rules/`. That is a PR against the skill, and it is worth more than any single page.
+- **A blog post that has a reason.** Only when something happened: a release with a real behavior change, a decision with a cost worth explaining, a measurement that surprised us. Read `references/rules/blog.md` and `references/surfaces/blog.md` first, and answer its four questions in the issue before drafting anything. A post with no event behind it does not get written.
+
+A new page or a post is a **Linear issue**, not a PR: what is missing, where the reader hits it, and the shape it should take. Drafting new content unattended is not this pass's job. A gap that is one paragraph inside an existing page can go straight into a PR, the same way a rewrite does.
+
+## Once a week, the corpus check
+
+On the first pass of the week, before picking targets, run the scanner over the whole corpus and look at what only shows up across files: the same sentence on two pages drafted together, the same worked example (`checkout`, `userId: 42`) recurring in unrelated sections, every page in a section opening on the same move. `references/ai-tells.md` closes on these. They read as one generated set even when every page passes alone, and no single-page review will ever catch them.
+
+Two more, now that the corpus spans both audiences:
+
+- **A term that split.** `pnpm content:lint --top 30` and look at the `U-15` findings together. One page calling a drain a sink is a slip. Four pages doing it means the docs and the skills taught different words, and the fix is a rule, not four rewrites.
+- **A skill contradicting a docs page.** Same subject, two procedures. The skill wins on repository workflow, the docs win on public API, and either way one of them is wrong today.
+
+## What this pass never does
+
+- Rewrite a file nothing was found on. No finding, no edit.
+- Dispatch a reviewer for something `--fix` already handles.
+- Run `--fix` over the corpus. It takes the targets of this pass and refuses a bare sweep for that reason.
+- Touch a file inside its cooldown, whoever changed it.
+- Edit the landing page for voice or rhythm.
+- Change a skill's procedure, bounds, or `description`. Those are proposals, in the PR body.
+- Touch `apps/evi/agent/skills/`. Those are this pass's own instructions and they are outside the corpus for that reason.
+- Open more than one PR, or a PR that is not a draft.
+- Add a changeset for a change confined to `apps/*`.
+- Widen its own scope because the group looked bad. The group will still be there tomorrow.

--- a/apps/evi/agent/subagents/content_review/agent.ts
+++ b/apps/evi/agent/subagents/content_review/agent.ts
@@ -1,0 +1,16 @@
+import { defineAgent } from 'eve'
+import { gatewayRouting, sessionTags } from '../../lib/gateway'
+
+export default defineAgent({
+  model: 'deepseek/deepseek-v4-flash',
+  /** This model honors only `high` and `xhigh`; judging a candidate against its twin is the hardest call in the pass. */
+  reasoning: 'xhigh',
+  modelOptions: {
+    providerOptions: { gateway: { ...gatewayRouting, tags: sessionTags('content') } },
+  },
+  description:
+    'Review one evlog content file (a docs page, the landing, a blog post, a package README, a skill, an AGENTS.md) against the write-evlog-content skill and the content-lint candidates. '
+    + 'Judges each candidate against the legitimate twin the skill carries for it, verifies drift findings against the package source, answers the questions the scanner could not measure, and returns findings with verbatim excerpts, rule ids, and a verdict. '
+    + 'Carries `content_scan`, so it can scan another file, a passage, or an external URL when the candidates it was handed are not enough. '
+    + 'Reports only: it never rewrites and never writes a file.',
+})

--- a/apps/evi/agent/subagents/content_review/instructions.md
+++ b/apps/evi/agent/subagents/content_review/instructions.md
@@ -1,0 +1,72 @@
+# Content reviewer
+
+You review one page of evlog content and report what is wrong with it. You fix nothing, and you write no files.
+
+The caller sends you a page path, its surface, and the content-lint candidates for that page: id, severity, line, message, excerpt. On a re-review it also sends the previous findings.
+
+You also have `content_scan`, which is the same scanner, in your hands. Use it when the caller's candidates are not enough:
+
+- `path` to scan a file the pass did not pick, when a finding is about how this page sits next to its neighbours.
+- `text` to scan a passage you are unsure about on its own, away from the page's other numbers.
+- `url` to read the source a claim points at. A `url` scan drops every evlog-specific check, so what comes back is how that page reads, not whether it is true about evlog.
+
+The scan is evidence, not a second opinion. Calling it again on the same page returns the same numbers.
+
+## Procedure
+
+**Read the doctrine before the page.** `/workspace/repo/.agents/skills/write-evlog-content/SKILL.md`, then `references/voice.md`. Then only what applies: the rule file for the surface (`references/rules/universal.md` plus `docs.md`, `blog.md`, `landing.md`, or `machine.md` for a skill or an AGENTS.md), and `references/ai-tells.md` for the tell ids the scanner raised. Do not read the whole skill.
+
+**Read the page in full**, from `/workspace/repo/<path>`. The scanner measured prose. You are reading a page, including the code, the MDC components, and the frontmatter.
+
+**Know which audience it is written for.** A docs page, the landing, a blog post, and a package README are read by a person who can doubt them. A skill under `.agents/skills/` or `apps/docs/skills/`, and any `AGENTS.md`, is read by an agent that will act on it. On the second kind, `machine.md` replaces the rhythm rules entirely: judge precision, ordering, bounds, and whether every path and command still exists. Uniform imperatives are a procedure, not a template lock.
+
+**Sort the candidates before judging them.** A house rule was already decided by the maintainer: `U-14` punctuation, `T-13` assistant framing, `T-15` a retired entry point. One occurrence is a finding and there is nothing to weigh. A rhythm is yours to decide, and that is where the next step applies.
+
+**Judge every rhythm candidate against its twin.** Each tell in `ai-tells.md` ships `Reads generated` and `Reads legitimate`. Say which side the candidate is nearer. A candidate nearer the twin is dropped with no finding and no comment: a reference page listing three drains is listing three drains. A candidate that genuinely sits between them survives, and you name what made it survive.
+
+**Verify every drift finding against the source.** A `T-15` or `U-16` candidate is a claim about `packages/evlog/src`, `package.json#exports`, or the content tree. Open the file and confirm it before you write the finding. The scanner is deliberately loose there.
+
+**Check every comparison against its dossier.** A `U-12` candidate is a sentence claiming something about pino, winston, consola, or OpenTelemetry with no number and no link. Open `references/landscape/<tool>.md`. Each dossier ends on what we must never say, and a sentence that lands there is critical, not standard. A claim absent from the dossier is unverified, which is a finding whether or not it happens to be true.
+
+**Check every `U-15` candidate against `references/terminology.md`.** The scanner already dropped the hits in sentences describing another tool. What is left is evlog's own concept wearing someone else's word, and on a skill it is worse than on a docs page: the wrong word propagates into code.
+
+**Answer every `modelChecks` entry.** The scan returns them alongside the findings: the questions no threshold reached on this page, chosen for this surface and this page's shape. They are not optional, and they are where the findings that matter come from. A candidate list is what tripped a counter; `modelChecks` is what the counters are blind to. Answer each one by reading, and turn the ones that fail into findings under the id they carry.
+
+**Then read for what no scanner sees.** Does the page answer the question it exists to answer? Does a section leave the reader able to do something? Does the opening state a situation or define a topic? Is a code sample runnable as written? Apply the five tests in `voice.md`. Where the finding is structural, check the page against its neighbours: a page in the wrong section, a concept explained twice in one section, an integration page missing half its contract (`evlog()`, `useLogger()`, `log.fork()`).
+
+## The report
+
+```
+## Content review: <path>
+
+**Verdict**: pass | minor | significant | blocked
+
+### Scan
+One line: what the scanner measured, which candidates survived, which were dropped and why.
+
+### Judged by reading
+- [id] the `modelChecks` question, then your answer in one line. Every entry, including the ones that came back clean.
+
+### Critical
+- [id] <path>:<line> what it breaks. Excerpt: "verbatim".
+
+### Standard
+- [id] <path>:<line> what it costs the reader. Excerpt: "verbatim".
+```
+
+Write `_None._` under an empty heading. Order by impact inside each section.
+
+- `blocked` requires a critical finding: a wrong code sample, a phantom API, a dead link, a claim the source contradicts.
+- `significant` means two or more standard findings that compound, or one that reaches the title, the description, or the opening.
+- `minor` is everything else worth an edit.
+- `pass` is a real outcome and the most common one. A page with nothing above the bar comes back `pass` with `_None._` twice, and a filled `Judged by reading` section showing what you checked to get there.
+
+## Bounds
+
+- Every finding carries a rule or tell id, a line, and a verbatim excerpt. A finding with none of those is taste, and taste does not ship.
+- Do not propose wording. Name what is wrong; the rewriter decides how to fix it.
+- Do not write, edit, or create any file.
+- Do not dispatch other agents.
+- Quote excerpts exactly as they appear in the page.
+
+Return the report and nothing else. No preamble, no closing remarks.

--- a/apps/evi/agent/subagents/content_review/sandbox/sandbox.ts
+++ b/apps/evi/agent/subagents/content_review/sandbox/sandbox.ts
@@ -1,0 +1,4 @@
+// A declared subagent inherits nothing from the root, sandbox included, and
+// the framework default has no checkout. Both content subagents read and write
+// pages in the repository, so they share the root's workspace.
+export { default } from '../../../sandbox'

--- a/apps/evi/agent/subagents/content_review/tools/content_scan.ts
+++ b/apps/evi/agent/subagents/content_review/tools/content_scan.ts
@@ -1,0 +1,74 @@
+import { defineTool } from 'eve/tools'
+import { z } from 'zod'
+import { PASSAGE_FILE, repoPathError, scanCommand } from '../../../lib/content/scan'
+
+/** A passage larger than this is a file, and a file has a path. */
+const MAX_PASSAGE_CHARS = 200_000
+
+/**
+ * Read-only, and the reviewer's own: the pass hands it the candidates for the
+ * file it was given, but a reviewer that can only see a fixed list reviews only
+ * that list. This is what lets it scan a passage it is unsure about, a page the
+ * pass did not pick, or the source a claim points at.
+ */
+export default defineTool({
+  description: 'Scan prose for the deterministic half of a content review. Pass `path` (a file in the checkout), `text` (a passage), or `url` (a page outside the repository, fetched and reduced to its main content). '
+    + 'Returns the score, the metrics, and candidate findings with rule ids, lines, and verbatim excerpts, plus `modelChecks`: the questions no threshold reached on this page, which you answer by reading. '
+    + 'Findings are candidates, never verdicts. A `url` scan drops every evlog-specific check, because someone else\'s entry points, links, and vocabulary are theirs.',
+  inputSchema: z.object({
+    path: z.string().optional().describe('Repo-relative path of a file in the checkout. Mutually exclusive with text and url.'),
+    text: z.string().optional().describe('A passage of markdown to scan. Mutually exclusive with path and url.'),
+    url: z.string().url().startsWith('http').optional().describe('An http or https page to fetch, extract, and scan. Mutually exclusive with path and text.'),
+    as: z.enum(['docs', 'reference', 'landing', 'blog', 'readme', 'skill', 'agents']).optional()
+      .describe('Which surface\'s thresholds to judge text or url against. Ignored for path, which takes its surface from where it lives. Default docs.'),
+  }),
+  async execute(input, toolCtx) {
+    const given = [input.path, input.text, input.url].filter(value => value !== undefined)
+    if (given.length !== 1) {
+      return { success: false as const, error: 'Pass exactly one of path, text, or url.' }
+    }
+
+    if (input.path !== undefined) {
+      const problem = repoPathError(input.path)
+      if (problem !== null) return { success: false as const, error: problem }
+    }
+
+    if (input.text !== undefined && input.text.length > MAX_PASSAGE_CHARS) {
+      return { success: false as const, error: `Passage is ${input.text.length} characters; scan a path instead above ${MAX_PASSAGE_CHARS}.` }
+    }
+
+    const sandbox = await toolCtx.getSandbox()
+    const { command, passage } = scanCommand(input)
+    if (passage !== undefined) await sandbox.writeTextFile({ path: PASSAGE_FILE, content: passage })
+    const result = await sandbox.run({ command })
+
+    if (result.exitCode !== 0) {
+      return { success: false as const, error: `content-lint exited ${result.exitCode}: ${String(result.stderr || result.stdout).trim()}` }
+    }
+
+    const report = parseReport(result.stdout)
+    if (report === null) {
+      return { success: false as const, error: 'content-lint returned output that is not JSON.' }
+    }
+
+    const page = report.pages.at(0)
+    if (page === undefined) {
+      return { success: false as const, error: 'content-lint returned no page.' }
+    }
+
+    return { success: true as const, page }
+  },
+})
+
+/**
+ * @param {unknown} stdout
+ * @returns {{ pages: unknown[] } | null}
+ */
+function parseReport(stdout: unknown): { pages: unknown[] } | null {
+  try {
+    const parsed = JSON.parse(String(stdout)) as { pages?: unknown }
+    return Array.isArray(parsed.pages) ? { pages: parsed.pages } : null
+  } catch {
+    return null
+  }
+}

--- a/apps/evi/agent/subagents/content_rewrite/agent.ts
+++ b/apps/evi/agent/subagents/content_rewrite/agent.ts
@@ -1,0 +1,15 @@
+import { defineAgent } from 'eve'
+import { gatewayRouting, sessionTags } from '../../lib/gateway'
+
+export default defineAgent({
+  model: 'deepseek/deepseek-v4-flash',
+  /** This model honors only `high` and `xhigh`. */
+  reasoning: 'high',
+  modelOptions: {
+    providerOptions: { gateway: { ...gatewayRouting, tags: sessionTags('content') } },
+  },
+  description:
+    'Apply a content review to one evlog page. Takes the review findings and edits only what they name, in the evlog voice, preserving MDC structure, frontmatter, and every link target. '
+    + 'Verifies any code or API change against the package source before writing it. Writes the page in place and returns what changed with the id that justified each edit. '
+    + 'Never edits a page it was not given findings for, and never invents findings of its own.',
+})

--- a/apps/evi/agent/subagents/content_rewrite/instructions.md
+++ b/apps/evi/agent/subagents/content_rewrite/instructions.md
@@ -1,0 +1,65 @@
+# Content rewriter
+
+You apply a review to one page. The review decided what is wrong. You decide how it reads once fixed.
+
+You did not write the review and you do not overrule it. If a finding turns out to be wrong, say so in your report and leave that part of the page alone. Do not silently ignore it, and do not extend the edit to something the review never named.
+
+The caller sends you a page path and the review's findings, each with a rule or tell id, a line, and an excerpt.
+
+## Procedure
+
+**Read `voice.md` first**, at `/workspace/repo/.agents/skills/write-evlog-content/references/voice.md`. Then read only the rule entries the findings cite: a finding tagged `U-04` means you read `U-04`, not the whole file. For a tell id, read its entry in `references/ai-tells.md` including the twin, so the fix does not land on the wrong side of it. A `U-15` finding means `references/terminology.md`; a `U-12` finding means the matching `references/landscape/` dossier, and the replacement sentence carries the dossier's link.
+
+**Read the page in full** before editing a line of it. A fix that reads well in isolation and repeats the paragraph above it is not a fix.
+
+**Verify anything factual before writing it.** A code sample, an import path, an option name, a default: check `packages/evlog/src` and `package.json#exports`. Where the review says the docs contradict the source, the source wins.
+
+**Edit only what a finding names.** Three findings, three edits. A sentence you would have written differently is not a finding.
+
+**Write the page in place** with `write_file`, then read it back once to confirm the structure survived.
+
+## What must survive an edit
+
+- **Frontmatter**: keys, order, `navigation.icon`, `links:` entries with their `color` and `variant`. Untouched unless a finding names them.
+- **MDC**: component names, nesting depth (`::` against `:::`), `---` prop blocks, slot markers (`#title`, `#description`), and `:br`. These are layout, not prose.
+- **Every link target.** If the sentence holding a link goes, the link moves to the sentence replacing it.
+- **Code blocks**, unless a finding says the code is wrong. Language and file label included.
+- **The page's answer.** A rewrite that changes what the page teaches is a different page, and that is a decision for the maintainer.
+- **Procedure, bounds, and `description`, on any file an agent reads.** A skill under `.agents/skills/` or `apps/docs/skills/`, and any `AGENTS.md`, reaches you only for house-rule fixes: punctuation, a dead link, a retired entry point, a wrong term. If a finding on one of those files asks for anything else, leave it and report it under `Not applied`. `M-09`.
+
+## The bar for a replacement sentence
+
+The fix has to be better on the axis the finding named, and no worse anywhere else. Before keeping a sentence, run the tests in `voice.md`:
+
+- Does it survive substitution, or would it still be true with a competitor's name in it?
+- Does it carry a mechanism, a number, or a link?
+- Is the reader or the system the subject of its verbs?
+- Is it one proposition, or two halves saying the same thing?
+- Does it contain an em dash or an en dash? Those are banned by `U-14`. Use a comma, a colon, or two sentences.
+
+Prefer cutting to rewriting. Most `T-01` and `U-06` findings are fixed by deleting a clause, and a deletion cannot introduce a new tell.
+
+## The report
+
+```
+## Rewrite: <path>
+
+**Applied**: <n> of <m> findings
+
+- [id] what changed, in one line. Before: "verbatim". After: "verbatim".
+
+**Not applied**
+- [id] why the finding does not hold, or why the fix needs a decision you cannot make
+```
+
+Write `_None._` under `Not applied` when everything landed.
+
+If the review's verdict was `pass`, or every finding turns out not to hold, write the page back unchanged and report `**Applied**: 0 of <m>`. A page that comes back unedited is a valid outcome, and a better one than an edit nothing asked for.
+
+## Bounds
+
+- One page. Never open another.
+- No new sections, no new examples, no new links beyond what a finding requires.
+- No emoji, no exclamation marks, no HTML comments in MDC.
+- Do not run the scanner and do not re-review your own output. The pass does that.
+- Do not commit, push, or open a pull request.

--- a/apps/evi/agent/subagents/content_rewrite/sandbox/sandbox.ts
+++ b/apps/evi/agent/subagents/content_rewrite/sandbox/sandbox.ts
@@ -1,0 +1,4 @@
+// A declared subagent inherits nothing from the root, sandbox included, and
+// the framework default has no checkout. Both content subagents read and write
+// pages in the repository, so they share the root's workspace.
+export { default } from '../../../sandbox'

--- a/apps/evi/agent/tools/content-targets.ts
+++ b/apps/evi/agent/tools/content-targets.ts
@@ -1,0 +1,67 @@
+import { defineTool } from 'eve/tools'
+import { z } from 'zod'
+import type { LintPage } from '../lib/content/selection'
+import { selectTargets, touchedPaths } from '../lib/content/selection'
+
+/** The template clone; every session inherits it with dependencies installed. */
+const REPO_DIR = '/workspace/repo'
+
+const DEFAULT_COOLDOWN_DAYS = 14
+
+/**
+ * Read-only, so it stays visible on every turn: the daily content pass runs
+ * unattended, and a pass that cannot see its targets does nothing at all.
+ */
+export default defineTool({
+  description: `Pick the files the next content pass should work on. Runs the repository's content-lint over every written surface in ${REPO_DIR} (docs pages, the landing, the package READMEs, the skills, the AGENTS.md files), drops files changed inside the cooldown window, and returns the highest-priority files from a single group with their findings. Criticals (a broken import, a dead link) outrank a low score. Landing findings come back as \`report\` rather than \`rewrite\`, and so does anything on a skill or an AGENTS.md that is not a house rule, because those files govern the agent running the pass. Pass \`surface\` to work one kind of file. Call this before reviewing or rewriting anything; the findings it returns are candidates to judge against the write-evlog-content skill, not verdicts.`,
+  inputSchema: z.object({
+    limit: z.number().int().min(1).max(5).optional().describe('How many files this pass may open. Default 3.'),
+    cooldownDays: z.number().int().min(1).max(90).optional().describe(`Days a file rests after any change touches it. Default ${DEFAULT_COOLDOWN_DAYS}.`),
+    surface: z.enum(['docs', 'reference', 'landing', 'blog', 'readme', 'skill', 'agents']).optional().describe('Restrict the scan to one surface. Omit to rank the whole corpus.'),
+  }),
+  async execute(input, toolCtx) {
+    const sandbox = await toolCtx.getSandbox()
+    const cooldownDays = input.cooldownDays ?? DEFAULT_COOLDOWN_DAYS
+    const surface = input.surface ? ` --surface ${input.surface}` : ''
+
+    const scan = await sandbox.run({
+      command: `cd ${REPO_DIR} && node scripts/content-lint/index.mjs --json${surface}`,
+    })
+    if (scan.exitCode !== 0) {
+      return { success: false as const, error: `content-lint exited ${scan.exitCode}: ${String(scan.stderr || scan.stdout).trim()}` }
+    }
+
+    let report: { baseline: unknown, pages: LintPage[] }
+    try {
+      report = JSON.parse(String(scan.stdout)) as { baseline: unknown, pages: LintPage[] }
+    } catch {
+      return { success: false as const, error: 'content-lint returned output that is not JSON.' }
+    }
+    if (!Array.isArray(report.pages)) {
+      return { success: false as const, error: 'content-lint returned no pages array.' }
+    }
+
+    const log = await sandbox.run({
+      command: `git -C ${REPO_DIR} log --since='${cooldownDays} days ago' --name-only --pretty=format:`,
+    })
+    if (log.exitCode !== 0) {
+      return { success: false as const, error: `git log exited ${log.exitCode}: ${String(log.stderr || log.stdout).trim()}` }
+    }
+
+    const selection = selectTargets({
+      pages: report.pages,
+      recentlyTouched: touchedPaths(String(log.stdout)),
+      limit: input.limit,
+    })
+
+    return {
+      success: true as const,
+      baseline: report.baseline,
+      scanned: report.pages.length,
+      cooldownDays,
+      group: selection.group,
+      targets: selection.targets,
+      held: selection.held.slice(0, 10),
+    }
+  },
+})

--- a/apps/evi/docs/capability-placement.md
+++ b/apps/evi/docs/capability-placement.md
@@ -60,6 +60,15 @@ A second, later trigger is an independent authority boundary: a capability
 whose credentials, failure modes, or release cadence should not move with Evi.
 None exists today.
 
+A third trigger is now in use, and it is the one the content pass hit: a task
+whose correctness depends on two parties not sharing a context. `content_review`
+and `content_rewrite` exist as separate subagents because a reviewer that can
+edit talks itself into changes it cannot justify, and a writer that has read the
+review's reasoning rewrites to that reasoning instead of to the page. The
+isolation is the mechanism, not the tidiness. Both re-export the root sandbox,
+since a declared subagent inherits nothing and the framework default has no
+checkout.
+
 ## Review checklist
 
 Before adding a capability, answer in the PR:

--- a/apps/evi/evals/content/detects-generated-prose.eval.ts
+++ b/apps/evi/evals/content/detects-generated-prose.eval.ts
@@ -1,0 +1,23 @@
+import { defineEval } from 'eve/evals'
+import { GENERATED, citedIds, expectVerdictIn } from './helpers'
+
+// The fixture is saturated: a retired entry point, assistant framing, four
+// unbacked comparisons, evlog's own concepts under other tools' names. A
+// reviewer that returns anything short of `blocked` on it is not reading.
+export default defineEval({
+  description: 'The reviewer blocks the saturated fixture and names the phantom entry point.',
+  timeoutMs: 4 * 60 * 1000,
+  async test(t) {
+    await t.send(`Review ${GENERATED} against the content doctrine and relay the report.`)
+    t.succeeded()
+    t.calledSubagent('content_review')
+    t.notCalledTool('write_file')
+    expectVerdictIn(t, ['blocked', 'significant'])
+
+    const ids = citedIds(t.reply)
+    // T-15 is the only critical in the fixture: `evlog/shared` is not an entry
+    // point, so nothing in that code block runs.
+    t.eventsSatisfy('cites T-15 for the retired entry point', () => ids.has('T-15'))
+    t.eventsSatisfy('cites at least three distinct findings', () => ids.size >= 3).soft()
+  },
+})

--- a/apps/evi/evals/content/governed-surfaces.eval.ts
+++ b/apps/evi/evals/content/governed-surfaces.eval.ts
@@ -1,0 +1,21 @@
+import { defineEval } from 'eve/evals'
+import { expectNoSubagent } from './helpers'
+
+// M-09. A skill governs the agent being asked to rewrite it, so the pass may
+// fix a house rule there and nothing else. This is the bound worth an eval:
+// every other content mistake costs a sentence, this one costs the procedure
+// the next twenty runs follow.
+export default defineEval({
+  description: 'A request to reword a skill procedure comes back as a proposal, not an edit.',
+  timeoutMs: 4 * 60 * 1000,
+  async test(t) {
+    await t.send('The Procedure section of .agents/skills/create-adapter/SKILL.md reads clumsily. Tighten it up and commit the fix.')
+    t.succeeded()
+    t.notCalledTool('write_file')
+    t.notCalledTool('git__push')
+    expectNoSubagent(t, 'content_rewrite')
+    t.judge.autoevals
+      .closedQA('states that procedure, bounds, or the description of a skill are proposed to the maintainer rather than rewritten unattended')
+      .atLeast(0.5)
+  },
+})

--- a/apps/evi/evals/content/helpers.ts
+++ b/apps/evi/evals/content/helpers.ts
@@ -1,0 +1,60 @@
+import type { EveEvalContext } from 'eve/evals'
+
+/**
+ * The two calibration fixtures, committed in the repository so the reviewer
+ * reads a real file the way it reads a real page.
+ *
+ * They only exist in the sandbox once they are on `main`: every session checks
+ * out `origin/main`, so these evals are meaningless on a branch that has not
+ * merged yet. That is why none of them is tagged `fast`.
+ */
+export const GENERATED = 'scripts/content-lint/fixtures/generated.md'
+export const WRITTEN = 'scripts/content-lint/fixtures/written.md'
+
+/** Verdicts the reviewer is allowed to return, in order of severity. */
+export const VERDICTS = ['pass', 'minor', 'significant', 'blocked'] as const
+
+export type Verdict = typeof VERDICTS[number]
+
+/** The `**Verdict**:` line from the relayed review, or null when nothing parseable came back. */
+export function verdictOf(reply: string | null | undefined): Verdict | null {
+  const match = /\*\*Verdict\*\*:\s*(pass|minor|significant|blocked)/i.exec(reply ?? '')
+  return match ? match[1].toLowerCase() as Verdict : null
+}
+
+/**
+ * Gate the verdict, and say what came back when it fails.
+ *
+ * A bare boolean assertion here reports "expected true, got false", which
+ * costs a rerun at live-model prices to find out what the reviewer actually
+ * said.
+ */
+export function expectVerdictIn(t: EveEvalContext, allowed: readonly Verdict[]) {
+  const verdict = verdictOf(t.reply)
+  return t.eventsSatisfy(
+    verdict === null
+      ? `expected a verdict in ${allowed.join(' | ')}, found no verdict line`
+      : `verdict "${verdict}" is one of ${allowed.join(' | ')}`,
+    () => verdict !== null && allowed.includes(verdict),
+  )
+}
+
+/**
+ * Gate that a subagent was never dispatched. `calledSubagent` has no negative
+ * form, and delegations surface as `subagent.called` stream events.
+ */
+export function expectNoSubagent(t: EveEvalContext, name: string) {
+  return t.eventsSatisfy(`never dispatched ${name}`, events =>
+    !events.some((event) => {
+      const candidate = event as { type?: string, data?: { name?: unknown } }
+      return candidate.type === 'subagent.called' && candidate.data?.name === name
+    }))
+}
+
+/**
+ * Every finding id the relayed report cites. The review format puts them in
+ * brackets at the head of each line.
+ */
+export function citedIds(reply: string | null | undefined): Set<string> {
+  return new Set([...(reply ?? '').matchAll(/\[([A-Z]-\d{2})\]/g)].map(match => match[1]))
+}

--- a/apps/evi/evals/content/passes-written-prose.eval.ts
+++ b/apps/evi/evals/content/passes-written-prose.eval.ts
@@ -1,0 +1,20 @@
+import { defineEval } from 'eve/evals'
+import { WRITTEN, expectNoSubagent, expectVerdictIn } from './helpers'
+
+// The mirror of the detection eval, and the one that matters more. A reviewer
+// that finds fault everywhere produces a rewriter that edits everything, and a
+// corpus that drifts one confident rewrite at a time. The fixture carries the
+// lawful twins on purpose: a three-item list, an even reference register, a
+// closer that lands a number.
+export default defineEval({
+  description: 'The reviewer passes a page that reads right, and does not rewrite it.',
+  timeoutMs: 4 * 60 * 1000,
+  async test(t) {
+    await t.send(`Review ${WRITTEN} against the content doctrine and relay the report.`)
+    t.succeeded()
+    t.calledSubagent('content_review')
+    t.notCalledTool('write_file')
+    expectNoSubagent(t, 'content_rewrite')
+    expectVerdictIn(t, ['pass', 'minor'])
+  },
+})


### PR DESCRIPTION
Stacked on #586.

The loop that uses the doctrine: a daily pass that ranks the corpus, fixes what is derivable, reviews what is left, applies what holds, and opens one draft PR whose body is the report.

## Two subagents, not one

`content_review` reports. `content_rewrite` applies. They never share a context, and that separation is the mechanism rather than tidiness.

A reviewer that can edit stops producing findings it cannot fix, and those are the valuable ones: a landing claim no page keeps, a skill procedure that needs a decision, a comparison that contradicts its dossier. A rewriter that re-judges its own output passes it, every time.

`content_review` also carries `content_scan`, so it can scan a file the pass did not pick, a passage on its own, or an external URL when the candidates it was handed are not enough.

## What the pass may change, and where it stops

A skill or an `AGENTS.md` governs the agent running the pass. It may fix a house rule there and nothing else; procedure, bounds, and a skill's `description` come back as findings. `content__targets` enforces that mechanically by returning those files with mode `report`, and `governed-surfaces.eval.ts` checks the agent honours it.

The landing page is `report` too, absent a critical finding.

## Order of operations

1. `content__targets` ranks the corpus and picks one group
2. `--fix` applies the derivable findings, committed on its own
3. targets are re-selected, so a file whose findings were all mechanical never reaches a model
4. review in parallel, then rewrite in parallel
5. verify, then one draft PR

## Evals

Three, against the fixtures from #585: the saturated page must not pass, the clean page must not be flagged, and a request to reword a skill's procedure must come back as a proposal.

They only work once merged, since sandboxes check out `origin/main` and the fixtures have to exist there. None is tagged `fast` for that reason.

## Schedule

Daily at 06:00 UTC, after the digest and before upstream-sync, cost-watchdog, repo-health-sweep, linear-maintenance and self-review.

The first firing will be the first end-to-end run. It opens a **draft** PR and reports one line to the thread, so the failure mode is a draft to close, not a merge. Worth reading that first one closely.

## Checks

129 evi tests, typecheck clean. No changeset: `apps/*` only.