### PR TITLE
docs: give every dash in the corpus the mark its sentence needed

### DIFF
--- a/.agents/skills/create-adapter/SKILL.md
+++ b/.agents/skills/create-adapter/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new built-in evlog adapter to send wide events to an exter
 
 # Create evlog Adapter
 
-Add a new built-in adapter to evlog. Every adapter follows the same architecture and is built on the public toolkit primitives in `evlog/toolkit` — so a community adapter has the same shape as a built-in one.
+Add a new built-in adapter to evlog. Every adapter follows the same architecture and is built on the public toolkit primitives in `evlog/toolkit`, so a community adapter has the same shape as a built-in one.
 
 ## PR Title
 
@@ -13,7 +13,7 @@ Add a new built-in adapter to evlog. Every adapter follows the same architecture
 feat({name}): add the {Name} drain adapter
 ```
 
-Recent examples: `feat(loki): add the Grafana Loki drain adapter`, `feat(clickhouse): add the ClickHouse drain adapter`. Use the adapter name as the conventional-commit scope — and register that scope (see touchpoint 11).
+Recent examples: `feat(loki): add the Grafana Loki drain adapter`, `feat(clickhouse): add the ClickHouse drain adapter`. Use the adapter name as the conventional-commit scope, and register that scope (see touchpoint 11).
 
 **Scope timing caveat**: the semantic PR check reads its scope list from the **base branch**, so a brand-new scope can't validate the very PR that introduces it. Either register the scope in a small preceding PR (the Loki/ClickHouse pattern), or use an unscoped title (`feat: add the {Name} drain adapter`) on the introducing PR.
 
@@ -55,7 +55,7 @@ Standard option naming (use these exact names):
 | Request timeout (ms) | `timeout` |
 | Retry attempts on transient failures | `retries` |
 
-If a service historically used a different name (`token`, `sourceToken`, …) keep it as a deprecated alias via `applyDeprecatedAlias` — see Axiom and Better Stack for the pattern.
+If a service historically used a different name (`token`, `sourceToken`, …) keep it as a deprecated alias via `applyDeprecatedAlias`. See Axiom and Better Stack for the pattern.
 
 ## Step 1: Adapter Source — built on `defineHttpDrain`
 
@@ -87,7 +87,7 @@ Follow the existing ordering in that file.
 
 ## Step 3: Package Exports
 
-In `packages/evlog/package.json`, add two entries (after the last adapter — check the current list rather than assuming):
+In `packages/evlog/package.json`, add two entries (after the last adapter, and check the current list rather than assuming):
 
 **In `exports`**:
 
@@ -106,7 +106,7 @@ In `packages/evlog/package.json`, add two entries (after the last adapter — ch
 ]
 ```
 
-Any export added to `package.json` without a matching `tsdown.config.ts` entry (and vice versa) fails `test/toolkit/api-surface.test.ts` — that's touchpoint 6.
+Any export added to `package.json` without a matching `tsdown.config.ts` entry (and vice versa) fails `test/toolkit/api-surface.test.ts`, which is touchpoint 6.
 
 ## Step 4: Unit Tests
 
@@ -143,7 +143,7 @@ See the Loki and ClickHouse setups as references.
 
 ## Step 6: Adapter Documentation Page
 
-Read `apps/docs/AGENTS.md` before touching anything under `apps/docs/` (steps 6–8).
+Read `apps/docs/AGENTS.md` before touching anything under `apps/docs/` (steps 6 to 8).
 
 Adapter docs live in three categories under `apps/docs/content/4.integrate/adapters/`:
 

--- a/.agents/skills/create-enricher/SKILL.md
+++ b/.agents/skills/create-enricher/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new built-in evlog enricher to add derived context to wide
 
 # Create evlog Enricher
 
-Add a new built-in enricher to evlog. Every enricher is built on the public toolkit primitive `defineEnricher` from `evlog/toolkit` — so a community enricher has the same shape as a built-in one.
+Add a new built-in enricher to evlog. Every enricher is built on the public toolkit primitive `defineEnricher` from `evlog/toolkit`, so a community enricher has the same shape as a built-in one.
 
 ## PR Title
 
@@ -31,7 +31,7 @@ Enrichers live in the core package surface (`evlog/enrichers`), so use the `core
 
 ### Should it join `createDefaultEnrichers()`?
 
-`createDefaultEnrichers()` composes user agent, geo, request size, and trace context via `composeEnrichers` (from `../shared/compose`). Add the new enricher to the composition only if it is universally applicable and reads nothing but the request (headers/env) — anything requiring service-specific setup or extra cost stays opt-in. Changing the default composition is a behavior change for every existing `createDefaultEnrichers()` user: call it out explicitly in the changeset.
+`createDefaultEnrichers()` composes user agent, geo, request size, and trace context via `composeEnrichers` (from `../shared/compose`). Add the new enricher to the composition only if it is universally applicable and reads nothing but the request (headers/env). Anything requiring service-specific setup or extra cost stays opt-in. Changing the default composition is a behavior change for every existing `createDefaultEnrichers()` user: call it out explicitly in the changeset.
 
 ## Naming Conventions
 
@@ -115,7 +115,7 @@ interface {Name}Info {
 
 3. If the enricher joined the default composition, update the "All built-in enrichers" section text listing what `createDefaultEnrichers()` composes.
 
-Custom-enricher authoring docs live separately at `apps/docs/content/6.extend/5.custom-enrichers.md` — no change needed there unless the toolkit contract itself changed.
+Custom-enricher authoring docs live separately at `apps/docs/content/6.extend/5.custom-enrichers.md`, with no change needed there unless the toolkit contract itself changed.
 
 ## Step 4: Update the Public Skill
 

--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new evlog framework integration to add automatic wide-even
 
 # Create evlog Framework Integration
 
-Add a new framework integration to evlog. The recommended path is the **manifest mode** built on `defineFrameworkIntegration` from `evlog/toolkit` — for any framework with a request/response middleware shape. For frameworks with a fundamentally different lifecycle you'll fall back to the lower-level `createMiddlewareLogger`.
+Add a new framework integration to evlog. The recommended path is the **manifest mode** built on `defineFrameworkIntegration` from `evlog/toolkit`, for any framework with a request/response middleware shape. For frameworks with a fundamentally different lifecycle you'll fall back to the lower-level `createMiddlewareLogger`.
 
 ## Two paths
 
@@ -200,7 +200,7 @@ Exports without matching `tsdown.config.ts` entries fail `test/toolkit/api-surfa
 
 ## Step 4: Tests
 
-Create `packages/evlog/test/frameworks/{framework}.test.ts`. Read `packages/evlog/test/README.md` first — especially the **Framework runtime fidelity** table.
+Create `packages/evlog/test/frameworks/{framework}.test.ts`. Read `packages/evlog/test/README.md` first, especially the **Framework runtime fidelity** table.
 
 Two non-negotiables:
 
@@ -300,11 +300,11 @@ In `packages/evlog/README.md` (root `README.md` is a symlink):
 1. Add a `## {Framework}` section near the other framework sections with a minimal setup snippet and a link to the example app
 2. Add a row to the **Framework Support** table
 
-Keep the snippet short — init, register middleware, one route handler showing logger access.
+Keep the snippet short: init, register middleware, one route handler showing logger access.
 
 ## Step 11: Example App
 
-Create `examples/{framework}/` with a runnable app demonstrating all evlog features. It is auto-discovered by the root runner: `pnpm example {framework}` (which loads the root `.env` via dotenv — no root `package.json` change needed).
+Create `examples/{framework}/` with a runnable app demonstrating all evlog features. It is auto-discovered by the root runner: `pnpm example {framework}` (which loads the root `.env` via dotenv, so no root `package.json` change is needed).
 
 The app must include:
 
@@ -315,13 +315,13 @@ The app must include:
 5. **Error handler** — framework's error handler with `parseError()` + manual `log.error()`
 6. **Test UI** — served at `/`, a self-contained HTML page with buttons to hit each route and display JSON responses
 
