### PR TITLE
fix(evi): stop the cooldown from holding the whole corpus on a shallow clone

### DIFF
--- a/.agents/skills/write-evlog-content/SKILL.md
+++ b/.agents/skills/write-evlog-content/SKILL.md
@@ -73,7 +73,7 @@ pnpm content:lint --url https://example.com/post --as blog   # a page outside th
 cat draft.md | pnpm content:lint --stdin                     # prose that is not a file yet
 ```
 
-Some findings are fixed before anyone reads them. `pnpm content:lint <paths> --fix` applies the rules whose corrected text follows from the rule itself: a retired entry point, a term with one replacement, a link with a redirect behind it. Punctuation is not among them, so every dash reaches you. It re-scans and reverts anything that scored worse. Run it before reviewing, so a review spends its attention on what a codemod cannot decide.
+Some findings are fixed before anyone reads them. `pnpm content:lint <paths> --fix` applies the rules whose corrected text follows from the rule itself: a retired entry point, a term with one replacement, a link with a redirect behind it. Punctuation is not among them, so every dash reaches you. It re-scans afterwards and reverts any file that scored worse or that introduced a finding id the page did not have, so a fix that trades one problem for another never lands. Run it before reviewing, so a review spends its attention on what a codemod cannot decide.
 
 Rates are compared per surface. A reference page and a skill file have different natural rhythms, and one median over both flatters whichever is looser. A `--url` scan drops every evlog-specific check: someone else's entry points, links, and vocabulary are theirs, so what comes back is how the page reads.
 

--- a/.agents/skills/write-evlog-content/SKILL.md
+++ b/.agents/skills/write-evlog-content/SKILL.md
@@ -73,7 +73,7 @@ pnpm content:lint --url https://example.com/post --as blog   # a page outside th
 cat draft.md | pnpm content:lint --stdin                     # prose that is not a file yet
 ```
 
-Some findings are fixed before anyone reads them. `pnpm content:lint <paths> --fix` applies the rules whose corrected text follows from the rule itself: a retired entry point, a term with one replacement, a link with a redirect behind it, a dash pair around a parenthetical. It re-scans and reverts anything that scored worse. Run it before reviewing, so a review spends its attention on what a codemod cannot decide.
+Some findings are fixed before anyone reads them. `pnpm content:lint <paths> --fix` applies the rules whose corrected text follows from the rule itself: a retired entry point, a term with one replacement, a link with a redirect behind it. Punctuation is not among them, so every dash reaches you. It re-scans and reverts anything that scored worse. Run it before reviewing, so a review spends its attention on what a codemod cannot decide.
 
 Rates are compared per surface. A reference page and a skill file have different natural rhythms, and one median over both flatters whichever is looser. A `--url` scan drops every evlog-specific check: someone else's entry points, links, and vocabulary are theirs, so what comes back is how the page reads.
 

--- a/.agents/skills/write-evlog-content/references/rules/universal.md
+++ b/.agents/skills/write-evlog-content/references/rules/universal.md
@@ -119,10 +119,19 @@ Why: the admission is what makes the rest of the page believable, and evlog's co
 
 **U-14 · No em dashes, no en dashes** · `standard`
 
-Rule: no `—` and no `–` in prose, in any language, on any surface. Use a comma, a colon, a period, or two sentences. Hyphens in compound words are fine, and so are dashes inside code blocks and inside a verbatim quote.
+Rule: no `—` and no `–` in prose, in any language, on any surface. Hyphens in compound words are fine, and so are dashes inside code blocks and inside a verbatim quote.
 Bad: "The drain batches events, then retries with backoff, before it gives up."  written as "The drain batches events — then retries with backoff — before it gives up."
 Better: "The drain batches events, retries with backoff, then gives up."
-Why: this is a maintainer decision about how evlog sounds, and it is the punctuation most associated with machine-written prose. Every occurrence is a finding; there is no density threshold to argue about.
+Why: this is a maintainer decision about how evlog sounds, and it is the punctuation most associated with machine-written prose. Every occurrence is a finding, and there is no density threshold to argue about.
+
+**What replaces it**, in the order to try:
+
+1. **A comma**, when the clause continues the sentence. "the integration path for oRPC v1, and it remains the entrypoint".
+2. **A period**, when the second half is its own thought. Two short sentences beat one hinged sentence.
+3. **A colon**, when the second half explains or lists what the first half named.
+4. **Nothing**, when the dash was joining two things that did not need joining. Cutting is a valid fix and the only one that cannot introduce a new tell.
+
+**Never a semicolon.** It is not in this register, it reads as a writer who could not choose between a comma and a period, and swapping one unusual mark for another leaves the sentence exactly as stiff as it was. A replacement that a reader would notice is not a fix.
 Note: the corpus predates the rule, so most pages still carry them. A content pass removes the ones on the pages it touches and does not open a PR just to sweep them.
 
 ---

--- a/.agents/skills/write-evlog-content/references/rules/universal.md
+++ b/.agents/skills/write-evlog-content/references/rules/universal.md
@@ -132,6 +132,8 @@ Why: this is a maintainer decision about how evlog sounds, and it is the punctua
 4. **Nothing**, when the dash was joining two things that did not need joining. Cutting is a valid fix and the only one that cannot introduce a new tell.
 
 **Never a semicolon.** It is not in this register, it reads as a writer who could not choose between a comma and a period, and swapping one unusual mark for another leaves the sentence exactly as stiff as it was. A replacement that a reader would notice is not a fix.
