### PR TITLE
fix(docs): repair the broken import sample and the three dead links

### DIFF
--- a/apps/docs/content/1.start/2.why-evlog.md
+++ b/apps/docs/content/1.start/2.why-evlog.md
@@ -148,8 +148,8 @@ Teams in regulated verticals — fintech, healthtech, B2B SaaS — should treat 
 Your application code never depends on a vendor — it emits to the drain pipeline. On day 0 that's stdout in dev and a [filesystem drain](/integrate/adapters/self-hosted/fs) in CI. The day you decide to query logs:
 
 ```typescript [nuxt.config.ts]
-import { createAxiomDrain } from 'evlog/adapters/axiom'
-import { createSentryDrain } from 'evlog/adapters/sentry'
+import { createAxiomDrain } from 'evlog/axiom'
+import { createSentryDrain } from 'evlog/sentry'
 
 export default defineNuxtConfig({
   evlog: {

--- a/apps/docs/content/2.learn/4.lifecycle.md
+++ b/apps/docs/content/2.learn/4.lifecycle.md
@@ -32,7 +32,7 @@ evlog events follow a pipeline from creation to delivery. The pipeline differs s
 | **Enrich** | Via global drain | Via global drain | Via hooks or callbacks |
 | **Drain** | Via global drain | Via global drain | Via hooks or callbacks |
 
-After **`emit`** (including when sampling returns no output), the request logger is **sealed**: later `set` / `error` / `info` / `warn` calls are ignored with a console warning. For background work that needs its own event, use **`log.fork()`** where your integration supports it. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+After **`emit`** (including when sampling returns no output), the request logger is **sealed**: later `set` / `error` / `info` / `warn` calls are ignored with a console warning. For background work that needs its own event, use **`log.fork()`** where your integration supports it. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ## Request Logging — Step by Step
 

--- a/apps/docs/content/4.integrate/0.overview.md
+++ b/apps/docs/content/4.integrate/0.overview.md
@@ -24,7 +24,7 @@ Once you understand the [logging modes](/learn/overview), there are two question
 
 The two are independent. A Nuxt app can drain to Axiom, an Express app can drain to OTLP + Sentry simultaneously, a SvelteKit app can drain to a local file in dev and to Datadog in production.
 
-Once something is wired, try [`evlog map`](/cli/map) (`npx @evlog/cli map`) to see which entry points are still dark — or [`evlog doctor`](/cli/doctor) if nothing is showing up. Separate early package; optional, worth a run.
+Once something is wired, try [`evlog map`](/cli/map) (`npx @evlog/cli map`) to see which entry points are still dark, or [`evlog doctor`](/cli/doctor) if nothing is showing up. Separate early package; optional, worth a run.
 
 ::card-group
   :::card
@@ -50,7 +50,7 @@ Once something is wired, try [`evlog map`](/cli/map) (`npx @evlog/cli map`) to s
 
 ## Don't see your framework?
 
-Check [Custom Framework Integration](/extend/custom-framework). The `evlog/toolkit` package exposes the same building blocks every built-in integration uses — most HTTP frameworks need ~30 lines of glue.
+Check [Custom Framework Integration](/extend/custom-framework). The `evlog/toolkit` package exposes the same building blocks every built-in integration uses. Most HTTP frameworks need ~30 lines of glue.
 
 ## Don't see your destination?
 

--- a/apps/docs/content/4.integrate/adapters/01.overview.md
+++ b/apps/docs/content/4.integrate/adapters/01.overview.md
@@ -142,7 +142,7 @@ initLogger({ drain: createAxiomDrain() })
   title: Axiom
   to: /integrate/adapters/cloud/axiom
   ---
-  Send logs to Axiom for powerful querying and dashboards.
+  Send logs to Axiom, which indexes every field so you can query on any of them.
   :::
   :::card
   ---
@@ -361,7 +361,7 @@ Every adapter receives a `DrainContext` with:
 
 All adapters support automatic configuration via environment variables. No code changes needed when deploying to different environments.
 
-Each adapter reads from standard environment variables — the same names work in every framework:
+Each adapter reads from standard environment variables, and the same names work in every framework:
 
 ```bash [.env]
 # Axiom
@@ -398,7 +398,7 @@ CLICKHOUSE_ENDPOINT=http://localhost:8123
 CLICKHOUSE_PASSWORD=your-password
 ```
 
-Adapters auto-read from these variables, so just call `createXDrain()` with no arguments.
+Adapters auto-read from these variables, so a `create*Drain()` factory takes no arguments.
 
 ## Missing credentials
 

--- a/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/01.axiom.md
@@ -18,7 +18,7 @@ links:
     variant: subtle
 ---
 
-[Axiom](https://axiom.co) is a cloud-native logging platform with powerful querying capabilities. The evlog Axiom adapter sends your wide events directly to Axiom datasets.
+[Axiom](https://axiom.co) is a cloud-native logging platform that indexes every field of an event, so any of them is queryable without a schema. The evlog Axiom adapter sends your wide events directly to Axiom datasets.
 
 ::prompt
 ---

--- a/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
@@ -187,7 +187,7 @@ Under the hood, `createPostHogDrain()` wraps the OTLP adapter's `sendBatchToOTLP
 
 ## Choosing a Record Shape
 
-PostHog treats log attributes as facets: you filter, break down, and alert on them. With the default `json` shape a nested field arrives as one serialized attribute — `ai` = `{"calls":2,"costUsd":0.0012}` — which PostHog can display but not chart.
+PostHog treats log attributes as facets: you filter, break down, and alert on them. With the default `json` shape a nested field arrives as one serialized attribute (`ai` = `{"calls":2,"costUsd":0.0012}`), which PostHog can display but not chart.
 
 `compact` flattens those into `ai.calls` and `ai.costUsd`, and replaces the body with a one-line summary instead of repeating the whole event:
 
