### PR TITLE
docs: use evlog's own name for a drain everywhere

### DIFF
--- a/.agents/skills/write-evlog-content/references/rules/universal.md
+++ b/.agents/skills/write-evlog-content/references/rules/universal.md
@@ -141,7 +141,7 @@ Note: the corpus predates the rule, so most pages still carry them. A content pa
 **U-15 · evlog's parts keep evlog's names** · `standard`
 
 Rule: drain, enricher, error catalog, `log.fork()`, wide event, pipeline. The full table, and the reason each alternative is wrong, is in `references/terminology.md`.
-Bad: "Register the sink and every event reaches it."
+Bad: "Register the drain and every event reaches it."
 Better: "Register the drain and every event reaches it."
 Why: a term the reader learns here and cannot find in the API costs them the search twice.
 Exception: a sentence describing another tool uses that tool's vocabulary. The scanner already drops any hit in a sentence that names an alternative.

--- a/.agents/skills/write-evlog-content/references/terminology.md
+++ b/.agents/skills/write-evlog-content/references/terminology.md
@@ -6,9 +6,9 @@ Rule id: `U-15`. The scanner raises a candidate from `scripts/content-lint/lib/c
 
 | evlog says | Not | Why |
 | --- | --- | --- |
-| **drain** | sink, transport, exporter | A drain is where events leave the process. `transport` is pino's word, `exporter` is OpenTelemetry's, and both carry the other tool's model with them. |
+| **drain** | drain, transport, exporter | A drain is where events leave the process. `transport` is pino's word, `exporter` is OpenTelemetry's, and both carry the other tool's model with them. |
 | **enricher** | enrichment plugin, context provider, middleware | An enricher adds fields to an event before it is emitted. Calling it middleware puts it in the request chain, which is where it is not. |
-| **error catalog** | error registry, error map, error dictionary | `defineErrorCatalog` is the API. Anything else is a term the reader cannot grep for. |
+| **error catalog** | error catalog, error map, error dictionary | `defineErrorCatalog` is the API. Anything else is a term the reader cannot grep for. |
 | **`log.fork()`** | child logger, sub-logger | pino's `child()` inherits bindings. `fork()` branches accumulated context and can be discarded. The distinction is the feature. |
 | **wide event** | wide log, fat event, structured log | One event per unit of work, with every field the work touched. `structured log` is the category, not this. |
 | **pipeline** | chain, middleware stack | `createDrainPipeline` composes drains. |
@@ -19,7 +19,7 @@ Rule id: `U-15`. The scanner raises a candidate from `scripts/content-lint/lib/c
 
 A sentence describing another tool uses that tool's vocabulary, and has to. "pino writes through a transport that runs in a worker thread" is correct and the scanner drops it: the check skips any sentence naming an alternative.
 
-What survives is a sentence about evlog wearing another tool's word. "Register the sink" is the finding, whatever page it lands on.
+What survives is a sentence about evlog wearing another tool's word. "Register the drain" is the finding, whatever page it lands on.
 
 ## When the word is genuinely missing
 

--- a/apps/docs/content/3.cli/0.overview.md
+++ b/apps/docs/content/3.cli/0.overview.md
@@ -65,7 +65,7 @@ Requires Node 20 or later. The package installs a single `evlog` binary.
   to: /cli/init
   color: neutral
   ---