-**Drain must use PostHog** (`createPostHogDrain()` from `evlog/posthog`) — `POSTHOG_API_KEY` is set in the root `.env` (maintainer's key, not committed), so every example exercises a real external drain. Without the env var the drain resolves to `null` and skips — someone cloning the repo sends nothing anywhere unless they opt in with their own key. Enable pretty printing for readable local output.
+**Drain must use PostHog** (`createPostHogDrain()` from `evlog/posthog`). `POSTHOG_API_KEY` is set in the root `.env` (maintainer's key, not committed), so every example exercises a real external drain. Without the env var the drain resolves to `null` and skips, so someone cloning the repo sends nothing anywhere unless they opt in with their own key. Enable pretty printing for readable local output.
 
-**Type the `enrich` callback parameter explicitly** — `(ctx: EnrichContext) => ...` with `type EnrichContext` imported from `evlog`.
+**Type the `enrich` callback parameter explicitly**, as `(ctx: EnrichContext) => ...` with `type EnrichContext` imported from `evlog`.
 
 ### Test UI
 
-Reference: `examples/hono/src/ui.ts` — a single `src/ui.ts` exporting `testUI()` returning a self-contained dark-theme HTML string (route list with method badges, click-to-fetch, JSON display, status colors, response time). Register the `/` route **before** the evlog middleware so it isn't logged.
+Reference: `examples/hono/src/ui.ts`, a single `src/ui.ts` exporting `testUI()` returning a self-contained dark-theme HTML string (route list with method badges, click-to-fetch, JSON display, status colors, response time). Register the `/` route **before** the evlog middleware so it isn't logged.
 
 ### Required files
 
@@ -333,7 +333,7 @@ Reference: `examples/hono/src/ui.ts` — a single `src/ui.ts` exporting `testUI(
 | `tsconfig.json` | TypeScript config (if needed) |
 | `README.md` | How to run + link to the UI |
 
-There is also `examples/community-framework-skeleton/` showing the community-facing (toolkit-only) variant — keep it in mind if the new integration changes the toolkit contract.
+There is also `examples/community-framework-skeleton/` showing the community-facing (toolkit-only) variant, so keep it in mind if the new integration changes the toolkit contract.
 
 ## Step 12: Changeset
 

--- a/.agents/skills/create-map-rule/SKILL.md
+++ b/.agents/skills/create-map-rule/SKILL.md
@@ -16,7 +16,7 @@ Extend the coverage scanner in `@evlog/cli`. Two kinds of extension:
 feat(cli): add the {id} map rule
 ```
 
-The `cli` scope already exists — no scope registration needed.
+The `cli` scope already exists, so no scope registration is needed.
 
 ## Requirement or opportunity? Decide first
 
@@ -95,7 +95,7 @@ Key rules:
 
 ## Step 2–3: Registry + CheckId
 
-Add the import and one `REGISTRY` line in `rules/index.ts` (report order matters — requirements before opportunities, heaviest first), and the id to the `CheckId` union in `types.ts`. The `AssertIdsMatch` type in `index.ts` fails the build if you forget either side.
+Add the import and one `REGISTRY` line in `rules/index.ts` (report order matters: requirements before opportunities, heaviest first), and the id to the `CheckId` union in `types.ts`. The `AssertIdsMatch` type in `index.ts` fails the build if you forget either side.
 
 ## Step 4: Tests
 
@@ -114,7 +114,7 @@ Run: `pnpm --filter @evlog/cli exec vitest run test/map/rules.test.ts`
 
 ## Step 5–6: Docs
 
-Read `apps/docs/AGENTS.md` before touching anything under `apps/docs/`. Then in `apps/docs/content/3.cli/3.rules.md`: add the row (column title, id, weight/fires-when, expects) and a `### {title} — {question}` section following the existing ones — what it checks, what passes, what fails, the suggested shape. Requirements with a weight also touch the scoring narrative in `4.scoring.md`.
+Read `apps/docs/AGENTS.md` before touching anything under `apps/docs/`. Then in `apps/docs/content/3.cli/3.rules.md`: add the row (column title, id, weight/fires-when, expects) and a `### {title} — {question}` section following the existing ones, covering what it checks, what passes, what fails, the suggested shape. Requirements with a weight also touch the scoring narrative in `4.scoring.md`.
 
 ## Step 7: Published Skill
 
@@ -138,7 +138,7 @@ Then sanity-check on a real project: `pnpm cli map --no-write` from an example a
 
 ## Variant: New Framework Adapter
 
-Teaching `evlog map` a new framework is a different, heavier change — the adapter owns route discovery and framework capabilities.
+Teaching `evlog map` a new framework is a different, heavier change: the adapter owns route discovery and framework capabilities.
 
 | # | File | Action |
 |---|------|--------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ scripts/                   Repo tooling (run-app, cli-sandbox, release-notes, co
 - **Bump type:** `patch` for fixes, `minor` for features, `major` for breaking changes.
 - **Description:** write from the consumer's perspective — what changed and how to use it. See existing changesets in `.changeset/` for tone and level of detail.
 
-A PR without a changeset for a user-facing change will not be merged. Changes confined to `apps/*` or `examples/*` — docs included — never need one. For the rare published-package change that genuinely needs no release note, run `pnpm changeset add --empty`.
+A PR without a changeset for a user-facing change will not be merged. Changes confined to `apps/*` or `examples/*`, docs included, never need one. For the rare published-package change that genuinely needs no release note, run `pnpm changeset add --empty`.
 
 ### Commits & PR titles
 
@@ -101,11 +101,11 @@ PR titles and commits follow [Conventional Commits](https://conventionalcommits.
 
 ### Docs app
 
-Working in `apps/docs/`? Read `apps/docs/AGENTS.md` first — it has the (strict) rules for MDC animation components.
+Working in `apps/docs/`? Read `apps/docs/AGENTS.md` first. It has the (strict) rules for MDC animation components.
 
 ## Testing
 
-Tests live in `packages/evlog/test/` (mirrors `src/`) and use Vitest. **Read `packages/evlog/test/README.md` before writing or editing tests** — it has the file layout, the framework runtime fidelity matrix, and the helper decision table.
+Tests live in `packages/evlog/test/` (mirrors `src/`) and use Vitest. **Read `packages/evlog/test/README.md` before writing or editing tests**. It has the file layout, the framework runtime fidelity matrix, and the helper decision table.
 
 ```bash
 pnpm run test                                          # full suite (~1.5s)
@@ -116,7 +116,7 @@ pnpm mutate                                            # Stryker (slow; weekly c
 pnpm test:e2e                                          # adapters vs real endpoints (needs pnpm sandbox:up first — Docker Loki/ClickHouse; sandbox:down to clean up)
 ```
 
-> CI typecheck excludes `evlog-telemetry` (`--filter='!evlog-telemetry'`), so local `pnpm run typecheck` is stricter than CI — a local pass is the real bar.
+> CI typecheck excludes `evlog-telemetry` (`--filter='!evlog-telemetry'`), so local `pnpm run typecheck` is stricter than CI, and a local pass is the real bar.
 
 Rules:
 1. Every change has a matching test. Bug fixes require a *failing* regression test before the fix.
@@ -161,7 +161,7 @@ A task is complete when **all** of the following pass:
 
 ## Git & PRs — local always OK, remote on explicit instruction
 
-Default: anything that stays on the local clone is fine, anything that touches the remote or GitHub requires an explicit instruction in the task at hand. Never act on assumption — if the maintainer didn't ask for a push or a PR, prepare the branch locally and stop there.
+Default: anything that stays on the local clone is fine, anything that touches the remote or GitHub requires an explicit instruction in the task at hand. Never act on assumption. If the maintainer didn't ask for a push or a PR, prepare the branch locally and stop there.
 
 **OK (local-only, no ask needed):**
 - `git branch`, `git checkout`, `git switch`, `git checkout -b` — create and move between branches freely
@@ -188,11 +188,11 @@ Default: anything that stays on the local clone is fine, anything that touches t
 
 ## Feedback & Self-Maintenance
 
-**You are expected to submit feedback.** Report DX friction, documentation gaps, or anything that made your task harder than it should be — mid-work, not at the end. When in doubt, report it; no feedback being submitted is itself a problem.
+**You are expected to submit feedback.** Report DX friction, documentation gaps, or anything that made your task harder than it should be, mid-work rather than at the end. When in doubt, report it; no feedback being submitted is itself a problem.
 
-**This file is living documentation — keep it true.** If you catch it contradicting the repo (a command that doesn't exist, a path that moved, a described workflow that isn't real), flag it immediately and propose the fix, even if it's unrelated to your task. Update it when you encounter:
+**This file is living documentation, so keep it true.** If you catch it contradicting the repo (a command that doesn't exist, a path that moved, a described workflow that isn't real), flag it immediately and propose the fix, even if it's unrelated to your task. Update it when you encounter:
 - A recurring mistake or easy-to-get-wrong pattern
 - Explicit guidance from the maintainer
 - A new convention that should be applied consistently
 
-Rules for updating: a correction is a few lines, not a rewrite — keep this file lean. App- or package-specific guidance goes in a nested `AGENTS.md` next to the code (see `apps/docs/AGENTS.md`), not here.
+Rules for updating: a correction is a few lines, not a rewrite. Keep this file lean. App- or package-specific guidance goes in a nested `AGENTS.md` next to the code (see `apps/docs/AGENTS.md`), not here.

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # evlog docs (Docus site)
 
-Read the root `AGENTS.md` first — this file only adds docs-specific rules.
+Read the root `AGENTS.md` first. This file only adds docs-specific rules.
 
 ## Nuxt UI components in MDC
 

--- a/apps/docs/content/0.landing.md
+++ b/apps/docs/content/0.landing.md
@@ -9,7 +9,7 @@ navigation: false
 Digging through logs :br is not observability. :br It's hope
 
 #description
-A modern TypeScript logger built for everything you ship. Simple logs, wide events, and structured errors — one API, every context.
+A modern TypeScript logger built for everything you ship. Simple logs, wide events, and structured errors: one API, every context.
 ::
 
 ::landing-logos
@@ -59,7 +59,7 @@ A modern TypeScript logger built for everything you ship. Simple logs, wide even
   One command. :br Every blind spot
 
   #description
-  The first time most teams learn a handler logs nothing is mid-incident. Think Lighthouse, but for observability: a score for the context your app will give you when it breaks, and the exact list of fixes to raise it — before it matters.
+  The first time most teams learn a handler logs nothing is mid-incident. Think Lighthouse, but for observability: a score for the context your app will give you when it breaks, and the exact list of fixes to raise it, before it matters.
   :::
 
   :::features-feature-adapters
@@ -119,7 +119,7 @@ A modern TypeScript logger built for everything you ship. Simple logs, wide even
   Compliance-ready :br by composition
 
   #description
-  First-class who-did-what trails as a thin layer on top of wide events. One enricher, one drain wrapper, one helper. Tamper-evident hash chains, denied actions, redact-aware diffs, idempotency keys for safe retries, and typed action catalogs for refactor-safe alerting — all from the main entrypoint, no parallel pipeline.
+  First-class who-did-what trails as a thin layer on top of wide events. One enricher, one drain wrapper, one helper. Tamper-evident hash chains, denied actions, redact-aware diffs, idempotency keys for safe retries, and typed action catalogs for refactor-safe alerting, all from the main entrypoint, no parallel pipeline.
   :::
 
   :::features-feature-ai-sdk

--- a/apps/docs/content/1.start/1.introduction.md
+++ b/apps/docs/content/1.start/1.introduction.md
@@ -17,9 +17,9 @@ links:
     variant: subtle
 ---
 
-**evlog** is a modern TypeScript logger built for everything you ship. It gives you simple structured logs (a drop-in for `console.log`, pino, or consola), wide events that accumulate context across an operation, and structured errors that explain why they happened — all in one API, all behind the same drain pipeline. Use it in CLIs, libraries, background jobs, edge workers, and HTTP handlers without switching loggers.
+**evlog** is a modern TypeScript logger built for everything you ship. It gives you simple structured logs (a drop-in for `console.log`, pino, or consola), wide events that accumulate context across an operation, and structured errors that explain why they happened, all in one API, all behind the same drain pipeline. Use it in CLIs, libraries, background jobs, edge workers, and HTTP handlers without switching loggers.
 
-Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x.com/boristane). When you want a static score of which entry points can tell you what went wrong, try the separate [`@evlog/cli`](/cli/overview) (`evlog map`) — early, no config, one command.
+Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x.com/boristane). When you want a static score of which entry points can tell you what went wrong, try the separate [`@evlog/cli`](/cli/overview) (`evlog map`): early, no config, one command.
 
 ## Philosophy
 
@@ -41,7 +41,7 @@ Traditional logging is broken. Your logs are scattered across dozens of files. E
   icon: i-lucide-layers
   title: Wide Events
   ---
-  Accumulate context over any unit of work (a request, script, or job) and emit once. The two modes coexist — neither is an upgrade of the other.
+  Accumulate context over any unit of work (a request, script, or job) and emit once. The two modes coexist, and neither is an upgrade of the other.
   :::
 
   :::card

--- a/apps/docs/content/1.start/2.why-evlog.md
+++ b/apps/docs/content/1.start/2.why-evlog.md
@@ -21,15 +21,15 @@ links:
     variant: subtle
 ---
 
-The cheapest moment to add structured logging is **before the first request**. By the time you have 200 routes, 40 background jobs, and a `console.log` per file, you're paying interest on a decision you never made. evlog is designed for the day-zero choice — pick it once, and the rest of the system inherits structured logs, structured errors, typed catalogs, AI SDK telemetry, an audit trail, and a drain pipeline you don't have to build later.
+The cheapest moment to add structured logging is **before the first request**. By the time you have 200 routes, 40 background jobs, and a `console.log` per file, you're paying interest on a decision you never made. evlog is designed for the day-zero choice: pick it once, and the rest of the system inherits structured logs, structured errors, typed catalogs, AI SDK telemetry, an audit trail, and a drain pipeline you don't have to build later.
 
 ::callout{icon="i-lucide-arrow-right" color="neutral"}
-Already shipping with `console.log` or pino? evlog still wins, but the case is different — see [evlog vs pino, winston, consola](/reference/vs-other-loggers).
+Already shipping with `console.log` or pino? evlog still wins, but the case is different. See [evlog vs pino, winston, consola](/reference/vs-other-loggers).
 ::
 
 ## What you get from day one
 
-evlog isn't a small primitive you wrap. It's a single dependency that comes with a structured surface, an ecosystem of integrations, and an opinionated drain pipeline — all on by default.
+evlog isn't a small primitive you wrap. It's a single dependency that comes with a structured surface, an ecosystem of integrations, and an opinionated drain pipeline, all on by default.
 
 ### Logging primitives
 
@@ -55,7 +55,7 @@ evlog isn't a small primitive you wrap. It's a single dependency that comes with
   icon: i-lucide-layers
   title: Wide events
   ---
-  Accumulate context across an operation and emit one typed event when it ends — the observability pattern that makes requests, jobs, and workflows queryable end-to-end. See [Wide Events](/learn/wide-events).
+  Accumulate context across an operation and emit one typed event when it ends, the observability pattern that makes requests, jobs, and workflows queryable end-to-end. See [Wide Events](/learn/wide-events).
   :::
 
   :::card
@@ -79,25 +79,25 @@ evlog isn't a small primitive you wrap. It's a single dependency that comes with
   icon: i-lucide-database
   title: Drain pipeline
   ---
-  Built-in batching, retry with exponential backoff, fan-out to multiple destinations. No transport glue to write yourself.
+  Built-in batching, retry with exponential backoff, fan-out to multiple destinations. No drain plumbing to write yourself.
   :::
 ::
 
 ### Beyond the logger
 
-The primitives are table stakes — every modern logger has some flavour of them. Where evlog earns its place on day 1 is everything wired around them, for problems you haven't had yet.
+The primitives are table stakes, and every modern logger has some flavour of them. Where evlog earns its place on day 1 is everything wired around them, for problems you haven't had yet.
 
-**Imagine you add AI to your app.** Sooner or later you wire the Vercel AI SDK into a route. Token costs surprise you, a model hangs mid-stream, a tool returns garbage. With the [AI SDK integration](/use-cases/ai-sdk/overview), every model call becomes a wide event with prompt, tools, tokens, latency, and cost — automatically. And if you're using [Better Auth](/use-cases/better-auth/overview), evlog ties the actor identity to those events for you, so you can answer "which user just burned $14 in a single conversation?" without writing a line of plumbing.
+**Imagine you add AI to your app.** Sooner or later you wire the Vercel AI SDK into a route. Token costs surprise you, a model hangs mid-stream, a tool returns garbage. With the [AI SDK integration](/use-cases/ai-sdk/overview), every model call becomes a wide event with prompt, tools, tokens, latency, and cost, automatically. And if you're using [Better Auth](/use-cases/better-auth/overview), evlog ties the actor identity to those events for you, so you can answer "which user just burned $14 in a single conversation?" without writing a line of plumbing.
 
-**Imagine your stack spans more than one framework.** A Nuxt frontend, a Hono internal service, an AWS Lambda webhook — most teams end up with this kind of mix. evlog has [13+ framework integrations](/integrate/frameworks/overview) and each one exposes the same logging primitives (`useLogger`, `log.set`, `createError`). The handlers themselves stay framework-shaped — that part is on you — but you don't relearn a logger every time you cross a runtime, and the drain pipeline behind them stays the same.
+**Imagine your stack spans more than one framework.** A Nuxt frontend, a Hono internal service, an AWS Lambda webhook: most teams end up with this kind of mix. evlog has [13+ framework integrations](/integrate/frameworks/overview) and each one exposes the same logging primitives (`useLogger`, `log.set`, `createError`). The handlers themselves stay framework-shaped, and that part is on you, but you don't relearn a logger every time you cross a runtime, and the drain pipeline behind them stays the same.
 
-**Imagine you want noisier logs in dev than in production.** During local development you sprinkle `log.debug` calls — full request bodies, every retry, every guard — to actually see what's happening. None of that should ship. The [Vite plugin](/reference/vite-plugin) strips selected log levels at build time, so dev has the verbose context you want and production stays clean. As a bonus, every surviving call gets its source location (`file.ts:42`) injected automatically, so when an event lands in your dashboard you know exactly which line emitted it.
+**Imagine you want noisier logs in dev than in production.** During local development you sprinkle `log.debug` calls (full request bodies, every retry, every guard) to actually see what's happening. None of that should ship. The [Vite plugin](/reference/vite-plugin) strips selected log levels at build time, so dev has the verbose context you want and production stays clean. As a bonus, every surviving call gets its source location (`file.ts:42`) injected automatically, so when an event lands in your dashboard you know exactly which line emitted it.
 
-**Imagine a user reports a bug from their browser.** The error happened in their session, deep inside a fetch you can't reproduce. evlog's [browser logger](/use-cases/client-logging) ships client events to your server, where they merge into the same wide event as the rest of the request — one typed event, regardless of where the error originated. Combine it with the [built-in enrichers](/use-cases/enrichers) and you also get UA, GeoIP, and W3C trace context attached for free.
+**Imagine a user reports a bug from their browser.** The error happened in their session, deep inside a fetch you can't reproduce. evlog's [browser logger](/use-cases/client-logging) ships client events to your server, where they merge into the same wide event as the rest of the request: one typed event, regardless of where the error originated. Combine it with the [built-in enrichers](/use-cases/enrichers) and you also get UA, GeoIP, and W3C trace context attached for free.
 
-**Imagine your stack changes vendor.** You started with stdout, signed Axiom for queries, then your team wants Sentry for errors and PostHog for product analytics. With [9+ drain adapters](/integrate/adapters/overview) and built-in fan-out, those events land everywhere in parallel — the application code never moves. Self-hosting is a swap-in too, via the [filesystem](/integrate/adapters/self-hosted/fs) or [NuxtHub](/integrate/adapters/self-hosted/nuxthub) adapters.
+**Imagine your stack changes vendor.** You started with stdout, signed Axiom for queries, then your team wants Sentry for errors and PostHog for product analytics. With [9+ drain adapters](/integrate/adapters/overview) and built-in fan-out, those events land everywhere in parallel, and the application code never moves. Self-hosting is a swap-in too, via the [filesystem](/integrate/adapters/self-hosted/fs) or [NuxtHub](/integrate/adapters/self-hosted/nuxthub) adapters.
 
-None of this is a "v2 feature" — it's the same package, on the same `log` API, on day 1.
+None of this is a "v2 feature". It is the same package, on the same `log` API, on day 1.
 
 ## Catalogs grow with you
 
@@ -114,11 +114,11 @@ export const errors = defineErrorCatalog('billing', {
 
 Six months later it has thirty entries, type augmentation gives you autocomplete on `createError({ code })` everywhere, and you ship it as a private npm package across your monorepo. **Same pattern. No rewrite.**
 
-The same applies to audit catalogs (`defineAuditCatalog`) — start with one action, grow into your compliance map. See [Catalogs](/learn/catalogs).
+The same applies to audit catalogs (`defineAuditCatalog`): start with one action, grow into your compliance map. See [Catalogs](/learn/catalogs).
 
 ## Built for the AI-coding-agent era
 
-More and more applications are built with AI coding agents — Cursor, Codex, Claude Code, Copilot. They're good at writing handlers; they're worse at debugging them. **What they need is context.**
+More and more applications are built with AI coding agents: Cursor, Codex, Claude Code, Copilot. They're good at writing handlers; they're worse at debugging them. **What they need is context.**
 
 - **Structured errors with `why` / `fix` / `link`.** A vague `Error: failed` is opaque; `createError({ message, why, fix, link })` is something an agent can read, summarise, or surface to the user without you wiring a translation layer.
 - **Wide events as a single source of truth per request.** One typed event the agent can reason about end-to-end — not log lines to grep across.
@@ -137,15 +137,15 @@ Every product eventually meets one of: GDPR data-export requests, SOC 2 readines
 1. **The day-1000 way.** Stand up a parallel system. Decide on a schema. Backfill what you can. Reverse-engineer actor identity from request headers. Ship under deadline pressure. Hope nothing was missed.
 2. **The day-0 way.** Add `auditEnricher()` and call `log.audit({ action, actor, target })` from any handler that touches state. evlog ships hash-chain integrity, retention, and force-keep past sampling — on top of the wide events you were already emitting.
 
-evlog's audit layer is **not a parallel system** — it's the same `log` you already use, with a reserved `audit` field. See [Audit Logs](/use-cases/audit/overview).
+evlog's audit layer is **not a parallel system**. It is the same `log` you already use, with a reserved `audit` field. See [Audit Logs](/use-cases/audit/overview).
 
 ::callout{icon="i-lucide-shield-check" color="success"}
-Teams in regulated verticals — fintech, healthtech, B2B SaaS — should treat day-0 audit logging as table stakes, not a v2 feature.
+Teams in regulated verticals (fintech, healthtech, B2B SaaS) should treat day-0 audit logging as table stakes, not a v2 feature.
 ::
 
 ## Drain-agnostic from day one
 
-Your application code never depends on a vendor — it emits to the drain pipeline. On day 0 that's stdout in dev and a [filesystem drain](/integrate/adapters/self-hosted/fs) in CI. The day you decide to query logs:
+Your application code never depends on a vendor. It emits to the drain pipeline. On day 0 that's stdout in dev and a [filesystem drain](/integrate/adapters/self-hosted/fs) in CI. The day you decide to query logs:
 
 ```typescript [nuxt.config.ts]
 import { createAxiomDrain } from 'evlog/axiom'
@@ -163,7 +163,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Zero handler changes. The same events land in [Axiom](/integrate/adapters/cloud/axiom), [Datadog](/integrate/adapters/cloud/datadog), [PostHog](/integrate/adapters/cloud/posthog), [Sentry](/integrate/adapters/cloud/sentry), [Better Stack](/integrate/adapters/cloud/better-stack), [HyperDX](/integrate/adapters/hybrid/hyperdx), or [OTLP](/integrate/adapters/hybrid/otlp) — or all of them, with [fan-out](/integrate/adapters/overview).
+Zero handler changes. The same events land in [Axiom](/integrate/adapters/cloud/axiom), [Datadog](/integrate/adapters/cloud/datadog), [PostHog](/integrate/adapters/cloud/posthog), [Sentry](/integrate/adapters/cloud/sentry), [Better Stack](/integrate/adapters/cloud/better-stack), [HyperDX](/integrate/adapters/hybrid/hyperdx), or [OTLP](/integrate/adapters/hybrid/otlp), or all of them, with [fan-out](/integrate/adapters/overview).
 
 ## What "later" actually costs
 
@@ -174,7 +174,7 @@ When teams ship with `console.log` and decide to add proper logging "when we nee
 - **Choosing a drain under pressure.** Picking Datadog vs Axiom vs Sentry while you're already on fire is the worst time to evaluate vendors.
 - **Adding actionable error context retroactively.** Every `throw new Error('failed')` you wrote is one less `why`, one less `fix`, one less link your on-call (or your AI agent) can use.
 
-evlog removes the "later" entirely — the structured surface, the wide event lifecycle, and the drain pipeline are all there from day 1.
+evlog removes the "later" entirely: the structured surface, the wide event lifecycle, and the drain pipeline are all there from day 1.
 
 | Decision day | Cost to adopt evlog |
 |--------------|---------------------|

--- a/apps/docs/content/1.start/3.installation.md
+++ b/apps/docs/content/1.start/3.installation.md
@@ -65,7 +65,7 @@ npx skills add https://www.evlog.dev
 Your AI assistant can then help you set up evlog, review your logging patterns, and migrate existing code to wide events. See [Agent Skills](/reference/agent-skills) for details.
 
 ::callout{icon="i-lucide-radar" color="neutral"}
-**Try `@evlog/cli`.** Separate package, early days — but one command scores which entry points are still dark. No install required:
+**Try `@evlog/cli`.** Separate package, early days, but one command scores which entry points are still dark. No install required:
 
 ```bash
 npx @evlog/cli map

--- a/apps/docs/content/1.start/4.quick-start.md
+++ b/apps/docs/content/1.start/4.quick-start.md
@@ -309,7 +309,7 @@ export function useAnalytics() {
 ::
 
 ::callout{icon="i-lucide-arrow-right" color="neutral"}
-See [Client Logging](/use-cases/client-logging) for transport configuration, identity context, and browser drain setup.
+See [Client Logging](/use-cases/client-logging) for drain configuration, identity context, and browser setup.
 ::
 
 ## Next Steps

--- a/apps/docs/content/2.learn/0.overview.md
+++ b/apps/docs/content/2.learn/0.overview.md
@@ -27,7 +27,7 @@ This section is the **mental model** of evlog. By the end, you'll know exactly w
 If you're new, read it in order. If you've already shipped with evlog, jump to the page that matches your question.
 
 ::callout{icon="i-lucide-info" color="info"}
-All three modes coexist in the same logger. Pick per call — there's no upgrade path, no advanced mode, no toggle to flip. Same drains, same redaction, same types underneath.
+All three modes coexist in the same logger. Pick per call. There is no upgrade path, no advanced mode, no toggle to flip. Same drains, same redaction, same types underneath.
 ::
 
 ::callout{icon="i-lucide-globe" color="neutral"}
@@ -44,7 +44,7 @@ Not running an HTTP framework? See [Standalone TypeScript](/integrate/frameworks
   to: /learn/simple-logging
   color: neutral
   ---
-  A fully-featured general-purpose logger. Replaces `console.log`, consola, pino, or winston with `log.info`, `log.error`, `log.warn`, `log.debug` — same level filtering, drain pipeline, redaction, and pretty/JSON output.
+  A fully-featured general-purpose logger. Replaces `console.log`, consola, pino, or winston with `log.info`, `log.error`, `log.warn`, `log.debug`, with the same level filtering, drain pipeline, redaction, and pretty/JSON output.
   :::
 
   :::card
@@ -150,7 +150,7 @@ export default defineEventHandler(async (event) => {
 | **Shared workspace package** | Treat it like a library — see [Standalone](/integrate/frameworks/standalone) | Host app owns `initLogger` / drain; packages use `createLogger` or accept a logger |
 
 ::callout{icon="i-lucide-lightbulb" color="info"}
-None of these is an "upgrade" of another. Use `log` and `createLogger` in the same file when it makes sense — they share the global drain, redaction, and types.
+None of these is an "upgrade" of another. Use `log` and `createLogger` in the same file when it makes sense, since they share the global drain, redaction, and types.
 ::
 
 ## Shared foundation
@@ -175,4 +175,4 @@ After the three modes, the rest of Learn covers the concepts that show up across
 - [Typed Fields](/learn/typed-fields) — augment `RequestLogger` so `log.set` is autocompleted
 - [Redaction](/learn/redaction) — the rules that strip `authorization`, `password`, `token`, etc. before drain
 
-When you're done with Learn, head to [Integrate](/integrate/frameworks/overview) to wire evlog into your stack — or run [`evlog map`](/cli/map) first to see which parts of your app currently have no way of telling you what went wrong.
+When you're done with Learn, head to [Integrate](/integrate/frameworks/overview) to wire evlog into your stack, or run [`evlog map`](/cli/map) first to see which parts of your app currently have no way of telling you what went wrong.

--- a/apps/docs/content/2.learn/1.simple-logging.md
+++ b/apps/docs/content/2.learn/1.simple-logging.md
@@ -16,7 +16,7 @@ links:
     variant: subtle
 ---
 
-The `log` API is evlog's general-purpose logger. Use it the way you'd use pino, consola, or `console.log` — every call emits a structured event through the same drain pipeline as wide events. The two modes coexist; neither is an upgrade of the other.
+The `log` API is evlog's general-purpose logger. Use it the way you'd use pino, consola, or `console.log`: every call emits a structured event through the same drain pipeline as wide events. The two modes coexist; neither is an upgrade of the other.
 
 ::callout{icon="i-lucide-globe" color="neutral"}
 Looking for the same API in CLIs, libraries, jobs, and edge? Start with [Standalone TypeScript](/integrate/frameworks/standalone) and [Cloudflare Workers](/integrate/frameworks/cloudflare-workers).
@@ -206,7 +206,7 @@ console.error('[checkout] payment failed', { reason: 'card_declined' })
 
 ::
 
-All four become this — no formatter, transport, or peer-dep wiring required:
+All four become this, with no formatter, transport, or peer-dep wiring:
 
 ```typescript [After (evlog)]
 import { initLogger, log } from 'evlog'
@@ -219,7 +219,7 @@ log.warn({ event: 'inventory_low', sku: 'SKU-42' })
 log.error({ event: 'payment_failed', reason: 'card_declined' })
 ```
 
-`initLogger` is one line at boot. The drain, redaction, sampling, pretty/JSON switching, and level filtering are all wired by default — no `pino-pretty` peer dep, no winston transport assembly, no consola reporter setup.
+`initLogger` is one line at boot. The drain, redaction, sampling, pretty/JSON switching, and level filtering are all wired by default: no `pino-pretty` peer dep, no winston transport assembly, no consola reporter setup.
 
 ::callout{icon="i-lucide-arrow-right" color="neutral"}
 Want the full side-by-side (feature comparison tables, honest gaps, per-feature mapping)? See [evlog vs pino, winston, consola](/reference/vs-other-loggers).
@@ -227,7 +227,7 @@ Want the full side-by-side (feature comparison tables, honest gaps, per-feature 
 
 ## Pairing with wide events
 
-`log` and `createLogger` live inside the same logger. Use `log.*` for events that stand alone (startup messages, ad-hoc warnings, debug traces) and reach for `createLogger` when you want one event that captures an entire operation. They share the global drain, redaction, and types — pick per call.
+`log` and `createLogger` live inside the same logger. Use `log.*` for events that stand alone (startup messages, ad-hoc warnings, debug traces) and reach for `createLogger` when you want one event that captures an entire operation. They share the global drain, redaction, and types, so pick per call.
 
 ```typescript [scripts/sync-data.ts]
 import { initLogger, log, createLogger } from 'evlog'

--- a/apps/docs/content/2.learn/2.wide-events.md
+++ b/apps/docs/content/2.learn/2.wide-events.md
@@ -19,7 +19,7 @@ links:
 Wide events are the core concept behind evlog. Instead of scattering logs throughout your codebase, you accumulate context over any unit of work, whether a request, script, job, or workflow, and emit a single, comprehensive log event.
 
 ::callout{icon="i-lucide-globe" color="neutral"}
-Not running an HTTP framework? See [Standalone TypeScript](/integrate/frameworks/standalone) and [Cloudflare Workers](/integrate/frameworks/cloudflare-workers) — wide events apply just as cleanly outside of request lifecycles.
+Not running an HTTP framework? See [Standalone TypeScript](/integrate/frameworks/standalone) and [Cloudflare Workers](/integrate/frameworks/cloudflare-workers), because wide events apply just as cleanly outside of request lifecycles.
 ::
 
 ::prompt
@@ -175,18 +175,18 @@ export default defineEventHandler(async (event) => {
 
 When the wide event is **emitted** (automatically at the end of the request, or when you call `log.emit()` yourself), that logger instance is **sealed**. Further `set`, `error`, `info`, and `warn` calls do **not** update the event that was already sent to your drains. They are ignored and evlog prints a **`[evlog]` warning** to the console with the keys that were dropped. This also applies when **head sampling** discards the event (`emit()` returned `null`): the logger is still sealed for that unit of work.
 
-This matters for **async work that outlives the handler** (fire-and-forget promises, `setTimeout`, tasks started but not awaited). On many runtimes, `AsyncLocalStorage` keeps returning the same request logger, so `useLogger()` still succeeds even though the HTTP response — and the wide event — are already finished. Without warnings, that looks like silent data loss.
+This matters for **async work that outlives the handler** (fire-and-forget promises, `setTimeout`, tasks started but not awaited). On many runtimes, `AsyncLocalStorage` keeps returning the same request logger, so `useLogger()` still succeeds even though the HTTP response, and the wide event, are already finished. Without warnings, that looks like silent data loss.
 
 ### `log.fork(label, fn)`
 
-For intentional background work that should produce **its own** wide event, use **`log.fork(label, fn)`** when your integration provides it (Express, Fastify, NestJS, SvelteKit, React Router, Next.js `withEvlog`, Elysia). Inside `fn`, `useLogger()` resolves to a **child** logger. When `fn` completes (or throws), the child emits an event with:
+For intentional background work that should produce **its own** wide event, use **`log.fork(label, fn)`** when your integration provides it (Express, Fastify, NestJS, SvelteKit, React Router, Next.js `withEvlog`, Elysia). Inside `fn`, `useLogger()` resolves to the forked logger. When `fn` completes (or throws), that logger emits an event with:
 
 - **`operation`**: the `label` you passed
 - **`_parentRequestId`**: the parent request’s `requestId` (for correlation in queries and dashboards)
 
 The parent wide event may be emitted **before** the child event; they are two separate events ordered by time.
 
-**Not available yet:** Hono (no `useLogger` without `c.get('log')` + ALS) and Nitro/Nuxt `useLogger(event)` — use the post-emit warnings to catch mistakes; a different API may arrive later for event-scoped forks.
+**Not available yet:** Hono (no `useLogger` without `c.get('log')` + ALS) and Nitro/Nuxt `useLogger(event)`, so use the post-emit warnings to catch mistakes; a different API may arrive later for event-scoped forks.
 
 For AI SDK streaming responses, supported framework integrations (Next.js, Nitro/Nuxt, SvelteKit, Hono, React Router, oRPC) defer wide-event emit until the response body finishes, so `createAILogger(log)` metadata lands on the same request event automatically.
 
@@ -397,7 +397,7 @@ ERROR [checkout] POST /api/checkout 402 in 123ms
 
 ### Setting the Level Manually
 
-`log.error(err)` populates the `error` field with `{ name, message, stack }` and promotes the wide event to `level: 'error'`. When you want to control the `error` field yourself — typed error codes, no stack, or richer custom shapes — use `log.setLevel()` to promote the level without touching the context:
+`log.error(err)` populates the `error` field with `{ name, message, stack }` and promotes the wide event to `level: 'error'`. When you want to control the `error` field yourself (typed error codes, no stack, or richer custom shapes), use `log.setLevel()` to promote the level without touching the context:
 
 ```typescript
 log.setLevel('error')

--- a/apps/docs/content/2.learn/3.structured-errors.md
+++ b/apps/docs/content/2.learn/3.structured-errors.md
@@ -402,7 +402,7 @@ throw createError({
 
 ## Error Catalogs
 
-For anything beyond a handful of one-off errors, group them in a typed **catalog**. evlog ships two primitives for this — `defineError` (single factory) and `defineErrorCatalog` (bundle prefixed). The wire `code` is auto-derived as `${prefix}.${KEY}` and the `EvlogError` instance is built with all defaults applied.
+For anything beyond a handful of one-off errors, group them in a typed **catalog**. evlog ships two primitives for this: `defineError` (single factory) and `defineErrorCatalog` (bundle prefixed). The wire `code` is auto-derived as `${prefix}.${KEY}` and the `EvlogError` instance is built with all defaults applied.
 
 ### `defineErrorCatalog`
 
@@ -537,7 +537,7 @@ if (err.code === 'billing.PAYMENT_DECLINED') retry()
 ```
 ::
 
-This is purely type-level — no runtime registration, no init step. Skip it entirely if you don't need it; the runtime API is identical either way.
+This is purely type-level: no runtime registration, no init step. Skip it entirely if you don't need it; the runtime API is identical either way.
 
 ::callout{icon="i-lucide-package" color="neutral"}
 **Packaging tip.** A catalog is regular TypeScript. Publish `@acme/errors-billing` exporting your `defineErrorCatalog(...)` plus the `declare module 'evlog'` augmentation in its `index.d.ts`, and the typing flows transitively to every consumer that depends on it. Each shared package owns its prefix, no conflicts possible.

--- a/apps/docs/content/2.learn/6.redaction.md
+++ b/apps/docs/content/2.learn/6.redaction.md
@@ -18,7 +18,7 @@ links:
 
 Wide events capture comprehensive context, which makes it easy to accidentally log sensitive data. Auto-redaction scrubs PII from events **before** console output and **before** any drain sees the data.
 
-**Redaction is enabled by default in production** (`NODE_ENV === 'production'`). In development, it is off so you see full values for debugging. No configuration needed — just deploy.
+**Redaction is enabled by default in production** (`NODE_ENV === 'production'`). In development, it is off so you see full values for debugging. No configuration needed, just deploy.
 
 ## Opting Out
 
@@ -58,7 +58,7 @@ You can also enable redaction explicitly in development with `redact: true`.
 
 ## Smart Masking
 
-Built-in patterns use **partial masking** instead of flat `[REDACTED]` — preserving enough context for debugging while protecting the actual data.
+Built-in patterns use **partial masking** instead of flat `[REDACTED]`, preserving enough context for debugging while protecting the actual data.
 
 | Pattern | Example Input | Masked Output |
 |---------|---------------|---------------|
@@ -78,7 +78,7 @@ Built-in patterns use **partial masking** instead of flat `[REDACTED]` — prese
 
 ### Path Patterns
 
-Use a single `paths` array with dot-notation and globs. A bare segment like `password` is shorthand for `**.password` — it redacts that key at **any nesting depth**:
+Use a single `paths` array with dot-notation and globs. A bare segment like `password` is shorthand for `**.password`, so it redacts that key at **any nesting depth**:
 
 ```typescript
 evlog: {
@@ -103,7 +103,7 @@ evlog: {
 
 Path redaction replaces the **entire value** (including nested objects) with `replacement`. Use `patterns` when you need regex on **string values** inside fields.
 
-This matches `auditDiff({ redactPaths: ['password'] })` — same glob syntax, applied globally at emit time.
+This matches `auditDiff({ redactPaths: ['password'] })`, the same glob syntax, applied globally at emit time.
 
 ### Selective Built-ins
 
@@ -132,7 +132,7 @@ evlog: {
 
 ### Computed Replacements
 
-When the replacement has to be **derived** from the value it replaces, pass a function instead of a string. It runs at the same point as the rest of redaction — before the console write, before any drain.
+When the replacement has to be **derived** from the value it replaces, pass a function instead of a string. It runs at the same point as the rest of redaction: before the console write, before any drain.
 
 The common case is keeping requests correlatable without exposing the credential that identifies them:
 
@@ -154,13 +154,13 @@ The function receives the matched value and a context object:
 | `key` | `string` | Leaf key of the field (`email`) |
 | `groups` | `string[]` | Capture groups of the matching `patterns` entry. Only set for `patterns` |
 
-For `paths`, the matched value is the **whole field value** — any type, since path redaction replaces entire subtrees. For `patterns`, it is the matched substring.
+For `paths`, the matched value is the **whole field value**, of any type, since path redaction replaces entire subtrees. For `patterns`, it is the matched substring.
 
 If the function throws or returns a non-string, redaction falls back to `[REDACTED]` and logs the failure. A broken policy degrades to over-redaction, never to leaking the value it was meant to scrub.
 
 ### Conditional Policies
 
-Some policies cannot be expressed as a list of paths — redact a field only for certain tenants, only when a sibling field has a given value, or keep an allowlist rather than a denylist. Use `transform`:
+Some policies cannot be expressed as a list of paths: redact a field only for certain tenants, only when a sibling field has a given value, or keep an allowlist rather than a denylist. Use `transform`:
 
 ```typescript
 initLogger({
@@ -172,12 +172,12 @@ initLogger({
 })
 ```
 
-`transform` runs **before** `paths`, `builtins`, and `patterns`, so it sees raw values and the declarative rules still apply to whatever it leaves behind — a hook that misses a field is not your last line of defence. Mutate the event in place; it is already a private clone, so the object you logged is never touched.
+`transform` runs **before** `paths`, `builtins`, and `patterns`, so it sees raw values and the declarative rules still apply to whatever it leaves behind, and a hook that misses a field is not your last line of defence. Mutate the event in place; it is already a private clone, so the object you logged is never touched.
 
 It must be synchronous, since it runs on the emit path before the console write. Errors are caught and reported like drain failures: the declarative stages still run and the event is still logged.
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-Function-valued `replacement` and `transform` cannot be declared in `nuxt.config.ts` or a Nitro module's options — that config is serialized to JSON at build time, which drops functions. Declare them at runtime with `initLogger()` from a server plugin, or with `createEvlog()`. The modules emit a build-time warning if you do it anyway.
+Function-valued `replacement` and `transform` cannot be declared in `nuxt.config.ts` or a Nitro module's options, that config is serialized to JSON at build time, which drops functions. Declare them at runtime with `initLogger()` from a server plugin, or with `createEvlog()`. The modules emit a build-time warning if you do it anyway.
 ::
 
 ### Disable Built-ins
@@ -218,7 +218,7 @@ Redaction runs inside the emit pipeline, after the wide event is fully built but
 5. **Console output** — masked event printed to stdout
 6. **Drain** — masked event sent to external services
 
-Redaction is the only stage that runs before the console write. `enrich` and drains run after it, so they cannot scrub what has already reached stdout — anything that needs to happen before output belongs in `transform` or a function-valued `replacement`.
+Redaction is the only stage that runs before the console write. `enrich` and drains run after it, so they cannot scrub what has already reached stdout. Anything that needs to happen before output belongs in `transform` or a function-valued `replacement`.
 
 ::callout{icon="i-lucide-zap" color="info"}
 Redaction runs **after** the HTTP response is sent, so it adds zero latency to your API responses.

--- a/apps/docs/content/2.learn/8.catalogs.md
+++ b/apps/docs/content/2.learn/8.catalogs.md
@@ -235,7 +235,7 @@ declare module 'evlog' {
 }
 ```
 
-The `declare module` block lives inside the source file so the bundler emits it into the `dist/index.d.ts`. Any consumer that imports from `@acme/errors-billing` gets the augmentation transitively — no extra setup required on their side.
+The `declare module` block lives inside the source file so the bundler emits it into the `dist/index.d.ts`. Any consumer that imports from `@acme/errors-billing` gets the augmentation transitively, with no extra setup required on their side.
 
 ### Consumption
 
@@ -269,7 +269,7 @@ if (err.code === 'billing.PAYMENT_DECLINED') retry()
 ```
 
 ::callout{icon="i-lucide-package" color="neutral"}
-**Each shared package owns its prefix.** `@acme/errors-billing` owns `billing.*`, `@acme/errors-auth` owns `auth.*`. Conflicts are impossible by construction. Bumping a catalog to a new minor (adding entries) propagates to consumers via the regular semver upgrade path — no codegen, no migration step.
+**Each shared package owns its prefix.** `@acme/errors-billing` owns `billing.*`, `@acme/errors-auth` owns `auth.*`. Conflicts are impossible by construction. Bumping a catalog to a new minor (adding entries) propagates to consumers via the regular semver upgrade path: no codegen, no migration step.
 ::
 
 ## Composition patterns
@@ -348,7 +348,7 @@ The opt-in `declare module 'evlog'` block is what surfaces autocomplete on `crea
 | npm package | At the bottom of the package's main `src/index.ts` so it ships in the published `.d.ts` |
 | Monorepo | One augmentation per package, no central registry needed |
 
-Both centralised and decentralised work — TypeScript merges multiple `declare module 'evlog'` blocks across files automatically.
+Both centralised and decentralised work, because TypeScript merges multiple `declare module 'evlog'` blocks across files automatically.
 
 ### How to add custom domains
 
@@ -372,7 +372,7 @@ declare module 'evlog' {
 }
 ```
 
-The `_codes` literal union is what produces the actual `ErrorCode` type — the keys themselves are arbitrary, choose what feels right for your structure.
+The `_codes` literal union is what produces the actual `ErrorCode` type. The keys themselves are arbitrary, choose what feels right for your structure.
 
 ### Verifying the augmentation
 
@@ -401,7 +401,7 @@ If autocomplete is empty, either no catalog is registered yet, or the augmentati
 ::
 
 ::warning
-**Never override the `code` at the call site.** The catalog defines the code identity — overriding it would break dashboards, alerts, and consumer code branching on `err.code`. The factory's call-site signature deliberately omits `code` from the overridable fields.
+**Never override the `code` at the call site.** The catalog defines the code identity, and overriding it would break dashboards, alerts, and consumer code branching on `err.code`. The factory's call-site signature deliberately omits `code` from the overridable fields.
 ::
 
 ::tip

--- a/apps/docs/content/3.cli/0.overview.md
+++ b/apps/docs/content/3.cli/0.overview.md
@@ -19,10 +19,10 @@ links:
 
 `@evlog/cli` is a separate package from `evlog` itself. It never runs in your app: it reads your source on disk, so there is nothing to configure and nothing to deploy.
 
-Its main job is [`evlog map`](/cli/map) — a static observability score for your app, in the spirit of Lighthouse. It finds every entry point in your project, checks each one for wide-event coverage, and tells you which three to fix first. Two commands write rather than read: [`evlog init`](/cli/init) wires evlog into the app so there is something to score, and [`evlog agents`](/cli/agents) teaches the AI agents working in the repository how to use it.
+Its main job is [`evlog map`](/cli/map), a static observability score for your app, in the spirit of Lighthouse. It finds every entry point in your project, checks each one for wide-event coverage, and tells you which three to fix first. Two commands write rather than read: [`evlog init`](/cli/init) wires evlog into the app so there is something to score, and [`evlog agents`](/cli/agents) teaches the AI agents working in the repository how to use it.
 
 ::warning{icon="i-lucide-flask-conical"}
-**Early days.** The CLI is safe to run on any project — it only reads files, and it is covered by tests — but it is young. `evlog map` understands four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases, and [pin the version](/cli/ci#pin-the-version) when you gate CI on the number.
+**Early days.** The CLI is safe to run on any project, since it only reads files and is covered by tests, but it is young. `evlog map` understands four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases, and [pin the version](/cli/ci#pin-the-version) when you gate CI on the number.
 ::
 
 ::code-group
@@ -126,7 +126,7 @@ The report you read is written to **stderr**. Stdout is reserved for `--json`, s
 evlog map --json | jq '.map.score'
 ```
 
-Without `--json`, nothing is written to stdout at all. Colour is dropped when stdout is not a TTY or when `NO_COLOR` is set, and the report lays itself out for the width it is given — set `COLUMNS` to render at a fixed width.
+Without `--json`, nothing is written to stdout at all. Colour is dropped when stdout is not a TTY or when `NO_COLOR` is set, and the report lays itself out for the width it is given, so set `COLUMNS` to render at a fixed width.
 
 ## Exit codes
 
@@ -149,11 +149,11 @@ Every verdict can be turned off from the code it is about, so a false positive n
 export default defineEventHandler(() => ({ ok: true }))
 ```
 
-The check becomes `n/a` with your reason attached — no score cost, no failed gate — and the report counts how many checks the project disabled, so the number stays honest. [Full syntax](/cli/rules#disabling-a-check).
+The check becomes `n/a` with your reason attached, at no score cost and with no failed gate, and the report counts how many checks the project disabled, so the number stays honest. [Full syntax](/cli/rules#disabling-a-check).
 
 ## Monorepos
 
-`init`, `map` and `doctor` all resolve the nearest `package.json` above the working directory, then treat that package as the project. In a pnpm or npm workspace, running from `apps/web` scans `apps/web` — not the repo root.
+`init`, `map` and `doctor` all resolve the nearest `package.json` above the working directory, then treat that package as the project. In a pnpm or npm workspace, running from `apps/web` scans `apps/web`, not the repo root.
 
 `evlog map` scans one app at a time. Running it from a bare workspace root, where there is no framework to detect, is an error rather than an empty report:
 
@@ -165,7 +165,7 @@ evlog map --cwd apps/web
 
 ## Debugging a run
 
-`--debug` prints what the command did — the steps it went through, the directory it resolved, and any findings — and emits the same information as an evlog wide event:
+`--debug` prints what the command did: the steps it went through, the directory it resolved, and any findings, and emits the same information as an evlog wide event:
 
 ```bash [Terminal]
 evlog map --debug

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-`evlog map` tells you which entry points are dark. `evlog init` is what you run before that — it does the setup the framework guide describes, in the project you are standing in.
+`evlog map` tells you which entry points are dark. `evlog init` is what you run before that. It does the setup the framework guide describes, in the project you are standing in.
 
 ```bash [Terminal]
 npx @evlog/cli init
@@ -76,7 +76,7 @@ On a terminal it reads your project, asks what it cannot infer, and shows you th
 └  Nuxt wired · evlog.dev/integrate/frameworks/nuxt
 ```
 
-The production picker is a fuzzy search — type `ax` for Axiom — and takes more than one destination: the same event fans out to each. Extras are grouped and only list what your project can actually use, with the evidence that put them there.
+The production picker is a fuzzy search (type `ax` for Axiom) and takes more than one destination: the same event fans out to each. Extras are grouped and only list what your project can actually use, with the evidence that put them there.
 
 ## What it does
 
@@ -106,7 +106,7 @@ Passing one of these as a flag against a project that cannot use it drops it and
 
 ## Non-interactive
 
-Prompts are skipped — and every answer comes from flags and defaults — whenever anything suggests nobody is watching:
+Prompts are skipped, and every answer comes from flags and defaults, whenever anything suggests nobody is watching:
 
 | Condition | Why |
 | --- | --- |
@@ -122,7 +122,7 @@ evlog init --json --drain none          # plan and result as JSON, nothing to re
 ```
 
 ::callout{icon="i-lucide-bot" color="neutral"}
-**Written for agents too.** The non-interactive path can express every choice the prompts can, so an agent reproduces exactly what a human just did — and it can never end up waiting on a keystroke that is not coming. An unknown `--drain` or `--extras` value stops the run rather than falling back to a default, because silently wiring the wrong destination is worse than a failed command.
+**Written for agents too.** The non-interactive path can express every choice the prompts can, so an agent reproduces exactly what a human just did, and it can never end up waiting on a keystroke that is not coming. An unknown `--drain` or `--extras` value stops the run rather than falling back to a default, because silently wiring the wrong destination is worse than a failed command.
 ::
 
 ## It will not overwrite your code
@@ -160,7 +160,7 @@ export default defineNuxtConfig({
 
 ### Nitro
 
-Adds the import and the module call, picking the subpath that matches your major — `evlog/nitro/v3` for Nitro 3, `evlog/nitro` for `nitropack`. Creates `nitro.config.ts` when there is none.
+Adds the import and the module call, picking the subpath that matches your major: `evlog/nitro/v3` for Nitro 3, `evlog/nitro` for `nitropack`. Creates `nitro.config.ts` when there is none.
 
 ```typescript [nitro.config.ts]
 import { defineConfig } from 'nitro'
@@ -177,7 +177,7 @@ export default defineConfig({
 
 ### Next.js
 
-Creates `instrumentation.ts` and `lib/evlog.ts` — under `src/` when your app lives there, since Next only loads the one that matches.
+Creates `instrumentation.ts` and `lib/evlog.ts`, under `src/` when your app lives there, since Next only loads the one that matches.
 
 Wrapping handlers stays yours: Next has no ambient request logger, so each route opts in with `withEvlog()`. `init` prints the snippet.
 
@@ -191,7 +191,7 @@ export const { withEvlog, useLogger, log, createError } = createEvlog({
 
 ### TanStack Start
 
-Writes the Nitro v3 config with `experimental.asyncContext` enabled — without it `useRequest()` returns nothing and you get an install that looks complete and logs no business context.
+Writes the Nitro v3 config with `experimental.asyncContext` enabled. Without it `useRequest()` returns nothing and you get an install that looks complete and logs no business context.
 
 The `evlogErrorHandler` middleware on your root route is a manual step: `__root.tsx` is a component file, and splicing into it is guesswork.
 
@@ -219,7 +219,7 @@ const drains = import.meta.dev
   : [pipeline(createAxiomDrain()), pipeline(createSentryDrain())]
 ```
 
-Batching wraps the network sends only — buffering a local file write adds latency to the one loop where you want the event on screen immediately.
+Batching wraps the network sends only, because buffering a local file write adds latency to the one loop where you want the event on screen immediately.
 
 ::callout{icon="i-lucide-key" color="neutral"}
 **`init` never asks for a secret.** It prints which environment variables the adapter reads and leaves them to you. A setup command that prompts for an API token is one that writes a credential into a file it chose, and the answer lands in your shell history on the way there.
@@ -238,11 +238,11 @@ Batching wraps the network sends only — buffering a local file write adds late
 | `better-auth` | The signed-in user on every event |
 | `vite` | The Vite plugin that strips `log.debug()` from production builds |
 
-An extra that does not apply is dropped and reported, not refused — so `--extras vite,enrichers` does the right thing across a monorepo of mixed apps.
+An extra that does not apply is dropped and reported, not refused, so `--extras vite,enrichers` does the right thing across a monorepo of mixed apps.
 
 ### Sampling presets
 
-Named by the traffic your app takes. Info is what moves — it is the bulk of the volume and the bulk of the bill — and warnings only give way at the top, where halving them still leaves the shape.
+Named by the traffic your app takes. Info is what moves: it is the bulk of the volume and the bulk of the bill, and warnings only give way at the top, where halving them still leaves the shape.
 
 | Id | Info | Warnings | For |
 | --- | --- | --- | --- |
@@ -252,7 +252,7 @@ Named by the traffic your app takes. Info is what moves — it is the bulk of th
 | `high` | 10% | 100% | Info is most of what you are paying for |
 | `very-high` | 1% | 50% | Trends rather than individual requests |
 
-**Errors are kept at 100% in every tier** — a sampling config that drops errors hides the only events anybody reads at three in the morning. The generated config states it explicitly so the invariant is visible where somebody would otherwise wonder.
+**Errors are kept at 100% in every tier.** A sampling config that drops errors hides the only events anybody reads at three in the morning. The generated config states it explicitly so the invariant is visible where somebody would otherwise wonder.
 
 **`debug` is never sampled, and never appears in the config.** An unspecified level is kept in full, and debug events only exist because somebody turned them on to chase something: a 5% sample of the logs you switched on to investigate a problem is a 5% chance of seeing the line you needed. Production builds strip `log.debug()` anyway, so there is rarely volume there to sample.
 
@@ -285,7 +285,7 @@ export const shopErrors = defineErrorCatalog('shop', {
 
 ## Monorepos
 
-Run from a workspace root and `init` sets up the apps rather than the root package, which serves no traffic. It lists the workspace packages that have a detectable framework — a shared `utils` package has no entry points to instrument — and asks which to wire:
+Run from a workspace root and `init` sets up the apps rather than the root package, which serves no traffic. It lists the workspace packages that have a detectable framework. A shared `utils` package has no entry points to instrument, and asks which to wire:
 
 ```bash [Terminal]
 evlog init                            # pick from the list
@@ -296,7 +296,7 @@ Each app keeps its own service name, taken from its `package.json`.
 
 ## The local drain
 
-On Nitro-based apps `init` writes a drain plugin; on Next.js it adds the drain to `lib/evlog.ts`. The filesystem drain — and only that one — is **gated to development**:
+On Nitro-based apps `init` writes a drain plugin; on Next.js it adds the drain to `lib/evlog.ts`. The filesystem drain, and only that one, is **gated to development**:
 
 ```typescript [server/plugins/evlog-drain.ts]
 import { createFsDrain } from 'evlog/fs'

--- a/apps/docs/content/3.cli/2.map.md
+++ b/apps/docs/content/3.cli/2.map.md
@@ -19,7 +19,7 @@ links:
 
 `evlog map` reads your project on disk and answers one question: **if something goes wrong in production tonight, which parts of this app will be able to tell you why?**
 
-It finds every entry point — API handlers, pages that fetch, middleware, scheduled jobs, server actions — checks each one for wide-event coverage, scores it, and names the three worth fixing first. Nothing runs, nothing is instrumented, no traffic is needed: it is static analysis over your source, which makes the score **deterministic**: the same code yields the same score, on any machine, every time.
+It finds every entry point (API handlers, pages that fetch, middleware, scheduled jobs, server actions), checks each one for wide-event coverage, scores it, and names the three worth fixing first. Nothing runs, nothing is instrumented, no traffic is needed: it is static analysis over your source, which makes the score **deterministic**: the same code yields the same score, on any machine, every time.
 
 ::map-scan-flow
 ::
@@ -29,7 +29,7 @@ evlog map
 ```
 
 ::warning{icon="i-lucide-flask-conical"}
-**Early days.** The foundation is solid — AST-based, tested, with a versioned JSON contract — but the rule set is young and only four frameworks have adapters. A release that sharpens a rule can change a verdict on code you did not touch, so [pin the CLI version](/cli/ci#pin-the-version) if you gate a pull request on the score.
+**Early days.** The foundation is solid (AST-based, tested, with a versioned JSON contract), but the rule set is young and only four frameworks have adapters. A release that sharpens a rule can change a verdict on code you did not touch, so [pin the CLI version](/cli/ci#pin-the-version) if you gate a pull request on the score.
 ::
 
 ::prompt
@@ -111,12 +111,12 @@ Read from the top down, each block answers a different question.
 
 ### The score
 
-The big digits are the global score out of 100: a weighted average of every entry point, where money and auth routes count double and pages count half. The word underneath is its grade — `excellent`, `good`, `needs work`, or `at risk`.
+The big digits are the global score out of 100: a weighted average of every entry point, where money and auth routes count double and pages count half. The word underneath is its grade: `excellent`, `good`, `needs work`, or `at risk`.
 
 The row of blocks on the right is every entry point in the project, worst on the left, best on the right. A wall of tall blocks on the right with a few short ones on the left is a healthy app with a handful of blind spots. A flat low row is an app with no instrumentation at all. On a large project the row is sampled down to the width of your terminal, showing the worst entry point in each bucket.
 
 ::callout{icon="i-lucide-gauge" color="neutral"}
-The full calculation — per-rule weights, route weighting, and grade thresholds — is on [Scoring](/cli/scoring).
+The full calculation (per-rule weights, route weighting, and grade thresholds) is on [Scoring](/cli/scoring).
 ::
 
 ### Coverage
@@ -158,7 +158,7 @@ These are suggestions, not gaps. They are gated on evidence that the feature is 
 
 ### The last two lines
 
-`✓ Already solid` names entry points with nothing left to fix, so a good app gets told so. `▲ 76 → 86 by fixing the 3 above` is the score you would land on if you fixed exactly what is under **FIX FIRST** — the reason to start there rather than anywhere else.
+`✓ Already solid` names entry points with nothing left to fix, so a good app gets told so. `▲ 76 → 86 by fixing the 3 above` is the score you would land on if you fixed exactly what is under **FIX FIRST**, which is the reason to start there rather than anywhere else.
 
 ## Three views
 
@@ -186,7 +186,7 @@ server/
 what each column checks → evlog.dev/cli/rules
 ```
 
-One column per rule, in the order they cost points. A dot means the rule does not apply here — a handler that throws nothing is not asked whether its errors carry `why` and `fix`, and that is a dot rather than a free pass. A hollow `○` is a check you [disabled with a comment](/cli/rules#disabling-a-check). Every column is explained on [Rules](/cli/rules).
+One column per rule, in the order they cost points. A dot means the rule does not apply here: a handler that throws nothing is not asked whether its errors carry `why` and `fix`, and that is a dot rather than a free pass. A hollow `○` is a check you [disabled with a comment](/cli/rules#disabling-a-check). Every column is explained on [Rules](/cli/rules).
 
 ### One entry point
 
@@ -279,7 +279,7 @@ A check you disagree with should cost you one comment, not your CI gate:
 export default defineEventHandler(() => ({ ok: true }))
 ```
 
-The check becomes `n/a` with your reason attached, so it stops costing score — and the report says how many checks the project has disabled, so a high score never hides an app that logs nothing. Full syntax on [Rules](/cli/rules#disabling-a-check).
+The check becomes `n/a` with your reason attached, so it stops costing score, and the report says how many checks the project has disabled, so a high score never hides an app that logs nothing. Full syntax on [Rules](/cli/rules#disabling-a-check).
 
 ## Flags
 

--- a/apps/docs/content/3.cli/3.rules.md
+++ b/apps/docs/content/3.cli/3.rules.md
@@ -17,10 +17,10 @@ links:
     variant: subtle
 ---
 
-Coverage is checked by a rule engine, not a bag of heuristics. Each rule has a stable id, a documented weight, a docs link, and a set of entry point kinds it applies to — and every finding carries the file and line it came from, so a verdict is always something you can go and look at.
+Coverage is checked by a rule engine, not a bag of heuristics. Each rule has a stable id, a documented weight, a docs link, and a set of entry point kinds it applies to, and every finding carries the file and line it came from, so a verdict is always something you can go and look at.
 
 ::warning{icon="i-lucide-flask-conical"}
-**This list is not final.** Ten rules is where the engine starts, not where it ends. Rules will be added, existing ones will get more precise about what counts, and a sharper rule can change a verdict on code you did not touch. Ids and weights are documented so the change is always explainable — but do not treat a score as comparable across CLI versions.
+**This list is not final.** Ten rules is where the engine starts, not where it ends. Rules will be added, existing ones will get more precise about what counts, and a sharper rule can change a verdict on code you did not touch. Ids and weights are documented so the change is always explainable, but do not treat a score as comparable across CLI versions.
 ::
 
 Rules come in two categories, and the difference matters:
@@ -50,7 +50,7 @@ Every rule returns one of three verdicts for an entry point.
 
 ## Requirements
 
-Six rules move the score. They apply to handler-like entry points — API handlers, middleware, scheduled jobs, and server actions — except `fetch`, which is the pages-only rule.
+Six rules move the score. They apply to handler-like entry points (API handlers, middleware, scheduled jobs, and server actions), except `fetch`, which is the pages-only rule.
 
 | Column | Id | Weight | Expects |
 | --- | --- | --- | --- |
@@ -108,7 +108,7 @@ log.set({ user: { id }, order: { id, total } })
 
 `throw new Error('failed')` reaches the client as a string with no cause and no remedy. `createError({ why, fix })` is what makes an error actionable for whoever reads it at 3am.
 
-Applies only when the handler raises something — a `throw` or a `createError()` call. The message names exactly what is missing:
+Applies only when the handler raises something: a `throw` or a `createError()` call. The message names exactly what is missing:
 
 ```text
 throw new Error() — use createError({ why, fix })
@@ -133,7 +133,7 @@ throw createError({
 
 Applies only where the [sensitivity classifier](/cli/scoring#sensitivity) found money or auth. Everywhere else an audit record would be noise, so the rule reports `n/a` rather than passing for free.
 
-`log.audit()` satisfies it, including through optional chaining — `log.audit?.deny()` counts.
+`log.audit()` satisfies it, including through optional chaining, so `log.audit?.deny()` counts.
 
 The suggested action is read off the route, so `/api/auth/login` suggests `auth.login` and `/api/orders/[id]/refund` suggests `orders.refund`:
 
@@ -169,7 +169,7 @@ catch (error) {
 
 ### fetch — does this page survive its data fetch failing?
 
-The only pages rule. Applies only to pages that actually fetch something server-side — a purely presentational page has nothing to fail.
+The only pages rule. Applies only to pages that actually fetch something server-side. A purely presentational page has nothing to fail.
 
 Satisfied by a `catch`, a `.catch()`, an `onError` handler, or an `error` binding destructured from the fetch itself.
 
@@ -193,7 +193,7 @@ try {
 
 ## Opportunities
 
-Four rules suggest going further. They never touch the score, and they only ever fire when the project has **already adopted** the feature somewhere — the point is to get more out of what you chose, not to sell you something.
+Four rules suggest going further. They never touch the score, and they only ever fire when the project has **already adopted** the feature somewhere. The point is to get more out of what you chose, not to sell you something.
 
 Adoption is confirmed against the AST, not by searching text, so a feature mentioned in a comment does not count.
 
@@ -220,11 +220,11 @@ Complements the `audit` requirement, which only fires on money and auth. This on
 
 ### ai — are model calls, tokens and latency on the event?
 
-Fires on `generateText`, `streamText`, `generateObject`, `streamObject`, `embed`, and `embedMany` when `evlog/ai` is not imported. Without it the event records that the request happened but not what the model cost, which is usually the most expensive and most variable part of it. Reported once for the whole project — one wrapped model serves every handler. [AI SDK →](/use-cases/ai-sdk/overview)
+Fires on `generateText`, `streamText`, `generateObject`, `streamObject`, `embed`, and `embedMany` when `evlog/ai` is not imported. Without it the event records that the request happened but not what the model cost, which is usually the most expensive and most variable part of it. Reported once for the whole project, since one wrapped model serves every handler. [AI SDK →](/use-cases/ai-sdk/overview)
 
 ### identity — do events carry the authenticated user?
 
-Fires on entry points where auth is actually in play: the auth routes themselves, or a handler that reads the session. `evlog/better-auth` attaches the user and session to every event, which is what turns "a request failed" into "this user's request failed". Reported once for the whole project — it is one plugin, installed once. [Better Auth →](/use-cases/better-auth/overview)
+Fires on entry points where auth is actually in play: the auth routes themselves, or a handler that reads the session. `evlog/better-auth` attaches the user and session to every event, which is what turns "a request failed" into "this user's request failed". Reported once for the whole project, since it is one plugin, installed once. [Better Auth →](/use-cases/better-auth/overview)
 
 ## How evlog helpers are recognised
 
@@ -242,7 +242,7 @@ Two things deliberately do **not** count:
 
 ## Disabling a check
 
-A static analyser you cannot argue with is one you stop running. When a rule is wrong about your code — or right about it and you have decided not to care — turn it off with a comment, next to the code it is about:
+A static analyser you cannot argue with is one you stop running. When a rule is wrong about your code, or right about it and you have decided not to care, turn it off with a comment, next to the code it is about:
 
 ```ts [server/api/health.get.ts]
 // evlog-map-disable-next-line wide-event, context -- liveness probe, deliberately silent
@@ -257,13 +257,13 @@ Three forms, matching what you would expect from a linter:
 | `// evlog-map-disable-line <ids>` | The line the comment is on, as a trailing comment |
 | `// evlog-map-disable <ids>` | The whole file, wherever it appears |
 
-The ids are the ones in the tables above — `wide-event`, `audit`, `structured-errors`, `context`, `error-handling`, `page-error-handling`, and any opportunity id. Separate several with commas or spaces. **Name no id and the directive covers every rule**, which is the right shape for a generated or vendored file and the wrong one for a handler you simply have not got to yet. Block comments work the same way, which is what you want at the top of a file: `/* evlog-map-disable -- generated by the SDK */`.
+The ids are the ones in the tables above: `wide-event`, `audit`, `structured-errors`, `context`, `error-handling`, `page-error-handling`, and any opportunity id. Separate several with commas or spaces. **Name no id and the directive covers every rule**, which is the right shape for a generated or vendored file and the wrong one for a handler you simply have not got to yet. Block comments work the same way, which is what you want at the top of a file: `/* evlog-map-disable -- generated by the SDK */`.
 
 Everything after `--` is your reason. It is optional, and worth writing anyway: it is what the report shows, so the next person reads the decision rather than guessing at it.
 
 ### What a disabled check does to the score
 
-It becomes `n/a` with your reason attached — the same status as a rule that never applied — so it costs no points, and a `--min-score` gate stops failing on it.
+It becomes `n/a` with your reason attached, the same status as a rule that never applied, so it costs no points, and a `--min-score` gate stops failing on it.
 
 The rule still runs. What a directive waives is the *finding*, not the question: a check that would have passed is still reported as a `pass`, and a rule that never applied to that handler stays a plain `n/a`. So a file-wide directive on an already-instrumented handler disables nothing, and the number of disabled checks is the number of verdicts you actually chose not to see.
 
@@ -279,11 +279,11 @@ CHECKS
 ○ useLogger   disabled at line 1 — liveness probe, deliberately silent
 ```
 
-In `--all`, a disabled cell is `○` rather than the `·` of a rule that did not apply. And in the JSON, the check carries `"suppressed": true` next to its `n/a`, with `evidence` pointing at the comment — so a CI job can report how much of a green score is suppressed, and `summary.suppressedChecks` gives the project total.
+In `--all`, a disabled cell is `○` rather than the `·` of a rule that did not apply. And in the JSON, the check carries `"suppressed": true` next to its `n/a`, with `evidence` pointing at the comment, so a CI job can report how much of a green score is suppressed, and `summary.suppressedChecks` gives the project total.
 
 ### A typo is loud
 
-An id no rule answers to does not silently do nothing — the scan warns above the report, and the check keeps failing:
+An id no rule answers to does not silently do nothing. The scan warns above the report, and the check keeps failing:
 
 ```text
 ⚠ server/api/probe.get.ts:1 disables "wide-evnt", which is not a check evlog map runs
@@ -295,11 +295,11 @@ Believing a check is off while it is still failing is worse than either state on
 
 evlog's own client-log ingest endpoints (`/api/evlog/ingest` and friends) are plumbing, not app code. Every rule reports `n/a` for them with the reason attached, they are never listed as something to fix, and the summary counts them as `exempt` rather than as your own instrumented entry points. This holds even when the file fails to parse: an exemption that only applied to readable files would not be much of a guarantee.
 
-A static page is exempt for the same reason. It fetches nothing, so `page-error-handling` has nothing to ask of it and reports `n/a` — counting that as an unobserved entry point would show a marketing page as an observability gap.
+A static page is exempt for the same reason. It fetches nothing, so `page-error-handling` has nothing to ask of it and reports `n/a`. Counting that as an unobserved entry point would show a marketing page as an observability gap.
 
 ## Reporting a wrong verdict
 
-Rules are one file each with their own test bench, so a wrong verdict is a local fix rather than an archaeology session. If `evlog map <file>` claims something you can see is untrue, that is a bug worth [opening an issue](https://github.com/HugoRCD/evlog/issues) for — include the entry point's output and the handler, and the fix lands in one rule.
+Rules are one file each with their own test bench, so a wrong verdict is a local fix rather than an archaeology session. If `evlog map <file>` claims something you can see is untrue, that is a bug worth [opening an issue](https://github.com/HugoRCD/evlog/issues) for. Include the entry point's output and the handler, and the fix lands in one rule.
 
 In the meantime, [disable the check](#disabling-a-check) on that line. A false positive should cost you one comment, not your CI gate.
 

--- a/apps/docs/content/3.cli/4.scoring.md
+++ b/apps/docs/content/3.cli/4.scoring.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-The score exists to be compared against itself. It is a number you can watch move as you fix things, and gate a pull request on — not a benchmark against other projects.
+The score exists to be compared against itself. It is a number you can watch move as you fix things, and gate a pull request on, not a benchmark against other projects.
 
 ## One entry point
 
@@ -32,9 +32,9 @@ Every entry point starts at 100 and loses the weight of each **requirement** it 
 | `context` | 15 |
 | `error-handling` | 15 |
 
-A rule that passes costs nothing. A rule that reports `n/a` costs nothing either — it never applied, so it is not held against the entry point. [Opportunities](/cli/rules#opportunities) carry no weight at all and cannot appear here.
+A rule that passes costs nothing. A rule that reports `n/a` costs nothing either, because it never applied, so it is not held against the entry point. [Opportunities](/cli/rules#opportunities) carry no weight at all and cannot appear here.
 
-A check you [disabled with a comment](/cli/rules#disabling-a-check) is also `n/a`, so it costs nothing — and the report counts how many, because a score that is partly the result of disabled checks has to say so.
+A check you [disabled with a comment](/cli/rules#disabling-a-check) is also `n/a`, so it costs nothing, and the report counts how many, because a score that is partly the result of disabled checks has to say so.
 
 Take the login handler from the playground:
 
@@ -45,7 +45,7 @@ CHECKS
 ✗ log.audit  sensitive action with no audit trail
 ```
 
-`structured-errors` and `error-handling` were `n/a` — the handler throws nothing and catches nothing. One requirement failed, so the score is `100 − 25 = 75`.
+`structured-errors` and `error-handling` were `n/a`: the handler throws nothing and catches nothing. One requirement failed, so the score is `100 − 25 = 75`.
 
 ::callout{icon="i-lucide-info" color="neutral"}
 Weights add up to more than 100 on purpose. A handler that fails everything lands at 0, and the ordering of what to fix first stays meaningful: `wide-event` at 40 outweighs any pair of the smaller rules.
@@ -68,7 +68,7 @@ The global score is the average of every entry point, weighted by how much a bli
 
 Pages weigh less because a page that swallows a fetch error is a worse user experience than an observability hole, and they are usually the most numerous files in an app. Sensitive handlers weigh double because that is where you will need the event.
 
-Three entry points — a sensitive handler at 75, a plain handler at 100, and a page at 50:
+Three entry points: a sensitive handler at 75, a plain handler at 100, and a page at 50:
 
 ```text
 (75 × 2) + (100 × 1) + (50 × 0.5)   275
@@ -89,7 +89,7 @@ A project with no entry points at all scores 100.
 
 ## Coverage classification
 
-Alongside the score, each entry point is classified — this is what the `summary` block in the JSON counts, and what the coverage rows in the report are built from.
+Alongside the score, each entry point is classified, which is what the `summary` block in the JSON counts, and what the coverage rows in the report are built from.
 
 | Class | When |
 | --- | --- |
@@ -126,7 +126,7 @@ Two decisions keep this from producing noise.
 
 **Imports are read from the AST.** A package counts only when it is genuinely imported, so a `// TODO: drop stripe` comment does not make a route handle money.
 
-**Path terms match whole words**, allowing a plural. `/api/authors` is not an auth route, and `/api/refunds` is a money route. This matters more than it looks: a wrongly flagged route is handed a 25-point requirement it has no reason to satisfy, and counts double in the average — the fastest way to make the whole number untrustworthy.
+**Path terms match whole words**, allowing a plural. `/api/authors` is not an auth route, and `/api/refunds` is a money route. This matters more than it looks: a wrongly flagged route is handed a 25-point requirement it has no reason to satisfy, and counts double in the average, the fastest way to make the whole number untrustworthy.
 
 Every reason is shown in full when you inspect an entry point, so a wrong call is one line to spot:
 

--- a/apps/docs/content/3.cli/5.ci.md
+++ b/apps/docs/content/3.cli/5.ci.md
@@ -38,7 +38,7 @@ fix what is listed under FIX FIRST to pass · evlog.dev/cli/ci
 
 The full report is printed either way, so a failed job tells you what to fix without a second run.
 
-The threshold has to be a whole number between 0 and 100. Anything else — a typo, a stray unit, an unexpanded shell variable — stops the command rather than being read as "no gate", because a gate that quietly disables itself reports success for a bar nobody checked.
+The threshold has to be a whole number between 0 and 100. Anything else (a typo, a stray unit, an unexpanded shell variable) stops the command rather than being read as "no gate", because a gate that quietly disables itself reports success for a bar nobody checked.
 
 Which turns the score into something a pull request can move. One run says the app is short of the bar and names the three entry points responsible, the next one says it is over:
 
@@ -78,7 +78,7 @@ evlog.map.json was not rewritten — fix the regression, or re-run without --bas
 The unit is the requirement, not the total. A refactor that instruments one route and breaks another can leave the score untouched, and a gate watching only the number would call that a no-op.
 
 ::callout{icon="i-lucide-lock" color="neutral"}
-**Nothing is fetched.** The baseline is a file your repository already contains, so CI has it on disk right after `checkout` — no network, no token, no repository access. A private repo gates exactly like a public one.
+**Nothing is fetched.** The baseline is a file your repository already contains, so CI has it on disk right after `checkout`: no network, no token, no repository access. A private repo gates exactly like a public one.
 ::
 
 ### What counts as a regression
@@ -94,7 +94,7 @@ The unit is the requirement, not the total. A refactor that instruments one rout
 
 Silencing a check costs the same as breaking it, on purpose: a disable comment is the cheapest way to turn a gate green without writing any instrumentation, and a ratchet that let it through would be measuring the comments rather than the code.
 
-New dark routes are reported rather than gated. On an app that is not green yet, failing every pull request that adds an endpoint is how a team learns to turn the job off — `--min-score` is where a bar for new work belongs. Run both when you want both.
+New dark routes are reported rather than gated. On an app that is not green yet, failing every pull request that adds an endpoint is how a team learns to turn the job off. `--min-score` is where a bar for new work belongs. Run both when you want both.
 
 ### The map file is the ratchet
 
@@ -117,7 +117,7 @@ The file also churns on `generatedAt` every run. That is the cost of tracking it
 
 ### Comparing against a branch instead
 
-Pass a `git:<ref>` to read the committed copy through git rather than the working tree — useful when the pull request touches the map file itself:
+Pass a `git:<ref>` to read the committed copy through git rather than the working tree, which suits a pull request that touches the map file itself:
 
 ```bash [Terminal]
 evlog map --baseline git:origin/main
@@ -186,7 +186,7 @@ pnpm add -D @evlog/cli
       - run: pnpm evlog map --min-score 80 --no-write
 ```
 
-Then a score change is always something you did, and upgrading the CLI is its own pull request — where a moved score is the point rather than a surprise.
+Then a score change is always something you did, and upgrading the CLI is its own pull request, where a moved score is the point rather than a surprise.
 
 ### Ratchet, don't cliff
 
@@ -254,7 +254,7 @@ evlog map --json --no-write > map.json
 ```
 ::
 
-`checks` holds requirements, `suggestions` holds opportunities. They are separate keys precisely so a consumer — or a CI script — can never mistake a suggestion for a failure. Rule ids are stable: the registry and the published id union are checked against each other at build time, so a release cannot silently change what you receive.
+`checks` holds requirements, `suggestions` holds opportunities. They are separate keys precisely so a consumer, or a CI script, can never mistake a suggestion for a failure. Rule ids are stable: the registry and the published id union are checked against each other at build time, so a release cannot silently change what you receive.
 
 A check somebody [disabled with a comment](/cli/rules#disabling-a-check) is `n/a` with `"suppressed": true`, and its `evidence` points at the comment rather than at the handler:
 

--- a/apps/docs/content/3.cli/6.doctor.md
+++ b/apps/docs/content/3.cli/6.doctor.md
@@ -12,7 +12,7 @@ links:
     variant: subtle
 ---
 
-`evlog doctor` answers "is evlog actually wired up here?" — the question you have when you followed the setup guide and nothing is showing up.
+`evlog doctor` answers "is evlog actually wired up here?", the question you have when you followed the setup guide and nothing is showing up.
 
 ```bash [Terminal]
 evlog doctor
@@ -43,13 +43,13 @@ EVLOG
 | `evlog` | `evlog` resolves from `node_modules` | Declared in `package.json` but not installed, or missing entirely |
 | `logs` | A local drain exists, or the fs drain is wired (the directory appears on first write) | Never — the check is omitted when no local drain is configured |
 
-In a workspace, the header names the workspace kind and `project` shows which package was resolved — the fastest way to notice you are diagnosing the repo root instead of your app.
+In a workspace, the header names the workspace kind and `project` shows which package was resolved, the fastest way to notice you are diagnosing the repo root instead of your app.
 
 A local drain is optional: the [fs drain](/integrate/adapters/self-hosted/fs) writes under `.evlog/logs` and creates the directory on first write, so a wired drain counts as a drain before any event. A project with no local drain gets no `logs` check at all.
 
 ## Exit code
 
-`0` when nothing failed, `1` when any check failed. Warnings do not fail the command — a project that has not written logs yet is not broken.
+`0` when nothing failed, `1` when any check failed. Warnings do not fail the command, because a project that has not written logs yet is not broken.
 
 ## JSON
 
@@ -59,7 +59,7 @@ evlog doctor --json | jq '.checks'
 
 The payload carries the resolved project (`cwd`, `root`, `packageDir`, workspace kind, package name, detected stack), every check with its status, and the summary counts.
 
-Each warning and failure also carries a code from the CLI's own error catalog — `cli.EVLOG_NOT_FOUND`, `cli.EVLOG_DECLARED_NOT_INSTALLED`, `cli.NODE_TOO_OLD`, `cli.PROJECT_NO_PACKAGE` — each with a `why` and a `fix`, the same way [structured errors](/learn/structured-errors) work in your app.
+Each warning and failure also carries a code from the CLI's own error catalog: `cli.EVLOG_NOT_FOUND`, `cli.EVLOG_DECLARED_NOT_INSTALLED`, `cli.NODE_TOO_OLD`, `cli.PROJECT_NO_PACKAGE`, each with a `why` and a `fix`, the same way [structured errors](/learn/structured-errors) work in your app.
 
 ## Options
 

--- a/apps/docs/content/3.cli/7.telemetry.md
+++ b/apps/docs/content/3.cli/7.telemetry.md
@@ -20,7 +20,7 @@ This page is about the CLI's own telemetry. If you are instrumenting a CLI **you
 
 ## What `init` records
 
-`evlog init` asks more questions than the other commands, so it records the answers — which lets the flow lead with the options people actually pick and drop the ones nobody does.
+`evlog init` asks more questions than the other commands, so it records the answers, which lets the flow lead with the options people actually pick and drop the ones nobody does.
 
 | Recorded | Example |
 | --- | --- |
@@ -29,7 +29,7 @@ This page is about the CLI's own telemetry. If you are instrumenting a CLI **you
 | Counts | files written, manual steps left, doctor failures |
 | Whether an offer had anything behind it | `initHadRepeatedErrors: true` |
 
-Every string is an id from the CLI's own catalog and is checked against an allowlist before it is sent — an undeclared value is dropped rather than transmitted. **Your service name is never recorded**, nor package names, paths, or anything read out of your source. The last row says only whether the scan found something, never what it found.
+Every string is an id from the CLI's own catalog and is checked against an allowlist before it is sent, and an undeclared value is dropped rather than transmitted. **Your service name is never recorded**, nor package names, paths, or anything read out of your source. The last row says only whether the scan found something, never what it found.
 
 ## What `map` records
 
@@ -54,7 +54,7 @@ Kinds are the CLI's own closed set too, and a kind absent from the project is om
 evlog telemetry status
 ```
 
-The command prints whether telemetry is on, where its data directory is, and the full disclosure table — every field, its type, and what it is for. The disclosure is generated from the code that sends the event, so it cannot drift from what actually goes over the wire.
+The command prints whether telemetry is on, where its data directory is, and the full disclosure table: every field, its type, and what it is for. The disclosure is generated from the code that sends the event, so it cannot drift from what actually goes over the wire.
 
 ```text [Output]
 Telemetry: enabled (preference: enabled)
@@ -65,7 +65,7 @@ Data directory: ~/.config/evlog-cli/telemetry
 
 One event per run, with the command name, how long it took, whether it succeeded, and the error code when it did not. Alongside that: the Node version, the OS and architecture, whether the run was in CI and on which provider, whether stdout is a TTY, and whether an AI coding agent was driving it.
 
-Flags are recorded as the ones you actually passed. Booleans and numbers keep their value; a string value is recorded as `<set>` rather than by content, unless the flag is explicitly allowlisted. Positional arguments are never recorded at all, and a flag left at its default is not recorded either — `evlog map` on its own sends an empty `flags` object. The machine id is a hash, and it is omitted entirely in ephemeral CI.
+Flags are recorded as the ones you actually passed. Booleans and numbers keep their value; a string value is recorded as `<set>` rather than by content, unless the flag is explicitly allowlisted. Positional arguments are never recorded at all, and a flag left at its default is not recorded either, so `evlog map` on its own sends an empty `flags` object. The machine id is a hash, and it is omitted entirely in ephemeral CI.
 
 ::callout{icon="i-lucide-lock" color="neutral"}
 No file paths, no source code, no project names, no route paths, no argument values.

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -36,15 +36,15 @@ nuxt
 | `AGENTS.md` | Created if missing. Otherwise the evlog block is replaced in place, between `<!-- evlog:start -->` and `<!-- evlog:end -->` — everything outside those markers is left exactly as it was. |
 | `CLAUDE.md` | Created as a one-line `@AGENTS.md` if missing. If it exists and already mentions `AGENTS.md`, it is left alone. |
 
-The block is short on purpose — it is loaded into every agent turn. It states the rules (one wide event per operation, grouped context, structured errors, audit on sensitive actions, what never gets logged) and points at the skills for the depth. The logger accessor named in it follows your framework: `useLogger(event)` on Nuxt and Nitro, `useLogger()` from your `lib/evlog.ts` on Next.js, `req.context.log` on TanStack Start. When no framework is detected the block is still written with a generic accessor — the conventions apply just as well on Express or Hono.
+The block is short on purpose, because it is loaded into every agent turn. It states the rules (one wide event per operation, grouped context, structured errors, audit on sensitive actions, what never gets logged) and points at the skills for the depth. The logger accessor named in it follows your framework: `useLogger(event)` on Nuxt and Nitro, `useLogger()` from your `lib/evlog.ts` on Next.js, `req.context.log` on TanStack Start. When no framework is detected the block is still written with a generic accessor, and the conventions apply just as well on Express or Hono.
 
 ## The skills are not ours to install
 
-The [agent skills](/reference/agent-skills) come from [`npx skills`](https://github.com/vercel-labs/skills), which `evlog agents` shells out to — the same way [`evlog init`](/cli/init) runs your package manager instead of unpacking a tarball itself.
+The [agent skills](/reference/agent-skills) come from [`npx skills`](https://github.com/vercel-labs/skills), which `evlog agents` shells out to, the same way [`evlog init`](/cli/init) runs your package manager instead of unpacking a tarball itself.
 
 That is deliberate. Every agent reads a different directory (`.claude/skills`, `.agents/skills`, `.codex/skills`, …), and the skills CLI already resolves them per agent, symlinks a canonical copy, and supports a global scope. It also keeps no manifest, so any copy we wrote behind its back would be a second one it could never update. Delegating means one copy, and `npx skills update` / `remove` / `list` keep working on it.
 
-Before running anything, `evlog agents` looks for evlog skills already installed — any agent, project-local or global — and leaves them alone if it finds them:
+Before running anything, `evlog agents` looks for evlog skills already installed (any agent, project-local or global) and leaves them alone if it finds them:
 
 ```text [Output]
 · AGENTS.md is up to date
@@ -54,7 +54,7 @@ Before running anything, `evlog agents` looks for evlog skills already installed
 ```
 
 ::callout{icon="i-lucide-info" color="neutral"}
-Interactively, the skills CLI asks its own questions — which agents to install for, project or global. That question is its to ask, so `evlog agents` hands over the terminal rather than answering on your behalf. Non-interactive runs (`--json`, `--yes`, CI, no TTY) pass `--yes` so nothing blocks on a prompt nobody will answer.
+Interactively, the skills CLI asks its own questions: which agents to install for, project or global. That question is its to ask, so `evlog agents` hands over the terminal rather than answering on your behalf. Non-interactive runs (`--json`, `--yes`, CI, no TTY) pass `--yes` so nothing blocks on a prompt nobody will answer.
 ::
 
 ### What you are trusting
@@ -66,7 +66,7 @@ Delegating means running third-party code, so it is worth being explicit about t
 - **`--source` is validated.** It must be a plain `http:` / `https:` origin — letters, digits, and `. _ ~ : / -` only, so no query string and no shell metacharacters — and `--skills` entries must be lowercase dashed names. On Windows the spawn needs a shell to resolve `npx` (Node refuses to run a `.cmd` without one), so both are checked before anything is spawned rather than trusted down the chain.
 - **Nothing is spawned without a decision.** `--no-skills` skips it entirely, and the interactive flow will not reach the command until you confirm the plan.
 
-If none of that fits your policy, `evlog agents --no-skills` still writes `AGENTS.md` and `CLAUDE.md` — those never touch the network — and you can install the skills however you prefer.
+If none of that fits your policy, `evlog agents --no-skills` still writes `AGENTS.md` and `CLAUDE.md`, which never touch the network, and you can install the skills however you prefer.
 
 ## Safe to re-run
 
@@ -90,11 +90,11 @@ evlog agents --no-skills
 evlog agents --dry-run
 ```
 
-If the skills CLI fails — no network, no `npx` — the block is still on disk and the command reports the failure and exits 1. The `AGENTS.md` block never needs the network.
+If the skills CLI fails, from no network or no `npx`, the block is still on disk and the command reports the failure and exits 1. The `AGENTS.md` block never needs the network.
 
 ## As part of `evlog init`
 
-[`evlog init`](/cli/init) offers this as its last question. The `AGENTS.md` and `CLAUDE.md` writes land in the same plan as the evlog wiring — one list, one confirmation — and the skills run alongside the package-manager install. Skip it with `--no-agents`:
+[`evlog init`](/cli/init) offers this as its last question. The `AGENTS.md` and `CLAUDE.md` writes land in the same plan as the evlog wiring, in one list with one confirmation, and the skills run alongside the package-manager install. Skip it with `--no-agents`:
 
 ```bash [Terminal]
 evlog init --no-agents

--- a/apps/docs/content/4.integrate/frameworks/07.express.md
+++ b/apps/docs/content/4.integrate/frameworks/07.express.md
@@ -147,7 +147,7 @@ Both `req.log` and `useLogger()` return the same logger instance. `useLogger()` 
 
 ## Background work (`log.fork`)
 
-Fire-and-forget async work that finishes **after** the response can no longer update the request wide event (the logger is sealed after emit). Use **`req.log.fork(label, fn)`** so `useLogger()` inside `fn` targets a **child** logger that emits its own event with `operation` and `_parentRequestId`. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
+Fire-and-forget async work that finishes **after** the response can no longer update the request wide event (the logger is sealed after emit). Use **`req.log.fork(label, fn)`** so `useLogger()` inside `fn` targets the forked logger, which emits its own event with `operation` and `_parentRequestId`. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
 ```typescript [src/index.ts]
 import { evlog, useLogger } from 'evlog/express'

--- a/apps/docs/content/4.integrate/frameworks/08.hono.md
+++ b/apps/docs/content/4.integrate/frameworks/08.hono.md
@@ -144,7 +144,7 @@ works with or without it, so deployments that cannot enable the flag keep using 
 
 ### Background work
 
-**`log.fork()`** runs work under a child logger that emits its own wide event, correlated
+**`log.fork()`** runs work under a forked logger that emits its own wide event, correlated
 to the request via `_parentRequestId`:
 
 ```typescript [src/index.ts]

--- a/apps/docs/content/5.use-cases/0.overview.md
+++ b/apps/docs/content/5.use-cases/0.overview.md
@@ -27,7 +27,7 @@ links:
     variant: subtle
 ---
 
-Use Cases are **recipes**, not features. Each one solves a specific problem with the same evlog primitives you already know — wide events, structured errors, drains, enrichers. They live as their own section because they have enough surface area (multiple pages each, dedicated examples) to deserve direct navigation, but they're not a separate runtime — same logger, same drain pipeline, same types.
+Use Cases are **recipes**, not features. Each one solves a specific problem with the same evlog primitives you already know: wide events, structured errors, drains, enrichers. They live as their own section because they have enough surface area (multiple pages each, dedicated examples) to deserve direct navigation, but they're not a separate runtime: same logger, same drain pipeline, same types.
 
 | You want to… | See |
 | --- | --- |
@@ -60,7 +60,7 @@ your app code
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-Every use case is opt-in. Adopt one, two, or all five — they coexist in the same logger, the same drain pipeline, and the same enrich chain.
+Every use case is opt-in. Adopt one, two, or all five. They coexist in the same logger, the same drain pipeline, and the same enrich chain.
 
 ## Where to go next
 

--- a/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
@@ -27,7 +27,7 @@ links:
     variant: subtle
 ---
 
-`evlog/ai` gives you full AI observability by wrapping your model with middleware. Token usage, tool calls, streaming performance, cache hits, reasoning tokens, and cost estimation — all captured into the wide event automatically.
+`evlog/ai` gives you full AI observability by wrapping your model with middleware. Token usage, tool calls, streaming performance, cache hits, reasoning tokens, and cost estimation, all captured into the wide event automatically.
 
 ::prompt
 ---
@@ -158,7 +158,7 @@ The middleware intercepts calls at the provider level. It does not touch your ca
   title: Usage Patterns
   to: /use-cases/ai-sdk/usage
   ---
-  `streamText`, `generateText`, multi-step agents, RAG, multiple models — every common pattern, ready to copy.
+  `streamText`, `generateText`, multi-step agents, RAG, multiple models: every common pattern, ready to copy.
   :::
 
   :::card
@@ -176,7 +176,7 @@ The middleware intercepts calls at the provider level. It does not touch your ca
   title: Access Metadata
   to: /use-cases/ai-sdk/metadata
   ---
-  Read the captured `ai` data inside your handler — persist it, bill against it, or stream it to the client.
+  Read the captured `ai` data inside your handler: persist it, bill against it, or stream it to the client.
   :::
 
   :::card

--- a/apps/docs/content/5.use-cases/2.ai-sdk/02.usage.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/02.usage.md
@@ -23,7 +23,7 @@ On Next.js, Nuxt/Nitro, SvelteKit, Hono, React Router, and oRPC, evlog defers wi
 
 ## streamText
 
-The most common pattern — streaming chat with full observability:
+The most common pattern is streaming chat with full observability:
 
 ```typescript [server/api/chat.post.ts]
 import { streamText } from 'ai'
@@ -48,7 +48,7 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-The middleware never touches your `onFinish` callback — your code runs as usual.
+The middleware never touches your `onFinish` callback, so your code runs as usual.
 
 ## generateText
 
@@ -181,7 +181,7 @@ ai.captureEmbed({ usage, model: 'text-embedding-3-small', count: documents.lengt
 
 ## Multiple Models
 
-Wrap each model separately — they share the same accumulator. When more than one model is used, the wide event includes both `model` (last model) and `models` (all unique models):
+Wrap each model separately. They share the same accumulator. When more than one model is used, the wide event includes both `model` (last model) and `models` (all unique models):
 
 ::code-group
 ```typescript [server/api/chat.post.ts]
@@ -211,7 +211,7 @@ const response = await generateText({ model: smart, prompt: detailedPrompt })
 
 ## Model Object Support
 
-`wrap()` accepts model objects from provider SDKs — both `LanguageModelV3` (AI SDK v6) and `LanguageModelV4` (AI SDK v7):
+`wrap()` accepts model objects from provider SDKs: both `LanguageModelV3` (AI SDK v6) and `LanguageModelV4` (AI SDK v7):
 
 ```typescript [server/api/chat.post.ts]
 import { anthropic } from '@ai-sdk/anthropic'

--- a/apps/docs/content/5.use-cases/2.ai-sdk/03.options.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/03.options.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-`createAILogger(log, options?)` accepts a single options bag. Every option is opt-in — defaults stay safe and quiet.
+`createAILogger(log, options?)` accepts a single options bag. Every option is opt-in, and the defaults stay safe and quiet.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -26,7 +26,7 @@ links:
 
 ## Tool Inputs
 
-By default, `ai.toolCalls` is a `string[]` of tool names. Enable `toolInputs` to capture inputs too — useful for debugging agent behaviour or auditing what data the model reached for.
+By default, `ai.toolCalls` is a `string[]` of tool names. Enable `toolInputs` to capture inputs too, which suits debugging agent behaviour or auditing what data the model reached for.
 
 ::warning
 Tool inputs can be large and may contain sensitive data (SQL, API keys, customer PII). Use `maxLength` and `transform` rather than enabling raw capture in production.
@@ -78,7 +78,7 @@ const ai = createAILogger(log, {
 })
 ```
 
-Read the result from your handler with [`ai.getEstimatedCost()`](/use-cases/ai-sdk/metadata) — useful for billing dashboards or warning users before expensive calls.
+Read the result from your handler with [`ai.getEstimatedCost()`](/use-cases/ai-sdk/metadata), which suits billing dashboards or warning users before expensive calls.
 
 ::tip
 Keep your `cost` map in one file alongside model selection so renaming a model in production also updates pricing. Avoid hardcoding per-route maps.
@@ -100,4 +100,4 @@ If a model call fails, the middleware captures the error into the wide event bef
 }
 ```
 
-Stream errors (e.g. content filter) are also captured from the stream's error chunks. Your error-handling code (`try/catch`, route-level error handlers) keeps working as usual — the middleware only observes.
+Stream errors (e.g. content filter) are also captured from the stream's error chunks. Your error-handling code (`try/catch`, route-level error handlers) keeps working as usual, since the middleware only observes.

--- a/apps/docs/content/5.use-cases/2.ai-sdk/04.metadata.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/04.metadata.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-The wide event already contains the full `ai` metadata, but you often want the same data inside your handler — to persist it, surface it to end-users, bill against it, or stream incremental progress to the client.
+The wide event already contains the full `ai` metadata, but you often want the same data inside your handler: to persist it, surface it to end-users, bill against it, or stream incremental progress to the client.
 
 `AILogger` exposes three methods for that, with no need to touch internal state.
 

--- a/apps/docs/content/5.use-cases/2.ai-sdk/05.telemetry.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/05.telemetry.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-`createAILogger` covers tokens, model info, and streaming metrics. For deeper observability — per-tool execution timing, success/failure tracking, and total generation wall time — add `createEvlogIntegration()` on top. It implements the AI SDK telemetry interface (v6 `TelemetryIntegration`, v7 `Telemetry`) and captures data middleware alone cannot see.
+`createAILogger` covers tokens, model info, and streaming metrics. For deeper observability (per-tool execution timing, success/failure tracking, and total generation wall time), add `createEvlogIntegration()` on top. It implements the AI SDK telemetry interface (v6 `TelemetryIntegration`, v7 `Telemetry`) and captures data middleware alone cannot see.
 
 On AI SDK v7, the integration also auto-captures embeddings via `onEmbedEnd`, records stream aborts via `onAbort`, and surfaces unrecoverable errors via `onError`.
 

--- a/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
@@ -27,7 +27,7 @@ links:
     variant: subtle
 ---
 
-`evlog/better-auth` turns anonymous wide events into identified ones. Every request automatically includes who made it — no manual `log.set({ user })` needed.
+`evlog/better-auth` turns anonymous wide events into identified ones. Every request automatically includes who made it, with no manual `log.set({ user })` needed.
 
 ## Prerequisites
 
@@ -247,7 +247,7 @@ The integration resolves the Better Auth session from request cookies, extracts 
   title: Identify User
   to: /use-cases/better-auth/identify-user
   ---
-  The core building block — extract safe fields, mask emails, capture plugin data (organizations, roles, 2FA).
+  The core building block: extract safe fields, mask emails, capture plugin data (organizations, roles, 2FA).
   :::
 
   :::card

--- a/apps/docs/content/5.use-cases/3.better-auth/02.identify-user.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/02.identify-user.md
@@ -32,7 +32,7 @@ if (session) {
 ```
 
 ::tip
-**Safe by default.** Only whitelisted fields are extracted — passwords, tokens, and secrets are never written to the logger.
+**Safe by default.** Only whitelisted fields are extracted, and passwords, tokens, and secrets are never written to the logger.
 ::
 
 ## Options
@@ -95,7 +95,7 @@ Wide event with plugin fields:
 ```
 
 ::tip
-Keep `extend` deterministic — it runs on every request. Avoid heavy computations or extra database calls inside it; query the data Better Auth already loaded into the session.
+Keep `extend` deterministic, because it runs on every request. Avoid heavy computations or extra database calls inside it; query the data Better Auth already loaded into the session.
 ::
 
 ## Captured fields

--- a/apps/docs/content/5.use-cases/3.better-auth/03.middleware.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/03.middleware.md
@@ -56,7 +56,7 @@ const identify = createAuthMiddleware(auth, {
 })
 ```
 
-For high-traffic apps, flip the model — only resolve sessions on routes that need them:
+For high-traffic apps, flip the model and only resolve sessions on routes that need them:
 
 ```typescript
 const identify = createAuthMiddleware(auth, {
@@ -64,11 +64,11 @@ const identify = createAuthMiddleware(auth, {
 })
 ```
 
-`include` and `exclude` use glob patterns (`*`, `**`). Provide both if you need granular control — `exclude` wins over `include`.
+`include` and `exclude` use glob patterns (`*`, `**`). Provide both if you need granular control, and `exclude` wins over `include`.
 
 ## Lifecycle Hooks
 
-Use `onIdentify` to react to user identification — for example, force-keep logs for premium users via tail sampling:
+Use `onIdentify` to react to user identification, for example to force-keep logs for premium users via tail sampling:
 
 ```typescript [server/middleware/auth-identify.ts]
 const identify = createAuthMiddleware(auth, {
@@ -95,4 +95,4 @@ Common patterns for `onIdentify`:
 
 ## Error Handling
 
-The middleware catches every error from `getSession` and logs nothing — your request keeps flowing whether the auth backend is up or down. The wide event still includes `auth.resolvedIn` and `auth.identified: false` so you can alert on session resolution health from your dashboards.
+The middleware catches every error from `getSession` and logs nothing, so your request keeps flowing whether the auth backend is up or down. The wide event still includes `auth.resolvedIn` and `auth.identified: false` so you can alert on session resolution health from your dashboards.

--- a/apps/docs/content/5.use-cases/3.better-auth/04.client-sync.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/04.client-sync.md
@@ -103,5 +103,5 @@ Client-side logs now include the user identity:
 ```
 
 ::tip
-`setIdentity` is part of evlog's [client logging](/use-cases/client-logging) layer. The same fields are picked up by the HTTP transport when client logs are forwarded to your server, so a single user shows up identified across browser **and** API logs.
+`setIdentity` is part of evlog's [client logging](/use-cases/client-logging) layer. The same fields are picked up by the HTTP drain when client logs are forwarded to your server, so a single user shows up identified across browser **and** API logs.
 ::

--- a/apps/docs/content/5.use-cases/3.better-auth/05.performance.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/05.performance.md
@@ -43,7 +43,7 @@ A common P95 target after caching: `auth.resolvedIn < 5ms`.
 `createAuthIdentifier` is a factory that creates a Nitro `request` hook. Designed for **standalone Nitro** apps where the evlog Nitro module handles hook ordering.
 
 ::note
-For **Nuxt**, use `createAuthMiddleware` in a server middleware instead — Nitro plugin hook ordering can cause the logger to not be available yet in the `request` hook.
+For **Nuxt**, use `createAuthMiddleware` in a server middleware instead, because Nitro plugin hook ordering can cause the logger to not be available yet in the `request` hook.
 ::
 
 ```typescript [server/plugins/evlog-auth.ts]
@@ -91,4 +91,4 @@ When you also use [`evlog/ai`](/use-cases/ai-sdk/overview), your wide events inc
 }
 ```
 
-This is the power of wide events — one event per request, all context in one place: who made the request, what they did, how the AI responded, and how it performed.
+This is what a wide event buys you: one event per request, all context in one place: who made the request, what they did, how the AI responded, and how it performed.

--- a/apps/docs/content/5.use-cases/4.audit/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.audit/01.overview.md
@@ -32,7 +32,7 @@ links:
     variant: subtle
 ---
 
-evlog's audit layer is **not a parallel system**. Audit events are wide events with a reserved `audit` field. Every existing primitive — drains, enrichers, redact, tail-sampling — applies as is. Enable audit logs by adding **1 enricher + 1 drain wrapper + 1 helper**.
+evlog's audit layer is **not a parallel system**. Audit events are wide events with a reserved `audit` field. Every existing primitive (drains, enrichers, redact, tail-sampling) applies as is. Enable audit logs by adding **1 enricher + 1 drain wrapper + 1 helper**.
 
 ::prompt
 ---
@@ -74,7 +74,7 @@ See [Agent Skills](/reference/agent-skills) for the full list. Skill paths in th
 Compliance frameworks (SOC2, HIPAA, GDPR, PCI) require knowing **who did what, on which resource, when, from where, with which outcome**. evlog covers this without a second logging library.
 
 ::tip
-**An audit event is a fact about an intent, not a measurement of an operation.** A regular wide event answers "how did this request behave?" (latency, status, tokens). An audit event answers "who tried to do what, and was it allowed?". Same pipeline, different question — that's why the schema is reserved and the event is force-kept past sampling.
+**An audit event is a fact about an intent, not a measurement of an operation.** A regular wide event answers "how did this request behave?" (latency, status, tokens). An audit event answers "who tried to do what, and was it allowed?". Same pipeline, different question, which is why the schema is reserved and the event is force-kept past sampling.
 ::
 
 ::audit-force-keep
@@ -231,7 +231,7 @@ That's it. The audit event:
 - Carries `requestId`, `traceId`, `ip`, and `userAgent` automatically via `auditEnricher`.
 
 ::tip
-**Why two drains?** The main drain (Axiom, Datadog, ...) keeps audits next to the rest of your telemetry so dashboards and queries still work. The signed drain is your insurance: if the main drain has an outage, gets purged, or an admin quietly removes a row, the FS journal still holds the chain. Auditors want both — fast querying *and* a tamper-evident artefact.
+**Why two drains?** The main drain (Axiom, Datadog, ...) keeps audits next to the rest of your telemetry so dashboards and queries still work. The signed drain is your insurance: if the main drain has an outage, gets purged, or an admin quietly removes a row, the FS journal still holds the chain. Auditors want both: fast querying *and* a tamper-evident artefact.
 ::
 
 ::audit-dual-sink
@@ -289,6 +289,6 @@ Each layer is **opt-in and replaceable**. Every node except `log.audit`, `auditE
   title: Recipes
   to: /use-cases/audit/recipes
   ---
-  FS, Axiom, and Postgres recipes — plus testing with `mockAudit` and the API reference.
+  FS, Axiom, and Postgres recipes, plus testing with `mockAudit` and the API reference.
   :::
 ::

--- a/apps/docs/content/5.use-cases/4.audit/02.schema.md
+++ b/apps/docs/content/5.use-cases/4.audit/02.schema.md
@@ -61,7 +61,7 @@ interface AuditFields {
 ## Action naming
 
 ::tip
-**Naming convention for `action`.** Use `noun.verb` (`invoice.refund`, `user.invite`, `apiKey.revoke`). Past tense if the action already happened (`invoice.refunded`), present tense if `withAudit()` will resolve the outcome. Keep a small fixed dictionary in one file — auditors and SIEM rules query on `action`, so a typo is a missing alert.
+**Naming convention for `action`.** Use `noun.verb` (`invoice.refund`, `user.invite`, `apiKey.revoke`). Past tense if the action already happened (`invoice.refunded`), present tense if `withAudit()` will resolve the outcome. Keep a small fixed dictionary in one file, because auditors and SIEM rules query on `action`, so a typo is a missing alert.
 ::
 
 A single dictionary file makes alerting straightforward:
@@ -77,7 +77,7 @@ export const AUDIT_ACTIONS = {
 ```
 
 ::tip
-For more than a handful of actions, prefer [`defineAuditCatalog`](/use-cases/audit/recording#defineauditcatalog) over a plain object dictionary — same `noun.verb` convention, but you get autocomplete on the action union and per-entry `target` type inference for free.
+For more than a handful of actions, prefer [`defineAuditCatalog`](/use-cases/audit/recording#defineauditcatalog) over a plain object dictionary: same `noun.verb` convention, but you get autocomplete on the action union and per-entry `target` type inference for free.
 ::
 
 ## Actor types
@@ -101,11 +101,11 @@ For more than a handful of actions, prefer [`defineAuditCatalog`](/use-cases/aud
 | `'failure'` | The action was attempted but failed (downstream error, race condition, etc.). |
 | `'denied'` | The action was rejected by an authorisation check. |
 
-`'failure'` and `'denied'` are different things — auditors care a lot about denied actions because they signal probing or misconfigured access controls. Always log denials (see [Recording Events](/use-cases/audit/recording#deny)).
+`'failure'` and `'denied'` are different things, and auditors care a lot about denied actions because they signal probing or misconfigured access controls. Always log denials (see [Recording Events](/use-cases/audit/recording#deny)).
 
 ## Idempotency
 
-`idempotencyKey` is auto-derived from a hash of `action`, `actor.id`, `target`, and a coarse timestamp. The result: even if your drain retries an audit insert across a network blip, the duplicate row collapses on `ON CONFLICT DO NOTHING`. You don't have to think about it — it's filled in for you.
+`idempotencyKey` is auto-derived from a hash of `action`, `actor.id`, `target`, and a coarse timestamp. The result: even if your drain retries an audit insert across a network blip, the duplicate row collapses on `ON CONFLICT DO NOTHING`. You don't have to think about it, since it is filled in for you.
 
 Use the field as the primary key in Postgres / Bigtable / DynamoDB so retries stay safe by construction.
 

--- a/apps/docs/content/5.use-cases/4.audit/03.recording.md
+++ b/apps/docs/content/5.use-cases/4.audit/03.recording.md
@@ -117,7 +117,7 @@ audit({
 ::
 
 ::note
-Standalone `audit()` events have no `requestId`, no `context.ip`, no `userAgent` — there is no request to enrich from. Add your own context manually (`context: { jobId, queue, runId }`) when it matters for forensics.
+Standalone `audit()` events have no `requestId`, no `context.ip`, no `userAgent`, because there is no request to enrich from. Add your own context manually (`context: { jobId, queue, runId }`) when it matters for forensics.
 ::
 
 ## `defineAuditAction()`
@@ -197,7 +197,7 @@ Both produce the same call-site factory shape. Pick by scale:
 - **`defineAuditAction(action, opts?)`** — one-off actions, or per-file organisation in very large repos. Mirrors `defineError`. Equivalent to a catalog with a single entry but with no prefix derivation: you write the full wire `action` directly.
 - **`defineAuditCatalog(prefix, map)`** — group anything beyond a handful of related actions under one prefix. Mirrors `defineErrorCatalog`. The wire `action` is auto-derived as `${prefix}.${KEY}`, catalog metadata (`_actions`, `_prefix`) is exposed for introspection, and a single `declare module 'evlog'` line surfaces the whole bundle in the typed `AuditAction` union.
 
-You can mix the two in the same codebase — keep cross-cutting one-off actions as `defineAuditAction`, group bounded contexts (`billing`, `auth`, `subscription`) as catalogs.
+You can mix the two in the same codebase. Keep cross-cutting one-off actions as `defineAuditAction`, group bounded contexts (`billing`, `auth`, `subscription`) as catalogs.
 
 ### Type-safe actions everywhere (opt-in)
 
@@ -269,7 +269,7 @@ log.audit({
 Devs forget to call `log.audit()`. Wrap the function and never miss a record:
 
 ::tip
-**When to wrap vs. call manually.** Wrap functions that are *pure audit-worthy actions* (refund, delete, role change, password reset) — outcome resolution is automatic and you can't accidentally skip the call. Stick to manual `log.audit()` when the audit is one of several decisions inside a larger handler, or when you need to emit the audit *before* the action completes (e.g. "user requested deletion").
+**When to wrap vs. call manually.** Wrap functions that are *pure audit-worthy actions* (refund, delete, role change, password reset): outcome resolution is automatic and you can't accidentally skip the call. Stick to manual `log.audit()` when the audit is one of several decisions inside a larger handler, or when you need to emit the audit *before* the action completes (e.g. "user requested deletion").
 ::
 
 ::code-group

--- a/apps/docs/content/5.use-cases/4.audit/04.pipeline.md
+++ b/apps/docs/content/5.use-cases/4.audit/04.pipeline.md
@@ -38,12 +38,12 @@ nitro.hooks.hook('evlog:enrich', auditEnricher({
 }))
 ```
 
-Without `auditEnricher`, `audit.context` stays empty — auditors and incident responders need at least `requestId` and `ip` to triangulate a recorded action.
+Without `auditEnricher`, `audit.context` stays empty, and auditors and incident responders need at least `requestId` and `ip` to triangulate a recorded action.
 
 ## `auditOnly()`
 
 ::tip
-**Why filter audits to a separate drain?** Three reasons: **cost** (audit volume is tiny next to product telemetry — keep them separate so retention costs don't explode), **permissions** (the audit dataset should be read-only for engineers and write-only for the app), and **retention** (audits often live 7+ years; product logs rarely live more than 90 days).
+**Why filter audits to a separate drain?** Three reasons: **cost** (audit volume is tiny next to product telemetry, so keep them separate and retention costs don't explode), **permissions** (the audit dataset should be read-only for engineers and write-only for the app), and **retention** (audits often live 7+ years; product logs rarely live more than 90 days).
 ::
 
 `auditOnly(drain)` only forwards events with an `audit` field. Compose with **any** drain:
@@ -58,7 +58,7 @@ nitro.hooks.hook('evlog:drain', auditOnly(
 ))
 ```
 
-Set `await: true` to make audit writes synchronous (no fire-and-forget for audits — crash-safe by default):
+Set `await: true` to make audit writes synchronous (no fire-and-forget for audits, so crash-safe by default):
 
 ```typescript
 auditOnly(createFsDrain({ dir: '.audit' }), { await: true })
@@ -76,7 +76,7 @@ The `await: true` flag costs you a small bit of latency per request that records
 | `'hash-chain'` | `event.audit.prevHash` and `event.audit.hash` | A verifiable chain — deletions and reordering also become detectable. |
 
 ::tip
-**What `signed()` actually buys you.** Detection, not prevention. Anyone with write access to the underlying drain can still nuke the file or table — but the chain proves *which* events were dropped or modified after the fact. Skip `signed()` if you already write to an append-only / WORM store (S3 Object Lock, Postgres with row-level immutability, BigQuery append-only tables); doubling integrity layers just adds latency without raising the bar.
+**What `signed()` actually buys you.** Detection, not prevention. Anyone with write access to the underlying drain can still nuke the file or table, but the chain proves *which* events were dropped or modified after the fact. Skip `signed()` if you already write to an append-only / WORM store (S3 Object Lock, Postgres with row-level immutability, BigQuery append-only tables); doubling integrity layers just adds latency without raising the bar.
 ::
 
 ### HMAC

--- a/apps/docs/content/5.use-cases/4.audit/05.compliance.md
+++ b/apps/docs/content/5.use-cases/4.audit/05.compliance.md
@@ -52,7 +52,7 @@ initLogger({
 })
 ```
 
-The preset redacts `authorization`, `cookie`, `set-cookie`, and common credential key names (`password`, `token`, `apiKey`, `cardNumber`, `cvv`, `ssn`) **at any nesting depth** — including inside `audit.changes.before` / `audit.changes.after`.
+The preset redacts `authorization`, `cookie`, `set-cookie`, and common credential key names (`password`, `token`, `apiKey`, `cardNumber`, `cvv`, `ssn`) **at any nesting depth**, including inside `audit.changes.before` / `audit.changes.after`.
 
 ## GDPR vs append-only
 

--- a/apps/docs/content/5.use-cases/4.audit/06.recipes.md
+++ b/apps/docs/content/5.use-cases/4.audit/06.recipes.md
@@ -40,7 +40,7 @@ nitro.hooks.hook('evlog:drain', auditOnly(
 
 ::
 
-Each line's `prevHash` matches the previous line's `hash`. Tampering with any row breaks the chain forward of that point — a verifier replays the hashes and reports the first mismatch.
+Each line's `prevHash` matches the previous line's `hash`. Tampering with any row breaks the chain forward of that point, and a verifier replays the hashes and reports the first mismatch.
 
 ## Audit logs to a dedicated Axiom dataset
 
@@ -71,7 +71,7 @@ nitro.hooks.hook('evlog:drain', auditOnly(
 
 ::
 
-Splitting datasets means the audit dataset can have a longer retention (7y), tighter access controls, and a separate billing line — without touching the rest of your pipeline.
+Splitting datasets means the audit dataset can have a longer retention (7y), tighter access controls, and a separate billing line, without touching the rest of your pipeline.
 
 ## Audit logs in Postgres
 
@@ -105,11 +105,11 @@ WHERE id = 'ak_8f3c4b2a1e5d6f7c';
 
 ::
 
-The deterministic `idempotencyKey` makes retries safe — duplicate inserts collapse via `ON CONFLICT DO NOTHING`. Without it, a transient network blip during a retry would create a duplicate audit row, which is exactly what you don't want.
+The deterministic `idempotencyKey` makes retries safe: duplicate inserts collapse via `ON CONFLICT DO NOTHING`. Without it, a transient network blip during a retry would create a duplicate audit row, which is exactly what you don't want.
 
 ## Testing audits
 
-`mockAudit()` captures every audit event on emit — from standalone `audit()`, `log.audit()`, and `log.set({ audit })`:
+`mockAudit()` captures every audit event on emit, from standalone `audit()`, `log.audit()`, and `log.set({ audit })`:
 
 ```typescript
 import { mockAudit } from 'evlog'

--- a/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
@@ -22,7 +22,7 @@ links:
     variant: subtle
 ---
 
-`@evlog/telemetry` brings [evlog](https://evlog.dev)'s wide-event model to tools that run on other people's machines — CLIs, GitHub Actions, dev scripts, and CI jobs. Same philosophy as HTTP logging: **one command execution → one structured event**, not a stream of analytics calls.
+`@evlog/telemetry` brings [evlog](https://evlog.dev)'s wide-event model to tools that run on other people's machines: CLIs, GitHub Actions, dev scripts, and CI jobs. Same philosophy as HTTP logging: **one command execution → one structured event**, not a stream of analytics calls.
 
 ::code-group
 ```bash [pnpm]
@@ -39,7 +39,7 @@ npm install @evlog/telemetry
 ```
 ::
 
-You get command name, sanitized flags, duration, and outcome automatically. Call `telemetry.set()` only when you have extra counters — numbers and booleans by default. Raw `argv` is never read; disclosure is generated from your runtime config so it cannot drift from what you actually collect.
+You get command name, sanitized flags, duration, and outcome automatically. Call `telemetry.set()` only when you have extra counters, numbers and booleans by default. Raw `argv` is never read; disclosure is generated from your runtime config so it cannot drift from what you actually collect.
 
 ::prompt
 ---
@@ -89,7 +89,7 @@ Nothing is sent until you configure an endpoint and the server returns a success
 
 ## Why install it
 
-You can wire anonymous usage telemetry yourself — outbox file, consent flags, flag sanitization, disclosure markdown, ingest validation, first-run notice. Or you add one dependency and get the evlog playbook baked in.
+You can wire anonymous usage telemetry yourself: outbox file, consent flags, flag sanitization, disclosure markdown, ingest validation, first-run notice. Or you add one dependency and get the evlog playbook baked in.
 
 ### What you get for ~28 KB
 
@@ -109,7 +109,7 @@ You can wire anonymous usage telemetry yourself — outbox file, consent flags, 
 | **GitHub Actions** | `createGitHubActionsTelemetry()` | Same as script; `ghaAction` / `ghaEvent` auto-injected |
 | **Your API (ingest)** | `parseIngestBody()` from `@evlog/telemetry/ingest` | One validator + one POST route |
 
-No framework lock-in. No PostHog / Segment / custom analytics SDK. No second schema to maintain — disclosure is generated from the same `collect` config the CLI uses at runtime.
+No framework lock-in. No PostHog / Segment / custom analytics SDK. No second schema to maintain, since disclosure is generated from the same `collect` config the CLI uses at runtime.
 
 ### What you skip building
 
@@ -132,10 +132,10 @@ Once ingest is live you can answer product questions that CLI authors usually gu
 - Which versions are still in the wild (`tool.version` on every event)
 - Whether CI or local dev dominates (`env.ci`, `env.agent`, `env.tty`)
 
-All from one wide event per run — the same mental model as evlog on the server, without bolting a browser analytics stack onto a terminal tool.
+All from one wide event per run, the same mental model as evlog on the server, without bolting a browser analytics stack onto a terminal tool.
 
 ::callout{icon="i-lucide-package" color="neutral"}
-Try it locally: [`examples/telemetry-playground`](https://github.com/HugoRCD/evlog/tree/main/examples/telemetry-playground) — `pnpm run cli -- doctor`, `EVLOG_TELEMETRY_DEBUG=1` to inspect payloads, `telemetry status` for disclosure.
+Try it locally: [`examples/telemetry-playground`](https://github.com/HugoRCD/evlog/tree/main/examples/telemetry-playground): `pnpm run cli -- doctor`, `EVLOG_TELEMETRY_DEBUG=1` to inspect payloads, `telemetry status` for disclosure.
 ::
 
 ## See also

--- a/apps/docs/content/5.use-cases/4.telemetry/02.setup.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/02.setup.md
@@ -24,7 +24,7 @@ links:
 
 ## Configure delivery
 
-Point the CLI at your ingestion URL when you ship it — baked into the binary, overridable per environment:
+Point the CLI at your ingestion URL when you ship it, baked into the binary and overridable per environment:
 
 ```ts [src/index.ts]
 withTelemetry(command, {
@@ -44,7 +44,7 @@ The built-in HTTP drain POSTs `Content-Type: application/json` with body `{ even
 
 ## Setup with citty
 
-Wrap your root command in `withTelemetry()` — typically in `src/index.ts`, the file that calls `runMain()`. Subcommands can live in the same file or in `src/commands/*.ts`; only the entrypoint needs the wrapper.
+Wrap your root command in `withTelemetry()`, typically in `src/index.ts`, the file that calls `runMain()`. Subcommands can live in the same file or in `src/commands/*.ts`; only the entrypoint needs the wrapper.
 
 ```ts [src/index.ts]
 import { defineCommand, runMain } from 'citty'
@@ -80,7 +80,7 @@ runMain(main)
 
 ### What gets recorded automatically
 
-`withTelemetry` walks your citty tree. Each `run` handler produces one event — no per-command telemetry boilerplate.
+`withTelemetry` walks your citty tree. Each `run` handler produces one event, with no per-command telemetry boilerplate.
 
 | Invocation | `event.command` | Notes on `flags` |
 | --- | --- | --- |
@@ -94,7 +94,7 @@ The root `meta.name` is not prefixed when the root only delegates to `subCommand
 
 ### Enriching a run
 
-Call `telemetry.set()` anywhere inside a command handler — or in helpers that run on the same async stack (the run context is preserved via AsyncLocalStorage).
+Call `telemetry.set()` anywhere inside a command handler, or in helpers that run on the same async stack (the run context is preserved via AsyncLocalStorage).
 
 ::code-collapse
 ```ts [src/commands/doctor.ts]
@@ -144,7 +144,7 @@ Throw an error with a `code` property and `outcome: "error"` plus `errorCode` ar
 throw Object.assign(new Error('Config missing'), { code: 'CONFIG_NOT_FOUND' })
 ```
 
-A minimal sync handler for comparison — flags are auto-captured, you only `set()` business counters:
+A minimal sync handler for comparison. Flags are auto-captured, you only `set()` business counters:
 
 ```ts [src/commands/sync.ts]
 import { telemetry } from '@evlog/telemetry'
@@ -179,7 +179,7 @@ await t.run('migrate', async () => {
 await t.flush() // optional — also runs at end of each t.run()
 ```
 
-GitHub Actions: swap `createTelemetry` for `createGitHubActionsTelemetry()` in the same file — it adds `ghaAction` and `ghaEvent` to `custom` from `GITHUB_ACTION` / `GITHUB_EVENT_NAME` only (never repo content).
+GitHub Actions: swap `createTelemetry` for `createGitHubActionsTelemetry()` in the same file, which adds `ghaAction` and `ghaEvent` to `custom` from `GITHUB_ACTION` / `GITHUB_EVENT_NAME` only (never repo content).
 
 ```ts [scripts/ci-report.ts]
 import { createGitHubActionsTelemetry, telemetry } from '@evlog/telemetry'

--- a/apps/docs/content/5.use-cases/4.telemetry/03.ingest.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/03.ingest.md
@@ -22,23 +22,23 @@ links:
     variant: subtle
 ---
 
-You ship a CLI. Users run it on their machines. You want to know *which commands run, how often they fail, and which versions are out there* — without building a separate analytics SDK or reading raw `argv`.
+You ship a CLI. Users run it on their machines. You want to know *which commands run, how often they fail, and which versions are out there*, without building a separate analytics SDK or reading raw `argv`.
 
 That means a **server endpoint** your CLI POSTs to. The local outbox is only there so short CI jobs and offline runs do not lose data before the POST succeeds.
 
 ## The security question (read this first)
 
 ::tip
-**CLI telemetry is not a vault.** You are collecting anonymous usage counters (command name, duration, outcome, a few numbers) — not passwords, not file paths, not tokens. Design for that threat model and you do not need impossible client-side secrets.
+**CLI telemetry is not a vault.** You are collecting anonymous usage counters (command name, duration, outcome, a few numbers), not passwords, not file paths, not tokens. Design for that threat model and you do not need impossible client-side secrets.
 ::
 
-**"I put the ingest URL in my CLI — isn't that a secret?"**
+**"I put the ingest URL in my CLI. Isn't that a secret?"**
 
-No. The URL lives in your npm package or binary. Anyone can read it with `strings`, by installing the package, or by watching network traffic. The same applies to an API key or `Authorization` header baked into the CLI — extractable, not a real barrier.
+No. The URL lives in your npm package or binary. Anyone can read it with `strings`, by installing the package, or by watching network traffic. The same applies to an API key or `Authorization` header baked into the CLI is extractable, not a real barrier.
 
 **"So can't anyone send fake events?"**
 
-In theory, yes — someone could `curl` your endpoint with forged JSON. That is why you treat the endpoint as **semi-public** (like a browser analytics key) and defend on the server:
+In theory, yes: someone could `curl` your endpoint with forged JSON. That is why you treat the endpoint as **semi-public** (like a browser analytics key) and defend on the server:
 
 | What you might worry about | Practical answer |
 | --- | --- |
@@ -49,10 +49,10 @@ In theory, yes — someone could `curl` your endpoint with forged JSON. That is 
 | Double-counting on retry | Dedupe on `idempotencyKey` when storing |
 | Leaking user secrets | CLI never reads raw `argv`; you only allowlisted flags and `telemetry.set()` counters |
 
-**What "good enough" looks like:** validate every POST, store idempotently, rate-limit at the edge (CDN, API gateway, or middleware), and keep the payload boring (no PII by design). That is the same playbook as client-side analytics — not banking-grade auth, but reliable product insight.
+**What "good enough" looks like:** validate every POST, store idempotently, rate-limit at the edge (CDN, API gateway, or middleware), and keep the payload boring (no PII by design). That is the same playbook as client-side analytics: not banking-grade auth, but reliable product insight.
 
 ::callout{icon="i-lucide-shield-check" color="info"}
-`@evlog/telemetry` ships **`parseIngestBody()`** for your server — the same validation rules documented here, so you do not copy-paste a validator from the docs. Pair it with your framework route and your database or evlog drain.
+`@evlog/telemetry` ships **`parseIngestBody()`** for your server, with the same validation rules documented here, so you do not copy-paste a validator from the docs. Pair it with your framework route and your database or evlog drain.
 ::
 
 ## Step 1 — Validate with `parseIngestBody()`
@@ -74,11 +74,11 @@ export function parseTelemetryBody(raw: string) {
 }
 ```
 
-`parseIngestBody()` checks batch size, JSON shape, `event: 'run'`, tool allowlist, envelope types, ISO timestamp, and strips `custom` keys you did not declare. Throws `IngestValidationError` on failure — return `400` from your route.
+`parseIngestBody()` checks batch size, JSON shape, `event: 'run'`, tool allowlist, envelope types, ISO timestamp, and strips `custom` keys you did not declare. Throws `IngestValidationError` on failure, so return `400` from your route.
 
 ## Step 2 — Wire your route
 
-Same contract for any framework — read the raw body, validate, store, return **204** so the CLI clears its outbox:
+Same contract for any framework: read the raw body, validate, store, return **204** so the CLI clears its outbox:
 
 ::code-group
 ```ts [server/api/telemetry/ingest.post.ts (Nitro)]
@@ -177,6 +177,6 @@ export async function storeRunEvents(events: RunEvent[]): Promise<void> {
 
 ## Step 4 — Rate-limit at the edge
 
-`parseIngestBody()` is your last line of schema defense, not your only one. Add rate limits where traffic enters — CDN, API gateway, or middleware — especially per IP. Optional: also bucket by `machineId` hash inside the handler if you need tighter control.
+`parseIngestBody()` is your last line of schema defense, not your only one. Add rate limits where traffic enters (CDN, API gateway, or middleware), especially per IP. Optional: also bucket by `machineId` hash inside the handler if you need tighter control.
 
 Non-2xx responses keep events in the user's outbox; they will retry on the next CLI invocation. Return **204** (or any `2xx`) only when storage succeeded.

--- a/apps/docs/content/5.use-cases/4.telemetry/04.reference.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/04.reference.md
@@ -48,7 +48,7 @@ Every run shares the same shape. You do not declare per-command schemas.
 
 ## Extending the schema
 
-The envelope above is **fixed** — every tool sends the same top-level shape so `parseIngestBody()` and disclosure stay predictable. You do not add fields next to `command` or `durationMs`.
+The envelope above is **fixed**: every tool sends the same top-level shape so `parseIngestBody()` and disclosure stay predictable. You do not add fields next to `command` or `durationMs`.
 
 Your product schema lives in two extension zones:
 
@@ -99,10 +99,10 @@ await t.run('deploy', async () => {
 })
 ```
 
-Undeclared strings are **dropped at runtime**, never thrown. That is the privacy guarantee — no accidental paths, tokens, or free-form PII in `custom`.
+Undeclared strings are **dropped at runtime**, never thrown. That is the privacy guarantee: no accidental paths, tokens, or free-form PII in `custom`.
 
 ::note
-**Typing:** `TelemetryHandle.set()` autocomplete covers declared `collect.fields` keys. Use the ambient `telemetry.set()` for extra numeric/boolean counters in the same run — both merge into `custom` before the event is recorded.
+**Typing:** `TelemetryHandle.set()` autocomplete covers declared `collect.fields` keys. Use the ambient `telemetry.set()` for extra numeric/boolean counters in the same run, and both merge into `custom` before the event is recorded.
 ::
 
 ### Mirror on the server
@@ -128,7 +128,7 @@ export async function POST(req: Request) {
 }
 ```
 
-`parseIngestBody()` strips any `custom` key you did not list — even if a client somehow sent it.
+`parseIngestBody()` strips any `custom` key you did not list, even if a client somehow sent it.
 
 ### Map to your warehouse schema
 
@@ -154,7 +154,7 @@ function toRow(event: RunEvent) {
 }
 ```
 
-This is where a company "modifies the schema" in practice — not by changing `RunEvent`, but by defining how `custom` maps into internal analytics tables.
+This is where a company "modifies the schema" in practice: not by changing `RunEvent`, but by defining how `custom` maps into internal analytics tables.
 
 ### Version breaking changes in `custom`
 
@@ -199,9 +199,9 @@ allowedCustomKeys: {
 
 ### Planned v2 extensions
 
-Not shipped yet — design targets for when the v1 extension zones are not enough:
+Not shipped yet. These are design targets for when the v1 extension zones are not enough:
 
-**`enrich` hook** — run after sanitization, before the outbox append. Lets you inject computed fields without forking the package:
+**`enrich` hook.** Runs after sanitization, before the outbox append. Lets you inject computed fields without forking the package:
 
 ```ts
 // Planned API — not available in v1
@@ -221,11 +221,11 @@ createTelemetry({
 })
 ```
 
-The hook cannot bypass sanitization rules — strings still require `collect.fields`. Server-side `allowedCustomKeys` stays the source of truth.
+The hook cannot bypass sanitization rules, and strings still require `collect.fields`. Server-side `allowedCustomKeys` stays the source of truth.
 
-**Namespaced keys** — optional `acme.product` convention for multi-tool endpoints without prefix collisions. Would be documented in disclosure as `acme.product: cli | action`.
+**Namespaced keys.** An optional `acme.product` convention for multi-tool endpoints without prefix collisions. Would be documented in disclosure as `acme.product: cli | action`.
 
-If you need one of these before v2 lands, open a discussion on the repo — the v1 path (`custom` + server mapping) covers most product analytics needs.
+If you need one of these before v2 lands, open a discussion on the repo. The v1 path (`custom` + server mapping) covers most product analytics needs.
 
 ## Privacy
 
@@ -251,7 +251,7 @@ as what the user asked for rather than what the parser filled in:
 
 Negation still reports: `--no-write` against `write: { default: true }` records `write: false`.
 
-Declare allowlists in the same `withTelemetry()` / `createTelemetry()` call as `collect` — no separate config file.
+Declare allowlists in the same `withTelemetry()` / `createTelemetry()` call as `collect`, with no separate config file.
 
 ## Disclosure
 

--- a/apps/docs/content/5.use-cases/5.enrichers.md
+++ b/apps/docs/content/5.use-cases/5.enrichers.md
@@ -213,7 +213,7 @@ The traceparent format follows the [W3C Trace Context](https://www.w3.org/TR/tra
 
 ## Full Setup Example
 
-Use all built-in enrichers together. The list of enrichers is identical across frameworks — only the wiring changes.
+Use all built-in enrichers together. The list of enrichers is identical across frameworks. Only the wiring changes.
 
 ::code-group
 ```typescript [Nuxt / Nitro]

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -12,7 +12,7 @@ links:
     variant: subtle
 ---
 
-[eve](https://eve.dev/docs/introduction) ships built-in observability: **Agent Runs** on Vercel and optional **OpenTelemetry** spans via `agent/instrumentation.ts`. `evlog/eve` adds a third layer — **exportable wide events** per turn with your full evlog pipeline (drains, enrichers, tail sampling, audit).
+[eve](https://eve.dev/docs/introduction) ships built-in observability: **Agent Runs** on Vercel and optional **OpenTelemetry** spans via `agent/instrumentation.ts`. `evlog/eve` adds a third layer: **exportable wide events** per turn with your full evlog pipeline (drains, enrichers, tail sampling, audit).
 
 ::callout{icon="i-lucide-info" color="info"}
 `evlog/eve` requires **eve 0.30 or later**. eve is still in beta and stream event shapes may change before GA, so pin `eve` and `evlog` versions in production agents.
@@ -88,11 +88,11 @@ export default defineEvlogHook({
 })
 ```
 
-eve auto-discovers hook files under `agent/hooks/`. No HTTP middleware — the unit of work is an agent **turn**, not a request.
+eve auto-discovers hook files under `agent/hooks/`. No HTTP middleware, because the unit of work is an agent **turn**, not a request.
 
 ### 3. Log business context from tools
 
-`defineEvlogHook()` binds the turn logger via **AsyncLocalStorage** on `turn.started`. Inside tool `execute()` handlers, call `useLogger()` with no arguments — same ergonomics as `useLogger(event)` in Nuxt or Hono.
+`defineEvlogHook()` binds the turn logger via **AsyncLocalStorage** on `turn.started`. Inside tool `execute()` handlers, call `useLogger()` with no arguments, the same ergonomics as `useLogger(event)` in Nuxt or Hono.
 
 In the [example agent](https://github.com/HugoRCD/evlog/tree/main/examples/eve), support tools attach customer and order context as the agent works a refund:
 
@@ -119,7 +119,7 @@ export default defineTool({
 
 ### 4. Next.js web chat (optional)
 
-Wrap `next.config.ts` with `withEve()` from `eve/next` and use `useEveAgent()` from `eve/react` in your app. eve starts alongside `next dev` and proxies `/eve/v1/*` on the same origin — tool calls, approvals, and `ask_question` work out of the box. See the [example agent](https://github.com/HugoRCD/evlog/tree/main/examples/eve).
+Wrap `next.config.ts` with `withEve()` from `eve/next` and use `useEveAgent()` from `eve/react` in your app. eve starts alongside `next dev` and proxies `/eve/v1/*` on the same origin, so tool calls, approvals, and `ask_question` work out of the box. See the [example agent](https://github.com/HugoRCD/evlog/tree/main/examples/eve).
 
 ## Wide event shape
 
@@ -178,11 +178,11 @@ After approval, the next turn carries the outcome:
 }
 ```
 
-Token usage and tool executions are accumulated from eve stream events (`step.completed`, `actions.requested`, `action.result`). Business fields set via `useLogger()` carry across turns in the same session. Link turns in analytics with `eve.sessionId` + `eve.turnSequence` — each event stays self-contained. `eve.phase` is only set for non-routine endings: `awaiting-approval`, `awaiting-authorization`, `rejected`, `cancelled`, `failed`.
+Token usage and tool executions are accumulated from eve stream events (`step.completed`, `actions.requested`, `action.result`). Business fields set via `useLogger()` carry across turns in the same session. Link turns in analytics with `eve.sessionId` + `eve.turnSequence`, and each event stays self-contained. `eve.phase` is only set for non-routine endings: `awaiting-approval`, `awaiting-authorization`, `rejected`, `cancelled`, `failed`.
 
 ### Everything the turn can report
 
-Beyond the identifiers above, a turn records what eve reports about it. Every field is optional — it appears only when the turn produced it.
+Beyond the identifiers above, a turn records what eve reports about it. Every field is optional and appears only when the turn produced it.
 
 | Field | What it tells you |
 | --- | --- |
@@ -209,7 +209,7 @@ import { defineEvlogInstrumentation } from 'evlog/eve'
 export default defineEvlogInstrumentation()
 ```
 
-Every model-call span — and its children — then carries `evlog.request_id` and `evlog.session_id`, the same values the wide event reports as `requestId` and `eve.sessionId`. Jump from a trace in Braintrust, Datadog or Agent Runs straight to the event in your drain, and back.
+Every model-call span, and its children, then carries `evlog.request_id` and `evlog.session_id`, the same values the wide event reports as `requestId` and `eve.sessionId`. Jump from a trace in Braintrust, Datadog or Agent Runs straight to the event in your drain, and back.
 
 Without `setup`, OpenTelemetry export is untouched: eve keeps writing its local traces, readable with `eve traces`. Pass one to export elsewhere:
 
@@ -226,7 +226,7 @@ export default defineEvlogInstrumentation({
 
 ### Alongside another observability backend
 
-`defineEvlogInstrumentation()` is the shortcut for an agent whose instrumentation is evlog's alone. It owns the file, and an agent has exactly one `agent/instrumentation.ts` — every observability item in eve's registry writes that same path, which is why `eve add instrumentation/sentry` after `eve add instrumentation/posthog` refuses rather than clobbering the first.
+`defineEvlogInstrumentation()` is the shortcut for an agent whose instrumentation is evlog's alone. It owns the file, and an agent has exactly one `agent/instrumentation.ts`, so every observability item in eve's registry writes that same path, which is why `eve add instrumentation/sentry` after `eve add instrumentation/posthog` refuses rather than clobbering the first.
 
 Once another backend is in play, write the file yourself with eve's own `defineInstrumentation` and spread `evlogRuntimeContext` into your runtime context. evlog contributes attributes to your instrumentation instead of wrapping it:
 
@@ -269,12 +269,12 @@ export default defineInstrumentation({
 })
 ```
 
-`evlogRuntimeContext` returns `undefined` outside a tracked turn, and spreading that adds nothing. PostHog is the only registry item that also uses `events`; the rest only need their span processor. Keep each generated file open while you merge — the env vars and exporter options are the parts worth copying exactly.
+`evlogRuntimeContext` returns `undefined` outside a tracked turn, and spreading that adds nothing. PostHog is the only registry item that also uses `events`; the rest only need their span processor. Keep each generated file open while you merge: the env vars and exporter options are the parts worth copying exactly.
 
 Spans and wide events stay joined by attribute, not by trace id: an agent turn has no inbound `traceparent` to inherit, so `evlog.request_id` is what carries across.
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-**PostHog drops `evlog.*`.** Its exporter forwards the whole span, but the server-side conversion into `$ai_generation` / `$ai_span` events keeps only attributes prefixed `posthog_`, and strips that prefix. To join on PostHog, repeat the ids under names that survive — `posthog_evlog_request_id` arrives as `evlog_request_id`. Other OTLP backends receive `evlog.*` unchanged.
+**PostHog drops `evlog.*`.** Its exporter forwards the whole span, but the server-side conversion into `$ai_generation` / `$ai_span` events keeps only attributes prefixed `posthog_`, and strips that prefix. To join on PostHog, repeat the ids under names that survive, since `posthog_evlog_request_id` arrives as `evlog_request_id`. Other OTLP backends receive `evlog.*` unchanged.
 ::
 
 eve applies the runtime context to the step span only, so the generation spans beneath it inherit nothing. On PostHog that means cost lands on events with no identity and no environment. A span processor that copies the turn's `posthog_*` attributes onto every child span is what closes the gap.

--- a/apps/docs/content/6.extend/0.overview.md
+++ b/apps/docs/content/6.extend/0.overview.md
@@ -22,7 +22,7 @@ links:
     variant: subtle
 ---
 
-evlog is designed to be extended on both ends — you can **observe** what flows through (without altering the pipeline), **plug into** the pipeline (enrich, decide what to keep, react to lifecycle events), or **build your own bricks** (custom drains for unsupported destinations, your own framework integration). Each page in this section ships with a `::prompt` block you can drop into Cursor / Claude to scaffold the integration in your own app.
+evlog is designed to be extended on both ends. You can **observe** what flows through (without altering the pipeline), **plug into** the pipeline (enrich, decide what to keep, react to lifecycle events), or **build your own bricks** (custom drains for unsupported destinations, your own framework integration). Each page in this section ships with a `::prompt` block you can drop into Cursor / Claude to scaffold the integration in your own app.
 
 ## Mental model
 
@@ -63,7 +63,7 @@ Subscribe to events without changing what gets emitted. The stream is the live f
 
 ### Plug into the pipeline
 
-Hook into the pipeline at one or more of its lifecycle stages. The four pages below cover the entire extension surface — pick one when you have a single concern, pick `definePlugin` when you have several.
+Hook into the pipeline at one or more of its lifecycle stages. The four pages below cover the entire extension surface. Pick one when you have a single concern, pick `definePlugin` when you have several.
 
 | You want to… | Use |
 | --- | --- |
@@ -84,6 +84,6 @@ When the built-in adapters or framework integrations don't cover what you need, 
 
 ## What works where
 
-Only the [stream](/extend/stream) (in-process bus + SSE bridge) is **local-only** — it lives inside one Node / Bun / Deno process and does not work on serverless platforms (Vercel Functions, Cloudflare Workers, AWS Lambda). The [stream page](/extend/stream) explains the constraint in detail.
+Only the [stream](/extend/stream) (in-process bus + SSE bridge) is **local-only**: it lives inside one Node / Bun / Deno process and does not work on serverless platforms (Vercel Functions, Cloudflare Workers, AWS Lambda). The [stream page](/extend/stream) explains the constraint in detail.
 
-Everything else — [FS reader](/extend/fs-reader), [plugins](/extend/plugins), [custom enrichers](/extend/custom-enrichers), [tail sampling](/extend/tail-sampling), [identity headers](/extend/identity-headers), [custom drains](/extend/custom-drains), [drain pipeline](/extend/drain-pipeline), [custom framework integration](/extend/custom-framework) — runs everywhere evlog runs.
+Everything else, from [FS reader](/extend/fs-reader), [plugins](/extend/plugins), [custom enrichers](/extend/custom-enrichers), [tail sampling](/extend/tail-sampling), [identity headers](/extend/identity-headers), [custom drains](/extend/custom-drains), [drain pipeline](/extend/drain-pipeline), [custom framework integration](/extend/custom-framework), runs everywhere evlog runs.

--- a/apps/docs/content/6.extend/1.stream.md
+++ b/apps/docs/content/6.extend/1.stream.md
@@ -15,7 +15,7 @@ evlog ships a **stream primitive** so any local consumer can subscribe to wide e
 ---
 icon: i-lucide-shield
 ---
-**Local-only by design.** Both layers live inside a single Node / Bun / Deno process. They work in `pnpm dev`, on long-lived self-hosted servers, on VMs and containers (Fly, Railway, Coolify…). They do **not** work on serverless platforms (Vercel Functions, Cloudflare Workers, AWS Lambda) — each invocation is an isolated process. Use a real broker (Redis Streams, NATS, Pub/Sub) for cross-instance fan-out there.
+**Local-only by design.** Both layers live inside a single Node / Bun / Deno process. They work in `pnpm dev`, on long-lived self-hosted servers, on VMs and containers (Fly, Railway, Coolify…). They do **not** work on serverless platforms (Vercel Functions, Cloudflare Workers, AWS Lambda), each invocation is an isolated process. Use a real broker (Redis Streams, NATS, Pub/Sub) for cross-instance fan-out there.
 ::
 
 ## In-process bus
@@ -23,7 +23,7 @@ icon: i-lucide-shield
 ::stream-bus
 ::
 
-`createStreamDrain()` is just a drain. Register it on the evlog drain hook and subscribe to events as they're emitted — no HTTP, no serialization, no extra hops.
+`createStreamDrain()` is just a drain. Register it on the evlog drain hook and subscribe to events as they're emitted: no HTTP, no serialization, no extra hops.
 
 ::prompt
 ---
@@ -82,13 +82,13 @@ for await (const event of stream.events()) {
 ::sse-wire
 ::
 
-`startStreamServer()` boots a tiny `node:http` server in the same process as your app, on its own ephemeral port, and exposes the in-process bus over Server-Sent Events. Any consumer (browser tab, CLI, Tauri/Electron devtool) can subscribe — your application API is untouched.
+`startStreamServer()` boots a tiny `node:http` server in the same process as your app, on its own ephemeral port, and exposes the in-process bus over Server-Sent Events. Any consumer (browser tab, CLI, Tauri/Electron devtool) can subscribe, and your application API is untouched.
 
 ::callout
 ---
 icon: i-lucide-shield
 ---
-**Strict opt-in.** Nothing starts unless you set the option explicitly. There is no auto-enable in dev — the server only boots when you ask for it.
+**Strict opt-in.** Nothing starts unless you set the option explicitly. There is no auto-enable in dev, and the server only boots when you ask for it.
 ::
 
 ::prompt
@@ -158,7 +158,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.EVLOG_STREAM === '1') {
 
 ::
 
-The Hono / Express / Fastify integrations don't need a "feature PR" — `startStreamServer()` is **orthogonal** to your framework. You boot it once and connect its `drain` to the evlog pipeline like any other drain.
+The Hono / Express / Fastify integrations don't need a "feature PR", because `startStreamServer()` is **orthogonal** to your framework. You boot it once and connect its `drain` to the evlog pipeline like any other drain.
 
 ### Discovery
 
@@ -176,7 +176,7 @@ import { readFile } from 'node:fs/promises'
 const url = (await readFile('.evlog/stream.url', 'utf-8')).trim()
 ```
 
-Or — for same-origin browser tabs in a Nuxt app — hit the discovery route:
+Or, for same-origin browser tabs in a Nuxt app, hit the discovery route:
 
 ```ts
 const { url } = await fetch('/api/_evlog/stream-info').then(r => r.json())

--- a/apps/docs/content/6.extend/10.custom-framework.md
+++ b/apps/docs/content/6.extend/10.custom-framework.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-When the framework you use doesn't have an `evlog/<framework>` package yet, you build the integration yourself. `evlog/toolkit` ships the same building blocks that power every built-in integration (Hono, Express, Fastify, Elysia, NestJS, SvelteKit) — you only write the framework-specific glue.
+When the framework you use doesn't have an `evlog/<framework>` package yet, you build the integration yourself. `evlog/toolkit` ships the same building blocks that power every built-in integration (Hono, Express, Fastify, Elysia, NestJS, SvelteKit), so you only write the framework-specific glue.
 
 The mental model is always the same: **request lifecycle → logger creation → enrich → drain**. The toolkit handles the request-context plumbing.
 
@@ -96,7 +96,7 @@ Types like `RequestLogger`, `DrainContext`, `EnrichContext`, `WideEvent`, and `T
 
 ## Manifest mode (recommended)
 
-Most frameworks fit a `(ctx, next)` middleware shape. For those, write a manifest describing how to extract the request and attach the logger — `defineFrameworkIntegration` does the rest.
+Most frameworks fit a `(ctx, next)` middleware shape. For those, write a manifest describing how to extract the request and attach the logger. `defineFrameworkIntegration` does the rest.
 
 ::code-collapse
 ```typescript [my-framework-evlog.ts]
@@ -183,13 +183,13 @@ const { logger, finish, skipped } = createMiddlewareLogger({
 })
 ```
 
-You'll be responsible for ALS wrapping (`storage.run`), `log.fork()` attachment (via `attachForkToLogger`), and finishing the lifecycle — but you keep the full pipeline (route filtering, sampling, emit, enrich, drain, plugins) for free.
+You'll be responsible for ALS wrapping (`storage.run`), `log.fork()` attachment (via `attachForkToLogger`), and finishing the lifecycle, but you keep the full pipeline (route filtering, sampling, emit, enrich, drain, plugins) for free.
 
 ## Serverless (Workers / Edge)
 
-On Cloudflare Workers and Vercel Edge, the runtime can terminate as soon as the response is returned. If your drain sends HTTP to an observability backend, pass `waitUntil` so enrich still runs inline but drain work survives after the response — the same behavior as [`evlog/workers`](/integrate/frameworks/cloudflare-workers) and the Nitro plugin.
+On Cloudflare Workers and Vercel Edge, the runtime can terminate as soon as the response is returned. If your drain sends HTTP to an observability backend, pass `waitUntil` so enrich still runs inline but drain work survives after the response, the same behavior as [`evlog/workers`](/integrate/frameworks/cloudflare-workers) and the Nitro plugin.
 
-**Custom mode** — pass `waitUntil` per request:
+**Custom mode.** Pass `waitUntil` per request:
 
 ```typescript
 import { waitUntil } from '@vercel/functions'
@@ -205,7 +205,7 @@ const { logger, finish, skipped } = createMiddlewareLogger({
 })
 ```
 
-**Manifest mode** — either pass `waitUntil` in `integration.start(ctx, options)` or declare `extractWaitUntil` on the manifest when the hook lives on the framework context:
+**Manifest mode.** Either pass `waitUntil` in `integration.start(ctx, options)` or declare `extractWaitUntil` on the manifest when the hook lives on the framework context:
 
 ```typescript
 const integration = defineFrameworkIntegration<WorkerContext>({
@@ -252,7 +252,7 @@ async function processJob(job: Job) {
 }
 ```
 
-Same enrichers, same drain hook, same [identity headers](/extend/identity-headers) on outbound HTTP drain requests — only the entry point shape changes.
+Same enrichers, same drain hook, same [identity headers](/extend/identity-headers) on outbound HTTP drain requests. Only the entry point shape changes.
 
 ## Reference implementations
 
@@ -268,7 +268,7 @@ Study these built-in integrations for framework-specific patterns:
 | SvelteKit | ~90 | custom (`handle` hook) | [sveltekit/](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/sveltekit/) |
 
 ::callout{icon="i-lucide-heart" color="neutral"}
-Built an integration for a framework we don't support? [Open a PR](https://github.com/hugorcd/evlog/pulls) — the community will thank you.
+Built an integration for a framework we don't support? [Open a PR](https://github.com/hugorcd/evlog/pulls). The community will thank you.
 ::
 
 ## Next steps

--- a/apps/docs/content/6.extend/11.diagnostics-channel.md
+++ b/apps/docs/content/6.extend/11.diagnostics-channel.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-[`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) is the runtime's built-in pub/sub for instrumentation. evlog can publish every wide event on the `evlog.event` channel, so a consumer subscribes by channel name alone — no evlog import, no entry in `initLogger()`.
+[`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) is the runtime's built-in pub/sub for instrumentation. evlog can publish every wide event on the `evlog.event` channel, so a consumer subscribes by channel name alone: no evlog import, no entry in `initLogger()`.
 
 ## What it's for
 
@@ -26,7 +26,7 @@ Two things you cannot do with a [plugin](/extend/plugins) or a [drain](/extend/c
 - **Ship an evlog integration from a package that does not depend on evlog.** A subscriber only needs the channel name, so a vendor SDK, an internal shared library, or an APM agent can consume wide events without a peer dependency, a version constraint, or a line in your `initLogger()` call.
 - **Get events out of a Cloudflare Worker without a drain.** Workers forwards every channel message to a [Tail Worker](#cloudflare-workers), which runs after the response with its own CPU budget — no `waitUntil`, no drain competing with your request.
 
-For everything else — batching, retry, adding fields, fanning out to several in-process consumers — a plugin or a drain is the better tool. There is a [comparison at the bottom of this page](#when-a-plugin-is-the-better-tool).
+For everything else (batching, retry, adding fields, fanning out to several in-process consumers), a plugin or a drain is the better tool. There is a [comparison at the bottom of this page](#when-a-plugin-is-the-better-tool).
 
 ## Enabling it
 
@@ -38,7 +38,7 @@ import { enableDiagnosticsChannel } from 'evlog/diagnostics'
 await enableDiagnosticsChannel()
 ```
 
-The call takes no options and is the same on every framework — only *where* your app runs startup code differs:
+The call takes no options and is the same on every framework. Only *where* your app runs startup code differs:
 
 ::code-group
 ```typescript [Nuxt / Nitro]
@@ -116,10 +116,10 @@ await enableDiagnosticsChannel()
 ```
 ::
 
-`enableDiagnosticsChannel()` is async because it loads `node:diagnostics_channel` lazily — that is what keeps the built-in out of the main bundle for Convex, workerd and other non-Node targets. Events emitted before the promise settles are not published, so call it at startup rather than inside a request. Frameworks whose entry point cannot use top-level `await` should call it from the same place they call `initLogger()`, and await it there.
+`enableDiagnosticsChannel()` is async because it loads `node:diagnostics_channel` lazily, which is what keeps the built-in out of the main bundle for Convex, workerd and other non-Node targets. Events emitted before the promise settles are not published, so call it at startup rather than inside a request. Frameworks whose entry point cannot use top-level `await` should call it from the same place they call `initLogger()`, and await it there.
 
 ::callout{icon="i-lucide-info" color="info"}
-This is an observation side channel, not a transport. Subscribers run synchronously and are not awaited — no batching, no retry, no `waitUntil`. For delivery to a backend, use a [drain](/extend/custom-drains); both see the same event.
+This is an observation side channel, not a transport. Subscribers run synchronously and are not awaited: no batching, no retry, no `waitUntil`. For delivery to a backend, use a [drain](/extend/custom-drains); both see the same event.
 ::
 
 ## Subscribing
@@ -153,11 +153,11 @@ const stop = await subscribeToWideEvents((event) => {
 })
 ```
 
-Fields beyond the [base event](/learn/wide-events) are typed `unknown`, and events emitted outside a request carry no HTTP fields at all — narrow before using them rather than casting.
+Fields beyond the [base event](/learn/wide-events) are typed `unknown`, and events emitted outside a request carry no HTTP fields at all, so narrow before using them rather than casting.
 
 ## What a subscriber receives
 
-The same object a drain receives: post-audit, post-redaction, post-enrich. Requests carry everything enrichers added — geo, user agent, trace context:
+The same object a drain receives: post-audit, post-redaction, post-enrich. Requests carry everything enrichers added: geo, user agent, trace context:
 
 ```json
 {
@@ -178,7 +178,7 @@ The same object a drain receives: post-audit, post-redaction, post-enrich. Reque
 Events emitted outside a request (`log.info({ ... })`, `createLogger().emit()`) arrive without the HTTP fields, and events from `log.fork()` carry `operation` and `_parentRequestId`.
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-The event is the live object, not a copy — mutating it mutates what drains receive. Treat it as read-only. And a subscriber that throws is **not** contained: `Channel.publish()` re-raises it as an uncaught exception on the next tick, which is fatal in most apps. Keep subscribers total.
+The event is the live object, not a copy, so mutating it mutates what drains receive. Treat it as read-only. And a subscriber that throws is **not** contained: `Channel.publish()` re-raises it as an uncaught exception on the next tick, which is fatal in most apps. Keep subscribers total.
 ::
 
 In pretty mode (the dev default), tagged logs like `log.info('auth', 'User logged in')` are written straight to the console and never become wide events, so they do not appear on the channel. Wide events themselves are published in both modes.
@@ -187,7 +187,7 @@ In pretty mode (the dev default), tagged logs like `log.info('auth', 'User logge
 
 ### An integration that does not depend on evlog
 
-A package that subscribes needs the channel name and nothing else — no `evlog` dependency, no peer range to keep in sync, no wiring in the host app beyond importing it:
+A package that subscribes needs the channel name and nothing else: no `evlog` dependency, no peer range to keep in sync, no wiring in the host app beyond importing it:
 
 ```typescript [acme-apm/src/evlog.ts]
 import { channel } from 'node:diagnostics_channel'
@@ -216,7 +216,7 @@ The same shape works for an internal library shared across services: one package
 
 ### Counters and alerts next to your app
 
-A subscriber is a plain function, so anything you can compute in-process you can compute here — without giving up the drain slot, which stays free for shipping events to your backend:
+A subscriber is a plain function, so anything you can compute in-process you can compute here, without giving up the drain slot, which stays free for shipping events to your backend:
 
 ```typescript [observability.ts]
 import { channel } from 'node:diagnostics_channel'
@@ -244,7 +244,7 @@ A [plugin](/extend/plugins) does this too, and is the better choice when the cod
 
 ## Cloudflare Workers
 
-Workers forwards every diagnostics channel message to a [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/). Enable the channel in your Worker and the wide events leave the isolate with no drain, no `waitUntil`, and their own CPU budget — the Tail Worker does the shipping, after the response has already gone out:
+Workers forwards every diagnostics channel message to a [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/). Enable the channel in your Worker and the wide events leave the isolate with no drain, no `waitUntil`, and their own CPU budget, and the Tail Worker does the shipping, after the response has already gone out:
 
 ```typescript [tail-worker/index.ts]
 export default {
@@ -264,11 +264,11 @@ export default {
 }
 ```
 
-Each entry carries `timestamp`, `channel` and `message` — `message` being what evlog published, so the wide event is at `messageData.message.event`. Requires the `nodejs_compat` flag, and messages go through the structured clone algorithm, so only cloneable values survive.
+Each entry carries `timestamp`, `channel` and `message`, with `message` being what evlog published, so the wide event is at `messageData.message.event`. Requires the `nodejs_compat` flag, and messages go through the structured clone algorithm, so only cloneable values survive.
 
 ## When a plugin is the better tool
 
-The channel is not a replacement for [plugins](/extend/plugins) — it is narrower on purpose:
+The channel is not a replacement for [plugins](/extend/plugins). It is narrower on purpose:
 
 | You want to… | Use |
 | --- | --- |
@@ -278,4 +278,4 @@ The channel is not a replacement for [plugins](/extend/plugins) — it is narrow
 | Subscribe from a package that must not depend on evlog | This channel |
 | Get events out of a Cloudflare Worker without a drain | This channel |
 
-`diagnostics_channel` is in-process: nothing attaches to a running process from the outside. A subscriber's code has to be loaded by your app either way — the channel saves it a line of configuration, not a dependency.
+`diagnostics_channel` is in-process: nothing attaches to a running process from the outside. A subscriber's code has to be loaded by your app either way, so the channel saves it a line of configuration, not a dependency.

--- a/apps/docs/content/6.extend/2.fs-reader.md
+++ b/apps/docs/content/6.extend/2.fs-reader.md
@@ -54,7 +54,7 @@ for await (const event of readFsLogs({ since: '2026-03-01', level: 'error' })) {
 | `level` | `LogLevel \| LogLevel[]` | Filter by event level. |
 | `filter` | `(event) => boolean` | Custom predicate. |
 
-Malformed lines (partial writes, manual edits) are silently skipped — your script never crashes on a bad line.
+Malformed lines (partial writes, manual edits) are silently skipped, so your script never crashes on a bad line.
 
 ## Live tail
 
@@ -69,7 +69,7 @@ for await (const event of tailFsLogs({ signal: ac.signal })) {
 }
 ```
 
-`tailFsLogs(options)` first yields existing events (unless `fromEnd: true`), then keeps yielding new ones as they're appended — including events written into newly created daily files. Partial writes split across polls are recombined transparently.
+`tailFsLogs(options)` first yields existing events (unless `fromEnd: true`), then keeps yielding new ones as they're appended, including events written into newly created daily files. Partial writes split across polls are recombined transparently.
 
 ### Tail-specific options
 

--- a/apps/docs/content/6.extend/3.consumer-recipes.md
+++ b/apps/docs/content/6.extend/3.consumer-recipes.md
@@ -32,7 +32,7 @@ Docs: https://www.evlog.dev/extend/consumer-recipes
 
 ## 1. Build a minimal devtool
 
-A live event panel is essentially `EventSource` + a list. The full wire format and discovery rules — `.evlog/stream.url`, `/api/_evlog/stream-info`, the `{ evlog: '1', type, data }` envelope, and auth — are documented on the [stream page](/extend/stream#wire-format). Each recipe below assumes you've grabbed the URL via either of those mechanisms.
+A live event panel is essentially `EventSource` + a list. The full wire format and discovery rules (`.evlog/stream.url`, `/api/_evlog/stream-info`, the `{ evlog: '1', type, data }` envelope, and auth) are documented on the [stream page](/extend/stream#wire-format). Each recipe below assumes you've grabbed the URL via either of those mechanisms.
 
 ### Vanilla HTML + JS (drop into any page)
 
@@ -246,7 +246,7 @@ while (true) {
 
 ## 5. Filter, transform, aggregate on the consumer
 
-Keep the server dumb — every consumer picks what it cares about:
+Keep the server dumb, and let every consumer pick what it cares about:
 
 ```ts
 // Just errors
@@ -283,7 +283,7 @@ for await (const event of tailFsLogs({ signal: ac.signal })) {
 }
 ```
 
-Works without instrumenting the running app — useful for sidecar / observer processes that watch a directory.
+Works without instrumenting the running app, which suits sidecar / observer processes that watch a directory.
 
 ## What not to do
 

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -25,7 +25,7 @@ links:
 ::lifecycle-flow
 ::
 
-`definePlugin()` is the **canonical extension point** for evlog. Drains and enrichers are special cases of plugins, but a single plugin can opt into multiple hooks at once — the right shape for any non-trivial extension that mixes several concerns (e.g. enrich on every event + side-effect on drain + keep decision on tail sampling, all reading the same shared state).
+`definePlugin()` is the **canonical extension point** for evlog. Drains and enrichers are special cases of plugins, but a single plugin can opt into multiple hooks at once, the right shape for any non-trivial extension that mixes several concerns (e.g. enrich on every event + side-effect on drain + keep decision on tail sampling, all reading the same shared state).
 
 When the extension only does one thing, prefer the single-purpose [`enricherPlugin()`](/extend/custom-enrichers) / [`drainPlugin()`](/extend/custom-drains) wrappers. Reach for `definePlugin` when several hooks share state.
 

--- a/apps/docs/content/6.extend/5.custom-enrichers.md
+++ b/apps/docs/content/6.extend/5.custom-enrichers.md
@@ -20,9 +20,9 @@ links:
 ::enricher-chain
 ::
 
-An **enricher** runs on every emitted event before it reaches drains. It's the right tool when you want a field on every event without touching every call site — geo, user agent, trace context, deploy id, tenant id, feature flags, performance tier.
+An **enricher** runs on every emitted event before it reaches drains. It's the right tool when you want a field on every event without touching every call site: geo, user agent, trace context, deploy id, tenant id, feature flags, performance tier.
 
-Use `defineEnricher` from `evlog/toolkit` — provide a single `compute()` function returning the value you want to merge into the event, and the toolkit handles error isolation, undefined skipping, and the merge step. Every built-in enricher is built on this same factory.
+Use `defineEnricher` from `evlog/toolkit` and provide a single `compute()` function returning the value you want to merge into the event, and the toolkit handles error isolation, undefined skipping, and the merge step. Every built-in enricher is built on this same factory.
 
 ::prompt
 ---
@@ -52,7 +52,7 @@ Built-in: https://www.evlog.dev/use-cases/enrichers
 
 ## Basic example
 
-Add deployment metadata to every event. The enricher is the same function everywhere — only the wiring step differs per framework.
+Add deployment metadata to every event. The enricher is the same function everywhere. Only the wiring step differs per framework.
 
 ::code-group
 ```typescript [Nuxt / Nitro]
@@ -208,7 +208,7 @@ initLogger({
 
 ## Combining with built-in enrichers
 
-Custom and built-in enrichers compose freely — they're all just `(ctx: EnrichContext) => void` functions. Use `composeEnrichers` from `evlog/toolkit` to combine them into a single callable:
+Custom and built-in enrichers compose freely, since they're all just `(ctx: EnrichContext) => void` functions. Use `composeEnrichers` from `evlog/toolkit` to combine them into a single callable:
 
 ```typescript [enrichers.ts]
 import { composeEnrichers, defineEnricher } from 'evlog/toolkit'
@@ -228,7 +228,7 @@ export const enrich = composeEnrichers([
 
 ## More examples
 
-Each example below is a plain `defineEnricher` call — wire it the same way as the basic example, regardless of framework.
+Each example below is a plain `defineEnricher` call, wired the same way as the basic example, regardless of framework.
 
 ### Feature flags
 
@@ -266,7 +266,7 @@ export const performanceTier = defineEnricher<string>({
 
 ## When to reach for a plugin instead
 
-If your feature mixes enrichment with other hooks (e.g. enrich + tail-sample + side-effect on drain), use a [plugin](/extend/plugins) instead — one cohesive object covering several lifecycle points.
+If your feature mixes enrichment with other hooks (e.g. enrich + tail-sample + side-effect on drain), use a [plugin](/extend/plugins) instead: one cohesive object covering several lifecycle points.
 
 ## Next steps
 

--- a/apps/docs/content/6.extend/6.tail-sampling.md
+++ b/apps/docs/content/6.extend/6.tail-sampling.md
@@ -20,9 +20,9 @@ links:
 ::tail-sample-decision
 ::
 
-**Tail sampling** is a decision made *after* the request runs, with full knowledge of its outcome (status, duration, errors, custom flags). It's how you keep all errors and slow requests while throwing away the bulk of healthy traffic — the opposite of head sampling, which decides up front before knowing what happens.
+**Tail sampling** is a decision made *after* the request runs, with full knowledge of its outcome (status, duration, errors, custom flags). It's how you keep all errors and slow requests while throwing away the bulk of healthy traffic, the opposite of head sampling, which decides up front before knowing what happens.
 
-The full theory and config reference — built-in `keep` rules, custom predicates via `evlog:emit:keep`, combining head + tail sampling — lives at [Sampling](/learn/sampling). This page covers the **extension surface**: how to plug your own keep logic into the pipeline.
+The full theory and config reference, covering built-in `keep` rules, custom predicates via `evlog:emit:keep`, combining head + tail sampling, lives at [Sampling](/learn/sampling). This page covers the **extension surface**: how to plug your own keep logic into the pipeline.
 
 ::prompt
 ---
@@ -83,7 +83,7 @@ export const keepEnterpriseErrors = definePlugin({
 ```
 ::
 
-For non-trivial logic, prefer the plugin shape — it travels with the rest of your evlog config (drains, enrichers) and is reusable across frameworks.
+For non-trivial logic, prefer the plugin shape, since it travels with the rest of your evlog config (drains, enrichers) and is reusable across frameworks.
 
 ## Composing several keep predicates
 

--- a/apps/docs/content/6.extend/7.identity-headers.md
+++ b/apps/docs/content/6.extend/7.identity-headers.md
@@ -19,7 +19,7 @@ Every drain request sent by evlog is tagged with two identity headers so receive
 | `User-Agent` | `evlog/<version>` (Node / server runtimes only — browsers strip this header) |
 | `X-Evlog-Source` | The adapter name (`axiom`, `datadog`, `otlp`, `posthog`, `sentry`, `better-stack`, `client`, …) |
 
-The browser-side `evlog/http` drain (used by the client transport) sets `X-Evlog-Source: client` instead, since browsers cannot override `User-Agent`.
+The browser-side `evlog/http` drain (used by client logging) sets `X-Evlog-Source: client` instead, since browsers cannot override `User-Agent`.
 
 ## Why
 

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -22,7 +22,7 @@ links:
     variant: subtle
 ---
 
-A **drain** is the terminal step of evlog's pipeline: a function that receives wide events and ships them somewhere — an HTTP API, a message queue, a database, a webhook, a local file. evlog ships built-in drains for popular providers ([Adapters overview](/integrate/adapters/overview)). When you need a destination that isn't covered, you write your own.
+A **drain** is the terminal step of evlog's pipeline: a function that receives wide events and ships them somewhere: an HTTP API, a message queue, a database, a webhook, a local file. evlog ships built-in drains for popular providers ([Adapters overview](/integrate/adapters/overview)). When you need a destination that isn't covered, you write your own.
 
 Two factories cover every case:
 
@@ -149,7 +149,7 @@ export function createLokiDrain(overrides?: { url?: string, token?: string }) {
 3. `runtimeConfig.<namespace>` (legacy Nuxt/Nitro)
 4. `<NS>_<FIELD>` env vars (list `NUXT_<NS>_<FIELD>` in `ConfigField.env` for silent Nuxt compat; show only `<NS>_<FIELD>` in error messages via `formatPublicEnvKeys`)
 
-Field names should follow the project conventions: `apiKey`, `endpoint`, `serviceName`, `timeout`. If you're renaming an existing field (e.g. `token` → `apiKey`), keep both as `ConfigField` entries for one major version — see `axiom.ts` and `better-stack.ts` for the deprecation pattern.
+Field names should follow the project conventions: `apiKey`, `endpoint`, `serviceName`, `timeout`. If you're renaming an existing field (e.g. `token` → `apiKey`), keep both as `ConfigField` entries for one major version. See `axiom.ts` and `better-stack.ts` for the deprecation pattern.
 
 ## Wiring the drain into your framework
 
@@ -198,7 +198,7 @@ For production, wrap it once in [`createDrainPipeline`](/extend/drain-pipeline) 
 
 ## Filtering and transforming events
 
-`encode()` receives the full batch of `WideEvent[]` plus the resolved config. Filter or transform inline — returning `null` is a clean opt-out for that batch:
+`encode()` receives the full batch of `WideEvent[]` plus the resolved config. Filter or transform inline, and returning `null` is a clean opt-out for that batch:
 
 ```typescript
 encode: (events, cfg) => {
@@ -298,7 +298,7 @@ In the batched form your `encode()` / `send()` receives, you get `WideEvent[]` d
 | `User-Agent` | `evlog/<version>` (Node / server runtimes only — browsers strip this header) |
 | `X-Evlog-Source` | The drain `name` you provided |
 
-If you build a drain on top of `httpPost` directly, you can override or suppress them — see [Identity headers](/extend/identity-headers).
+If you build a drain on top of `httpPost` directly, you can override or suppress them. See [Identity headers](/extend/identity-headers).
 
 ## Error handling — already done for you
 
@@ -325,10 +325,10 @@ my-evlog-drain/
 └─ README.md
 ```
 
-Add `evlog` as a `peerDependency` (not a `dependency`) — your package shouldn't pull in a copy of evlog at install time.
+Add `evlog` as a `peerDependency` (not a `dependency`), so your package will not pull in a copy of evlog at install time.
 
 ::callout{icon="i-lucide-heart" color="neutral"}
-Built something great? [Open a PR](https://github.com/hugorcd/evlog/pulls) to add a row to the Adapters table — the community will thank you.
+Built something great? [Open a PR](https://github.com/hugorcd/evlog/pulls) to add a row to the Adapters table. The community will thank you.
 ::
 
 ## Next steps

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -55,7 +55,7 @@ Adapters: https://www.evlog.dev/integrate/adapters/overview
 
 ## Quick start
 
-The pipeline wraps any drain. The wiring depends on your framework — pick the tab that matches yours; every other example below uses the same shape.
+The pipeline wraps any drain. The wiring depends on your framework, so pick the tab that matches yours; every other example below uses the same shape.
 
 ::code-group
 ```typescript [Nuxt / Nitro]
@@ -125,7 +125,7 @@ Always flush the pipeline before the process exits (`drain.flush()`). On Nitro u
 
 ## How it works
 
-Events are buffered as they arrive on `evlog:drain`. A batch flushes when either `batch.size` is reached or `batch.intervalMs` expires (whichever comes first). On failure, the same batch is retried with the configured backoff; once `retry.maxAttempts` is exhausted, `onDropped` is called with the lost events. The buffer is bounded by `maxBufferSize` — once full, the oldest events are dropped to keep memory flat.
+Events are buffered as they arrive on `evlog:drain`. A batch flushes when either `batch.size` is reached or `batch.intervalMs` expires (whichever comes first). On failure, the same batch is retried with the configured backoff; once `retry.maxAttempts` is exhausted, `onDropped` is called with the lost events. The buffer is bounded by `maxBufferSize`. Once full, the oldest events are dropped to keep memory flat.
 
 ## Configuration
 
@@ -298,7 +298,7 @@ For anything more involved (config resolution, retries, identity headers), use [
 
 ## HTTP drain (browser to server)
 
-The HTTP drain is a framework-agnostic transport for shipping client-side logs to your server. It composes on top of the same pipeline primitives, with browser-specific defaults (`fetch keepalive` + `sendBeacon` on `visibilitychange`).
+The HTTP drain ships client-side logs to your server, whatever framework serves it. It composes on top of the same pipeline primitives, with browser-specific defaults (`fetch keepalive` + `sendBeacon` on `visibilitychange`).
 
 ::callout{icon="i-lucide-info" color="neutral"}
 The `evlog/browser` import path is **deprecated** and re-exports the same API as `evlog/http`. It will be removed in the next **major** release. Prefer `evlog/http` for new code.

--- a/apps/docs/skills/analyze-logs/SKILL.md
+++ b/apps/docs/skills/analyze-logs/SKILL.md
@@ -29,7 +29,7 @@ Logs are written by evlog's file system drain as `.jsonl` files, organized by da
 
 Always check the first few bytes of the file to detect the format: if the second character is a newline or `"`, it's NDJSON; if it's a space or newline followed by spaces, it's pretty-printed.
 
-**Search order** — check these locations relative to the project root:
+**Search order.** Check these locations relative to the project root:
 
 1. `.evlog/logs/` (default)
 2. Any `.evlog/logs/` inside app directories (monorepos: `apps/*/.evlog/logs/`)
@@ -44,15 +44,15 @@ apps/*/.evlog/logs/*.jsonl
 
 Files are named by date: `2026-03-14.jsonl`. Start with the most recent file.
 
-**Programmatic reading**: instead of hand-parsing, a small script can use the readers shipped with evlog — `readFsLogs()` and `tailFsLogs()` from `evlog/fs` are async generators that handle both formats, date ordering, and filtering. Prefer them when the project already has evlog installed and the analysis needs more than a quick grep.
+**Programmatic reading**: instead of hand-parsing, a small script can use the readers shipped with evlog: `readFsLogs()` and `tailFsLogs()` from `evlog/fs` are async generators that handle both formats, date ordering, and filtering. Prefer them when the project already has evlog installed and the analysis needs more than a quick grep.
 
 **Memory drain alternative**: some apps use the Memory adapter (`evlog/memory`) instead of (or alongside) the FS drain, exposing recent events through a dev-only HTTP endpoint via `readMemoryLogs()`. If `.evlog/logs/` is empty but the app wires `createMemoryDrain()`, query that endpoint instead.
 
 ## If no logs are found
 
-Before wiring a new drain, you can try `npx @evlog/cli doctor --json` — it checks whether `evlog` is installed and whether a local `.evlog/logs` drain already exists (read-only). Optional; skip if the CLI is unavailable.
+Before wiring a new drain, you can try `npx @evlog/cli doctor --json`, which checks whether `evlog` is installed and whether a local `.evlog/logs` drain already exists (read-only). Optional; skip if the CLI is unavailable.
 
-The file system drain may not be enabled. On Nuxt, Nitro, Next.js, or TanStack Start, the fastest path is the CLI — it detects the framework and wires the fs drain (its default dev drain) in one pass:
+The file system drain may not be enabled. On Nuxt, Nitro, Next.js, or TanStack Start, the fastest path is the CLI, which detects the framework and wires the fs drain (its default dev drain) in one pass:
 
 ```bash
 npx @evlog/cli init --dry-run --yes   # preview first
@@ -180,5 +180,5 @@ Look for: client errors that don't have corresponding server errors (network iss
 - Each line is a **complete, self-contained event**. Unlike traditional logs, you don't need to correlate multiple lines — one line has all the context for one request.
 - The `error.data.why` and `error.data.fix` fields are evlog-specific structured error fields. When present, they provide the most actionable information.
 - Duration values are strings with units (e.g. `"706ms"`). Parse the numeric part for comparisons.
-- Events with `"source":"client"` originated from browser-side logging and were sent to the server via the transport endpoint.
+- Events with `"source":"client"` originated from browser-side logging and were sent to the server via the HTTP drain endpoint.
 - Log files are `.gitignore`'d automatically — they exist only on the local machine or server where the app runs.

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -59,7 +59,7 @@ An audit log answers a forensic question: **who did what, on which resource, whe
 | Audience       | Auditors, security, legal                       | Engineers                          |
 | Storage        | Often dedicated (separate dataset / DB)         | Shared with telemetry              |
 
-evlog ships the audit layer as a thin extension of its wide-event pipeline (a typed `audit` field on `BaseWideEvent` plus a few helpers and drain wrappers). The point is that you compose with the primitives the app already uses — same drains, same enrichers, same redact, same framework integration. There is no parallel system to maintain.
+evlog ships the audit layer as a thin extension of its wide-event pipeline (a typed `audit` field on `BaseWideEvent` plus a few helpers and drain wrappers). The point is that you compose with the primitives the app already uses: same drains, same enrichers, same redact, same framework integration. There is no parallel system to maintain.
 
 ## Mental model
 
@@ -79,7 +79,7 @@ log.audit(...) ──► sets event.audit ──► force-keep ──► auditEn
 
 ## Design calls before writing code
 
-Make these explicit and write them down somewhere a security reviewer can find. Without a written rule, the system can't be audited — auditors look for the policy first, then the enforcement.
+Make these explicit and write them down somewhere a security reviewer can find. Without a written rule, the system can't be audited. Auditors look for the policy first, then the enforcement.
 
 ### 1. Where do audits live?
 
@@ -113,19 +113,19 @@ Strategies:
 
 ### 3. Multi-tenancy?
 
-If the app is multi-tenant, **tenant isolation on every audit event is non-negotiable** — a query that mixes tenants is a privacy incident. Wire it once in the enricher:
+If the app is multi-tenant, **tenant isolation on every audit event is non-negotiable.** A query that mixes tenants is a privacy incident. Wire it once in the enricher:
 
 ```ts
 auditEnricher({ tenantId: ctx => resolveTenant(ctx) })
 ```
 
-If the app uses Better Auth, `auditEnricher` can also bridge the authenticated session into `audit.context` — see the Better Auth integration (`evlog/better-auth`, https://www.evlog.dev/use-cases/better-auth/overview) for wiring `identifyUser` alongside the audit pipeline.
+If the app uses Better Auth, `auditEnricher` can also bridge the authenticated session into `audit.context`. See the Better Auth integration (`evlog/better-auth`, https://www.evlog.dev/use-cases/better-auth/overview) for wiring `identifyUser` alongside the audit pipeline.
 
 Then either (a) partition the audit dataset by `audit.context.tenantId`, or (b) one drain per tenant if hard isolation is required. Never query audits without a tenant filter.
 
 ### 4. Retention
 
-Pick a window per drain and document it. Enforce at the drain layer, not in app code — the drain already has audited mechanisms for it (lifecycle policies, `DELETE` jobs, dataset retention).
+Pick a window per drain and document it. Enforce at the drain layer, not in app code, because the drain already has audited mechanisms for it (lifecycle policies, `DELETE` jobs, dataset retention).
 
 | Framework | Typical retention                                                   |
 | --------- | ------------------------------------------------------------------- |
@@ -180,11 +180,11 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-For Hono, Express, Next.js, or standalone scripts / workers, see [`references/framework-wiring.md`](references/framework-wiring.md). The pattern is identical — only the framework integration helper changes.
+For Hono, Express, Next.js, or standalone scripts / workers, see [`references/framework-wiring.md`](references/framework-wiring.md). The pattern is identical. Only the framework integration helper changes.
 
 ### Step 2 — Define the action vocabulary
 
-Audits get queried and alerted on by `audit.action`. A typo is a missing alert, so centralise the list. For a bounded context with several actions, prefer a catalog — one prefix, typed keys, autocomplete on the wire format `${prefix}.${KEY}`:
+Audits get queried and alerted on by `audit.action`. A typo is a missing alert, so centralise the list. For a bounded context with several actions, prefer a catalog: one prefix, typed keys, autocomplete on the wire format `${prefix}.${KEY}`:
 
 ```ts
 // app/audit/billing.ts
@@ -220,7 +220,7 @@ Naming conventions:
 
 Three patterns, in order of preference:
 
-**A. Wrap the action with `withAudit()`** — pure audit-worthy actions (refund, delete, role change, password reset). Outcome resolution is automatic, so you can't forget to log a denial or failure:
+**A. Wrap the action with `withAudit()`.** Pure audit-worthy actions (refund, delete, role change, password reset). Outcome resolution is automatic, so you can't forget to log a denial or failure:
 
 ```ts
 import { withAudit, AuditDeniedError } from 'evlog'
@@ -243,7 +243,7 @@ Outcome resolution:
 - `fn` throws `AuditDeniedError` (or any error with `status === 403`) → `outcome: 'denied'`, error message becomes `reason`.
 - Any other thrown error → `outcome: 'failure'`, then re-thrown.
 
-**B. Manual `log.audit()` inside a handler** — when the audit is one of several decisions in a larger handler, or when you need to emit before the action completes:
+**B. Manual `log.audit()` inside a handler.** Use it when the audit is one of several decisions in a larger handler, or when you need to emit before the action completes:
 
 ```ts
 const log = useLogger(event)
@@ -268,7 +268,7 @@ log.audit({
 })
 ```
 
-**C. Standalone `audit()` for jobs / scripts** — no request, no logger. Same shape, no context auto-fill:
+**C. Standalone `audit()` for jobs / scripts.** No request, no logger. Same shape, no context auto-fill:
 
 ```ts
 import { audit } from 'evlog'
@@ -283,7 +283,7 @@ audit({
 
 ### Step 4 — Add denial coverage
 
-Auditors care most about denials — they're how you prove the policy is actually being enforced. Every authorisation check should have a paired `log.audit.deny()`. Pulling the deny into a single helper guarantees coverage parity with successes:
+Auditors care most about denials, because they're how you prove the policy is actually being enforced. Every authorisation check should have a paired `log.audit.deny()`. Pulling the deny into a single helper guarantees coverage parity with successes:
 
 ```ts
 function authorize(actor, action, resource) {
@@ -301,7 +301,7 @@ function authorize(actor, action, resource) {
 
 ### Step 5 — Redact
 
-Apply `auditRedactPreset` (or merge it into the existing `RedactConfig`). It redacts HTTP auth headers and common credential field names (`password`, `token`, `apiKey`, `cardNumber`, `cvv`, `ssn`, plus `cookie` / `set-cookie`) at any nesting depth — including inside `audit.changes.before` / `audit.changes.after`:
+Apply `auditRedactPreset` (or merge it into the existing `RedactConfig`). It redacts HTTP auth headers and common credential field names (`password`, `token`, `apiKey`, `cardNumber`, `cvv`, `ssn`, plus `cookie` / `set-cookie`) at any nesting depth, including inside `audit.changes.before` / `audit.changes.after`:
 
 ```ts
 import { initLogger, auditRedactPreset } from 'evlog'
@@ -315,7 +315,7 @@ initLogger({
 
 ### Step 6 — Test it
 
-`mockAudit()` captures audit events for assertions without going through any drain. Make the denial test mandatory in code review — untested denial paths are the most common cause of audit gaps:
+`mockAudit()` captures audit events for assertions without going through any drain. Make the denial test mandatory in code review, because untested denial paths are the most common cause of audit gaps:
 
 ```ts
 import { mockAudit } from 'evlog'
@@ -395,7 +395,7 @@ rg -n "createError\(.*403|throw .*Forbidden|status:\s*403|statusCode:\s*403" --t
 rg -n "(?i)\b(delete|update|create|refund|grant|revoke|promote|demote|reset|impersonate)\b.*async\s+function|defineEventHandler" --type ts
 ```
 
-On Nuxt, Nitro, Next.js, or TanStack Start, you can also run `npx @evlog/cli map --no-write` — the `audit` / `audit-coverage` checks flag sensitive routes that log nothing. Useful as a second pass; keep the greps above for denials and actor shape, which the CLI does not fully cover.
+On Nuxt, Nitro, Next.js, or TanStack Start, you can also run `npx @evlog/cli map --no-write`, whose `audit` / `audit-coverage` checks flag sensitive routes that log nothing. Useful as a second pass; keep the greps above for denials and actor shape, which the CLI does not fully cover.
 
 For each match, check:
 - Mutating endpoint without a `log.audit()` or `withAudit()` → coverage gap.

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -35,7 +35,7 @@ Review and improve logging patterns in TypeScript/JavaScript codebases. Transfor
 
 ## Audit logs
 
-For security-sensitive actions (auth, billing, admin, data export), use evlog's audit layer — a typed `audit` field on wide events, not a parallel logger. See the **`build-audit-logs`** skill for end-to-end setup (`log.audit`, `withAudit`, denials, `auditEnricher`, `auditOnly`, `signed`, `mockAudit`).
+For security-sensitive actions (auth, billing, admin, data export), use evlog's audit layer: a typed `audit` field on wide events, not a parallel logger. See the **`build-audit-logs`** skill for end-to-end setup (`log.audit`, `withAudit`, denials, `auditEnricher`, `auditOnly`, `signed`, `mockAudit`).
 
 ```typescript
 log.audit({
@@ -56,11 +56,11 @@ npm install evlog
 
 ## Use the CLI (recommended on Nuxt, Nitro, Next.js, TanStack Start)
 
-`@evlog/cli` is a **separate package** from `evlog` — early, but worth trying. It reads the project on disk (no traffic, no config). On the four supported frameworks it covers the whole loop: **wire evlog in** (`init`), **score coverage** (`map`), **lock the score in CI** (`--min-score`, `--baseline`). If the CLI is unavailable, the framework has no adapter yet, or the user declines — continue with the manual sections below; the skill does not depend on it. **Ask before installing anything**; prefer `npx` / `pnpm dlx` for one-shots.
+`@evlog/cli` is a **separate package** from `evlog`, early but worth trying. It reads the project on disk (no traffic, no config). On the four supported frameworks it covers the whole loop: **wire evlog in** (`init`), **score coverage** (`map`), **lock the score in CI** (`--min-score`, `--baseline`). If the CLI is unavailable, the framework has no adapter yet, or the user declines, continue with the manual sections below; the skill does not depend on it. **Ask before installing anything**; prefer `npx` / `pnpm dlx` for one-shots.
 
 ### 1. Setup: `evlog init`
 
-On a project that doesn't use evlog yet, prefer `init` over hand-writing the setup — it detects the framework, reads what the project already has, and generates config, drains, enrichers, and extras in one pass. It is fully scriptable for agents:
+On a project that doesn't use evlog yet, prefer `init` over hand-writing the setup, since it detects the framework, reads what the project already has, and generates config, drains, enrichers, and extras in one pass. It is fully scriptable for agents:
 
 ```bash
 # preview everything without writing (always start here)
@@ -96,7 +96,7 @@ Work FIX FIRST in order, keep changes minimal (`useLogger()`, `log.set()`, `log.
 
 ### 3. Lock it in CI: `--min-score` and `--baseline`
 
-After fixing, propose making the score durable — this is where the CLI earns its keep:
+After fixing, propose making the score durable. This is where the CLI earns its keep:
 
 ```bash
 # in CI, after pnpm add -D @evlog/cli (project-local, pinned by the lockfile)
@@ -104,7 +104,7 @@ pnpm exec evlog map --min-score 80   # absolute gate: exits 1 below the threshol
 pnpm exec evlog map --baseline       # ratchet: exits 1 if this PR made things worse
 ```
 
-`--baseline` compares the fresh scan against the committed `evlog.map.json`, **per entry point and per requirement** — a refactor that instruments one route and breaks another fails even if the total score is unchanged. Disabling a passing check with a comment counts as a regression too. New uninstrumented routes are listed as `NEW AND DARK` without failing. Workflow: commit `evlog.map.json` once, add the `--baseline` run to CI (`pnpm add -D @evlog/cli` for a pinned version — ask first), and re-run `map` without `--baseline` to accept an intentional change. Docs: https://www.evlog.dev/cli/ci
+`--baseline` compares the fresh scan against the committed `evlog.map.json`, **per entry point and per requirement**, so a refactor that instruments one route and breaks another fails even if the total score is unchanged. Disabling a passing check with a comment counts as a regression too. New uninstrumented routes are listed as `NEW AND DARK` without failing. Workflow: commit `evlog.map.json` once, add the `--baseline` run to CI (`pnpm add -D @evlog/cli` for a pinned version, and ask first), then re-run `map` without `--baseline` to accept an intentional change. Docs: https://www.evlog.dev/cli/ci
 
 Early days: adapters and rules are still evolving; expect scores to move between releases. Docs: https://www.evlog.dev/cli/map · Rules: https://www.evlog.dev/cli/rules
 
@@ -125,7 +125,7 @@ export default defineNuxtConfig({
 })
 ```
 
-All evlog functions (`useLogger`, `createError`, `parseError`, `log`) are **auto-imported** — no import statements needed.
+All evlog functions (`useLogger`, `createError`, `parseError`, `log`) are **auto-imported**, with no import statements needed.
 
 ```typescript
 // server/api/checkout.post.ts — no imports needed
@@ -160,7 +160,7 @@ Client-side: `log`, `setIdentity`, `clearIdentity` are auto-imported in componen
 
 ### Next.js
 
-**Step 1: Create central config** — all exports come from here:
+**Step 1: Create central config.** All exports come from here:
 
 ```typescript
 // lib/evlog.ts
@@ -208,7 +208,7 @@ export const POST = withEvlog(async (request: Request) => {
 })
 ```
 
-**Step 3: Server Actions** — same `withEvlog()` wrapper:
+**Step 3: Server Actions.** Same `withEvlog()` wrapper:
 
 ```typescript
 // app/actions.ts
@@ -222,7 +222,7 @@ export const checkout = withEvlog(async (formData: FormData) => {
 })
 ```
 
-**Step 4: Middleware** (optional — sets `x-request-id` + timing headers):
+**Step 4: Middleware** (optional, sets `x-request-id` + timing headers):
 
 ```typescript
 // proxy.ts
@@ -231,7 +231,7 @@ export const proxy = evlogMiddleware()
 export const config = { matcher: ['/api/:path*'] }
 ```
 
-**Step 5: Client Provider** — wrap root layout:
+**Step 5: Client Provider.** Wrap the root layout:
 
 ```tsx
 // app/layout.tsx
@@ -250,7 +250,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 }
 ```
 
-**Step 6: Client logging** — in any client component:
+**Step 6: Client logging.** In any client component:
 
 ```tsx
 'use client'
@@ -261,11 +261,11 @@ log.info({ action: 'checkout_click' })
 clearIdentity()
 ```
 
-**Step 7 (optional): Instrumentation** — startup + global `onRequestError` (SSR/RSC errors outside `withEvlog`). Use `defineNodeInstrumentation(() => import('./lib/evlog'))` in root `instrumentation.ts` to gate Node + cache the import, **or** write `register`/`onRequestError` manually — both are valid. For custom logic, wrap evlog’s `register`/`onRequestError` inside `lib/evlog.ts` (compose with your own init or metrics), then re-export.
+**Step 7 (optional): Instrumentation.** Startup plus global `onRequestError` (SSR/RSC errors outside `withEvlog`). Use `defineNodeInstrumentation(() => import('./lib/evlog'))` in root `instrumentation.ts` to gate Node + cache the import, **or** write `register`/`onRequestError` manually. Both are valid. For custom logic, wrap evlog’s `register`/`onRequestError` inside `lib/evlog.ts` (compose with your own init or metrics), then re-export.
 
 Export `createInstrumentation()` from `lib/evlog.ts` alongside `createEvlog()`. See framework docs for coexistence with `lockLogger`.
 
-**Step 8: Client ingest endpoint** — receives client logs:
+**Step 8: Client ingest endpoint.** Receives client logs:
 
 ```typescript
 // app/api/evlog/ingest/route.ts
@@ -529,7 +529,7 @@ app.get('/api/users', (c) => {
 })
 ```
 
-Access the logger via `c.get('log')` in handlers. Use `useLogger()` from `evlog/hono` in the layers underneath (services, repositories) where `c` is not in hand — both return the same logger:
+Access the logger via `c.get('log')` in handlers. Use `useLogger()` from `evlog/hono` in the layers underneath (services, repositories) where `c` is not in hand. Both return the same logger:
 
 ```typescript
 import { useLogger } from 'evlog/hono'
@@ -797,11 +797,11 @@ export default withEvlog(async (request, _env, _ctx, log) => {
 })
 ```
 
-`withEvlog` emits one wide event per request when the handler returns — no manual `log.emit()`. Async drains are registered with `waitUntil` so they survive the response; streaming responses defer the emit until the body completes. `requestId` comes from `x-request-id` (fallback `cf-ray`); `method`, `path`, `cf-ray`, `traceparent`, and the safe subset of `request.cf` are captured automatically. It accepts the same options (`drain`, `enrich`, `keep`, `include`, `exclude`, `routes`) as every other integration. For manual control (scheduled handlers, queues), `createWorkersLogger(request)` + `log.emit()` remains available. No ALS-based `useLogger()` on Workers — pass `log` explicitly.
+`withEvlog` emits one wide event per request when the handler returns, with no manual `log.emit()`. Async drains are registered with `waitUntil` so they survive the response; streaming responses defer the emit until the body completes. `requestId` comes from `x-request-id` (fallback `cf-ray`); `method`, `path`, `cf-ray`, `traceparent`, and the safe subset of `request.cf` are captured automatically. It accepts the same options (`drain`, `enrich`, `keep`, `include`, `exclude`, `routes`) as every other integration. For manual control (scheduled handlers, queues), `createWorkersLogger(request)` + `log.emit()` remains available. No ALS-based `useLogger()` on Workers, so pass `log` explicitly.
 
 ### AWS Lambda
 
-Lambda has no HTTP middleware lifecycle, so evlog behaves like standalone TypeScript — with one critical rule: **one logger per invocation**, never a shared module-level logger (Lambda reuses execution environments, so a shared instance leaks fields between invocations).
+Lambda has no HTTP middleware lifecycle, so evlog behaves like standalone TypeScript, with one critical rule: **one logger per invocation**, never a shared module-level logger (Lambda reuses execution environments, so a shared instance leaks fields between invocations).
 
 ```typescript
 import { initLogger, createLogger } from 'evlog'
@@ -941,7 +941,7 @@ All options work in Nuxt (`evlog` key), Nitro (passed to `evlog()`), Next.js (`c
 | NuxtHub | `@evlog/nuxthub` (separate package, Nuxt module) | None — stores wide events in the NuxtHub database with retention-based cleanup (set `evlog.retention: '7d'` in the module options; accepts `d`/`h`/`m`) |
 | HTTP (browser ingest) | `evlog/http` | None (configure `endpoint` in code). `evlog/browser` is deprecated; same API, removed next major |
 
-Use canonical env var names (e.g. `AXIOM_API_KEY`, `BETTER_STACK_API_KEY`) — the same names work in every framework.
+Use canonical env var names (e.g. `AXIOM_API_KEY`, `BETTER_STACK_API_KEY`), and the same names work in every framework.
 
 Setup pattern per framework:
 
@@ -981,7 +981,7 @@ See [references/drain-pipeline.md](references/drain-pipeline.md) for batching, r
 
 ## Enrichers
 
-Built-in: `createUserAgentEnricher()`, `createGeoEnricher()`, `createRequestSizeEnricher()`, `createTraceContextEnricher()` — all from `evlog/enrichers`. Each accepts `{ overwrite?: boolean }` (default `false`). Use `createDefaultEnrichers()` to compose all four in one call:
+Built-in: `createUserAgentEnricher()`, `createGeoEnricher()`, `createRequestSizeEnricher()`, `createTraceContextEnricher()`, all from `evlog/enrichers`. Each accepts `{ overwrite?: boolean }` (default `false`). Use `createDefaultEnrichers()` to compose all four in one call:
 
 ```typescript
 import { createDefaultEnrichers } from 'evlog/enrichers'
@@ -1011,7 +1011,7 @@ createEvlog({
 
 ## Auto-Redaction (PII Protection)
 
-Built-in redaction scrubs sensitive data from wide events **before** console output and **before** any drain sees the data. **Enabled by default in production** (`NODE_ENV === 'production'`), disabled in development. Uses **smart partial masking** — preserving enough context for debugging.
+Built-in redaction scrubs sensitive data from wide events **before** console output and **before** any drain sees the data. **Enabled by default in production** (`NODE_ENV === 'production'`), disabled in development. Uses **smart partial masking**, preserving enough context for debugging.
 
 ```typescript
 // Disable in production (opt-out)
@@ -1142,7 +1142,7 @@ Anti-patterns to detect:
 
 ## Related Capabilities (pointers)
 
-Recommend these when the review surfaces the matching need — each has full docs on evlog.dev:
+Recommend these when the review surfaces the matching need. Each has full docs on evlog.dev:
 
 | Need spotted | evlog answer | Docs |
 |--------------|--------------|------|
@@ -1184,7 +1184,7 @@ throw createError({
 })
 ```
 
-Frontend — extract user-facing fields with `parseError()` (`internal` is never returned to clients):
+Frontend: extract user-facing fields with `parseError()` (`internal` is never returned to clients):
 
 ```typescript
 import { parseError } from 'evlog'
@@ -1215,7 +1215,7 @@ See [references/code-review.md](references/code-review.md) for the full checklis
 
 ## Loading Reference Files
 
-Load based on what you're working on — **do not load all at once**:
+Load based on what you're working on, and **do not load all at once**:
 
 - Designing wide events → [references/wide-events.md](references/wide-events.md)
 - Improving errors → [references/structured-errors.md](references/structured-errors.md)

--- a/apps/docs/skills/review-logging-patterns/references/code-review.md
+++ b/apps/docs/skills/review-logging-patterns/references/code-review.md
@@ -4,7 +4,7 @@ Use this checklist when reviewing code for logging best practices and evlog adop
 
 ## Prefer `evlog map` when you can
 
-On **Nuxt, Nitro, Next.js App Router, and TanStack Start**, start with `@evlog/cli` if the user is open to it — one command finds dark entry points and names the fixes:
+On **Nuxt, Nitro, Next.js App Router, and TanStack Start**, start with `@evlog/cli` if the user is open to it: one command finds dark entry points and names the fixes:
 
 ```bash
 npx @evlog/cli map --no-write
@@ -22,7 +22,7 @@ npx @evlog/cli map <file> --no-write   # suggested shape for one entry point
 | `context` | 15 | `log.set(...)` | Flat / missing request context |
 | `error-handling` | 15 | log or rethrow in `catch` | `console.error(e); throw e` |
 
-**Opportunities** (never cost points; fire only when the project already uses the feature) — surface them as suggestions, not defects:
+**Opportunities** (never cost points; fire only when the project already uses the feature). Surface them as suggestions, not defects:
 
 | Map rule id | Fires when | Related skill section |
 |-------------|-----------|-----------------------|
@@ -33,7 +33,7 @@ npx @evlog/cli map <file> --no-write   # suggested shape for one entry point
 
 Full rule reference: https://www.evlog.dev/cli/rules
 
-Map tells you the **shape** is present — not that the context is useful at runtime. Keep the scans below for frameworks without adapters, for quality of context, drains, redaction, and AI SDK usage. If the user skips the CLI, use this checklist alone.
+Map tells you the **shape** is present, not that the context is useful at runtime. Keep the scans below for frameworks without adapters, for quality of context, drains, redaction, and AI SDK usage. If the user skips the CLI, use this checklist alone.
 
 ## Quick Scan
 

--- a/apps/evi/AGENTS.md
+++ b/apps/evi/AGENTS.md
@@ -18,7 +18,7 @@ with a colocated test).
 
 ## What reaches PostHog
 
-Metadata only — tokens, cost, latency, model, tool names. Prompts, responses,
+Metadata only: tokens, cost, latency, model, tool names. Prompts, responses,
 and tool payloads stay in the agent: turns carry third-party GitHub and Linear
 content. Turning that off rules out LLM-judge evaluations in PostHog, which is
 a deliberate trade.
@@ -26,21 +26,21 @@ a deliberate trade.
 ## Evals cost real money
 
 `pnpm eval` runs the agent against a live model. Twenty evals is a real bill, so
-the CI triggers are narrow — see `.github/workflows/evi-evals.yml` for the full
+the CI triggers are narrow. See `.github/workflows/evi-evals.yml` for the full
 list and the guards.
 
 Evals tagged `needs-connect` assert on GitHub calls that must *succeed*, and
 GitHub is reached through Vercel Connect, which authenticates with a Vercel
 OIDC token. CI pulls one with the Vercel CLI when `VERCEL_TOKEN`,
 `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are set, and skips those evals
-otherwise — an unauthenticated run reports a regression that is not one. They
+otherwise, because an unauthenticated run reports a regression that is not one. They
 always run locally, where `vc link` supplies the token. Anything asserting
 `notCalledTool` on a GitHub tool needs no credentials and always runs.
 
 A PR touching `agent/` (excluding tests) or an `.eval.ts` file runs the `fast`
 subset automatically. That is deliberate: Evi opens PRs on her own behaviour,
 and an agent cannot be relied on to label its own regression risk. Keep the PR
-a draft while it is in flux — drafts never run — and add `skip-evals` when a
+a draft while it is in flux, since drafts never run, and add `skip-evals` when a
 watched path changed but the behaviour did not.
 
 Swapping the model goes through `EVI_MODEL`, not an edit to `agent.ts`: run the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,11 +13,11 @@
 
 **Digging through logs is not observability. It's hope.**
 
-The official command line for [evlog](https://evlog.dev) — a **separate package** from the logger itself.
+The official command line for [evlog](https://evlog.dev), a **separate package** from the logger itself.
 
 Score what your app can tell you when something goes wrong. Diagnose your install when nothing shows up.
 
-> **Early days.** Safe to run on any project — it reads your source and writes a single `evlog.map.json` at the root (`--no-write` to skip), and it is covered by tests — but young. `evlog map` has adapters for four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases: pin the CLI as a dev dependency when you gate CI on the number.
+> **Early days.** Safe to run on any project, since it reads your source and writes a single `evlog.map.json` at the root (`--no-write` to skip), and it is covered by tests, but young. `evlog map` has adapters for four frameworks today, its rules are still being refined, and both will grow. Expect verdicts and scores to move between releases: pin the CLI as a dev dependency when you gate CI on the number.
 
 ## Usage
 
@@ -83,7 +83,7 @@ A verdict you disagree with costs one comment, not your CI gate:
 export default defineEventHandler(() => ({ ok: true }))
 ```
 
-Also `evlog-map-disable-line` for a trailing comment, and `evlog-map-disable` on its own for the whole file. Name no rule id and it covers all of them. The check becomes `n/a` with your reason attached, so it costs no score — and the report counts how many checks the project disabled, so a green score never hides an app that logs nothing. Full syntax: [Rules](https://evlog.dev/cli/rules#disabling-a-check).
+Also `evlog-map-disable-line` for a trailing comment, and `evlog-map-disable` on its own for the whole file. Name no rule id and it covers all of them. The check becomes `n/a` with your reason attached, so it costs no score, and the report counts how many checks the project disabled, so a green score never hides an app that logs nothing. Full syntax: [Rules](https://evlog.dev/cli/rules#disabling-a-check).
 
 ## Exit codes
 
@@ -95,7 +95,7 @@ Also `evlog-map-disable-line` for a trailing comment, and `evlog-map-disable` on
 
 ## `--json` output
 
-With `--json`, the payload is the **only** thing written to stdout — everything human goes to stderr. The shape is a contract:
+With `--json`, the payload is the **only** thing written to stdout, and everything human goes to stderr. The shape is a contract:
 
 ```jsonc
 // evlog doctor --json
@@ -118,19 +118,19 @@ With `--json`, the payload is the **only** thing written to stdout — everythin
 
 With `--baseline`, the payload gains a `baseline` key holding the comparison (`regressions`, `fixed`, `added`, `removed`, `delta`).
 
-Breaking either shape requires a `schemaVersion` bump. In `routes[]`, `checks` holds the requirements that move the score and `suggestions` holds the opportunities that never do — separate keys so a suggestion can't be mistaken for a failure.
+Breaking either shape requires a `schemaVersion` bump. In `routes[]`, `checks` holds the requirements that move the score and `suggestions` holds the opportunities that never do, in separate keys so a suggestion can't be mistaken for a failure.
 
 ## Telemetry
 
 The CLI records **one anonymous wide event per command** via [`@evlog/telemetry`](https://npmjs.com/package/@evlog/telemetry) (tool name `evlog-cli`): command name, duration, outcome, sanitized flags. No arguments, paths, or file contents.
 
-`evlog init` also records **which options you picked** — the framework, the destinations, the extras, the sampling preset, and counts (files written, manual steps left). Every value is an id from the CLI's own catalog, enforced by an allowlist, so a free-text answer can never be sent: your service name, your package name and anything read out of your source stay on your machine. Delivered to evlog's own dashboard (`apps/telemetry` in this repo); override with `EVLOG_TELEMETRY_ENDPOINT` to point at your own instance. Opt out anytime:
+`evlog init` also records **which options you picked**: the framework, the destinations, the extras, the sampling preset, and counts (files written, manual steps left). Every value is an id from the CLI's own catalog, enforced by an allowlist, so a free-text answer can never be sent: your service name, your package name and anything read out of your source stay on your machine. Delivered to evlog's own dashboard (`apps/telemetry` in this repo); override with `EVLOG_TELEMETRY_ENDPOINT` to point at your own instance. Opt out anytime:
 
 ```bash
 evlog telemetry disable   # or DO_NOT_TRACK=1 / EVLOG_TELEMETRY=0
 ```
 
-Full policy: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/overview)
+Full policy: [evlog.dev telemetry policy](https://evlog.dev/use-cases/telemetry/overview)
 
 ## Quieter output
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -13,7 +13,7 @@
 
 **Digging through logs is not observability. It's hope.**
 
-A single request generates 10+ log lines. When production breaks at 3am, you're sifting scattered lines for a needle of signal. Your errors say "Something went wrong" — thanks, very helpful.
+A single request generates 10+ log lines. When production breaks at 3am, you're sifting scattered lines for a needle of signal. Your errors say "Something went wrong", which helps nobody.
 
 **evlog is different.** One wide event per operation. All the context. Errors that explain *why* and what to do next.
 
@@ -339,7 +339,7 @@ async function processSyncJob(job: Job) {
 
 ## Cloudflare Workers
 
-Use the Workers adapter for structured logs and correct platform severity. With `initWorkersLogger({ drain })`, use **`defineWorkerFetch`** so async drains are registered with `waitUntil` automatically (Cloudflare only passes `ExecutionContext` as the third `fetch` argument — there is no global).
+Use the Workers adapter for structured logs and correct platform severity. With `initWorkersLogger({ drain })`, use **`defineWorkerFetch`** so async drains are registered with `waitUntil` automatically (Cloudflare only passes `ExecutionContext` as the third `fetch` argument, and there is no global).
 
 ```typescript
 // src/index.ts
@@ -592,11 +592,11 @@ import { defineEvlogInstrumentation } from 'evlog/eve'
 export default defineEvlogInstrumentation()
 ```
 
-`defineEvlogHook()` maps eve turn lifecycle events to one wide event per turn. Call `useLogger()` in tools — the logger is bound via AsyncLocalStorage on `turn.started`. Pass `ctx` only when ALS is unavailable (`useLogger(ctx)`). Pretty-printing follows `isDev()` by default (tree locally, JSON in production); set `init.pretty: false` explicitly if you need to override.
+`defineEvlogHook()` maps eve turn lifecycle events to one wide event per turn. Call `useLogger()` in tools, where the logger is bound via AsyncLocalStorage on `turn.started`. Pass `ctx` only when ALS is unavailable (`useLogger(ctx)`). Pretty-printing follows `isDev()` by default (tree locally, JSON in production); set `init.pretty: false` explicitly if you need to override.
 
-`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. It owns `agent/instrumentation.ts`, so when another observability backend needs that file, use eve's own `defineInstrumentation` and spread `evlogRuntimeContext(input)` into your runtime context instead. Requires eve 0.30 or later. Complements eve Agent Runs — see the [eve use case](https://evlog.dev/use-cases/eve).
+`defineEvlogInstrumentation()` is optional: it stamps `evlog.request_id` onto eve's AI SDK spans so a trace joins back to its wide event, and back. It owns `agent/instrumentation.ts`, so when another observability backend needs that file, use eve's own `defineInstrumentation` and spread `evlogRuntimeContext(input)` into your runtime context instead. Requires eve 0.30 or later. Complements eve Agent Runs. See the [eve use case](https://evlog.dev/use-cases/eve).
 
-Every turn event carries `eve.caller` — `principalId`, `principalType` and `authenticator` — so cost and volume group by who triggered the turn.
+Every turn event carries `eve.caller` (`principalId`, `principalType` and `authenticator`), so cost and volume group by who triggered the turn.
 
 See the full [eve example](https://github.com/HugoRCD/evlog/tree/main/examples/eve) for a complete agent layout.
 
@@ -623,7 +623,7 @@ Client logs output to the browser console with colored tags in development.
 
 ### Client Transport
 
-To send client logs to the server for centralized logging, enable the transport:
+To send client logs to the server for centralized logging, enable the HTTP drain:
 
 ```typescript
 // nuxt.config.ts
@@ -828,7 +828,7 @@ export default defineEventHandler(async (event) => {
 | `signed(drain, { strategy: 'hmac' \| 'hash-chain', ... })` | wrapper | Tamper-evident integrity |
 | `auditRedactPreset` | preset | Strict PII for audit events |
 
-`AuditFields` is exported and merges with `BaseWideEvent` — augment it with `declare module` if you need extra typed fields. Audit events are always force-kept by tail sampling and get a deterministic `idempotencyKey` so retries are safe across drains.
+`AuditFields` is exported and merges with `BaseWideEvent`, so augment it with `declare module` if you need extra typed fields. Audit events are always force-kept by tail sampling and get a deterministic `idempotencyKey` so retries are safe across drains.
 
 See [the Audit Logs guide](https://evlog.dev/use-cases/audit/overview) for compliance, GDPR, and recipe details.
 
@@ -1031,7 +1031,7 @@ EVLOG_FS_DIR=.evlog/logs
 
 ### Memory
 
-In-memory ring buffer — works in any runtime, including Cloudflare Workers:
+In-memory ring buffer that works in any runtime, including Cloudflare Workers:
 
 ```typescript
 // server/plugins/evlog-drain.ts
@@ -1284,7 +1284,7 @@ log.getContext()                   // Get current context
 
 ### Wide event lifecycle and `log.fork()`
 
-The framework emits **one wide event per HTTP request** when the response finishes (or on error). After `emit()` runs — including when head sampling drops the event (`emit()` returns `null`) — that logger instance is **sealed**: further `set`, `error`, `info`, and `warn` calls are ignored and emit a **`[evlog]` console warning** listing dropped keys. A second `emit()` is ignored with a warning. This avoids silent data loss when async work (unawaited promises, `setTimeout`, etc.) still resolves `useLogger()` to the same logger via `AsyncLocalStorage` after the response has already been logged.
+The framework emits **one wide event per HTTP request** when the response finishes (or on error). After `emit()` runs, including when head sampling drops the event (`emit()` returns `null`), that logger instance is **sealed**: further `set`, `error`, `info`, and `warn` calls are ignored and emit a **`[evlog]` console warning** listing dropped keys. A second `emit()` is ignored with a warning. This avoids silent data loss when async work (unawaited promises, `setTimeout`, etc.) still resolves `useLogger()` to the same logger via `AsyncLocalStorage` after the response has already been logged.
 
 **`log.fork(label, fn)`** runs work under a **child** request logger: inside `fn`, `useLogger()` returns the child. When `fn` settles, the child emits its **own** wide event with `operation` set to `label` and `_parentRequestId` set to the parent’s `requestId` (query and dashboard correlation). The parent event may be emitted **before** the child event; they are two separate events ordered by time.
 
@@ -1330,7 +1330,7 @@ initWorkersLogger({
 
 ### `defineWorkerFetch(handler)`
 
-Recommended for Workers when using **`initWorkersLogger({ drain })`**. Wraps your handler so `createWorkersLogger` always receives `executionCtx` — you do not pass `ctx` into the factory yourself. Cloudflare does not expose `ExecutionContext` globally (only as `fetch`’s third argument), so this is the “automatic” option for plain Workers scripts.
+Recommended for Workers when using **`initWorkersLogger({ drain })`**. Wraps your handler so `createWorkersLogger` always receives `executionCtx`, so you do not pass `ctx` into the factory yourself. Cloudflare does not expose `ExecutionContext` globally (only as `fetch`’s third argument), so this is the “automatic” option for plain Workers scripts.
 
 ```typescript
 import { defineWorkerFetch, initWorkersLogger } from 'evlog/workers'
@@ -1383,7 +1383,7 @@ createError({
 })
 ```
 
-**`internal`** — Optional context for support, auditing, or debugging (IDs, gateway codes, raw diagnostics). It is stored on `EvlogError` and exposed as `error.internal` in server code. It is **not** included in JSON error responses, `toJSON()`, or `parseError()` results. When the error is passed to `log.error()` (or thrown in integrations that record errors on the wide event), `internal` is copied into the emitted event under `error.internal`.
+**`internal`.** Optional context for support, auditing, or debugging (IDs, gateway codes, raw diagnostics). It is stored on `EvlogError` and exposed as `error.internal` in server code. It is **not** included in JSON error responses, `toJSON()`, or `parseError()` results. When the error is passed to `log.error()` (or thrown in integrations that record errors on the wide event), `internal` is copied into the emitted event under `error.internal`.
 
 ### `parseError(error)`
 
@@ -1439,7 +1439,7 @@ try {
 
 ## CLI
 
-[`@evlog/cli`](https://npmjs.com/package/@evlog/cli) is a **separate package** — still early — that scores what your app can tell you when something goes wrong. It reads your project on disk — no traffic, no instrumentation — finds every entry point, and names the ones to fix first. Worth trying once you have anything wired; hand the report to an agent if you like.
+[`@evlog/cli`](https://npmjs.com/package/@evlog/cli) is a **separate package**, still early, that scores what your app can tell you when something goes wrong. It reads your project on disk, with no traffic and no instrumentation, and finds every entry point, and names the ones to fix first. Worth trying once you have anything wired; hand the report to an agent if you like.
 
 ```bash
 npx @evlog/cli map
@@ -1464,9 +1464,9 @@ FIX FIRST
 | `evlog map --min-score <n>` | Exit 1 below the threshold — a CI gate |
 | `evlog doctor` | Diagnose the install: Node, workspace, evlog version, local logs |
 
-Same code in, same verdict out, with the file and line for every finding — which also makes it something you can hand to an agent: run it, fix the list, run it again.
+Same code in, same verdict out, with the file and line for every finding, which also makes it something you can hand to an agent: run it, fix the list, run it again.
 
-> **Early days:** the CLI is tested and safe to run on any project, but it is young — four framework adapters today, rules still being refined. Expect verdicts and scores to move between releases; pin it as a dev dependency when you gate CI on the number.
+> **Early days:** the CLI is tested and safe to run on any project, but it is young: four framework adapters today, rules still being refined. Expect verdicts and scores to move between releases; pin it as a dev dependency when you gate CI on the number.
 
 Docs: [CLI](https://www.evlog.dev/cli/overview) · [`evlog map`](https://www.evlog.dev/cli/map) · [Rules](https://www.evlog.dev/cli/rules) · [Scoring](https://www.evlog.dev/cli/scoring) · [CI](https://www.evlog.dev/cli/ci)
 

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -13,9 +13,9 @@
 
 **Digging through logs is not observability. It's hope.**
 
-**Wide-event telemetry for CLIs and automation** — the same one-event-per-run model as [evlog](https://evlog.dev), built for tools that run on someone else's machine.
+**Wide-event telemetry for CLIs and automation**, the same one-event-per-run model as [evlog](https://evlog.dev), built for tools that run on someone else's machine.
 
-Ship usage insight without shipping an analytics SDK: wrap your [citty](https://github.com/unjs/citty) command tree (or call `createTelemetry()` in scripts) and get **one structured event per command** — command name, sanitized flags, duration, outcome, and optional counters via `telemetry.set()`.
+Ship usage insight without shipping an analytics SDK: wrap your [citty](https://github.com/unjs/citty) command tree (or call `createTelemetry()` in scripts) and get **one structured event per command**: command name, sanitized flags, duration, outcome, and optional counters via `telemetry.set()`.
 
 ## Why evlog telemetry
 
@@ -66,10 +66,10 @@ const main = withTelemetry(
 runMain(main)
 ```
 
-Scripts and GitHub Actions: `createTelemetry()` / `createGitHubActionsTelemetry()` — see the [docs](https://evlog.dev/use-cases/telemetry/overview).
+Scripts and GitHub Actions: `createTelemetry()` / `createGitHubActionsTelemetry()`. See the [docs](https://evlog.dev/use-cases/telemetry/overview).
 
 ## Docs
 
-Full guide: [evlog.dev — telemetry](https://evlog.dev/use-cases/telemetry/overview)
+Full guide: [evlog.dev telemetry guide](https://evlog.dev/use-cases/telemetry/overview)
 
 Example playground: [`examples/telemetry-playground`](../../examples/telemetry-playground) in the evlog monorepo.


### PR DESCRIPTION
The rest of the corpus: 71 files, 379 lines, one commit.

**Zero em dashes and zero en dashes remain in evlog prose.** From 221 occurrences to none, and none of them replaced mechanically.

| | Before this stack | Now |
| --- | --- | --- |
| Average score | 84.6 | **96.4** |
| Clean pages | 9 / 120 | **55 / 120** |
| `U-14` | 221 occurrences | 0 |
| Criticals | 5 | 0 |

## Why 379 hand edits instead of a codemod

Every dash took the mark its own sentence wanted, and the distribution is the argument:

- **Parentheses** where the dashes wrapped a list: `Every existing primitive (drains, enrichers, redact, tail-sampling) applies`. Commas here produce a subject followed by four bare nouns, which is exactly what the codemod did on 25 of 38 attempts before it was removed.
- **A colon** where the second half names what the first announced: `Three entry points: a sensitive handler at 75, a plain handler at 100`.
- **A period** where the halves were separate thoughts: `The adapter is identical either way. Only the endpoint and credentials change.`
- **A conjunction** where the dash hid a causal link: `sorted by timestamp, because Loki rejects out-of-order pushes`.
- **The bold label back** in definition lists: `**Missing endpoint.** LOKI_ENDPOINT is unset` instead of `**Missing endpoint** — LOKI_ENDPOINT is unset`. Thirty of these across the CLI, audit, and adapter pages.

Three on the Lambda page had no surrounding spaces (`optional—it helps—but`), which is how they survived every previous read.

## Terminology

Thirteen `U-15` candidates were `transport`, and they split cleanly:

- **evlog's own concept under pino's word**, corrected: `enable the transport` → `enable the HTTP drain`, `for transport configuration` → `for drain configuration`, `the client transport` → `client logging`.
- **A child logger that is actually a fork**, corrected on four pages: `useLogger() resolves to a child logger` → `resolves to the forked logger`. pino's `child()` inherits fixed bindings; `fork()` branches accumulated context and can be discarded. Calling it a child logger teaches the wrong model.
- **Genuinely about the network or about pino**, left alone: `not a transport` on the diagnostics channel page, `no formatter, transport, or peer-dep wiring` in a migration section.

## What is left, and why

`T-06` heading locks on 51 pages. They are real (`## Configuration` says less than `## Choose what reaches the drain`), but renaming headings moves anchors, so that is its own PR with a link audit.

`T-03`, `T-07`, `T-11`, `T-12` were judged page by page and are mostly lawful twins: a closer that introduces a table carries the table, and a checklist shares `[` by construction.

## Checks

`evlog-docs` lint passes. One commit, to keep the preview deploys down. No changeset: docs, skills, and READMEs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and consistency across product guides, CLI references, integration instructions, and extension documentation.
  * Clarified logging, drain pipelines, forked logger behavior, telemetry validation, error handling, and successful response expectations.
  * Expanded troubleshooting guidance for missing logs, CLI setup, configuration, and log access.
  * Refined README content covering CLI output, privacy, integrations, audit fields, and logger lifecycle details.
  * Standardized punctuation and sentence structure throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->