@@ -195,7 +195,7 @@ PostHog treats log attributes as facets: you filter, break down, and alert on th
 const drain = createPostHogDrain({ recordShape: 'compact' })
 ```
 
-This is the recommended shape for PostHog. It also cuts what you send: Logs is billed per GB ingested, and the default shape transmits every field twice — once in the body, once in the attributes.
+This is the recommended shape for PostHog. It also cuts what you send: Logs is billed per GB ingested, and the default shape transmits every field twice: once in the body, once in the attributes.
 
 ::callout{icon="i-lucide-info" color="info"}
 `compact` becomes the default in the next major. Set it on a new project now; switching later means rewriting the saved views and alerts built on the `json` shape.
@@ -203,7 +203,7 @@ This is the recommended shape for PostHog. It also cuts what you send: Logs is b
 
 ## Linking Logs to People and Session Replays
 
-A log that carries a person identifier shows up on that person's profile in PostHog, under the **Logs** tab — no service-name guessing to find what a specific user hit. Carry a session id too and the log links to their session replay.
+A log that carries a person identifier shows up on that person's profile in PostHog, under the **Logs** tab, with no service-name guessing to find what a specific user hit. Carry a session id too and the log links to their session replay.
 
 PostHog reads both from log attributes: `posthogDistinctId` for the person, `sessionId` for the replay. The adapter fills them from your wide event, so this works as soon as your event carries the values:
 
@@ -216,7 +216,7 @@ log.set({
 })
 ```
 
-The session id comes from the frontend — read it with `posthog.get_session_id()` and send it along with the request:
+The session id comes from the frontend. Read it with `posthog.get_session_id()` and send it along with the request:
 
 ```typescript [app/checkout.ts]
 import posthog from 'posthog-js'
@@ -244,10 +244,10 @@ For an [eve agent](/use-cases/eve), the caller principal is the identity eve its
 const drain = createPostHogDrain({ distinctIdField: 'eve.caller.principalId' })
 ```
 
-A static `distinctId` overrides the field lookup entirely — use it for a backend that acts as one identity rather than on behalf of users.
+A static `distinctId` overrides the field lookup entirely. Use it for a backend that acts as one identity rather than on behalf of users.
 
 ::callout{icon="i-lucide-info" color="info"}
-PostHog matches the attribute value against every `distinct_id` it knows for a person, so any one of their identifiers works. The attribute key is configurable per project under **Settings** > **Logs** — leave it at the default `posthogDistinctId` and this works out of the box.
+PostHog matches the attribute value against every `distinct_id` it knows for a person, so any one of their identifiers works. The attribute key is configurable per project under **Settings** > **Logs**. Leave it at the default `posthogDistinctId` and this works out of the box.
 ::
 
 ## Regions
@@ -337,7 +337,7 @@ The `distinct_id` follows a fallback chain:
 
 An event that resolves to a real person is an **identified** event: PostHog creates a person profile for it and attaches person properties.
 