-  Install evlog, register the framework integration, and write a local sink.
+  Install evlog, register the framework integration, and write a local drain.
   :::
   :::card
   ---

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -197,7 +197,7 @@ The `evlogErrorHandler` middleware on your root route is a manual step: `__root.
 
 ## Destinations
 
-Two questions rather than one list: nobody sends local development traffic to Axiom, and nobody reads production logs off the box's filesystem. `--drain` sets the development sink (`fs` or `none`); `--prod-drain` takes one or more hosted destinations.
+Two questions rather than one list: nobody sends local development traffic to Axiom, and nobody reads production logs off the box's filesystem. `--drain` sets the development drain (`fs` or `none`); `--prod-drain` takes one or more hosted destinations.
 
 | Id | Destination | Needs |
 | --- | --- | --- |
@@ -294,7 +294,7 @@ evlog init --yes --apps apps/web,apps/api
 
 Each app keeps its own service name, taken from its `package.json`.
 
-## The local sink
+## The local drain
 
 On Nitro-based apps `init` writes a drain plugin; on Next.js it adds the drain to `lib/evlog.ts`. The filesystem drain — and only that one — is **gated to development**:
 
@@ -321,7 +321,7 @@ The directory it writes to is `.evlog/logs`, and evlog gitignores it on first wr
 | `--yes`, `-y` | Skip every question and take the defaults |
 | `--framework <name>` | Override detection (`nuxt`, `nitro`, `next`, `tanstack-start`) |
 | `--service <name>` | Service name on every wide event (default: your package name, unscoped) |
-| `--drain <id>` | Development sink: `fs` (default) or `none` |
+| `--drain <id>` | Development drain: `fs` (default) or `none` |
 | `--prod-drain <a,b>` | Production destinations — see the table above |
 | `--extras <a,b>` | Comma-separated, see Extras |
 | `--enrichers <a,b>` | `user-agent`, `geo`, `request-size`, `trace-context` (default: all) |

--- a/apps/docs/content/3.cli/6.doctor.md
+++ b/apps/docs/content/3.cli/6.doctor.md
@@ -41,11 +41,11 @@ EVLOG
 | `project` | A `package.json` was resolved | None found above the working directory |
 | `stack` | A framework was detected and evlog is installed | A framework was detected but evlog is not wired to it |
 | `evlog` | `evlog` resolves from `node_modules` | Declared in `package.json` but not installed, or missing entirely |
-| `logs` | A local sink exists, or the fs drain is wired (the directory appears on first write) | Never — the check is omitted when no local sink is configured |
+| `logs` | A local drain exists, or the fs drain is wired (the directory appears on first write) | Never — the check is omitted when no local drain is configured |
 
 In a workspace, the header names the workspace kind and `project` shows which package was resolved — the fastest way to notice you are diagnosing the repo root instead of your app.
 
-A local sink is optional: the [fs drain](/integrate/adapters/self-hosted/fs) writes under `.evlog/logs` and creates the directory on first write, so a wired drain counts as a sink before any event. A project with no local drain gets no `logs` check at all.
+A local drain is optional: the [fs drain](/integrate/adapters/self-hosted/fs) writes under `.evlog/logs` and creates the directory on first write, so a wired drain counts as a drain before any event. A project with no local drain gets no `logs` check at all.
 
 ## Exit code
 

--- a/apps/docs/content/3.cli/7.telemetry.md
+++ b/apps/docs/content/3.cli/7.telemetry.md
@@ -24,7 +24,7 @@ This page is about the CLI's own telemetry. If you are instrumenting a CLI **you
 
 | Recorded | Example |
 | --- | --- |
-| Framework, development sink, sampling preset | `nuxt`, `fs`, `balanced` |
+| Framework, development drain, sampling preset | `nuxt`, `fs`, `balanced` |
 | One flag per destination, extra and enricher chosen | `initProdAxiom: true` |
 | Counts | files written, manual steps left, doctor failures |
 | Whether an offer had anything behind it | `initHadRepeatedErrors: true` |

--- a/apps/docs/content/5.use-cases/4.audit/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.audit/01.overview.md
@@ -61,7 +61,7 @@ Adapters: https://www.evlog.dev/integrate/adapters/overview
 
 ## Agent Skills
 
-Install the evlog skill catalog so your assistant can follow **`build-audit-logs`** end to end: written policy, framework wiring, `withAudit` / `log.audit`, denials, redaction, multi-tenant isolation, tamper-evident sinks, and grep-based review passes. If you use the file-system drain for audits or general logs, **`analyze-logs`** teaches assistants to read NDJSON under `.evlog/logs/`.
+Install the evlog skill catalog so your assistant can follow **`build-audit-logs`** end to end: written policy, framework wiring, `withAudit` / `log.audit`, denials, redaction, multi-tenant isolation, tamper-evident drains, and grep-based review passes. If you use the file-system drain for audits or general logs, **`analyze-logs`** teaches assistants to read NDJSON under `.evlog/logs/`.
 
 ```bash [Terminal]
 npx skills add https://www.evlog.dev