+
+**No codemod touches this rule**, and the reason is worth keeping. Replacing a dashed pair with commas was tried across this corpus: 25 of 38 replacements turned a parenthetical list into a sentence whose subject was followed by four bare nouns. "It finds every entry point, API handlers, pages that fetch, middleware, checks each one" is not a fix, and the scanner cannot tell that span from an appositive. Which mark belongs here is a reading, so every dash arrives as a finding.
 Note: the corpus predates the rule, so most pages still carry them. A content pass removes the ones on the pages it touches and does not open a PR just to sweep them.
 
 ---

--- a/.agents/skills/write-evlog-content/references/voice.md
+++ b/.agents/skills/write-evlog-content/references/voice.md
@@ -22,7 +22,7 @@ evlog writes to someone in the middle of doing something. They arrived with a qu
 - Not enthusiastic. No exclamation marks, no emoji in prose, no "excited to announce".
 - Not hedged. If the mechanism is deterministic, say it happens. `often`, `typically`, `generally` on a guaranteed behavior is a lie that sounds careful.
 - Not abstract. Nothing "leverages", "empowers", or "unlocks". Things run, retry, drop, batch, fail.
-- Not punctuated with dashes. No em dash, no en dash, anywhere. A comma, a colon, or two sentences say the same thing without the tic. See `U-14`.
+- Not punctuated with dashes. No em dash, no en dash, anywhere. A comma, a period, or a colon says the same thing without the tic, and a semicolon is not the answer either. See `U-14`.
 
 ## The five tests
 

--- a/.agents/skills/write-evlog-content/references/voice.md
+++ b/.agents/skills/write-evlog-content/references/voice.md
@@ -22,7 +22,7 @@ evlog writes to someone in the middle of doing something. They arrived with a qu
 - Not enthusiastic. No exclamation marks, no emoji in prose, no "excited to announce".
 - Not hedged. If the mechanism is deterministic, say it happens. `often`, `typically`, `generally` on a guaranteed behavior is a lie that sounds careful.
 - Not abstract. Nothing "leverages", "empowers", or "unlocks". Things run, retry, drop, batch, fail.
-- Not punctuated with dashes. No em dash, no en dash, anywhere. A comma, a period, or a colon says the same thing without the tic, and a semicolon is not the answer either. See `U-14`.
+- Not punctuated with dashes. No em dash, no en dash, anywhere. `U-14` ranks what goes in its place, and a semicolon is never on that list.
 
 ## The five tests
 

--- a/apps/docs/content/4.integrate/frameworks/15.orpc.md
+++ b/apps/docs/content/4.integrate/frameworks/15.orpc.md
@@ -35,7 +35,7 @@ Set up evlog in my oRPC app.
 - Wrap your RPCHandler / OpenAPIHandler with withEvlog() from 'evlog/orpc'
 - Add os.use(evlog()) on your base procedure for typed context.log + per-procedure operation
 - Declare EvlogOrpcContext on your base context to type context.log
-- Throw evlog errors (createError or defineErrorCatalog) directly from procedures; evlog/orpc bridges them into ORPCError
+- Throw evlog errors (createError or defineErrorCatalog) directly from procedures. evlog/orpc bridges them into ORPCError
 - Pass drain, enrich, include, and keep options to withEvlog()
 
 Docs: https://www.evlog.dev/integrate/frameworks/orpc