-When no identifier resolves, the event is sent as **anonymous** — `$process_person_profile: false` — rather than piling every request onto one "person" named after your service. PostHog bills anonymous events at a lower rate and keeps them out of person profiles.
+When no identifier resolves, the event is sent as **anonymous** (`$process_person_profile: false`) rather than piling every request onto one "person" named after your service. PostHog bills anonymous events at a lower rate and keeps them out of person profiles.
 
 ```typescript [server/plugins/evlog-drain.ts]
 // Identified: events carrying `userId` create and update a person profile

--- a/apps/docs/content/4.integrate/adapters/cloud/04.better-stack.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/04.better-stack.md
@@ -18,7 +18,7 @@ links:
     variant: subtle
 ---
 
-[Better Stack](https://betterstack.com) is a DX-first log management platform with powerful search, alerting, and dashboards. The evlog Better Stack adapter sends your wide events to the Better Stack HTTP ingestion API.
+[Better Stack](https://betterstack.com) is a log management platform with search, alerting, and dashboards. The evlog Better Stack adapter sends your wide events to the Better Stack HTTP ingestion API.
 
 ::prompt
 ---
@@ -185,7 +185,7 @@ Better Stack accepts arbitrary JSON fields, so all your wide event context (leve
 
 ## Querying Logs in Better Stack
 
-Better Stack provides a powerful log search interface:
+Better Stack's log search takes a query over any field:
 
 - **Live tail**: Stream logs in real time
 - **Full-text search**: Search across all fields

--- a/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
@@ -189,7 +189,7 @@ For advanced use, `sanitizeWideEventForDatadog(event)` returns only the sanitize
 
 ## Trace correlation
 
-Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.span_id`** attributes at the **root** of the payload. Nested copies (`@evlog.traceId`) are searchable but do not correlate on their own — that takes a [Trace Id Remapper](https://docs.datadoghq.com/logs/log_configuration/processors/trace_remapper/) in a Datadog log pipeline, configuration living outside your codebase. The adapter lifts `event.traceId` and `event.spanId` into a root `dd` block instead, so correlation works with no pipeline setup:
+Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.span_id`** attributes at the **root** of the payload. Nested copies (`@evlog.traceId`) are searchable but do not correlate on their own. That takes a [Trace Id Remapper](https://docs.datadoghq.com/logs/log_configuration/processors/trace_remapper/) in a Datadog log pipeline, configuration living outside your codebase. The adapter lifts `event.traceId` and `event.spanId` into a root `dd` block instead, so correlation works with no pipeline setup:
 
 ```json
 {
@@ -202,9 +202,9 @@ Datadog links a log to a trace through the reserved **`dd.trace_id`** / **`dd.sp
 }
 ```
 
-The nested copy under `evlog` stays, so existing `@evlog.*` facets and dashboards keep working. Only **non-empty strings** are lifted — an empty or non-string `traceId` / `spanId` is skipped rather than sent as an id Datadog would fail to resolve, and the `dd` key is absent when neither id survives that check.
+The nested copy under `evlog` stays, so existing `@evlog.*` facets and dashboards keep working. Only **non-empty strings** are lifted, so an empty or non-string `traceId` / `spanId` is skipped rather than sent as an id Datadog would fail to resolve, and the `dd` key is absent when neither id survives that check.
 
-Those fields are populated by `createTraceContextEnricher`, included in [`createDefaultEnrichers()`](/use-cases/enrichers) — it parses the incoming W3C `traceparent` header into `event.traceId` / `event.spanId`:
+Those fields are populated by `createTraceContextEnricher`, included in [`createDefaultEnrichers()`](/use-cases/enrichers), which parses the incoming W3C `traceparent` header into `event.traceId` / `event.spanId`:
 
 ```typescript [server/plugins/evlog-enrich.ts]
 import { createDefaultEnrichers } from 'evlog/enrichers'

--- a/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
@@ -339,5 +339,5 @@ await sendBatchToLoki(events, { endpoint: 'http://localhost:3100' })
 
 - [Sampling](/learn/sampling) — control log volume before it reaches Loki
 - [Enrichers](/use-cases/enrichers) — add derived fields to every event
-- [Pipeline](/learn/pipeline) — batching, retries, and fan-out
+- [Drain pipeline](/extend/drain-pipeline) — batching, retries, and fan-out
 - [Adapters Overview](/integrate/adapters/overview) — all available destinations

--- a/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
@@ -21,7 +21,7 @@ links:
 
 The Loki adapter pushes wide events to [Grafana Loki](https://grafana.com/docs/loki/latest/) via its push API. It works with a self-hosted single-tenant instance, a multi-tenant deployment, and Grafana Cloud.
 
-Each event is pushed as a **JSON log line** under a small, low-cardinality label set. That distinction matters in Loki: labels are indexed and billed by cardinality, while the log line is searched at query time. evlog labels only `service`, `environment`, and `level` by default, and leaves everything else — `requestId`, `path`, `user`, your custom fields — in the line, queryable with `| json`.
+Each event is pushed as a **JSON log line** under a small, low-cardinality label set. That distinction matters in Loki: labels are indexed and billed by cardinality, while the log line is searched at query time. evlog labels only `service`, `environment`, and `level` by default, and leaves everything else (`requestId`, `path`, `user`, your custom fields) in the line, queryable with `| json`.
 
 ::prompt
 ---
@@ -162,7 +162,7 @@ Configuration is resolved highest to lowest:
 
 ## Deployment
 
-Loki runs either way, and the adapter is the same in both cases — only
+Loki runs either way, and the adapter is the same in both cases. Only
 authentication differs.
 
 ### Self-hosted
@@ -177,7 +177,7 @@ createLokiDrain({ endpoint: 'http://localhost:3100' })
 LOKI_ENDPOINT=http://localhost:3100
 ```
 
-For a **multi-tenant** deployment, name the tenant — it is sent as `X-Scope-OrgID`:
+For a **multi-tenant** deployment, name the tenant, and it is sent as `X-Scope-OrgID`:
 
 ```typescript [server/plugins/evlog.ts]
 createLokiDrain({
@@ -214,7 +214,7 @@ LOKI_API_KEY=glc_xxx
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-`user` is the **numeric instance ID** of the Loki datasource — find it under
+`user` is the **numeric instance ID** of the Loki datasource. Find it under
 *Connections → Data sources → Loki* in your Grafana Cloud stack. It is not your
 account email. Using the wrong value is the usual cause of a `401`.
 ::
@@ -233,7 +233,7 @@ account email. Using the wrong value is the usual cause of a `401`.
 ## Labels and cardinality
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-Never promote a high-cardinality field to a label. Loki creates one stream per unique label combination — labelling `requestId` or `userId` will create millions of streams and degrade or break your instance.
+Never promote a high-cardinality field to a label. Loki creates one stream per unique label combination, so labelling `requestId` or `userId` will create millions of streams and degrade or break your instance.
 ::
 
 Add a label only for values you filter on and that have a bounded set:
@@ -247,7 +247,7 @@ createLokiDrain({
 })
 ```
 
-Everything else stays in the JSON line and is fully queryable — see below.
+Everything else stays in the JSON line and is fully queryable. See below.
 
 ## Querying in Grafana
 
@@ -292,11 +292,11 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-Events sharing a label set are grouped into a single Loki stream, and entries are sorted by timestamp — Loki rejects out-of-order pushes within a stream.
+Events sharing a label set are grouped into a single Loki stream, and entries are sorted by timestamp, because Loki rejects out-of-order pushes within a stream.
 
 ## Verify it locally
 
-Spin up Loki in Docker and push a real event — no cloud account needed:
+Spin up Loki in Docker and push a real event, with no cloud account needed:
 
 ```bash [Terminal]
 docker compose -f packages/evlog/test/e2e/docker-compose.yml up -d
@@ -314,13 +314,13 @@ and run `{service="evlog-e2e"}`.
 
 ## Troubleshooting
 
-**`Missing endpoint`** — `LOKI_ENDPOINT` is unset and no `endpoint` was passed. The drain logs `[evlog/loki] Missing endpoint` once and then does nothing, so requests are never blocked or failed.
+**`Missing endpoint`.** `LOKI_ENDPOINT` is unset and no `endpoint` was passed. The drain logs `[evlog/loki] Missing endpoint` once and then does nothing, so requests are never blocked or failed.
 
-**`Loki API error: 401`** — On Grafana Cloud, check that `user` is the numeric **instance ID** of the Loki datasource, not your account email.
+**`Loki API error: 401`.** On Grafana Cloud, check that `user` is the numeric **instance ID** of the Loki datasource, not your account email.
 
-**`Loki API error: 400` mentioning out-of-order entries** — Older Loki versions reject entries older than the most recent one in a stream. evlog sorts within each push; if you still hit this, enable `unordered_writes` in Loki or reduce the batch interval.
+**`Loki API error: 400` mentioning out-of-order entries.** Older Loki versions reject entries older than the most recent one in a stream. evlog sorts within each push; if you still hit this, enable `unordered_writes` in Loki or reduce the batch interval.
 
-**Nothing appears in Grafana** — Confirm the label set you are querying. Run `{service=~".+"}` first to see which streams arrived.
+**Nothing appears in Grafana.** Confirm the label set you are querying. Run `{service=~".+"}` first to see which streams arrived.
 
 ## Direct API usage
 

--- a/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
@@ -21,7 +21,7 @@ links:
 
 The ClickHouse adapter inserts wide events over the [HTTP interface](https://clickhouse.com/docs/en/interfaces/http) in `JSONEachRow` format. It works with a local instance, a self-managed cluster, and ClickHouse Cloud.
 
-The default schema gives you **typed columns** for the fields you filter and aggregate on, plus the complete wide event as JSON in `data` — so no field is ever lost, and adding a field to your events never requires a migration.
+The default schema gives you **typed columns** for the fields you filter and aggregate on, plus the complete wide event as JSON in `data`, so no field is ever lost, and adding a field to your events never requires a migration.
 
 ::prompt
 ---
@@ -86,7 +86,7 @@ TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-`ORDER BY (service, environment, timestamp)` matches how you'll filter most often. Adjust the `TTL` to your retention policy — drop the clause entirely to keep events forever.
+`ORDER BY (service, environment, timestamp)` matches how you'll filter most often. Adjust the `TTL` to your retention policy, and drop the clause entirely to keep events forever.
 ::
 
 ## Quick Start
@@ -187,7 +187,7 @@ initLogger({
 
 ## Deployment
 
-The adapter is identical either way — only the endpoint and credentials change.
+The adapter is identical either way. Only the endpoint and credentials change.
 
 ### Self-hosted
 
@@ -226,7 +226,7 @@ CLICKHOUSE_DATABASE=logs
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-Copy the endpoint from *Connect → HTTPS* in the ClickHouse Cloud console —
+Copy the endpoint from *Connect → HTTPS* in the ClickHouse Cloud console,
 including the `:8443` port. Cloud services idle-suspend, so the first insert
 after a pause can take a few seconds; raise `timeout` if you see aborts.
 ::
@@ -253,7 +253,7 @@ compose file creates `evlog_events` from the schema above on first boot.
 Without `CLICKHOUSE_ENDPOINT` it skips itself with a visible label.
 
 To *see* the events rather than assert on them, seed the sandbox and open the
-provisioned dashboard — the stack ships a Grafana with the ClickHouse
+provisioned dashboard. The stack ships a Grafana with the ClickHouse
 datasource already wired up:
 
 ```bash [Terminal]
@@ -263,7 +263,7 @@ pnpm run sandbox:seed
 ```
 
 ClickHouse's built-in `/play` page at `http://localhost:8123/play` also works
-for raw SQL, but it is deliberately minimal — the dashboard is the better
+for raw SQL, but it is deliberately minimal, and the dashboard is the better
 starting point.
 
 ## Async inserts
@@ -276,7 +276,7 @@ async_insert=1&wait_for_async_insert=0
 
 ClickHouse buffers rows server-side and writes them in batches. Draining never blocks a request on disk writes.
 
-Set `waitForAsyncInsert: true` if you need the insert acknowledged as durable before the drain resolves — at the cost of latency. Set `asyncInsert: false` to insert synchronously, which only makes sense when you already batch client-side with `evlog/pipeline`.
+Set `waitForAsyncInsert: true` if you need the insert acknowledged as durable before the drain resolves, at the cost of latency. Set `asyncInsert: false` to insert synchronously, which only makes sense when you already batch client-side with `evlog/pipeline`.
 
 ## Querying
 
@@ -334,7 +334,7 @@ createClickHouseDrain({
 })
 ```
 
-Keys must match your column names — ClickHouse rejects a `JSONEachRow` insert containing unknown columns.
+Keys must match your column names, because ClickHouse rejects a `JSONEachRow` insert containing unknown columns.
 
 ## Batching
 
@@ -356,13 +356,13 @@ export default defineNitroPlugin((nitroApp) => {
 
 ## Troubleshooting
 
-**`Missing endpoint`** — `CLICKHOUSE_ENDPOINT` is unset and no `endpoint` was passed. The drain logs `[evlog/clickhouse] Missing endpoint` once and then does nothing, so requests are never blocked or failed.
+**`Missing endpoint`.** `CLICKHOUSE_ENDPOINT` is unset and no `endpoint` was passed. The drain logs `[evlog/clickhouse] Missing endpoint` once and then does nothing, so requests are never blocked or failed.
 
-**`ClickHouse API error: 401`** — Check `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD`. Credentials are sent as `X-ClickHouse-User` / `X-ClickHouse-Key` headers, never in the query string, so they never reach `system.query_log`.
+**`ClickHouse API error: 401`.** Check `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD`. Credentials are sent as `X-ClickHouse-User` / `X-ClickHouse-Key` headers, never in the query string, so they never reach `system.query_log`.
 
-**`ClickHouse API error: 400` mentioning unknown column** — Your table does not match the row shape. Either create the table from the DDL above, or supply a `transform` matching your columns.
+**`ClickHouse API error: 400` mentioning unknown column.** Your table does not match the row shape. Either create the table from the DDL above, or supply a `transform` matching your columns.
 
-**`Cannot parse input`** — The table exists but a column type disagrees. `status` is `Nullable(UInt16)` because it is absent on non-HTTP events.
+**`Cannot parse input`.** The table exists but a column type disagrees. `status` is `Nullable(UInt16)` because it is absent on non-HTTP events.
 
 ## Direct API usage
 

--- a/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
@@ -379,5 +379,5 @@ await sendBatchToClickHouse(events, { endpoint: 'http://localhost:8123' })
 
 - [Sampling](/learn/sampling) — control volume before it reaches ClickHouse
 - [Enrichers](/use-cases/enrichers) — add derived fields to every event
-- [Pipeline](/learn/pipeline) — batching, retries, and fan-out
+- [Pipeline](/extend/drain-pipeline) — batching, retries, and fan-out
 - [Adapters Overview](/integrate/adapters/overview) — all available destinations

--- a/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
@@ -179,7 +179,7 @@ const drain = createOTLPDrain({
 
 ## Deployment
 
-OTLP is a protocol, not a product — the same adapter talks to a collector you
+OTLP is a protocol, not a product. The same adapter talks to a collector you
 run yourself and to a managed gateway. Only the endpoint and headers change.
 
 ### Self-hosted
@@ -214,7 +214,7 @@ docker run --rm -p 4318:4318 \
 OTLP_ENDPOINT=http://localhost:4318
 ```
 
-From there the collector fans out wherever you want — Loki, ClickHouse,
+From there the collector fans out wherever you want: Loki, ClickHouse,
 Elasticsearch, a managed backend, or several at once. That indirection is the
 reason to pick OTLP over a direct adapter.
 
@@ -240,7 +240,7 @@ OTLP_HEADERS=x-honeycomb-team=your-api-key
 ::
 
 ::callout{icon="i-lucide-info" color="info"}
-Grafana Cloud uses URL-encoded headers — the `%20` is a space. The adapter
+Grafana Cloud uses URL-encoded headers, so the `%20` is a space. The adapter
 decodes that format automatically.
 ::
 
@@ -260,7 +260,7 @@ evlog maps wide events to the OTLP log format:
 | `spanId` | `spanId` |
 | All other fields | Log attributes |
 
-Every field of the wide event is sent as an OTLP record field, a resource attribute, or a log attribute. `null` and `undefined` are omitted rather than transmitted — `json` drops them at the top level, `compact` at every level, so a nested `{ user: { id: null } }` has no `user.id` attribute.
+Every field of the wide event is sent as an OTLP record field, a resource attribute, or a log attribute. `null` and `undefined` are omitted rather than transmitted. `json` drops them at the top level, `compact` at every level, so a nested `{ user: { id: null } }` has no `user.id` attribute.
 
 ### Record Shape
 
@@ -300,10 +300,10 @@ Every field of the wide event is sent as an OTLP record field, a resource attrib
   // → user.id, user.plan
   ```
 
-Only plain objects are walked. Arrays are serialized as a single JSON string — indexing them (`ai.tools.0.name`) would turn a list into an unbounded set of distinct attribute keys, which most backends charge for and none can chart — and so is anything else that is not a plain object, such as a `Date`. An empty object stays a single `{}` attribute rather than disappearing.
+Only plain objects are walked. Arrays are serialized as a single JSON string. Indexing them, as `ai.tools.0.name`, would turn a list into an unbounded set of distinct attribute keys, which most backends charge for and none can chart. The same goes for anything else that is not a plain object, such as a `Date`. An empty object stays a single `{}` attribute rather than disappearing.
 
 ::callout{icon="i-lucide-info" color="info"}
-`compact` becomes the default in the next major. Switch early if you are setting a project up now — moving later means rewriting the queries built on the `json` shape.
+`compact` becomes the default in the next major. Switch early if you are setting a project up now. Moving later means rewriting the queries built on the `json` shape.
 ::
 
 ### Severity Mapping

--- a/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
@@ -187,7 +187,7 @@ For self-hosted HyperDX, set `endpoint` to your OTLP HTTP base URL (same role as
 ## Deployment
 
 HyperDX is open source, so the adapter targets a managed account and a cluster
-you run yourself with the same code — only `endpoint` changes.
+you run yourself with the same code. Only `endpoint` changes.
 
 ### HyperDX Cloud
 
@@ -205,7 +205,7 @@ The endpoint defaults to `https://in-otel.hyperdx.io`.
 
 ### Self-hosted
 
-Point `endpoint` at your own OTLP HTTP collector — the same value you would put
+Point `endpoint` at your own OTLP HTTP collector, the same value you would put
 in an `otlphttp` exporter's `endpoint`:
 
 ```typescript [server/plugins/evlog.ts]
@@ -219,7 +219,7 @@ HYPERDX_API_KEY=your-key
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-Give the **base** URL, not the signal path — evlog appends `/v1/logs` itself.
+Give the **base** URL, not the signal path. evlog appends `/v1/logs` itself.
 A self-hosted collector on the default OTLP HTTP port is `http://host:4318`.
 ::
 
@@ -233,7 +233,7 @@ Under the hood, `createHyperDXDrain()` maps your HyperDX settings to the shared 
 
 ## Official HyperDX OpenTelemetry reference
 
-From [HyperDX — OpenTelemetry](https://hyperdx.io/docs/install/opentelemetry):
+From [HyperDX OpenTelemetry setup](https://hyperdx.io/docs/install/opentelemetry):
 
 > Our OpenTelemetry HTTP endpoint is hosted at `https://in-otel.hyperdx.io` (gRPC at port 4317), and requires the `authorization` header to be set to your API key.
 

--- a/apps/docs/content/4.integrate/adapters/self-hosted/01.fs.md
+++ b/apps/docs/content/4.integrate/adapters/self-hosted/01.fs.md
@@ -82,7 +82,7 @@ export const { withEvlog, useLogger, log, createError } = createEvlog({
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-The FS adapter requires Node.js (`node:fs`). On the Edge runtime, or when its directory is not writable, it logs a one-time `[evlog/fs]` warning and skips writes — so attaching it on a serverless host is safe but pointless, since only the temp directory is writable there and it does not outlive the instance. Use `evlog/memory` or an HTTP adapter for those.
+The FS adapter requires Node.js (`node:fs`). On the Edge runtime, or when its directory is not writable, it logs a one-time `[evlog/fs]` warning and skips writes, so attaching it on a serverless host is safe but pointless, since only the temp directory is writable there and it does not outlive the instance. Use `evlog/memory` or an HTTP adapter for those.
 ::
 ```typescript [Hono]
 import { createFsDrain } from 'evlog/fs'

--- a/apps/docs/content/4.integrate/adapters/self-hosted/03.memory.md
+++ b/apps/docs/content/4.integrate/adapters/self-hosted/03.memory.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-The Memory adapter stores wide events in a module-level ring buffer. Unlike the [File System adapter](/integrate/adapters/self-hosted/fs), it has **zero runtime dependencies** and runs anywhere — including Cloudflare Workers (workerd), Deno Deploy, and other edge runtimes that don't expose Node's `fs` module.
+The Memory adapter stores wide events in a module-level ring buffer. Unlike the [File System adapter](/integrate/adapters/self-hosted/fs), it has **zero runtime dependencies** and runs anywhere, including Cloudflare Workers (workerd), Deno Deploy, and other edge runtimes that don't expose Node's `fs` module.
 
 The primary use case is **local dev agent access**: wire the drain during development, expose a lightweight HTTP endpoint, and let your AI agent fetch structured logs over HTTP without any external tooling.
 
@@ -137,7 +137,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 An agent can now call `/_evlog/logs?level=error&limit=50&since=2026-01-01T00:00:00Z` and the query params are coerced to the correct types before being passed to `readMemoryLogs`. Supported query params: `store`, `since`, `until`, `level` (comma-separated for multiple), `limit`.
 
-The response is a JSON array of [`WideEvent`](/reference/configuration) objects — the same shape used by every other evlog adapter.
+The response is a JSON array of [`WideEvent`](/reference/configuration) objects, the same shape used by every other evlog adapter.
 
 ## Configuration
 

--- a/apps/docs/content/4.integrate/frameworks/00.overview.md
+++ b/apps/docs/content/4.integrate/frameworks/00.overview.md
@@ -112,7 +112,7 @@ On Hono, use `c.get('log')` inside handlers and `useLogger()` from `evlog/hono` 
   to: /integrate/frameworks/tanstack-start
   color: neutral
   ---
-  Uses Nitro v3 module with async context for seamless logging in server functions. Also covers TanStack Router (full-stack mode).
+  Uses Nitro v3 module with async context, so `useLogger()` works inside server functions. Also covers TanStack Router (full-stack mode).
   :::
   :::card
   ---

--- a/apps/docs/content/4.integrate/frameworks/01.nuxt.md
+++ b/apps/docs/content/4.integrate/frameworks/01.nuxt.md
@@ -148,7 +148,7 @@ All options are set in `nuxt.config.ts` under the `evlog` key:
 | `dev` | `'evlog' \| 'nitro' \| 'both' \| object` | `'evlog'` in pretty dev | Dev terminal presets or `{ frameworkOverlay, prettyError }` — see [Configuration — Dev terminal output](/reference/configuration#dev-terminal-output) |
 
 ::callout{icon="i-lucide-terminal" color="info"}
-**Dev terminal presets:** `'evlog'` (default) — one clean signal, evlog-only stack. `'nitro'` — wide event context + Nitro Youch stack (evlog prints Why/Fix only). `'both'` — full evlog block and Nitro overlay. With `pretty: false`, set `dev: { frameworkOverlay: false }` to suppress Nitro while logging JSON.
+**Dev terminal presets:** `'evlog'` (default) gives one clean signal, evlog-only stack. `'nitro'` gives the wide event context + Nitro Youch stack (evlog prints Why/Fix only). `'both'` gives the full evlog block and the Nitro overlay. With `pretty: false`, set `dev: { frameworkOverlay: false }` to suppress Nitro while logging JSON.
 ::
 
 | `silent` | `boolean` | `false` | Suppress console output. Events are still built, sampled, and drained. Use for stdout-based platforms |

--- a/apps/docs/content/4.integrate/frameworks/02.nextjs.md
+++ b/apps/docs/content/4.integrate/frameworks/02.nextjs.md
@@ -94,7 +94,7 @@ These two APIs serve different purposes and can be used independently or togethe
 
 ### 1. Split instrumentation from route config
 
-Keep Node-only imports (`evlog/fs`, heavy adapters) out of root `instrumentation.ts`. Use `defineNodeInstrumentation` with an options object — evlog loads `createInstrumentation` on Node.js only, without a visible `import()` in your file.
+Keep Node-only imports (`evlog/fs`, heavy adapters) out of root `instrumentation.ts`. Use `defineNodeInstrumentation` with an options object. evlog loads `createInstrumentation` on Node.js only, without a visible `import()` in your file.
 
 - Root `instrumentation.ts` → `defineNodeInstrumentation({ service, ... })`
 - `lib/evlog.ts` → `createEvlog()` and Node-only drains for API routes
@@ -154,7 +154,7 @@ Next.js automatically calls these exports:
 - `onRequestError()`: Called on every unhandled request error. Emits a structured error log with the error message, digest, stack trace, request path/method, and routing context (`routerKind`, `routePath`, `routeType`, `renderSource`).
 
 ::callout{icon="i-lucide-info" color="info"}
-`captureOutput` only activates in the Node.js runtime (`NEXT_RUNTIME === 'nodejs'`). It patches `process.stdout.write` and `process.stderr.write` to emit structured `log.info` / `log.error` events. When `silent` is `false` (the default), captured output is shown once as structured terminal output — the raw write is not duplicated. Set `silent: true` to keep the original passthrough alongside drain delivery. Known Next.js Edge bundler warnings are filtered by default so they are not re-emitted as evlog errors.
+`captureOutput` only activates in the Node.js runtime (`NEXT_RUNTIME === 'nodejs'`). It patches `process.stdout.write` and `process.stderr.write` to emit structured `log.info` / `log.error` events. When `silent` is `false` (the default), captured output is shown once as structured terminal output, and the raw write is not duplicated. Set `silent: true` to keep the original passthrough alongside drain delivery. Known Next.js Edge bundler warnings are filtered by default so they are not re-emitted as evlog errors.
 ::
 
 ### Configuration
@@ -287,7 +287,7 @@ All fields are merged into a single wide event emitted when the handler complete
 
 ## Background work (`log.fork`)
 
-Inside `withEvlog`, `useLogger()` returns a logger with **`fork`** for child wide events. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Inside `withEvlog`, `useLogger()` returns a logger with **`fork`** for child wide events. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [app/api/orders/route.ts]
 import { withEvlog, useLogger } from '@/lib/evlog'
@@ -357,7 +357,7 @@ export const POST = withEvlog(async (request: Request) => {
 }
 ```
 
-In the terminal, the error renders inside the wide event — error block first, then request context. Colors and tree connectors render in the terminal; the example below omits ANSI for readability.
+In the terminal, the error renders inside the wide event: error block first, then request context. Colors and tree connectors render in the terminal; the example below omits ANSI for readability.
 
 ```bash [Terminal output]
 ERROR [app] POST /api/payment/process 402 in 12ms
@@ -477,7 +477,7 @@ export const checkout = withEvlog(async (formData: FormData) => {
 
 ## Client Provider
 
-Wrap your root layout with `EvlogProvider` to enable client-side logging and transport:
+Wrap your root layout with `EvlogProvider` to enable client-side logging and its drain:
 
 ```tsx [app/layout.tsx]
 import { EvlogProvider } from 'evlog/next/client'

--- a/apps/docs/content/4.integrate/frameworks/03.sveltekit.md
+++ b/apps/docs/content/4.integrate/frameworks/03.sveltekit.md
@@ -163,7 +163,7 @@ Both `event.locals.log` and `useLogger()` return the same logger instance. `useL
 
 ## Background work (`log.fork`)
 
-Use `locals.log.fork(label, fn)` for a child wide event. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Use `locals.log.fork(label, fn)` for a child wide event. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/routes/api/orders/+server.ts]
 import { useLogger } from 'evlog/sveltekit'

--- a/apps/docs/content/4.integrate/frameworks/04.nitro.md
+++ b/apps/docs/content/4.integrate/frameworks/04.nitro.md
@@ -125,7 +125,7 @@ One request, one log line with all context:
   └─ requestId: a1b2c3d4-...
 ```
 
-Nitro uses **`useLogger(event)`** (event-bound scope), not `AsyncLocalStorage`, so **`log.fork()` is not available** here yet. For AI SDK streaming responses, evlog defers wide-event emit until the response body finishes so `createAILogger(log)` metadata stays on the same request event. Post-emit warnings only apply when code calls `set()` after the wide event has actually emitted — for example in non-streaming handlers or background work. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Nitro uses **`useLogger(event)`** (event-bound scope), not `AsyncLocalStorage`, so **`log.fork()` is not available** here yet. For AI SDK streaming responses, evlog defers wide-event emit until the response body finishes so `createAILogger(log)` metadata stays on the same request event. Post-emit warnings only apply when code calls `set()` after the wide event has actually emitted, for example in non-streaming handlers or background work. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ## Error Handling
 

--- a/apps/docs/content/4.integrate/frameworks/06.nestjs.md
+++ b/apps/docs/content/4.integrate/frameworks/06.nestjs.md
@@ -159,7 +159,7 @@ Both `req.log` and `useLogger()` return the same logger instance. `useLogger()` 
 
 ## Background work (`log.fork`)
 
-Use `req.log.fork(label, fn)` (or the logger from `useLogger()` in the same request) for child wide events. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Use `req.log.fork(label, fn)` (or the logger from `useLogger()` in the same request) for child wide events. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/orders.controller.ts]
 import { useLogger } from 'evlog/nestjs'

--- a/apps/docs/content/4.integrate/frameworks/07.express.md
+++ b/apps/docs/content/4.integrate/frameworks/07.express.md
@@ -147,7 +147,7 @@ Both `req.log` and `useLogger()` return the same logger instance. `useLogger()` 
 
 ## Background work (`log.fork`)
 
-Fire-and-forget async work that finishes **after** the response can no longer update the request wide event (the logger is sealed after emit). Use **`req.log.fork(label, fn)`** so `useLogger()` inside `fn` targets a **child** logger that emits its own event with `operation` and `_parentRequestId`. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Fire-and-forget async work that finishes **after** the response can no longer update the request wide event (the logger is sealed after emit). Use **`req.log.fork(label, fn)`** so `useLogger()` inside `fn` targets a **child** logger that emits its own event with `operation` and `_parentRequestId`. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/index.ts]
 import { evlog, useLogger } from 'evlog/express'

--- a/apps/docs/content/4.integrate/frameworks/08.hono.md
+++ b/apps/docs/content/4.integrate/frameworks/08.hono.md
@@ -12,7 +12,7 @@ links:
     variant: subtle
 ---
 
-The `evlog/hono` middleware auto-creates a request-scoped logger accessible via `c.get('log')` — or `useLogger()` anywhere deeper in the call stack — and emits a wide event when the response completes.
+The `evlog/hono` middleware auto-creates a request-scoped logger accessible via `c.get('log')`, or `useLogger()` anywhere deeper in the call stack, and emits a wide event when the response completes.
 
 ::prompt
 ---
@@ -122,7 +122,7 @@ All fields are merged into a single wide event emitted when the request complete
 ## Accessing the logger deeper in the stack
 
 `c.get('log')` is the idiomatic accessor inside a route handler. Once you are a few
-layers down — a service, a repository — threading `c` everywhere gets noisy. `useLogger()`
+layers down (a service, a repository), threading `c` everywhere gets noisy. `useLogger()`
 resolves the same request logger without it:
 
 ```typescript [src/services/payment.ts]
@@ -134,7 +134,7 @@ export async function chargeCard(amount: number) {
 }
 ```
 
-Both return the same logger — pick whichever reads better at the call site.
+Both return the same logger, so pick whichever reads better at the call site.
 
 ::callout{icon="i-lucide-info" color="info"}
 `useLogger()` is backed by `AsyncLocalStorage`. On Cloudflare Workers this requires the
@@ -158,7 +158,7 @@ app.post('/api/orders', (c) => {
 ```
 
 If you schedule async work after the response without forking, post-emit **`[evlog]` warnings**
-help you notice stale `set()` calls. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+help you notice stale `set()` calls. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ## Error Handling
 

--- a/apps/docs/content/4.integrate/frameworks/09.fastify.md
+++ b/apps/docs/content/4.integrate/frameworks/09.fastify.md
@@ -148,7 +148,7 @@ Both `request.log` and `useLogger()` return the same logger instance. `useLogger
 
 ## Background work (`log.fork`)
 
-Use `request.log.fork(label, fn)` for async work that should emit a **separate** child wide event after the response. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Use `request.log.fork(label, fn)` for async work that should emit a **separate** child wide event after the response. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/index.ts]
 import { evlog, useLogger } from 'evlog/fastify'

--- a/apps/docs/content/4.integrate/frameworks/10.elysia.md
+++ b/apps/docs/content/4.integrate/frameworks/10.elysia.md
@@ -144,7 +144,7 @@ Both `log` in context and `useLogger()` return the same logger instance. `useLog
 
 ## Background work (`log.fork`)
 
-Use `log.fork(label, fn)` from the route context for a child wide event. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+Use `log.fork(label, fn)` from the route context for a child wide event. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/index.ts]
 import { evlog, useLogger } from 'evlog/elysia'

--- a/apps/docs/content/4.integrate/frameworks/11.react-router.md
+++ b/apps/docs/content/4.integrate/frameworks/11.react-router.md
@@ -189,7 +189,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
 
 ## Background work (`log.fork`)
 
-The logger from `loggerContext` supports `fork` for child wide events. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+The logger from `loggerContext` supports `fork` for child wide events. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [app/routes/orders.tsx]
 import { loggerContext } from 'evlog/react-router'

--- a/apps/docs/content/4.integrate/frameworks/12.cloudflare-workers.md
+++ b/apps/docs/content/4.integrate/frameworks/12.cloudflare-workers.md
@@ -8,7 +8,7 @@ navigation:
 
 The `evlog/workers` adapter instruments Cloudflare Workers and Durable Objects with request-scoped loggers carrying Cloudflare-specific context.
 
-Use **`withEvlog`** to get the same middleware pipeline as every other framework integration — route filtering, redaction, enrich, tail sampling, plugins, drains, and automatic emit. Reach for `defineWorkerFetch` or `createWorkersLogger` when you'd rather own the emit yourself.
+Use **`withEvlog`** to get the same middleware pipeline as every other framework integration: route filtering, redaction, enrich, tail sampling, plugins, drains, and automatic emit. Reach for `defineWorkerFetch` or `createWorkersLogger` when you'd rather own the emit yourself.
 
 ::prompt
 ---
@@ -71,7 +71,7 @@ export default withEvlog(async (request, _env, _ctx, log) => {
 })
 ```
 
-`withEvlog` emits one wide event per request when the handler returns — no manual `log.emit()`. It reads `ExecutionContext` off the third argument, so async **`drain`** calls (PostHog, Axiom, …) are registered with `waitUntil` and stay alive after the response is returned. Streaming responses defer the emit until the body completes.
+`withEvlog` emits one wide event per request when the handler returns, with no manual `log.emit()`. It reads `ExecutionContext` off the third argument, so async **`drain`** calls (PostHog, Axiom, …) are registered with `waitUntil` and stay alive after the response is returned. Streaming responses defer the emit until the body completes.
 
 `requestId` comes from `x-request-id` when the caller sends one, falling back to `cf-ray`. `method`, `path`, `cf-ray`, `traceparent` and the safe subset of `request.cf` are captured automatically.
 

--- a/apps/docs/content/4.integrate/frameworks/14.astro.md
+++ b/apps/docs/content/4.integrate/frameworks/14.astro.md
@@ -41,7 +41,7 @@ On **Cloudflare Workers** (including Astro with `@astrojs/cloudflare`), set `wai
 
 For Astro **middleware** (not the raw Worker handler), there is no `defineWorkerFetch`; you still pass `waitUntil` from the adapter-exposed context.
 
-The exact way to read `ctx` from Astro middleware depends on your adapter version — check the [Cloudflare adapter docs](https://docs.astro.build/en/guides/integrations-guide/cloudflare/).
+The exact way to read `ctx` from Astro middleware depends on your adapter version, so check the [Cloudflare adapter docs](https://docs.astro.build/en/guides/integrations-guide/cloudflare/).
 ::
 
 ## Quick Start

--- a/apps/docs/content/4.integrate/frameworks/15.orpc.md
+++ b/apps/docs/content/4.integrate/frameworks/15.orpc.md
@@ -157,7 +157,7 @@ Both `context.log` and `useLogger()` return the same logger instance. `useLogger
 
 ## Background work (`log.fork`)
 
-`useLogger()` returns a logger that also supports `fork` for child wide events, so background work runs under its own wide event. See [Wide events — After emit](/learn/wide-events#after-emit-sealing-and-background-work).
+`useLogger()` returns a logger that also supports `fork` for child wide events, so background work runs under its own wide event. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [server/services/user.ts]
 import { useLogger } from 'evlog/orpc'

--- a/apps/docs/content/4.integrate/frameworks/16.aws-lambda.md
+++ b/apps/docs/content/4.integrate/frameworks/16.aws-lambda.md
@@ -37,7 +37,7 @@ Lambda **execution environments are reused**: the same process can handle many i
 
 **Do this:** `initLogger()` once at the top level (configuration only), and **`createLogger()` inside the handler** (or inside the loop over SQS records) for each unit of work.
 
-**Dependency injection** (passing `log` into functions) is optional—it helps tests and clarity—but what matters is **one logger per invocation**, not whether you use DI.
+**Dependency injection** (passing `log` into functions) is optional, it helps tests and clarity, but what matters is **one logger per invocation**, not whether you use DI.
 
 ## Quick Start
 
@@ -94,7 +94,7 @@ If you process the whole batch as one logical unit, use a **single** `createLogg
 
 ## Stdout and `silent`
 
-Many teams ingest Lambda logs from **CloudWatch** via stdout. If you use a **drain adapter** (OTLP, Datadog, Axiom, etc.) and want JSON or platform-specific formatting without duplicate console noise, set `silent: true` in production—see [Configuration](/reference/configuration#silent-mode).
+Many teams ingest Lambda logs from **CloudWatch** via stdout. If you use a **drain adapter** (OTLP, Datadog, Axiom, etc.) and want JSON or platform-specific formatting without duplicate console noise, set `silent: true` in production. See [Configuration](/reference/configuration#silent-mode).
 
 ```typescript [src/handler.ts]
 import { createAxiomDrain } from 'evlog/axiom'
@@ -113,7 +113,7 @@ If `silent` is enabled without a `drain`, events may not be visible anywhere. Se
 
 ## Error handling
 
-Use `createError` where you want structured fields (`why`, `fix`, `link`). Map failures to your Lambda return or rethrow so SQS retry/DLQ behavior stays correct—evlog does not replace AWS error semantics.
+Use `createError` where you want structured fields (`why`, `fix`, `link`). Map failures to your Lambda return or rethrow so SQS retry/DLQ behavior stays correct. evlog does not replace AWS error semantics.
 
 ```typescript [src/handler.ts]
 import { createError } from 'evlog'

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1509,6 +1509,6 @@ Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
 
 Made by [@HugoRCD](https://github.com/HugoRCD)


### PR DESCRIPTION
Every `critical` in the corpus, which is five findings across four files.

## A sample that cannot run

`1.start/2.why-evlog.md` is the page a reader hits before they have installed anything, and its drain example imports from entry points that do not exist:

```diff
- import { createAxiomDrain } from 'evlog/adapters/axiom'
- import { createSentryDrain } from 'evlog/adapters/sentry'
+ import { createAxiomDrain } from 'evlog/axiom'
+ import { createSentryDrain } from 'evlog/sentry'
```

`package.json#exports` has `./axiom` and `./sentry`. A reader pasting this gets a resolution error on the first thing they try.

## Three dead links

- `/learn/pipeline` on the Loki and ClickHouse pages. The page is `/extend/drain-pipeline`; there is no redirect, so both were 404s.
- `./LICENSE` in `packages/evlog/README.md`. The file is at the repository root, so the link resolves from the root README (a symlink) and 404s from the package one, which is the copy npm and GitHub show.

Checked for the same defects elsewhere: no other page imports `evlog/adapters/*` and no other page links `/learn/pipeline`.

## Checks

`evlog-docs` lint passes. The corpus now has zero critical findings. No changeset: the README change is a link, not behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated integration guidance and examples with current adapter import paths and navigation links.
  - Clarified adapter capabilities and configuration details, including Axiom indexing, Better Stack queries, and Datadog trace correlation.
  - Refined framework integration instructions for background work, async context, drains, and post-emission behavior.
  - Improved punctuation, wording, formatting, and link titles across adapter and framework documentation.
  - Updated the README license link to the repository license page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->