@@ -227,11 +227,11 @@ That's it. The audit event:
 
 - Travels through the same wide-event pipeline as the rest of your logs.
 - Is **always kept** past tail sampling.
-- Goes to your main drain (Axiom) **and** to a dedicated, signed, append-only sink (FS journal).
+- Goes to your main drain (Axiom) **and** to a dedicated, signed, append-only drain (FS journal).
 - Carries `requestId`, `traceId`, `ip`, and `userAgent` automatically via `auditEnricher`.
 
 ::tip
-**Why two drains?** The main drain (Axiom, Datadog, ...) keeps audits next to the rest of your telemetry so dashboards and queries still work. The signed sink is your insurance: if the main drain has an outage, gets purged, or an admin quietly removes a row, the FS journal still holds the chain. Auditors want both — fast querying *and* a tamper-evident artefact.
+**Why two drains?** The main drain (Axiom, Datadog, ...) keeps audits next to the rest of your telemetry so dashboards and queries still work. The signed drain is your insurance: if the main drain has an outage, gets purged, or an admin quietly removes a row, the FS journal still holds the chain. Auditors want both — fast querying *and* a tamper-evident artefact.
 ::
 
 ::audit-dual-sink

--- a/apps/docs/content/5.use-cases/4.audit/04.pipeline.md
+++ b/apps/docs/content/5.use-cases/4.audit/04.pipeline.md
@@ -43,7 +43,7 @@ Without `auditEnricher`, `audit.context` stays empty — auditors and incident r
 ## `auditOnly()`
 
 ::tip
