### PR TITLE
fix(evi): make the content pass report what it saw and scope its PR title

### DIFF
--- a/apps/evi/agent/lib/content/selection.test.ts
+++ b/apps/evi/agent/lib/content/selection.test.ts
@@ -118,6 +118,32 @@ describe('selectTargets', () => {
     expect(selectTargets({ pages: [procedure], recentlyTouched: [] }).targets[0].mode).toBe('report')
   })
 
+  it('counts what it saw, so a pass cannot call a full ranking empty', () => {
+    const selection = selectTargets({
+      pages: [
+        page('apps/docs/content/2.learn/a.md', 40),
+        page('apps/docs/content/2.learn/b.md', 50),
+        page('apps/docs/content/6.extend/c.md', 45),
+        { path: 'apps/docs/content/2.learn/clean.md', surface: 'docs', score: 100, findings: [] },
+      ],
+      recentlyTouched: ['apps/docs/content/2.learn/a.md'],
+    })
+
+    expect(selection.candidates).toBe(3)
+    expect(selection.eligible).toBe(2)
+  })
+
+  it('reports zero eligible when the cooldown holds everything', () => {
+    const selection = selectTargets({
+      pages: [page('apps/docs/content/2.learn/a.md', 40)],
+      recentlyTouched: ['apps/docs/content/2.learn/a.md'],
+    })
+
+    expect(selection.candidates).toBe(1)
+    expect(selection.eligible).toBe(0)
+    expect(selection.targets).toEqual([])
+  })
+
   it('ignores pages the scanner found nothing on', () => {
     const clean = { path: 'apps/docs/content/2.learn/a.md', surface: 'docs', score: 100, findings: [] }
 

--- a/apps/evi/agent/lib/content/selection.ts
+++ b/apps/evi/agent/lib/content/selection.ts
@@ -40,6 +40,10 @@ export interface Target extends LintPage {
 export interface Selection {
   targets: Target[]
   group: string | null
+  /** Files the scanner found something on, before the cooldown and the group filter. */
+  candidates: number
+  /** Files that ranked and were eligible: not in cooldown. Zero is the only reason to skip the rewrite half. */
+  eligible: number
   /** Pages that ranked but were held back, with the reason, so a pass can say what it skipped. */
   held: { path: string, reason: string }[]
 }
@@ -99,9 +103,11 @@ export function selectTargets(input: {
   const touched = new Set(input.recentlyTouched)
   const held: Selection['held'] = []
   const ranked: Target[] = []
+  let candidates = 0
 
   for (const page of input.pages) {
     if (page.findings.length === 0) continue
+    candidates += 1
     if (touched.has(page.path)) {
       held.push({ path: page.path, reason: 'changed inside the cooldown window' })
       continue
@@ -112,8 +118,10 @@ export function selectTargets(input: {
 
   ranked.sort((a, b) => b.criticals - a.criticals || a.score - b.score || a.path.localeCompare(b.path))
 
+  const counts = { candidates, eligible: ranked.length }
+
   const [lead] = ranked
-  if (lead === undefined) return { targets: [], group: null, held }
+  if (lead === undefined) return { targets: [], group: null, held, ...counts }
 
   const group = groupOf(lead)
   const targets = [lead]
@@ -127,7 +135,7 @@ export function selectTargets(input: {
     targets.push(page)
   }
 
-  return { targets, group, held }
+  return { targets, group, held, ...counts }
 }
 
 /**

--- a/apps/evi/agent/skills/content-pass/SKILL.md
+++ b/apps/evi/agent/skills/content-pass/SKILL.md
@@ -27,7 +27,9 @@ Call `content__targets`. It runs the scanner over the whole corpus, drops files 
 
 Pass `surface` when Hugo asked for one, or when the weekly corpus check found a surface drifting. Otherwise take what ranks.
 
-No targets means the rewrite half has nothing to do. Go to **Enrich**.
+**Read `eligible` before deciding anything.** It is the count of files with findings that are outside the cooldown, and it is the only number that says whether there is work. `eligible: 0` sends you to **Enrich**. Anything above zero means the rewrite half has targets, and the pass rewrites.
+
+Write the three numbers into the PR body verbatim: `scanned`, `candidates`, `eligible`. A pass that says the rewrite half was empty without them is asserting, not reporting, and a corpus of 120 files with 47 eligible pages has been called empty before.
 
 ### 2. Branch
 
@@ -96,7 +98,13 @@ If a file came back worse, drop it from the branch (`git checkout -- <path>`) an
 
 Commit with a conventional subject naming the group, push with `git__push`, and open a **draft** PR with `github__createPullRequest`.
 
-- Title: `docs: content pass on <group>`, or `fix(docs):` when the pass fixed a broken sample or a dead link, because that is what it was. A pass over the package README is `docs(core):`, and a pass over the skills carries no scope.
+**The title is validated by CI and a wrong scope means the PR cannot merge.** The accepted list is `scopes:` in `.github/workflows/semantic-pull-request.yml`. Read it rather than guessing, and note what is not in it:
+
+- **`evlog` is never a scope.** The whole monorepo is evlog, so a bare `docs:` already means evlog itself. `docs(evlog):` fails validation.
+- One docs page under `4.integrate/adapters/<name>/` or `4.integrate/frameworks/<name>` takes that subsystem's scope: `docs(posthog):`, `docs(hono):`.
+- Several pages, or a page belonging to no subsystem: `docs:` with no scope.
+- The package READMEs: `docs(core):`. The skills and the `AGENTS.md` files: no scope.
+- `fix(docs):` when the pass fixed a broken sample or a dead link, because that is what it was.
 - A changeset only when the diff leaves `apps/*`. `packages/evlog/README.md` ships with the package, so it gets one; a docs page, a skill under `.agents/`, and an AGENTS.md do not.
 - The body **is** the report:
 
@@ -127,7 +135,9 @@ Report to the thread: what group, how many files, the PR link. Two lines maximum
 
 ## Enrich
 
-Run this when the rewrite half is empty. It needs an observation, not an opinion: name the gap you found and where you found it, or drop it.
+Run this when `eligible` is 0. It needs an observation, not an opinion: name the gap you found and where you found it, or drop it.
+
+**Whatever file you end up editing, run `--fix` on it first.** A page you are already opening does not have "pre-existing" findings, it has findings, and the mechanical ones cost one command. Leaving an em dash on a page you just edited, and writing that it was out of scope, is the pass explaining why it did less than the tool it was given.
 
 Look, in this order, and stop at the first thing that holds:
 

--- a/apps/evi/agent/tools/content-targets.ts
+++ b/apps/evi/agent/tools/content-targets.ts
@@ -13,7 +13,7 @@ const DEFAULT_COOLDOWN_DAYS = 14
  * unattended, and a pass that cannot see its targets does nothing at all.
  */
 export default defineTool({
-  description: `Pick the files the next content pass should work on. Runs the repository's content-lint over every written surface in ${REPO_DIR} (docs pages, the landing, the package READMEs, the skills, the AGENTS.md files), drops files changed inside the cooldown window, and returns the highest-priority files from a single group with their findings. Criticals (a broken import, a dead link) outrank a low score. Landing findings come back as \`report\` rather than \`rewrite\`, and so does anything on a skill or an AGENTS.md that is not a house rule, because those files govern the agent running the pass. Pass \`surface\` to work one kind of file. Call this before reviewing or rewriting anything; the findings it returns are candidates to judge against the write-evlog-content skill, not verdicts.`,
+  description: `Pick the files the next content pass should work on. Runs the repository's content-lint over every written surface in ${REPO_DIR} (docs pages, the landing, the package READMEs, the skills, the AGENTS.md files), drops files changed inside the cooldown window, and returns the highest-priority files from a single group with their findings. Criticals (a broken import, a dead link) outrank a low score. Landing findings come back as \`report\` rather than \`rewrite\`, and so does anything on a skill or an AGENTS.md that is not a house rule, because those files govern the agent running the pass. Pass \`surface\` to work one kind of file. Also returns \`candidates\` (files with findings) and \`eligible\` (those outside the cooldown): the rewrite half is empty only when \`eligible\` is 0, whatever the top of the ranking looks like. Call this before reviewing or rewriting anything; the findings it returns are candidates to judge against the write-evlog-content skill, not verdicts.`,
   inputSchema: z.object({
     limit: z.number().int().min(1).max(5).optional().describe('How many files this pass may open. Default 3.'),
     cooldownDays: z.number().int().min(1).max(90).optional().describe(`Days a file rests after any change touches it. Default ${DEFAULT_COOLDOWN_DAYS}.`),
@@ -59,6 +59,11 @@ export default defineTool({
       baseline: report.baseline,
       scanned: report.pages.length,
       cooldownDays,
+      // Reported so a pass can say what it saw instead of characterising it.
+      // `eligible` is the only number that decides whether the rewrite half
+      // has work: zero means empty, anything else means targets exist.
+      candidates: selection.candidates,
+      eligible: selection.eligible,
       group: selection.group,
       targets: selection.targets,
       held: selection.held.slice(0, 10),


### PR DESCRIPTION
Two defects from the first real run, #589.

## It called a full ranking empty

The pass reported "the rewrite half came back empty (every page above the bar sits inside its cooldown window)" and switched to the enrich half. Replaying the same selection against `main`: 120 files scanned, 111 with findings, 64 held by the cooldown, **47 eligible**. `7.reference/4.best-practices.md` was sitting at score 70 with five findings.

There is no "bar" in the selection code, so that sentence was a characterisation, not a reading. The skill made it cheap to produce: *"No targets means the rewrite half has nothing to do"* is a condition an agent can satisfy by asserting it.

`content__targets` now returns `candidates` (files with findings) and `eligible` (those outside the cooldown), and the skill states that `eligible: 0` is the only thing that sends a pass to the enrich half. The three numbers go in the PR body verbatim, so the claim is checkable by whoever reads it.

## It used a scope that does not exist

The title was `docs(evlog):`, which fails `Validate PR title` — so the pass produced a PR that cannot merge. `AGENTS.md` already says the whole monorepo is evlog and a bare `docs:` means evlog itself, but the pass skill never said what scope a docs page takes, so it guessed, and guessed the one forbidden value. `posthog` was valid and correct for that page.

The skill now carries the rule, points at `scopes:` in `.github/workflows/semantic-pull-request.yml` as the source of truth, and says a wrong scope blocks the merge.

## It declined free work

#589 reported `T-06` and `U-14` on the page it was editing as "pre-existing and out of scope for a one-paragraph enrich". `content:lint --fix` clears `U-14` in one command, on a file already open in the diff.

The enrich half now runs `--fix` on whatever file it touches. A page you are opening does not have pre-existing findings, it has findings.

## Checks

131 evi tests, two new ones covering the counts. No changeset: `apps/*` only.