@@ -302,7 +302,7 @@ const handler = withEvlog(new RPCHandler(router), {
 })
 ```
 
-When a route is filtered out, the wrapper still injects a no-op `context.log` so procedures never crash on missing fields; the wide event simply isn't emitted and drain/enrich aren't called.
+When a route is filtered out, the wrapper still injects a no-op `context.log`, so procedures never crash on missing fields. The wide event simply isn't emitted, and drain/enrich aren't called.
 
 ## Run Locally
 

--- a/apps/evi/agent/lib/content-sandbox.ts
+++ b/apps/evi/agent/lib/content-sandbox.ts
@@ -20,9 +20,10 @@ export default defineSandbox({
   backend: defaultBackend({
     vercel: {
       resources: { vcpus: 2 },
-      // A reviewer or a rewriter lives for one dispatch. Nothing here is worth
-      // a snapshot the next pass will not reuse.
-      snapshotExpiration: 6 * 60 * 60 * 1000,
+      // One day is the platform floor: Vercel rejects anything between 0 and
+      // 86400000 ms. It also matches the pass's cadence, so a snapshot lives
+      // exactly as long as the gap between two runs.
+      snapshotExpiration: 24 * 60 * 60 * 1000,
     },
   }),
   revalidationKey: () => 'evlog-content-workspace-v1',

--- a/apps/evi/agent/lib/content-sandbox.ts
+++ b/apps/evi/agent/lib/content-sandbox.ts
@@ -11,10 +11,11 @@ import { defaultBackend, defineSandbox } from 'eve/sandbox'
  * was the slowest way to find out that any of them can fail.
  *
  * These two read pages and write pages. They run no checks, drive no browser,
- * and capture nothing, so the template stops at a checkout with dependencies
- * installed. What they lose against the root template is the primed turbo
- * cache, which they never used: the pass runs its own verification in the root
- * session, after the rewrite comes back.
+ * and capture nothing, so the template stops at a checkout. There is not even
+ * an install: `scripts/content-lint` imports node builtins and its own files,
+ * nothing else, and the pass runs its verification in the root session after
+ * the rewrite comes back. A checkout with no `node_modules` is also a checkout
+ * with nothing to go stale when `onSession` moves it to the current `main`.
  */
 export default defineSandbox({
   backend: defaultBackend({
@@ -26,11 +27,10 @@ export default defineSandbox({
       snapshotExpiration: 24 * 60 * 60 * 1000,
     },
   }),
-  revalidationKey: () => 'evlog-content-workspace-v1',
+  revalidationKey: () => 'evlog-content-workspace-v2',
   async bootstrap({ use }) {
     const sandbox = await use()
     await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
-    await sandbox.run({ command: 'cd repo && corepack enable && corepack prepare --activate && pnpm install && pnpm run dev:prepare' })
     await sandbox.run({ command: 'git config --global user.name "evlogai[bot]" && git config --global user.email "evlogai[bot]@users.noreply.github.com"' })
   },
   async onSession({ use }) {

--- a/apps/evi/agent/lib/content-sandbox.ts
+++ b/apps/evi/agent/lib/content-sandbox.ts
@@ -1,0 +1,42 @@
+import { defaultBackend, defineSandbox } from 'eve/sandbox'
+
+/**
+ * The workspace the content subagents share.
+ *
+ * A declared subagent inherits nothing from the root, sandbox included, and
+ * eve prewarms one template per subagent at build time. Re-exporting the root
+ * definition therefore built the root's template three times: clone, install,
+ * the full lint, typecheck, and test run, Chromium, and the before-after CLI,
+ * once for the root and once per content subagent. That tripled the deploy and
+ * was the slowest way to find out that any of them can fail.
+ *
+ * These two read pages and write pages. They run no checks, drive no browser,
+ * and capture nothing, so the template stops at a checkout with dependencies
+ * installed. What they lose against the root template is the primed turbo
+ * cache, which they never used: the pass runs its own verification in the root
+ * session, after the rewrite comes back.
+ */
+export default defineSandbox({
+  backend: defaultBackend({
+    vercel: {
+      resources: { vcpus: 2 },
+      // A reviewer or a rewriter lives for one dispatch. Nothing here is worth
+      // a snapshot the next pass will not reuse.
+      snapshotExpiration: 6 * 60 * 60 * 1000,
+    },
+  }),
+  revalidationKey: () => 'evlog-content-workspace-v1',
+  async bootstrap({ use }) {
+    const sandbox = await use()
+    await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
+    await sandbox.run({ command: 'cd repo && corepack enable && corepack prepare --activate && pnpm install && pnpm run dev:prepare' })
+    await sandbox.run({ command: 'git config --global user.name "evlogai[bot]" && git config --global user.email "evlogai[bot]@users.noreply.github.com"' })
+  },
+  async onSession({ use }) {
+    const sandbox = await use()
+    // The template snapshot is owned by the builder uid, not the session user;
+    // without these entries every git command dies on "dubious ownership".
+    await sandbox.run({ command: 'git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/repo' })
+    await sandbox.run({ command: 'cd repo && git fetch origin main && git checkout -B main origin/main' })
+  },
+})

--- a/apps/evi/agent/lib/content/selection.test.ts
+++ b/apps/evi/agent/lib/content/selection.test.ts
@@ -160,10 +160,12 @@ describe('touchedPaths', () => {
 })
 
 describe('cooldownCommand', () => {
-  it('excludes parentless commits, which a shallow clone always has', () => {
-    // Without this the graft boundary lists the whole repository and every
-    // file reads as recently touched.
+  it('passes --min-parents=1, which is what skips a shallow boundary commit', () => {
     expect(cooldownCommand('/workspace/repo', 14)).toContain('--min-parents=1')
+  })
+
+  it('quotes the repository path', () => {
+    expect(cooldownCommand('/tmp/a dir; rm -rf /', 14)).toContain(`'/tmp/a dir; rm -rf /'`)
   })
 
   it('asks for the window it was given', () => {

--- a/apps/evi/agent/lib/content/selection.test.ts
+++ b/apps/evi/agent/lib/content/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { groupOf, selectTargets, touchedPaths } from './selection'
+import { cooldownCommand, groupOf, selectTargets, touchedPaths } from './selection'
 
 const page = (path: string, score: number, criticals = 0, surface = 'docs') => ({
   path,
@@ -156,5 +156,17 @@ describe('touchedPaths', () => {
     const log = ['apps/docs/content/2.learn/a.md', '', 'packages/evlog/src/index.ts', 'AGENTS.md', 'apps/docs/content/2.learn/a.md']
 
     expect(touchedPaths(log.join('\n'))).toEqual(['apps/docs/content/2.learn/a.md', 'AGENTS.md'])
+  })
+})
+
+describe('cooldownCommand', () => {
+  it('excludes parentless commits, which a shallow clone always has', () => {
+    // Without this the graft boundary lists the whole repository and every
+    // file reads as recently touched.
+    expect(cooldownCommand('/workspace/repo', 14)).toContain('--min-parents=1')
+  })
+
+  it('asks for the window it was given', () => {
+    expect(cooldownCommand('/workspace/repo', 30)).toContain('--since=\'30 days ago\'')
   })
 })

--- a/apps/evi/agent/lib/content/selection.ts
+++ b/apps/evi/agent/lib/content/selection.ts
@@ -49,7 +49,7 @@ export interface Selection {
 }
 
 const CONTENT_ROOT = 'apps/docs/content'
-const DEFAULT_LIMIT = 3
+const DEFAULT_LIMIT = 5
 
 /** Findings a pass may fix on a file an agent reads. Everything else goes back as a proposal. */
 const HOUSE_RULES = new Set(['U-14', 'U-15', 'U-16', 'T-13', 'T-15'])
@@ -136,6 +136,18 @@ export function selectTargets(input: {
   }
 
   return { targets, group, held, ...counts }
+}
+
+/**
+ * The log that says which files are resting.
+ *
+ * `--min-parents=1` is load-bearing. The sandbox template clones `--depth 50`,
+ * so the oldest commit has no recorded parent and `--name-only` diffs it
+ * against nothing, listing every file in the repository. Without the flag the
+ * cooldown holds the whole corpus and the rewrite half is empty on every run.
+ */
+export function cooldownCommand(repoDir: string, days: number): string {
+  return `git -C ${repoDir} log --since='${days} days ago' --min-parents=1 --name-only --pretty=format:`
 }
 
 /**

--- a/apps/evi/agent/lib/content/selection.ts
+++ b/apps/evi/agent/lib/content/selection.ts
@@ -1,3 +1,5 @@
+import { shellQuote } from './scan'
+
 /**
  * Which pages the next content pass works on.
  *
@@ -141,13 +143,13 @@ export function selectTargets(input: {
 /**
  * The log that says which files are resting.
  *
- * `--min-parents=1` is load-bearing. The sandbox template clones `--depth 50`,
- * so the oldest commit has no recorded parent and `--name-only` diffs it
- * against nothing, listing every file in the repository. Without the flag the
- * cooldown holds the whole corpus and the rewrite half is empty on every run.
+ * `--min-parents=1` is load-bearing. In a shallow clone the boundary commit has
+ * no recorded parent, so `--name-only` diffs it against nothing and lists every
+ * file in the repository. Without the flag the cooldown holds the whole corpus
+ * and the rewrite half is empty on every run.
  */
 export function cooldownCommand(repoDir: string, days: number): string {
-  return `git -C ${repoDir} log --since='${days} days ago' --min-parents=1 --name-only --pretty=format:`
+  return `git -C ${shellQuote(repoDir)} log --since='${days} days ago' --min-parents=1 --name-only --pretty=format:`
 }
 
 /**

--- a/apps/evi/agent/skills/content-pass/SKILL.md
+++ b/apps/evi/agent/skills/content-pass/SKILL.md
@@ -47,7 +47,7 @@ Slugify the group: `.agents/skills/create-adapter` becomes `skills-create-adapte
 node scripts/content-lint/index.mjs <each target> --fix
 ```
 
-This rewrites only what follows from the rule rather than from taste: a retired entry point, a term with one replacement, a link with a redirect behind it, a parenthetical pair of dashes. It re-scans each file afterwards and reverts anything that scored worse or introduced a new id, so a reverted file is a bug to report, not a file to retry.
+This rewrites only what follows from the rule rather than from taste: a retired entry point, a term with one replacement, a link with a redirect behind it. Dashes are not mechanical and stay findings for the reviewer. It re-scans each file afterwards and reverts anything that scored worse or introduced a new id, so a reverted file is a bug to report, not a file to retry.
 
 Commit it on its own before anything else runs:
 
@@ -137,7 +137,7 @@ Report to the thread: what group, how many files, the PR link. Two lines maximum
 
 Run this when `eligible` is 0. It needs an observation, not an opinion: name the gap you found and where you found it, or drop it.
 
-**Whatever file you end up editing, run `--fix` on it first.** A page you are already opening does not have "pre-existing" findings, it has findings, and the mechanical ones cost one command. Leaving an em dash on a page you just edited, and writing that it was out of scope, is the pass explaining why it did less than the tool it was given.
+**Whatever file you end up editing, run `--fix` on it first.** A page you are already opening does not have "pre-existing" findings, it has findings, and the mechanical ones cost one command. Leaving a wrong term on a page you just edited, and writing that it was out of scope, is the pass explaining why it did less than the tool it was given.
 
 Look, in this order, and stop at the first thing that holds:
 

--- a/apps/evi/agent/subagents/content_review/sandbox/sandbox.ts
+++ b/apps/evi/agent/subagents/content_review/sandbox/sandbox.ts
@@ -1,4 +1,3 @@
-// A declared subagent inherits nothing from the root, sandbox included, and
-// the framework default has no checkout. Both content subagents read and write
-// pages in the repository, so they share the root's workspace.
-export { default } from '../../../sandbox'
+// A checkout without the root's build tooling. See `lib/content-sandbox.ts`
+// for why these two do not reuse the root sandbox.
+export { default } from '../../../lib/content-sandbox'

--- a/apps/evi/agent/subagents/content_rewrite/instructions.md
+++ b/apps/evi/agent/subagents/content_rewrite/instructions.md
@@ -35,7 +35,7 @@ The fix has to be better on the axis the finding named, and no worse anywhere el
 - Does it carry a mechanism, a number, or a link?
 - Is the reader or the system the subject of its verbs?
 - Is it one proposition, or two halves saying the same thing?
-- Does it contain an em dash or an en dash? Those are banned by `U-14`. Use a comma, a colon, or two sentences.
+- Does it contain an em dash or an en dash? Those are banned by `U-14`, which lists what replaces one, in order: a comma, a period, a colon, or nothing at all. Never a semicolon.
 
 Prefer cutting to rewriting. Most `T-01` and `U-06` findings are fixed by deleting a clause, and a deletion cannot introduce a new tell.
 

--- a/apps/evi/agent/subagents/content_rewrite/sandbox/sandbox.ts
+++ b/apps/evi/agent/subagents/content_rewrite/sandbox/sandbox.ts
@@ -1,4 +1,3 @@
-// A declared subagent inherits nothing from the root, sandbox included, and
-// the framework default has no checkout. Both content subagents read and write
-// pages in the repository, so they share the root's workspace.
-export { default } from '../../../sandbox'
+// A checkout without the root's build tooling. See `lib/content-sandbox.ts`
+// for why these two do not reuse the root sandbox.
+export { default } from '../../../lib/content-sandbox'

--- a/apps/evi/agent/tools/content-targets.ts
+++ b/apps/evi/agent/tools/content-targets.ts
@@ -1,7 +1,7 @@
 import { defineTool } from 'eve/tools'
 import { z } from 'zod'
 import type { LintPage } from '../lib/content/selection'
-import { selectTargets, touchedPaths } from '../lib/content/selection'
+import { cooldownCommand, selectTargets, touchedPaths } from '../lib/content/selection'
 
 /** The template clone; every session inherits it with dependencies installed. */
 const REPO_DIR = '/workspace/repo'
@@ -15,7 +15,7 @@ const DEFAULT_COOLDOWN_DAYS = 14
 export default defineTool({
   description: `Pick the files the next content pass should work on. Runs the repository's content-lint over every written surface in ${REPO_DIR} (docs pages, the landing, the package READMEs, the skills, the AGENTS.md files), drops files changed inside the cooldown window, and returns the highest-priority files from a single group with their findings. Criticals (a broken import, a dead link) outrank a low score. Landing findings come back as \`report\` rather than \`rewrite\`, and so does anything on a skill or an AGENTS.md that is not a house rule, because those files govern the agent running the pass. Pass \`surface\` to work one kind of file. Also returns \`candidates\` (files with findings) and \`eligible\` (those outside the cooldown): the rewrite half is empty only when \`eligible\` is 0, whatever the top of the ranking looks like. Call this before reviewing or rewriting anything; the findings it returns are candidates to judge against the write-evlog-content skill, not verdicts.`,
   inputSchema: z.object({
-    limit: z.number().int().min(1).max(5).optional().describe('How many files this pass may open. Default 3.'),
+    limit: z.number().int().min(1).max(8).optional().describe('How many files this pass may open. Default 5.'),
     cooldownDays: z.number().int().min(1).max(90).optional().describe(`Days a file rests after any change touches it. Default ${DEFAULT_COOLDOWN_DAYS}.`),
     surface: z.enum(['docs', 'reference', 'landing', 'blog', 'readme', 'skill', 'agents']).optional().describe('Restrict the scan to one surface. Omit to rank the whole corpus.'),
   }),