-**Why filter audits to a separate sink?** Three reasons: **cost** (audit volume is tiny next to product telemetry — keep them separate so retention costs don't explode), **permissions** (the audit dataset should be read-only for engineers and write-only for the app), and **retention** (audits often live 7+ years; product logs rarely live more than 90 days).
+**Why filter audits to a separate drain?** Three reasons: **cost** (audit volume is tiny next to product telemetry — keep them separate so retention costs don't explode), **permissions** (the audit dataset should be read-only for engineers and write-only for the app), and **retention** (audits often live 7+ years; product logs rarely live more than 90 days).
 ::
 
 `auditOnly(drain)` only forwards events with an `audit` field. Compose with **any** drain:
@@ -76,7 +76,7 @@ The `await: true` flag costs you a small bit of latency per request that records
 | `'hash-chain'` | `event.audit.prevHash` and `event.audit.hash` | A verifiable chain — deletions and reordering also become detectable. |
 
 ::tip
-**What `signed()` actually buys you.** Detection, not prevention. Anyone with write access to the underlying sink can still nuke the file or table — but the chain proves *which* events were dropped or modified after the fact. Skip `signed()` if you already write to an append-only / WORM store (S3 Object Lock, Postgres with row-level immutability, BigQuery append-only tables); doubling integrity layers just adds latency without raising the bar.
+**What `signed()` actually buys you.** Detection, not prevention. Anyone with write access to the underlying drain can still nuke the file or table — but the chain proves *which* events were dropped or modified after the fact. Skip `signed()` if you already write to an append-only / WORM store (S3 Object Lock, Postgres with row-level immutability, BigQuery append-only tables); doubling integrity layers just adds latency without raising the bar.
 ::
 
 ### HMAC

--- a/apps/docs/content/5.use-cases/4.audit/05.compliance.md
+++ b/apps/docs/content/5.use-cases/4.audit/05.compliance.md
@@ -66,9 +66,9 @@ A built-in `cryptoShredding` helper is on the [follow-up roadmap](https://github
 
 ## Retention
 
-Retention is a storage-layer concern by design. evlog's audit layer doesn't enforce retention windows because every supported sink already has a stronger, audited mechanism for it. Pick the one matching your sink:
+Retention is a storage-layer concern by design. evlog's audit layer doesn't enforce retention windows because every supported drain already has a stronger, audited mechanism for it. Pick the one matching your drain:
 
-| Sink | Retention mechanism |
+| Drain | Retention mechanism |
 |------|---------------------|
 | FS | Combine `createFsDrain({ maxFiles })` with a daily compactor. |
 | Postgres | Schedule `DELETE FROM audit_events WHERE timestamp < now() - interval '7 years'`. |

--- a/apps/docs/content/5.use-cases/4.audit/06.recipes.md
+++ b/apps/docs/content/5.use-cases/4.audit/06.recipes.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-Pick the recipe that matches your sink, drop it in, and you have a tamper-evident audit log. Each recipe composes the same primitives (`auditOnly`, `signed`, optional `await: true`) over different drains.
+Pick the recipe that matches your drain, drop it in, and you have a tamper-evident audit log. Each recipe composes the same primitives (`auditOnly`, `signed`, optional `await: true`) over different drains.
 
 ## Audit logs on disk
 

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -43,7 +43,7 @@ Build an evlog plugin that hooks into more than one lifecycle stage.
 
 - Import `definePlugin` from `evlog` and pick the hooks I need (`onRequestStart`, `enrich`, `drain`, `extendLogger`, `keep`, `onClientLog`, `onRequestFinish`)
 - Keep `enrich` pure (no I/O, no throwing — use try/catch internally)
-- For drains, batch and ship to the destination; respect backpressure if the sink is slow
+- For drains, batch and ship to the destination; respect backpressure if the drain is slow
 - Register the plugin via the framework config: Next/standalone `initLogger({ plugins: [myPlugin] })`, Hono/Express/Fastify/Elysia middleware option `{ plugins: [myPlugin] }`. For Nitro, register the individual hooks directly (`nitroApp.hooks.hook('evlog:enrich' | 'evlog:drain' | …)`)
 - Prefer single-purpose `enricherPlugin()` / `drainPlugin()` wrappers for simple extensions; use `definePlugin` only when several hooks are needed
 

--- a/apps/docs/skills/analyze-logs/SKILL.md
+++ b/apps/docs/skills/analyze-logs/SKILL.md
@@ -50,9 +50,9 @@ Files are named by date: `2026-03-14.jsonl`. Start with the most recent file.
 
 ## If no logs are found
 
-Before wiring a new drain, you can try `npx @evlog/cli doctor --json` — it checks whether `evlog` is installed and whether a local `.evlog/logs` sink already exists (read-only). Optional; skip if the CLI is unavailable.
+Before wiring a new drain, you can try `npx @evlog/cli doctor --json` — it checks whether `evlog` is installed and whether a local `.evlog/logs` drain already exists (read-only). Optional; skip if the CLI is unavailable.
 
-The file system drain may not be enabled. On Nuxt, Nitro, Next.js, or TanStack Start, the fastest path is the CLI — it detects the framework and wires the fs drain (its default dev sink) in one pass:
+The file system drain may not be enabled. On Nuxt, Nitro, Next.js, or TanStack Start, the fastest path is the CLI — it detects the framework and wires the fs drain (its default dev drain) in one pass:
 
 ```bash
 npx @evlog/cli init --dry-run --yes   # preview first

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -83,13 +83,13 @@ Make these explicit and write them down somewhere a security reviewer can find. 
 
 ### 1. Where do audits live?
 
-| Sink                              | Use when                                          | Trade-offs                                                                                  |
+| Drain                              | Use when                                          | Trade-offs                                                                                  |
 | --------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | **FS** (`evlog/fs` + `signed`)    | Self-hosted, simple, you control the disk         | Manual rotation/backup; single-process unless you persist hash-chain `state` externally     |
 | **Dedicated Axiom dataset**       | You already use Axiom                             | Easy queries, separate retention/billing; cost scales with volume                           |
 | **Postgres / Neon / Aurora**      | You want SQL queries, joins with app data         | Need a schema, indexes, retention job; idempotency key prevents duplicates                  |
 | **S3 + Object Lock**              | Append-only WORM compliance (HIPAA / FINRA)       | Read latency; pair with a queryable mirror (Athena)                                         |
-| **Multiple sinks**                | Different audiences (engineers ↔ legal)           | Use `auditOnly` per sink; sinks fail in isolation by design                                 |
+| **Multiple drains**                | Different audiences (engineers ↔ legal)           | Use `auditOnly` per drain; drains fail in isolation by design                                 |
 
 > **Rule of thumb.** Pick at least two: a queryable one (Axiom / Postgres) for day-to-day forensics + an append-only one (FS journal with hash-chain, or S3 Object Lock) as the compliance artefact. The two-drain pattern protects against vendor outages and admin mistakes on the queryable side.
 
@@ -98,12 +98,12 @@ Make these explicit and write them down somewhere a security reviewer can find. 
 Yes if any of:
 
 - A compliance framework requires tamper-evidence (SOC2 CC7, HIPAA §164.312(c)(1), PCI 10.5).
-- The sink is mutable by engineers / admins.
+- The drain is mutable by engineers / admins.
 - You may need to prove to a regulator that no events were modified after the fact.
 
 Skip if:
 
-- Sink is already WORM (S3 Object Lock, BigQuery append-only, Postgres with row-level immutability + monitored DDL).
+- Drain is already WORM (S3 Object Lock, BigQuery append-only, Postgres with row-level immutability + monitored DDL).
 - You're prototyping.
 
 Strategies:
@@ -121,11 +121,11 @@ auditEnricher({ tenantId: ctx => resolveTenant(ctx) })
 
 If the app uses Better Auth, `auditEnricher` can also bridge the authenticated session into `audit.context` — see the Better Auth integration (`evlog/better-auth`, https://www.evlog.dev/use-cases/better-auth/overview) for wiring `identifyUser` alongside the audit pipeline.
 
-Then either (a) partition the audit dataset by `audit.context.tenantId`, or (b) one sink per tenant if hard isolation is required. Never query audits without a tenant filter.
+Then either (a) partition the audit dataset by `audit.context.tenantId`, or (b) one drain per tenant if hard isolation is required. Never query audits without a tenant filter.
 
 ### 4. Retention
 
-Pick a window per sink and document it. Enforce at the sink layer, not in app code — the sink already has audited mechanisms for it (lifecycle policies, `DELETE` jobs, dataset retention).
+Pick a window per drain and document it. Enforce at the drain layer, not in app code — the drain already has audited mechanisms for it (lifecycle policies, `DELETE` jobs, dataset retention).
 
 | Framework | Typical retention                                                   |
 | --------- | ------------------------------------------------------------------- |
@@ -134,7 +134,7 @@ Pick a window per sink and document it. Enforce at the sink layer, not in app co
 | PCI DSS   | 1 year (3 months immediately accessible)                            |
 | GDPR      | "As long as necessary" — see "GDPR vs append-only" below            |
 
-How to enforce per sink:
+How to enforce per drain:
 
 - **FS**: `createFsDrain({ maxFiles })` + a daily compactor.
 - **Postgres**: `DELETE FROM audit_events WHERE timestamp < now() - interval '7 years'` on a cron.
@@ -154,7 +154,7 @@ A built-in `cryptoShredding` helper is on the roadmap; until then, encrypt in a 
 
 ### Step 1 — Wire the pipeline (one-time)
 
-The wiring shape is the same in every framework: register `auditEnricher()` so `event.audit.context` gets `requestId`, `traceId`, `ip`, `userAgent`, and (if configured) `tenantId` automatically, then add a main drain plus an audit-only sink.
+The wiring shape is the same in every framework: register `auditEnricher()` so `event.audit.context` gets `requestId`, `traceId`, `ip`, `userAgent`, and (if configured) `tenantId` automatically, then add a main drain plus an audit-only drain.
 
 The minimal Nuxt / Nitro setup looks like this:
 
@@ -356,9 +356,9 @@ Walk through this with a security stakeholder before declaring the system produc
 - [ ] `auditEnricher` is registered on every framework integration.
 - [ ] Every authorisation check has a paired `log.audit.deny()` (greppable).
 - [ ] Every mutating endpoint either uses `withAudit()` or calls `log.audit()` explicitly.
-- [ ] At least two sinks: one queryable (Axiom / Postgres) and one tamper-evident (FS + `signed` hash-chain, or S3 Object Lock).
+- [ ] At least two drains: one queryable (Axiom / Postgres) and one tamper-evident (FS + `signed` hash-chain, or S3 Object Lock).
 - [ ] `auditRedactPreset` (or stricter) is in the global `RedactConfig`.
-- [ ] Retention policy is documented per sink and enforced at the sink layer.
+- [ ] Retention policy is documented per drain and enforced at the drain layer.
 - [ ] Multi-tenant apps: `tenantId` is set on every audit event; queries always filter by tenant.
 - [ ] Hash-chain `state.{load,save}` persists across process restarts (file / Redis / Postgres).
 - [ ] HMAC `secret` rotation procedure is documented; `keyId` is embedded in `AuditFields` (extend via `declare module`).
@@ -380,10 +380,10 @@ rg -n "auditEnricher|auditOnly|signed\(" --type ts
 
 Flag if:
 - `auditEnricher()` is missing → `event.audit.context` is empty, no requestId / IP / tenant correlation.
-- An audit-only sink exists but is not wrapped in `auditOnly(...)` → main events leak into the audit dataset (privacy & cost incident).
-- Only one drain → no tamper-evident copy. Acceptable only if the single sink is WORM (S3 Object Lock, BigQuery append-only, Postgres immutable).
+- An audit-only drain exists but is not wrapped in `auditOnly(...)` → main events leak into the audit dataset (privacy & cost incident).
+- Only one drain → no tamper-evident copy. Acceptable only if the single drain is WORM (S3 Object Lock, BigQuery append-only, Postgres immutable).
 - `signed()` is used without a persisted `state` while running multiple processes → hash-chain breaks across restarts / instances.
-- `await: true` is missing on the audit-only sink → events may be lost on crash.
+- `await: true` is missing on the audit-only drain → events may be lost on crash.
 
 ### Pass 2 — Coverage (call sites)
 
@@ -434,7 +434,7 @@ Flag if:
 
 Group findings by severity for the user:
 
-- **P0 (blocker)**: missing `auditOnly` wrap on an audit sink, missing `auditRedactPreset`, denials not logged, no tamper-evident sink in a regulated context.
+- **P0 (blocker)**: missing `auditOnly` wrap on an audit drain, missing `auditRedactPreset`, denials not logged, no tamper-evident drain in a regulated context.
 - **P1 (compliance gap)**: missing tenant isolation, hash-chain state not persisted, no HMAC rotation, no denial test coverage.
 - **P2 (hygiene)**: action naming inconsistency, in-line actor objects (should use `defineAuditAction`), missing `causationId` / `correlationId` on chained operations.
 
@@ -449,7 +449,7 @@ Then map each finding to the relevant step in the buildout above (e.g. P0 → St
 - **Forgetting standalone jobs.** Cron, queue workers, CLIs trigger audit-worthy actions too — use `audit()` or `withAudit()`.
 - **Faking the actor type.** `actor.type: 'user'` for cron jobs gets flagged in audits. Use `'system'`, `'api'`, or `'agent'` accurately.
 - **Single global secret with no rotation.** HMAC keys must rotate; without a `keyId`, old events become unverifiable after rotation.
-- **One drain that fails takes audits down.** Sinks must fail in isolation. The default `drain: [...]` array does this; if you wrap in `Promise.all`, don't throw on a single rejection — log it.
+- **One drain that fails takes audits down.** Drains must fail in isolation. The default `drain: [...]` array does this; if you wrap in `Promise.all`, don't throw on a single rejection — log it.
 
 ## Glossary
 

--- a/apps/docs/skills/build-audit-logs/references/framework-wiring.md
+++ b/apps/docs/skills/build-audit-logs/references/framework-wiring.md
@@ -1,6 +1,6 @@
 # Framework Wiring
 
-The audit pipeline is the same shape in every framework: register `auditEnricher()`, wire a main drain, and add an audit-only sink. Pick the section that matches the user's stack.
+The audit pipeline is the same shape in every framework: register `auditEnricher()`, wire a main drain, and add an audit-only drain. Pick the section that matches the user's stack.
 
 ## Hono
 
@@ -93,5 +93,5 @@ audit({
 ## Notes that apply everywhere
 
 - Failure isolation between drains comes from `initLogger({ drain: [...] })` invoking each drain independently. If you instead use `Promise.all`, a single rejection takes the others down — wrap in `Promise.allSettled` and log failures, or stick with the array form.
-- `await: true` on `auditOnly` makes the wrapped drain block the request until the event is flushed. Use it for the tamper-evident sink so you don't lose audits on crash; the queryable sink can stay async.
+- `await: true` on `auditOnly` makes the wrapped drain block the request until the event is flushed. Use it for the tamper-evident drain so you don't lose audits on crash; the queryable drain can stay async.
 - For multi-process deployments behind hash-chain, persist `state.{load,save}` (Redis is the common choice) so the chain survives restarts and rolling deploys.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,7 +44,7 @@ pnpm evlog doctor
 | --- | --- |
 | `evlog init` | Interactive setup: install, register the framework integration, wire a drain |
 | `evlog init --yes` | Non-interactive — defaults for everything (also implied by `--json`, no TTY, or `CI`) |
-| `evlog init --drain <id>` | Development sink: `fs` (default) or `none` |
+| `evlog init --drain <id>` | Development drain: `fs` (default) or `none` |
 | `evlog init --prod-drain <a,b>` | `axiom`, `otlp`, `posthog`, `sentry`, `better-stack`, `datadog`, `hyperdx` — several fan out |
 | `evlog init --extras <a,b>` | `enrichers`, `pipeline`, `sampling`, `error-catalog`, `audit-catalog`, `ai`, `better-auth`, `vite` |
 | `evlog init --apps <a,b>` | Workspace packages to set up, from a monorepo root |


### PR DESCRIPTION
Stacked on #592. First PR of the sweep: the half that needs no judgment.

`content:lint --fix` over the whole corpus, 142 files scanned, **15 changed, 40 replacements, zero reverts**. Every one is `sink` → `drain` or `error registry` → `error catalog`: a concept evlog named, wearing another tool's word. `U-15` page-level findings drop from 33 to 23; what remains is `child logger` and `transport`, which do not have one correct replacement and go to a reviewer.

Sentences describing another logger keep that logger's vocabulary, so pino's transports are untouched.

## Two things the sweep found in the codemod

Both are fixed in #592 rather than here, and both were caught by running this before committing it.

**The dash rule had to go.** Replacing `A — B — C` with `A, B, C` is safe on an appositive and destroys a list. Measured over this corpus: **25 of 38** replacements produced a sentence whose subject is followed by four bare nouns.

```
- It finds every entry point — API handlers, pages that fetch, middleware — checks each one…
+ It finds every entry point, API handlers, pages that fetch, middleware, checks each one…
```

The scanner cannot tell an appositive from a list, so every dash now arrives as a finding for someone who can read the sentence. `U-14` records the measurement so nobody re-adds it.

**MDC structure is not prose.** The first run renamed `::audit-dual-sink` to `::audit-dual-drain`. The Vue file is `AuditDualSink.vue`, so that page would have stopped resolving, and the self-check missed it because the score improved. Component invocations, slot markers, and prop blocks are now skipped.

## Checks

`evlog-docs` lint passes, 103 scanner tests. No changeset: docs and `.agents/` only.