@@ -41,9 +41,7 @@ export default defineTool({
       return { success: false as const, error: 'content-lint returned no pages array.' }
     }
 
-    const log = await sandbox.run({
-      command: `git -C ${REPO_DIR} log --since='${cooldownDays} days ago' --name-only --pretty=format:`,
-    })
+    const log = await sandbox.run({ command: cooldownCommand(REPO_DIR, cooldownDays) })
     if (log.exitCode !== 0) {
       return { success: false as const, error: `git log exited ${log.exitCode}: ${String(log.stderr || log.stdout).trim()}` }
     }

--- a/scripts/content-lint/README.md
+++ b/scripts/content-lint/README.md
@@ -31,7 +31,7 @@ A rule reaches `lib/fix.mjs` only when the corrected text follows from the rule 
 | `T-15` | `evlog/shared` → `evlog/toolkit`, `evlog/browser` → `evlog/http` | a page documenting the deprecation, which is skipped |
 | `U-15` | `sink` → `drain`, `error registry` → `error catalog` | `child logger`, which does not slot into the same sentence |
 | `U-16` | a link with a redirect behind it | a link with no destination |
-| `U-14` | `A — B — C` → `A, B, C` | the single elaborating dash, which wants a comma here and a colon there |
+| `U-14` | nothing | every dash. A dashed span is sometimes an appositive and sometimes a list, and commas wreck the second kind |
 
 After writing, each file is re-scanned. If the score dropped or a new finding id appeared, the file is reverted and reported as unfixed — that check is the whole argument for running this before a reviewer sees the file. `--fix` refuses to run without explicit paths: a corpus-wide rewrite is a maintainer's decision.
 

--- a/scripts/content-lint/index.mjs
+++ b/scripts/content-lint/index.mjs
@@ -63,6 +63,7 @@ if (options.url !== null && !/^https?:\/\//i.test(options.url)) {
 if (options.fix && (options.url !== null || options.stdin)) fail('--fix writes files, so it takes paths.')
 // A corpus-wide rewrite is a maintainer's decision, not a default.
 if (options.fix && options.targets.length === 0) fail('--fix needs the files to fix. It never sweeps the corpus on its own.')
+if (options.dryRun && !options.fix) fail('--dry-run belongs with --fix.')
 
 const REDIRECTS_FILE = resolve(REPO_ROOT, 'apps/docs/config/redirects.ts')
 const api = loadApiSurface(REPO_ROOT)
@@ -122,7 +123,14 @@ if (files.length === 0 && loose === null) fail('no markdown files matched')
 let corpusRates = null
 const corpusBaseline = () => (corpusRates ??= buildBaseline(corpus.map(file => scan(file))))
 
-const fixes = options.fix ? files.map(fixFile) : []
+// Only the corpus is rewritable. A path argument can reach a generated file
+// (a CHANGELOG, a lockfile's neighbour) that no rule was written for, and a
+// codemod editing generated output is a diff nobody can explain.
+const rewritable = new Set(corpus)
+const fixes = options.fix ? files.filter(file => rewritable.has(file)).map(fixFile) : []
+if (options.fix && fixes.length === 0 && files.length > 0) {
+  fail('none of those paths are in the content corpus; see lib/surfaces.mjs')
+}
 
 const scanned = [...files.map(scan), ...(loose ? [loose] : [])]
 

--- a/scripts/content-lint/lib/fix.mjs
+++ b/scripts/content-lint/lib/fix.mjs
@@ -19,6 +19,8 @@ import { readFileSync } from 'node:fs'
 import { ALTERNATIVES } from './corpus.mjs'
 
 const FENCE = /^\s*(`{3,}|~{3,})/
+/** A component invocation, a slot marker, or an inline component: structure, never prose. */
+const MDC_LINE = /^\s*(:{1,}[a-z][\w-]*|#[\w-]+\s*$)/i
 const DOCUMENTING_A_DEPRECATION = /\b(deprecat\w*|removed|retired|renamed|legacy|instead of|prefer|migrat\w*|never|not\b)/i
 const REDIRECT_ENTRY = /['"](\/[^'"]*)['"]\s*:\s*r\(\s*['"]([^'"]*)['"]\s*\)/g
 
@@ -100,6 +102,8 @@ export function applyFixes(source, context = {}) {
 
   let fence = null
   let frontmatter = lines[0]?.trim() === '---'
+  let propBlock = false
+  let atComponent = false
 
   const fixed = lines.map((line, index) => {
     const number = index + 1
@@ -108,6 +112,18 @@ export function applyFixes(source, context = {}) {
       if (number > 1 && line.trim() === '---') frontmatter = false
       return line
     }
+
+    // A `---` block opening right after a component is that component's props.
+    if (propBlock) {
+      if (line.trim() === '---') propBlock = false
+      return line
+    }
+    if (atComponent && line.trim() === '---') {
+      atComponent = false
+      propBlock = true
+      return line
+    }
+    atComponent = false
 
     const opener = FENCE.exec(line)
     if (fence === null && opener) {
@@ -119,6 +135,14 @@ export function applyFixes(source, context = {}) {
       else return record(line, fixCode(line), 'T-15')
     }
     if (fence !== null || opener) return line
+    // MDC structure is not prose. `::audit-dual-sink` is a Vue component whose
+    // file is named for it, and renaming the term in the invocation gives a
+    // page that no longer resolves. Prop blocks are configuration for the same
+    // reason.
+    if (MDC_LINE.test(line)) {
+      atComponent = true
+      return line
+    }
 
     return record(line, fixProse(line, redirects), null)
 

--- a/scripts/content-lint/lib/fix.mjs
+++ b/scripts/content-lint/lib/fix.mjs
@@ -2,10 +2,12 @@
  * The fixes with a derivable answer.
  *
  * A rule belongs here only when the corrected text follows from the rule
- * itself, never from taste. `evlog/shared` has exactly one replacement.
- * `sink` has exactly one. A single elaborating em dash does not: it wants a
- * comma here and a colon there, and picking wrong makes a comma splice, so it
- * stays a finding for someone who can read the sentence.
+ * itself, never from taste. `evlog/shared` has exactly one replacement. `sink`
+ * has exactly one. Punctuation never does, which is why `U-14` is absent: a
+ * dashed span is sometimes an appositive and sometimes a list, and swapping the
+ * dashes for commas turns the second kind into a sentence whose subject is
+ * followed by four nouns. Measured over this corpus, that was 25 replacements
+ * out of 38. Dashes stay a finding for someone who can read the sentence.
  *
  * Everything works on raw text, line by line, because formatting has to survive
  * exactly and a round trip through `parseMarkdown` would not preserve it. Code
@@ -38,12 +40,6 @@ const TERMS = [
   { from: 'error registry', to: 'error catalog' },
   { from: 'error registries', to: 'error catalogs' },
 ]
-
-/**
- * A parenthetical wrapped in dashes, which becomes a pair of commas without
- * touching the clause structure (`U-14`). The single dash is not here.
- */
-const PAIRED_DASH = /(\S) [—–] ([^—–]+?) [—–] (?=\S)/g
 
 /**
  * Old path to new, from the docs redirect table. A dead link with a redirect
@@ -204,12 +200,6 @@ function prose(segment, redirects, ids) {
   if (relinked !== text) {
     ids.add('U-16')
     text = relinked
-  }
-
-  const undashed = text.replace(PAIRED_DASH, '$1, $2, ')
-  if (undashed !== text) {
-    ids.add('U-14')
-    text = undashed
   }
 
   // A sentence naming another logger is allowed to use that logger's words.

--- a/scripts/content-lint/lib/fix.mjs
+++ b/scripts/content-lint/lib/fix.mjs
@@ -19,8 +19,12 @@ import { readFileSync } from 'node:fs'
 import { ALTERNATIVES } from './corpus.mjs'
 
 const FENCE = /^\s*(`{3,}|~{3,})/
-/** A component invocation, a slot marker, or an inline component: structure, never prose. */
-const MDC_LINE = /^\s*(:{1,}[a-z][\w-]*|#[\w-]+\s*$)/i
+/** A block component. Only this one can be followed by a `---` prop block. */
+const MDC_BLOCK = /^\s*:{2,}[a-z][\w-]*/i
+/** A slot marker, or a component alone on its line. Structure, but no prop block follows. */
+const MDC_STANDALONE = /^\s*(#[\w-]+|:[a-z][\w-]*(\{.*\})?)\s*$/i
+/** A component embedded in a line of prose, with its optional slot and props. */
+const MDC_INLINE = /(:[a-z][\w-]*(?:\[[^\]]*\])?(?:\{[^}]*\})?)/i
 const DOCUMENTING_A_DEPRECATION = /\b(deprecat\w*|removed|retired|renamed|legacy|instead of|prefer|migrat\w*|never|not\b)/i
 const REDIRECT_ENTRY = /['"](\/[^'"]*)['"]\s*:\s*r\(\s*['"]([^'"]*)['"]\s*\)/g
 
@@ -139,10 +143,11 @@ export function applyFixes(source, context = {}) {
     // file is named for it, and renaming the term in the invocation gives a
     // page that no longer resolves. Prop blocks are configuration for the same
     // reason.
-    if (MDC_LINE.test(line)) {
+    if (MDC_BLOCK.test(line)) {
       atComponent = true
       return line
     }
+    if (MDC_STANDALONE.test(line)) return line
 
     return record(line, fixProse(line, redirects), null)
 
@@ -215,6 +220,15 @@ function fixProse(line, redirects) {
  * @returns {string}
  */
 function prose(segment, redirects, ids) {
+  // An inline component carries a name and props, not prose. Splitting on the
+  // capture keeps the odd entries intact while the rest is fixed.
+  if (MDC_INLINE.test(segment)) {
+    return segment
+      .split(new RegExp(MDC_INLINE.source, 'gi'))
+      .map((part, index) => (index % 2 === 1 ? part : prose(part, redirects, ids)))
+      .join('')
+  }
+
   let text = segment
 
   const relinked = text.replace(/\]\((\/[^)#?]*)([#?][^)]*)?\)/g, (match, path, suffix) => {

--- a/scripts/content-lint/lib/fix.test.mjs
+++ b/scripts/content-lint/lib/fix.test.mjs
@@ -88,6 +88,24 @@ describe('what it never touches', () => {
     expect(fix(source).source).toBe(source)
   })
 
+  it('leaves a component embedded in a line of prose', () => {
+    const source = '| :feature-label[Drain]{tip="Ships to a sink without wiring"} | Yes |'
+
+    expect(fix(source).source).toBe(source)
+  })
+
+  it('fixes the prose on a line that also carries a component', () => {
+    expect(fix('Register the sink. :br Then read it.').source).toBe('Register the drain. :br Then read it.')
+  })
+
+  it('does not read a slot marker as a component with props', () => {
+    // `#title` is a slot, so the `---` after it is a thematic break and the
+    // prose below it is still prose.
+    const source = '#title\n\n---\n\nRegister the sink.'
+
+    expect(fix(source).source).toBe('#title\n\n---\n\nRegister the drain.')
+  })
+
   it('still fixes the prose around a component block', () => {
     const source = '::note\nRegister the sink.\n::'
 

--- a/scripts/content-lint/lib/fix.test.mjs
+++ b/scripts/content-lint/lib/fix.test.mjs
@@ -42,15 +42,14 @@ describe('U-15 terminology', () => {
 })
 
 describe('U-14 dashes', () => {
-  it('replaces a parenthetical pair with commas', () => {
-    expect(fix('The drain batches — then retries with backoff — before it gives up.').source)
-      .toBe('The drain batches, then retries with backoff, before it gives up.')
-  })
+  it('leaves every dash to someone who can read the sentence', () => {
+    // A dashed span is sometimes an appositive and sometimes a list. Commas fix
+    // the first and wreck the second, and the second was the majority here.
+    const appositive = 'The drain batches — then retries with backoff — before it gives up.'
+    const list = 'It finds every entry point — handlers, pages, middleware — and scores each one.'
+    const single = 'evlog is built for the day-zero choice — pick it once.'
 
-  it('leaves a single dash for someone who can read the sentence', () => {
-    const source = 'evlog is built for the day-zero choice — pick it once.'
-
-    expect(fix(source).source).toBe(source)
+    for (const source of [appositive, list, single]) expect(fix(source).source).toBe(source)
   })
 })
 

--- a/scripts/content-lint/lib/fix.test.mjs
+++ b/scripts/content-lint/lib/fix.test.mjs
@@ -80,6 +80,20 @@ describe('what it never touches', () => {
     expect(fix(source).source).toBe('---\ntitle: The sink\n---\n\nRegister the drain.')
   })
 
+  it('leaves an MDC component name alone, however much it looks like prose', () => {
+    // The Vue file is named for the invocation, so renaming the term here
+    // gives a page that no longer resolves.
+    const source = '::audit-dual-sink\n---\ntitle: The sink\n---\n::'
+
+    expect(fix(source).source).toBe(source)
+  })
+
+  it('still fixes the prose around a component block', () => {
+    const source = '::note\nRegister the sink.\n::'
+
+    expect(fix(source).source).toBe('::note\nRegister the drain.\n::')
+  })
+
   it('leaves prose words inside a fence alone', () => {
     const source = '```bash\n# write to a sink\nevlog tail\n```'
 

--- a/scripts/content-lint/lib/metrics.mjs
+++ b/scripts/content-lint/lib/metrics.mjs
@@ -248,7 +248,9 @@ function bulletFrames(doc) {
 
   for (const list of doc.lists) {
     if (list.items.length < 3) continue
-    const firsts = list.items.map(item => item.text.toLowerCase().split(/\s+/)[0] ?? '')
+    // A task list shares `[` on every item by construction, which is a
+    // checkbox, not an anaphora.
+    const firsts = list.items.map(item => item.text.toLowerCase().replace(/^\[[ x]?\]\s*/, '').split(/\s+/)[0] ?? '')
     const tally = new Map()
     for (const first of firsts) tally.set(first, (tally.get(first) ?? 0) + 1)
     const top = Math.max(...tally.values())

--- a/scripts/content-lint/lib/metrics.test.mjs
+++ b/scripts/content-lint/lib/metrics.test.mjs
@@ -82,6 +82,23 @@ describe('contraction seam', () => {
   })
 })
 
+describe('bullet frames', () => {
+  it('does not read a checklist as an anaphora', () => {
+    // Every task item starts with `[`, which is a checkbox. `score.mjs` gates
+    // T-07 on this share, so it is the number that has to stay low.
+    const list = ['- [ ] Service name is set', '- [ ] Sampling is configured', '- [ ] Draining is set up', '- [ ] Pretty mode is off'].join('\n')
+    const frames = measureSource(list).bulletFrames
+
+    for (const frame of frames) expect(frame.anaphoraShare).toBeLessThan(0.75)
+  })
+
+  it('still catches four bullets that really do share an opener', () => {
+    const list = ['- Powerful drain support', '- Powerful enricher support', '- Powerful catalog support', '- Powerful sampling support'].join('\n')
+
+    expect(measureSource(list).bulletFrames).toHaveLength(1)
+  })
+})
+
 describe('unbacked sections', () => {
   it('flags a section that asserts behavior with nothing to check', () => {
     const filler = 'The system handles high throughput and keeps overhead low for demanding workloads. '


### PR DESCRIPTION
Why every run only ever touches one page, and why the dash fixes read badly.

## The cooldown was holding all 120 files

#591 reported `eligible 0` and went to the enrichment half. Replaying the same selection on a full clone gives **47 eligible**. The difference is the clone depth.

The sandbox template clones `--depth 50`. The oldest commit in a shallow clone has no recorded parent, so `git log --name-only` diffs it against nothing and lists **every file in the repository**. `touchedPaths` then marks the entire corpus as recently touched, `eligible` is 0, and the pass falls through to the enrichment half, which by design handles exactly one gap.

Reproduced:

```
$ git clone --depth 5 … && cd …
$ git log --since='14 days ago' --name-only --pretty=format: | grep '\.md$' | sort -u | wc -l
     211        # every .md in the repo
$ git log --since='14 days ago' --min-parents=1 --name-only --pretty=format: | grep '\.md$' | sort -u | wc -l
       3
```

So it was never "one page per run" by choice: the rewrite half has not run once since the corpus widened. `--min-parents=1` drops parentless commits, the command moves into `agent/lib/content/selection.ts` behind `cooldownCommand()`, and a test pins the flag with the reason.

The default limit also goes from 3 files to 5, since the rewrite half can now reach them.

## The dash replacements read as machine edits

#591 turned `procedures — evlog/orpc bridges them` into `procedures; evlog/orpc bridges them`. `U-14` said what to remove and never said what to put back, so the rewriter picked a mark that is rarer than the one it replaced.

`U-14` now ranks the replacements: a comma when the clause continues, a period when the second half is its own thought, a colon when it explains, and nothing at all when the dash was joining two things that did not need joining. Never a semicolon, because swapping one unusual mark for another leaves the sentence exactly as stiff as it was. The rewriter instructions and `voice.md` carry the same list.

Both semicolons #591 introduced into `15.orpc.md` are fixed here.

## Checks

133 evi tests, two new ones on `cooldownCommand`. `evlog-docs` lint passes. No changeset: `apps/*` and `.agents/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content targeting now considers recently changed files and supports selecting up to 8 files.
  * The default number of selected files increased from 3 to 5.
* **Bug Fixes**
  * Improved content selection by excluding commits without parent history and respecting the requested time window.
  * Content linting now preserves punctuation requiring contextual review and avoids modifying component content.
* **Documentation**
  * Clarified writing guidance to prohibit em dashes, en dashes, and semicolons, with preferred punctuation alternatives.
  * Updated framework documentation for clearer sentence structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->