### PR TITLE
feat: check what only the whole corpus can see

### DIFF
--- a/.agents/skills/write-evlog-content/references/rules/docs.md
+++ b/.agents/skills/write-evlog-content/references/rules/docs.md
@@ -80,4 +80,4 @@ Why: this is the only class of docs defect that silently converts a correct read
 
 Rule: at least one other page links to this one in prose, a table, or a card. The navigation is not a substitute: it lists what exists, it does not tell a reader when they need it.
 Why: `voice.md` promises that the docs suggest the next move rather than waiting to be searched. A page nothing points at is a page that only answers a search someone already knew how to run.
-Note: the scanner reads links from prose, from table cells, and from `to:` / `href:` props in MDC components, so a card group counts. Section indexes reached only by the nav are the honest exception, and they are the ones this rule keeps flagging.
+Note: the scanner reads links from prose, from table cells, and from `to:` / `href:` props in MDC components, so a card group counts. A section index is exempt, since the navigation is how it is meant to be reached, and a page linking to its own route does not count as being suggested.

--- a/.agents/skills/write-evlog-content/references/rules/docs.md
+++ b/.agents/skills/write-evlog-content/references/rules/docs.md
@@ -17,6 +17,8 @@ Rule: `description:` in frontmatter states what the reader gets, in a full sente
 Bad: `description: Documentation for the sampling feature.`
 Better: `description: Drop low-importance events at emit time and force-keep slow requests and errors, so your bill scales with signal instead of traffic.`
 Why: it is the highest-leverage sentence on the page and the one most often written last.
+Length: between 50 and 160 characters. A search result shows about 160, so anything past that is a sentence nobody finishes reading, and anything under 50 pays for a slot it does not use. The scanner measures both.
+Note: this applies to pages that serve a route. A `SKILL.md` description is a routing decision for an agent (`M-06`) and is long on purpose.
 
 ---
 
@@ -71,3 +73,11 @@ Rule: keys, order, `navigation.icon`, and `links:` entries survive an edit uncha
 
 Rule: symbols, option names, defaults, and error codes are verified against `packages/evlog/src` at review time. A rename in the package is a docs bug the moment it ships.
 Why: this is the only class of docs defect that silently converts a correct reader into a wrong one.
+
+---
+
+**D-11 · Every page is suggested by another page** · `standard`
+
+Rule: at least one other page links to this one in prose, a table, or a card. The navigation is not a substitute: it lists what exists, it does not tell a reader when they need it.
+Why: `voice.md` promises that the docs suggest the next move rather than waiting to be searched. A page nothing points at is a page that only answers a search someone already knew how to run.
+Note: the scanner reads links from prose, from table cells, and from `to:` / `href:` props in MDC components, so a card group counts. Section indexes reached only by the nav are the honest exception, and they are the ones this rule keeps flagging.

--- a/apps/docs/content/1.start/1.introduction.md
+++ b/apps/docs/content/1.start/1.introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: A modern TypeScript logger built for everything you ship. Simple structured logs, wide events, and structured errors in one API — drop-in for console.log, pino, or consola.
+description: A TypeScript logger for everything you ship: structured logs, wide events, and structured errors in one API. Drop-in for console.log or pino.
 navigation:
   icon: i-lucide-info
 links:

--- a/apps/docs/content/1.start/2.why-evlog.md
+++ b/apps/docs/content/1.start/2.why-evlog.md
@@ -1,6 +1,6 @@
 ---
 title: Why start with evlog
-description: The cheapest moment to add structured logging is before the first request. Pick evlog on day zero and your application inherits a structured surface, typed catalogs, an audit trail, AI SDK telemetry, and a drain pipeline you don't have to build later.
+description: The cheapest moment to add structured logging is before the first request. Pick evlog on day zero and the rest of the system inherits it.
 navigation:
   icon: i-lucide-rocket
 links:

--- a/apps/docs/content/2.learn/0.overview.md
+++ b/apps/docs/content/2.learn/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Learn evlog
-description: The mental model — three logging modes, the wide event lifecycle, sampling, typed fields, and redaction. Read this section in order if you're new; pick what you need if you're not.
+description: The mental model: three logging modes, the wide event lifecycle, sampling, typed fields, and redaction. Read it in order if you are new.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/2.learn/1.simple-logging.md
+++ b/apps/docs/content/2.learn/1.simple-logging.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Logging
-description: evlog's general-purpose logger. A drop-in for console.log, pino, or consola, with the same level filtering, drain pipeline, redaction, and pretty/JSON output as wide events.
+description: evlog's general-purpose logger, a drop-in for console.log, pino, or consola, with the same levels, drains, redaction, and output as wide events.
 navigation:
   icon: i-lucide-terminal
 links:

--- a/apps/docs/content/2.learn/4.lifecycle.md
+++ b/apps/docs/content/2.learn/4.lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Lifecycle
-description: Understand the full lifecycle of an evlog event, from creation to drain. Covers all three modes (simple logging, wide events, request logging), sampling, enrichment, and delivery.
+description: An evlog event from creation to drain, across all three modes, through sampling, enrichment, and delivery.
 navigation:
   icon: i-lucide-arrow-right-left
 links:

--- a/apps/docs/content/2.learn/5.sampling.md
+++ b/apps/docs/content/2.learn/5.sampling.md
@@ -1,6 +1,6 @@
 ---
 title: Sampling
-description: Control log volume with two-tier sampling. Head sampling drops noise by level, tail sampling rescues critical events based on outcome. Never miss errors, slow requests, or critical paths.
+description: Two-tier sampling: head sampling drops noise by level, tail sampling rescues events by outcome. Errors and slow requests are never dropped.
 navigation:
   icon: i-lucide-filter
 links:

--- a/apps/docs/content/2.learn/5.sampling.md
+++ b/apps/docs/content/2.learn/5.sampling.md
@@ -1,6 +1,6 @@
 ---
 title: Sampling
-description: Two-tier sampling: head sampling drops noise by level, tail sampling rescues events by outcome. Errors and slow requests are never dropped.
+description: Two-tier sampling: head sampling drops noise by level, and tail sampling keeps an event once its outcome is known.
 navigation:
   icon: i-lucide-filter
 links:

--- a/apps/docs/content/2.learn/8.catalogs.md
+++ b/apps/docs/content/2.learn/8.catalogs.md
@@ -1,6 +1,6 @@
 ---
 title: Catalogs
-description: Scale typed error and audit catalogs from a single file to multi-package monorepos. Conventions, npm packaging recipe, composition patterns, and the type-augmentation deep dive.
+description: Scale typed error and audit catalogs from one file to a monorepo: conventions, an npm packaging recipe, and type augmentation.
 navigation:
   icon: i-lucide-book-open
 links:

--- a/apps/docs/content/3.cli/0.overview.md
+++ b/apps/docs/content/3.cli/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: evlog CLI
-description: The evlog command line — map your app's observability coverage, diagnose your setup, and control telemetry. Install, global flags, output streams, exit codes, and monorepo behaviour.
+description: The evlog command line: map your observability coverage, diagnose your setup, control telemetry. Flags, output streams, and exit codes.
 navigation:
   title: Overview
   icon: i-lucide-terminal

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -1,6 +1,6 @@
 ---
 title: evlog init
-description: Wire evlog into an existing app — an interactive setup that installs the package, registers the framework integration, and wires the destination you pick. Fully driveable by flags for CI and agents.
+description: Wire evlog into an existing app. Interactive setup that installs the package, registers the integration, and wires the destination you pick.
 navigation:
   title: init
   icon: i-lucide-wand-sparkles

--- a/apps/docs/content/3.cli/2.map.md
+++ b/apps/docs/content/3.cli/2.map.md
@@ -1,6 +1,6 @@
 ---
 title: evlog map
-description: A deterministic observability test for your app, Lighthouse-style. Scans every entry point in a Nuxt, Nitro, Next.js, or TanStack Start project, scores wide-event coverage, and names the entry points to fix first. Same code, same score; gates in CI.
+description: A deterministic observability test for your app. Scans every entry point, scores wide-event coverage, and names what to fix first.
 navigation:
   title: map
   icon: i-lucide-radar

--- a/apps/docs/content/3.cli/3.rules.md
+++ b/apps/docs/content/3.cli/3.rules.md
@@ -1,6 +1,6 @@
 ---
 title: Map rules
-description: Every check evlog map runs — the six requirements that move the score, the four suggestions that never do, what satisfies each one, and how evlog helpers are recognised in your code.
+description: Every check evlog map runs: six requirements that move the score, four suggestions that never do, and what satisfies each one.
 navigation:
   title: Rules
   icon: i-lucide-list-checks

--- a/apps/docs/content/3.cli/4.scoring.md
+++ b/apps/docs/content/3.cli/4.scoring.md
@@ -1,6 +1,6 @@
 ---
 title: Map scoring
-description: How evlog map turns rule results into a score — per-entry weights, the weighted project average, grade thresholds, coverage classification, and how routes are flagged as money, auth, or PII.
+description: How evlog map turns rule results into a score: per-entry weights, the project average, grade thresholds, and how routes are flagged.
 navigation:
   title: Scoring
   icon: i-lucide-gauge

--- a/apps/docs/content/3.cli/5.ci.md
+++ b/apps/docs/content/3.cli/5.ci.md
@@ -1,6 +1,6 @@
 ---
 title: evlog map in CI
-description: Gate a pull request on your observability score with --min-score, read the JSON contract, and keep the map file out of the way. Exit codes, GitHub Actions, and jq recipes.
+description: Gate a pull request on your observability score with --min-score. The JSON contract, exit codes, GitHub Actions, and jq recipes.
 navigation:
   title: CI
   icon: i-lucide-git-pull-request

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -1,6 +1,6 @@
 ---
 title: evlog agents
-description: Teach the AI agents working in your repository how to use evlog — a short block of conventions in AGENTS.md, plus the published agent skills installed through npx skills.
+description: Teach the agents working in your repository how to use evlog: a short block of conventions in AGENTS.md, plus the published skills.
 navigation:
   title: agents
   icon: i-lucide-bot

--- a/apps/docs/content/4.integrate/0.overview.md
+++ b/apps/docs/content/4.integrate/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Integrate evlog
-description: Wire evlog into your stack — pick a framework integration to capture requests automatically, then pick adapters to ship events to Axiom, Sentry, PostHog, OTLP, and more. Frameworks decide where the logger lives; adapters decide where events go.
+description: Pick a framework integration to capture requests, then pick adapters to ship events. Frameworks decide where the logger lives, adapters where events go.
 navigation:
   title: Overview
   icon: i-lucide-plug

--- a/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/04.hyperdx.md
@@ -1,6 +1,6 @@
 ---
 title: HyperDX Adapter
-description: Send wide events to HyperDX via OTLP/HTTP using HyperDX’s documented OpenTelemetry endpoint and authorization header. Zero-config setup with environment variables.
+description: Send wide events to HyperDX over OTLP/HTTP, using its documented endpoint and authorization header. Configured from environment variables.
 navigation:
   title: HyperDX
   icon: i-custom-hyperdx

--- a/apps/docs/content/4.integrate/adapters/self-hosted/02.nuxthub.md
+++ b/apps/docs/content/4.integrate/adapters/self-hosted/02.nuxthub.md
@@ -1,6 +1,6 @@
 ---
 title: NuxtHub Storage
-description: Self-hosted log retention for evlog using NuxtHub database storage. Store, query, and automatically clean up your structured logs with zero external dependencies.
+description: Self-hosted retention using NuxtHub database storage. Store, query, and clean up your wide events with no external dependency.
 navigation:
   title: NuxtHub
   icon: i-simple-icons-nuxt

--- a/apps/docs/content/5.use-cases/0.overview.md
+++ b/apps/docs/content/5.use-cases/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: Recipes that solve a specific problem with evlog — capture browser logs, observe AI SDK calls, identify users from Better Auth, build a tamper-evident audit trail, instrument tool telemetry, enrich every event with derived context.
+description: Recipes that each solve one problem: browser logs, AI SDK calls, user identity, a tamper-evident audit trail, tool telemetry, derived context.
 navigation:
   title: Overview
   icon: i-lucide-list-checks

--- a/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/01.overview.md
@@ -1,6 +1,6 @@
 ---
 title: AI SDK Integration
-description: Capture token usage, tool calls, model info, and streaming metrics from the Vercel AI SDK into wide events. Wrap your model and get full AI observability with one line.
+description: Capture token usage, tool calls, model info, and streaming metrics from the Vercel AI SDK into wide events. Wrap your model, get the rest free.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Better Auth Integration
-description: Identify users on every request. Each wide event carries who made it, their profile, and session metadata, with no manual log.set call.
+description: Identify the user on authenticated requests, so each wide event carries who made it without a manual log.set call.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Better Auth Integration
-description: Automatically identify users on every request. Every wide event includes who made the request — userId, user profile, and session metadata — with zero manual work.
+description: Identify users on every request. Each wide event carries who made it, their profile, and session metadata, with no manual log.set call.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/5.use-cases/4.audit/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.audit/01.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Audit Logs
-description: First-class audit logs as a thin layer on top of evlog's wide events. Add tamper-evident audit trails to any app with one enricher, one drain wrapper, and one helper.
+description: Audit logs as a thin layer over wide events. A tamper-evident trail from one enricher, one drain wrapper, and one helper.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/5.use-cases/4.audit/03.recording.md
+++ b/apps/docs/content/5.use-cases/4.audit/03.recording.md
@@ -1,6 +1,6 @@
 ---
 title: Recording Events
-description: log.audit, log.audit.deny, standalone audit(), withAudit auto-instrumentation, defineAuditAction and defineAuditCatalog registries, and auditDiff change patches.
+description: log.audit and log.audit.deny, standalone audit(), withAudit, the defineAuditAction and defineAuditCatalog registries, and auditDiff.
 navigation:
   title: Recording
   icon: i-lucide-pen-line

--- a/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
@@ -1,6 +1,6 @@
 ---
 title: telemetry
-description: Wide-event telemetry for CLIs and automation — evlog's one-event-per-run model for tools on user machines, with privacy-safe flags, consent, outbox, and auto-generated disclosure.
+description: One event per run for CLIs and automation, with privacy-safe flags, consent, an outbox, and disclosure generated from the same config.
 navigation:
   title: Overview
   icon: i-lucide-list

--- a/apps/docs/content/5.use-cases/4.telemetry/03.ingest.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/03.ingest.md
@@ -1,6 +1,6 @@
 ---
 title: Telemetry Ingest
-description: Build a server ingestion endpoint for @evlog/telemetry — semi-public threat model, parseIngestBody validation, framework routes, idempotent storage, and rate limiting.
+description: Build the ingestion endpoint for @evlog/telemetry: the threat model, parseIngestBody validation, framework routes, storage, and rate limiting.
 navigation:
   title: Ingest
   icon: i-lucide-server

--- a/apps/docs/content/5.use-cases/5.enrichers.md
+++ b/apps/docs/content/5.use-cases/5.enrichers.md
@@ -1,6 +1,6 @@
 ---
 title: Enrichers
-description: Add derived context to every wide event automatically — user agent, geo, request size, and trace context. Built-in enrichers from evlog/enrichers, plus how to compose them with your own.
+description: Add derived context to every wide event: user agent, geo, request size, trace context. The built-ins, and how to compose them with your own.
 navigation:
   title: Enrichers
   icon: i-lucide-sparkles

--- a/apps/docs/content/5.use-cases/5.enrichers.md
+++ b/apps/docs/content/5.use-cases/5.enrichers.md
@@ -1,6 +1,6 @@
 ---
 title: Enrichers
-description: Add derived context to every wide event: user agent, geo, request size, trace context. The built-ins, and how to compose them with your own.
+description: Add derived context to every wide event, from user agent and geo to your own computed fields.
 navigation:
   title: Enrichers
   icon: i-lucide-sparkles

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -1,6 +1,6 @@
 ---
 title: eve
-description: Export one evlog wide event per eve agent turn — token usage, tool executions, business context, drains, enrichers, and tail sampling alongside Agent Runs and OpenTelemetry.
+description: One evlog wide event per eve agent turn: token usage, tool executions, and business context, through your own drains and tail sampling.
 navigation:
   title: eve
   icon: i-custom-eve

--- a/apps/docs/content/6.extend/0.overview.md
+++ b/apps/docs/content/6.extend/0.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Extend evlog
-description: Observe what flows through the pipeline (stream, fs reader, diagnostics channel, consumer recipes), plug into the pipeline (plugins, enrichers, tail sampling, identity headers), or build your own bricks (custom drains, drain pipeline, custom framework integration).
+description: Observe what flows through the pipeline, plug into it, or build your own bricks. The map of every extension point evlog exposes.
 navigation:
   title: Overview
   icon: i-lucide-blocks

--- a/apps/docs/content/6.extend/10.custom-framework.md
+++ b/apps/docs/content/6.extend/10.custom-framework.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Framework Integration
-description: Build evlog support for an HTTP framework (or non-HTTP runtime) without a built-in integration. Use defineFrameworkIntegration for the (ctx, next) middleware shape, or createMiddlewareLogger / createRequestLogger for everything else.
+description: Build evlog support for a framework or runtime that has no integration, with defineFrameworkIntegration or the lower-level helpers.
 navigation:
   title: Custom framework
   icon: i-lucide-puzzle

--- a/apps/docs/content/6.extend/11.diagnostics-channel.md
+++ b/apps/docs/content/6.extend/11.diagnostics-channel.md
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics Channel
-description: Publish every wide event on a node:diagnostics_channel so any consumer can subscribe without importing evlog — and so Cloudflare forwards them to a Tail Worker with no drain.
+description: Publish every wide event on a node:diagnostics_channel, so a consumer subscribes without importing evlog and Cloudflare can Tail Worker it.
 navigation:
   title: Diagnostics channel
   icon: i-lucide-radio-tower

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-description: definePlugin is the canonical extension point for evlog — opt into any subset of setup, onRequestStart, enrich, keep, drain, onRequestFinish, onClientLog, extendLogger from a single cohesive object.
+description: definePlugin is evlog's canonical extension point: opt into any subset of the lifecycle hooks from one cohesive object.
 navigation:
   title: Plugins
   icon: i-lucide-blocks

--- a/apps/docs/content/6.extend/5.custom-enrichers.md
+++ b/apps/docs/content/6.extend/5.custom-enrichers.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Enrichers
-description: Write custom enrichers to add derived context to your wide events. Add deployment metadata, tenant IDs, feature flags, geo, or any computed data — the toolkit handles error isolation, undefined skipping, and the merge step.
+description: Write an enricher that adds deployment metadata, tenant ids, feature flags, or anything computed. Error isolation and merging are handled.
 navigation:
   title: Custom enrichers
   icon: i-lucide-sparkles

--- a/apps/docs/content/6.extend/6.tail-sampling.md
+++ b/apps/docs/content/6.extend/6.tail-sampling.md
@@ -1,6 +1,6 @@
 ---
 title: Tail Sampling
-description: Decide post-hoc whether to keep an event with full knowledge of its outcome (status, duration, errors). The opposite of head sampling — keep all errors and slow requests while throwing away healthy noise.
+description: Decide after the fact whether to keep an event, knowing its status, duration, and errors. Keep every error, throw away healthy noise.
 navigation:
   title: Tail sampling
   icon: i-lucide-filter

--- a/apps/docs/content/6.extend/7.identity-headers.md
+++ b/apps/docs/content/6.extend/7.identity-headers.md
@@ -1,6 +1,6 @@
 ---
 title: Identity Headers
-description: Every drain request sent by evlog is tagged with User-Agent and X-Evlog-Source headers so receivers can identify and triage the traffic. Override or suppress them when your custom drain needs different identity.
+description: Every drain request carries User-Agent and X-Evlog-Source so receivers can triage the traffic. Override or suppress them when you need to.
 navigation:
   title: Identity headers
   icon: i-lucide-fingerprint

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Drains
-description: Build a drain for any backend without a built-in adapter — defineHttpDrain for HTTP destinations, defineDrain for any other transport. Standardized config resolution, retries, timeouts, and identity headers handled for you.
+description: Build a drain for any backend without a built-in adapter. Config resolution, retries, timeouts, and identity headers are handled for you.
 navigation:
   title: Custom drains
   icon: i-lucide-share-2

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: Drain Pipeline
-description: Batch events, retry on failure, fan out to multiple destinations, and ship browser logs to your server. The shared pipeline that wraps every drain in production.
+description: Batch events, retry on failure, fan out to several destinations, and ship browser logs to your server. The pipeline that wraps every drain.
 navigation:
   title: Drain pipeline
   icon: i-lucide-workflow

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: Drain Pipeline
-description: Batch events, retry on failure, fan out to several destinations, and ship browser logs to your server. The pipeline that wraps every drain.
+description: The pipeline wraps every drain: it batches events, retries on failure, fans out to several destinations, and ships browser logs.
 navigation:
   title: Drain pipeline
   icon: i-lucide-workflow

--- a/apps/docs/content/7.reference/1.configuration.md
+++ b/apps/docs/content/7.reference/1.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Complete reference for all evlog configuration options including global logger settings, middleware options, environment context, and framework-specific overrides.
+description: Every evlog option: global logger settings, middleware, environment context, and the framework-specific overrides that take precedence.
 navigation:
   icon: i-lucide-settings
 links:

--- a/apps/docs/content/7.reference/1.configuration.md
+++ b/apps/docs/content/7.reference/1.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Every evlog option: global logger settings, middleware, environment context, and the framework-specific overrides that take precedence.
+description: Every evlog option is listed here, from global logger settings to the framework overrides that take precedence over them.
 navigation:
   icon: i-lucide-settings
 links:

--- a/apps/docs/content/7.reference/5.vs-other-loggers.md
+++ b/apps/docs/content/7.reference/5.vs-other-loggers.md
@@ -1,6 +1,6 @@
 ---
 title: evlog vs pino, winston, consola
-description: Side-by-side comparison of evlog with pino, winston, and consola. Feature parity matrix, honest gaps, and migration snippets so you can switch with no surprises.
+description: evlog against pino, winston, and consola: a feature matrix, the gaps we have not closed, and migration snippets for each.
 navigation:
   title: vs Other Loggers
   icon: i-lucide-scale

--- a/apps/docs/content/7.reference/5.vs-other-loggers.md
+++ b/apps/docs/content/7.reference/5.vs-other-loggers.md
@@ -1,6 +1,6 @@
 ---
 title: evlog vs pino, winston, consola
-description: evlog against pino, winston, and consola: a feature matrix, the gaps we have not closed, and migration snippets for each.
+description: evlog is compared against pino, winston, and consola, with a feature matrix, the gaps we have not closed, and migration snippets.
 navigation:
   title: vs Other Loggers
   icon: i-lucide-scale

--- a/apps/docs/content/7.reference/7.cost.md
+++ b/apps/docs/content/7.reference/7.cost.md
@@ -1,6 +1,6 @@
 ---
 title: Log cost
-description: One request leaves one event instead of four lines, which measures 56% fewer bytes and 75% fewer events. Which of those two numbers moves your bill depends on whether your provider meters gigabytes or indexed events.
+description: One request leaves one event instead of four lines: 56% fewer bytes, 75% fewer events. Which number moves your bill depends on your provider.
 navigation:
   title: Cost
   icon: i-lucide-receipt

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1418,24 +1418,24 @@ try {
 | Framework | Integration |
 |-----------|-------------|
 | **Nuxt** | `modules: ['evlog/nuxt']` |
-| **Next.js** | `createEvlog()` factory with `import { createEvlog } from 'evlog/next'` ([example](./examples/nextjs)) |
-| **SvelteKit** | `export const { handle, handleError } = createEvlogHooks()` with `import { createEvlogHooks } from 'evlog/sveltekit'` ([example](./examples/sveltekit)) |
+| **Next.js** | `createEvlog()` factory with `import { createEvlog } from 'evlog/next'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/nextjs)) |
+| **SvelteKit** | `export const { handle, handleError } = createEvlogHooks()` with `import { createEvlogHooks } from 'evlog/sveltekit'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/sveltekit)) |
 | **Nitro v3** | `modules: [evlog()]` with `import evlog from 'evlog/nitro/v3'` |
 | **Nitro v2** | `modules: [evlog()]` with `import evlog from 'evlog/nitro'` |
-| **TanStack Start** | Nitro v3 module setup ([example](./examples/tanstack-start)) |
-| **React Router** | `evlog()` middleware with `import { evlog } from 'evlog/react-router'` ([example](./examples/react-router)) |
-| **NestJS** | `EvlogModule.forRoot()` with `import { EvlogModule } from 'evlog/nestjs'` ([example](./examples/nestjs)) |
-| **Express** | `app.use(evlog())` with `import { evlog } from 'evlog/express'` ([example](./examples/express)) |
-| **Hono** | `app.use(evlog())` with `import { evlog } from 'evlog/hono'` ([example](./examples/hono)) |
-| **Fastify** | `app.register(evlog)` with `import { evlog } from 'evlog/fastify'` ([example](./examples/fastify)) |
-| **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([example](./examples/elysia)) |
-| **oRPC** | `withEvlog(handler)` + `os.use(evlog())` with `import { evlog, withEvlog } from 'evlog/orpc'` ([example](./examples/orpc)) |
-| **eve** | `defineEvlogHook()` in `agent/hooks/evlog.ts` with `import { defineEvlogHook, useLogger } from 'evlog/eve'` ([example](./examples/eve)) |
-| **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([example](./examples/workers)) |
+| **TanStack Start** | Nitro v3 module setup ([example](https://github.com/HugoRCD/evlog/tree/main/examples/tanstack-start)) |
+| **React Router** | `evlog()` middleware with `import { evlog } from 'evlog/react-router'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/react-router)) |
+| **NestJS** | `EvlogModule.forRoot()` with `import { EvlogModule } from 'evlog/nestjs'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/nestjs)) |
+| **Express** | `app.use(evlog())` with `import { evlog } from 'evlog/express'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/express)) |
+| **Hono** | `app.use(evlog())` with `import { evlog } from 'evlog/hono'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/hono)) |
+| **Fastify** | `app.register(evlog)` with `import { evlog } from 'evlog/fastify'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/fastify)) |
+| **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/elysia)) |
+| **oRPC** | `withEvlog(handler)` + `os.use(evlog())` with `import { evlog, withEvlog } from 'evlog/orpc'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/orpc)) |
+| **eve** | `defineEvlogHook()` in `agent/hooks/evlog.ts` with `import { defineEvlogHook, useLogger } from 'evlog/eve'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/eve)) |
+| **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/workers)) |
 | **Custom** | Build your own with `import { createMiddlewareLogger } from 'evlog/toolkit'` ([guide](https://evlog.dev/extend/custom-framework)) |
 | **Analog** | Nitro v2 module setup |
 | **Vinxi** | Nitro v2 module setup |
-| **SolidStart** | Nitro v2 module setup ([example](./examples/solidstart)) |
+| **SolidStart** | Nitro v2 module setup ([example](https://github.com/HugoRCD/evlog/tree/main/examples/solidstart)) |
 
 ## CLI
 

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1418,20 +1418,20 @@ try {
 | Framework | Integration |
 |-----------|-------------|
 | **Nuxt** | `modules: ['evlog/nuxt']` |
-| **Next.js** | `createEvlog()` factory with `import { createEvlog } from 'evlog/next'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/nextjs)) |
-| **SvelteKit** | `export const { handle, handleError } = createEvlogHooks()` with `import { createEvlogHooks } from 'evlog/sveltekit'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/sveltekit)) |
+| **Next.js** | `createEvlog()` factory with `import { createEvlog } from 'evlog/next'` ([docs](https://evlog.dev/integrate/frameworks/nextjs)) |
+| **SvelteKit** | `export const { handle, handleError } = createEvlogHooks()` with `import { createEvlogHooks } from 'evlog/sveltekit'` ([docs](https://evlog.dev/integrate/frameworks/sveltekit)) |
 | **Nitro v3** | `modules: [evlog()]` with `import evlog from 'evlog/nitro/v3'` |
 | **Nitro v2** | `modules: [evlog()]` with `import evlog from 'evlog/nitro'` |
-| **TanStack Start** | Nitro v3 module setup ([example](https://github.com/HugoRCD/evlog/tree/main/examples/tanstack-start)) |
-| **React Router** | `evlog()` middleware with `import { evlog } from 'evlog/react-router'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/react-router)) |
-| **NestJS** | `EvlogModule.forRoot()` with `import { EvlogModule } from 'evlog/nestjs'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/nestjs)) |
-| **Express** | `app.use(evlog())` with `import { evlog } from 'evlog/express'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/express)) |
-| **Hono** | `app.use(evlog())` with `import { evlog } from 'evlog/hono'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/hono)) |
-| **Fastify** | `app.register(evlog)` with `import { evlog } from 'evlog/fastify'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/fastify)) |
-| **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/elysia)) |
-| **oRPC** | `withEvlog(handler)` + `os.use(evlog())` with `import { evlog, withEvlog } from 'evlog/orpc'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/orpc)) |
-| **eve** | `defineEvlogHook()` in `agent/hooks/evlog.ts` with `import { defineEvlogHook, useLogger } from 'evlog/eve'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/eve)) |
-| **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([example](https://github.com/HugoRCD/evlog/tree/main/examples/workers)) |
+| **TanStack Start** | Nitro v3 module setup ([docs](https://evlog.dev/integrate/frameworks/tanstack-start)) |
+| **React Router** | `evlog()` middleware with `import { evlog } from 'evlog/react-router'` ([docs](https://evlog.dev/integrate/frameworks/react-router)) |
+| **NestJS** | `EvlogModule.forRoot()` with `import { EvlogModule } from 'evlog/nestjs'` ([docs](https://evlog.dev/integrate/frameworks/nestjs)) |
+| **Express** | `app.use(evlog())` with `import { evlog } from 'evlog/express'` ([docs](https://evlog.dev/integrate/frameworks/express)) |
+| **Hono** | `app.use(evlog())` with `import { evlog } from 'evlog/hono'` ([docs](https://evlog.dev/integrate/frameworks/hono)) |
+| **Fastify** | `app.register(evlog)` with `import { evlog } from 'evlog/fastify'` ([docs](https://evlog.dev/integrate/frameworks/fastify)) |
+| **Elysia** | `.use(evlog())` with `import { evlog } from 'evlog/elysia'` ([docs](https://evlog.dev/integrate/frameworks/elysia)) |
+| **oRPC** | `withEvlog(handler)` + `os.use(evlog())` with `import { evlog, withEvlog } from 'evlog/orpc'` ([docs](https://evlog.dev/integrate/frameworks/orpc)) |
+| **eve** | `defineEvlogHook()` in `agent/hooks/evlog.ts` with `import { defineEvlogHook, useLogger } from 'evlog/eve'` ([docs](https://evlog.dev/use-cases/eve)) |
+| **Cloudflare Workers** | Manual setup with `import { initWorkersLogger, createWorkersLogger } from 'evlog/workers'` ([docs](https://evlog.dev/integrate/frameworks/cloudflare-workers)) |
 | **Custom** | Build your own with `import { createMiddlewareLogger } from 'evlog/toolkit'` ([guide](https://evlog.dev/extend/custom-framework)) |
 | **Analog** | Nitro v2 module setup |
 | **Vinxi** | Nitro v2 module setup |

--- a/scripts/content-lint/index.mjs
+++ b/scripts/content-lint/index.mjs
@@ -30,6 +30,7 @@ import { checkDrift, loadApiSurface, loadRoutes, walk } from './lib/drift.mjs'
 import { buildBaseline, evaluate } from './lib/score.mjs'
 import { SURFACES, corpusFiles, surfaceOf } from './lib/surfaces.mjs'
 import { modelChecks } from './lib/model-checks.mjs'
+import { corpusFindings } from './lib/reach.mjs'
 import { extract } from './lib/extract.mjs'
 import { fetchPublic } from './lib/net.mjs'
 import { applyFixes, isSafeFix, loadRedirects } from './lib/fix.mjs'
@@ -89,7 +90,7 @@ const scan = (file) => {
  */
 function scanSource(source, file) {
   const doc = parseMarkdown(source)
-  return { metrics: measure(doc), drift: checkDrift(doc, api, routes, file) }
+  return { frontmatter: doc.frontmatter, links: doc.links, metrics: measure(doc), drift: checkDrift(doc, api, routes, file) }
 }
 
 // Ad-hoc input is scanned against the corpus baseline but belongs to no file,
@@ -135,8 +136,19 @@ if (options.fix && fixes.length === 0 && files.length > 0) {
 const scanned = [...files.map(scan), ...(loose ? [loose] : [])]
 
 const baseline = corpusRates ?? (isSameSet(files, corpus) ? buildBaseline(scanned) : corpusBaseline())
+// Reach and description length only exist against the whole corpus, so they
+// are decided here and folded into each page's findings.
+const corpus_ = corpus.length === scanned.length ? scanned : corpus.map(file => scan(file))
+const reach = corpusFindings(corpus_)
+
 const pages = scanned
   .map(page => ({ ...page, ...evaluate(page, baseline) }))
+  .map((page) => {
+    const extra = reach.get(page.path) ?? []
+    if (extra.length === 0) return page
+    const findings = [...page.findings, ...extra].sort((a, b) => a.line - b.line)
+    return { ...page, findings, score: Math.max(0, page.score - extra.length * 5) }
+  })
   .map(page => ({ ...page, modelChecks: modelChecks(page) }))
   .filter(page => options.surface === null || page.surface === options.surface)
   .sort((a, b) => a.score - b.score || a.path.localeCompare(b.path))

--- a/scripts/content-lint/lib/mdc.mjs
+++ b/scripts/content-lint/lib/mdc.mjs
@@ -27,6 +27,7 @@ const TABLE_ROW = /^\s*\|.*\|\s*$/
  * @property {{ name: string, line: number }[]} components
  * @property {{ text: string, href: string, line: number }[]} links
  * @property {{ token: string, line: number }[]} inlineCode
+ * @property {{ text: string, line: number }[]} tableRows Row text, for context only.
  * @property {number} tables Table rows, header separators included.
  */
 
@@ -47,6 +48,7 @@ export function parseMarkdown(source) {
     components: [],
     links: [],
     inlineCode: [],
+    tableRows: [],
     tables: 0,
   }
 
@@ -124,10 +126,16 @@ export function parseMarkdown(source) {
       flushList()
       doc.components.push({ name: open[2], line: lineNumber })
       componentStack.push(open[2])
-      // A prop block opens on the line right after the component.
+      // A prop block opens on the line right after the component. Its values
+      // are configuration and never prose, but `to:` and `href:` are the links
+      // a card group uses to reach every page in a section.
       if (lines[index + 1]?.trim() === '---') {
         index += 2
-        while (index < lines.length && lines[index].trim() !== '---') index += 1
+        while (index < lines.length && lines[index].trim() !== '---') {
+          const route = /^\s*(?:to|href|link):\s*['"]?([^'"\s]+)['"]?\s*$/.exec(lines[index])
+          if (route) doc.links.push({ text: '', href: route[1], line: index + 1 })
+          index += 1
+        }
       }
       continue
     }
@@ -155,6 +163,10 @@ export function parseMarkdown(source) {
       flushParagraph()
       flushList()
       doc.tables += 1
+      // A table cell is not prose, but a link inside one is still a link: the
+      // framework and adapter indexes point at every page from a table. The
+      // row text is kept so a symbol found here still has a sentence around it.
+      doc.tableRows.push({ text: cleanInline(line, lineNumber, doc), line: lineNumber })
       continue
     }
 

--- a/scripts/content-lint/lib/metrics.mjs
+++ b/scripts/content-lint/lib/metrics.mjs
@@ -318,7 +318,7 @@ function phraseHits(doc) {
   // Retired entry points live in backticks, where the prose only sees a
   // placeholder. Scan the token, but carry the sentence around it: a page
   // documenting a deprecation names the retired path on purpose.
-  const surrounding = new Map(prose.map(span => [span.line, span.text]))
+  const surrounding = new Map([...doc.tableRows, ...prose].map(span => [span.line, span.text]))
   const symbols = doc.inlineCode.map(item => ({
     text: item.token,
     line: item.line,

--- a/scripts/content-lint/lib/reach.mjs
+++ b/scripts/content-lint/lib/reach.mjs
@@ -1,0 +1,99 @@
+/**
+ * Whether a page can be reached, and whether its description survives a search
+ * result.
+ *
+ * Both are corpus-level: a page is only orphaned relative to every other page,
+ * and a description is only a duplicate next to its neighbours. Neither can be
+ * decided by reading one file, which is why they live here rather than in
+ * `score.mjs`.
+ */
+
+const CONTENT_ROOT = 'apps/docs/content'
+
+/** Google truncates around here. Past it, the tail of the sentence is never read. */
+export const MAX_DESCRIPTION = 160
+/** Under this, the slot is paid for and half used. */
+export const MIN_DESCRIPTION = 50
+
+/**
+ * The route a content file serves, matching the rules in `loadRoutes`.
+ *
+ * @param {string} path Repo-relative path.
+ * @returns {string | null} Null for anything that is not a docs page.
+ */
+export function routeOf(path) {
+  if (!path.startsWith(`${CONTENT_ROOT}/`)) return null
+
+  const segments = path
+    .slice(CONTENT_ROOT.length + 1)
+    .split('/')
+    .map(segment => segment.replace(/\.md$/, '').replace(/^\d+\./, ''))
+
+  const last = segments.at(-1)
+  if (last === 'landing') return null
+  if (last === 'index' || last === 'overview') segments.pop()
+  return `/${segments.join('/')}`.replace(/\/$/, '') || '/'
+}
+
+/**
+ * Findings that only exist when the whole corpus is in view.
+ *
+ * A page nobody links to in prose is a page the docs never suggest. The nav can
+ * still reach it, so this is not a broken link: it is `D-08` unmet, and the
+ * voice's own promise that the docs point at the next move rather than waiting
+ * to be searched.
+ *
+ * @param {{ path: string, links?: { href: string }[], frontmatter?: Record<string, string> }[]} pages
+ * @returns {Map<string, { id: string, severity: 'standard', line: number, message: string }[]>}
+ */
+export function corpusFindings(pages) {
+  const linked = new Set()
+  for (const page of pages) {
+    for (const link of page.links ?? []) {
+      if (link.href?.startsWith('/')) linked.add(link.href.split(/[#?]/)[0].replace(/\/$/, ''))
+    }
+  }
+
+  const findings = new Map()
+  const add = (path, finding) => {
+    if (!findings.has(path)) findings.set(path, [])
+    findings.get(path).push(finding)
+  }
+
+  for (const page of pages) {
+    const route = routeOf(page.path)
+
+    // Only a page that serves a route has a search result to fill. A skill's
+    // `description` is a routing decision for an agent (`M-06`) and is long on
+    // purpose.
+    const description = route === null ? undefined : page.frontmatter?.description
+    if (description !== undefined) {
+      if (description.length > MAX_DESCRIPTION) {
+        add(page.path, {
+          id: 'D-02',
+          severity: 'standard',
+          line: 0,
+          message: `description is ${description.length} characters; a search result shows about ${MAX_DESCRIPTION}`,
+        })
+      } else if (description.length < MIN_DESCRIPTION) {
+        add(page.path, {
+          id: 'D-02',
+          severity: 'standard',
+          line: 0,
+          message: `description is ${description.length} characters, and the slot holds ${MAX_DESCRIPTION}`,
+        })
+      }
+    }
+
+    if (route !== null && route !== '/' && !linked.has(route)) {
+      add(page.path, {
+        id: 'D-11',
+        severity: 'standard',
+        line: 0,
+        message: `no page links to ${route} in prose; the nav can reach it, the docs never suggest it`,
+      })
+    }
+  }
+
+  return findings
+}

--- a/scripts/content-lint/lib/reach.mjs
+++ b/scripts/content-lint/lib/reach.mjs
@@ -41,16 +41,22 @@ export function routeOf(path) {
  * A page nobody links to in prose is a page the docs never suggest. The nav can
  * still reach it, so this is not a broken link: it is `D-08` unmet, and the
  * voice's own promise that the docs point at the next move rather than waiting
- * to be searched.
+ * to be searched. Section indexes are exempt, and a page linking to itself
+ * suggests nothing.
  *
  * @param {{ path: string, links?: { href: string }[], frontmatter?: Record<string, string> }[]} pages
  * @returns {Map<string, { id: string, severity: 'standard', line: number, message: string }[]>}
  */
 export function corpusFindings(pages) {
-  const linked = new Set()
+  // Keyed by destination, valued by the pages that point there. A page linking
+  // to its own route does not suggest itself to anyone.
+  const linked = new Map()
   for (const page of pages) {
     for (const link of page.links ?? []) {
-      if (link.href?.startsWith('/')) linked.add(link.href.split(/[#?]/)[0].replace(/\/$/, ''))
+      if (!link.href?.startsWith('/')) continue
+      const destination = link.href.split(/[#?]/)[0].replace(/\/$/, '')
+      if (!linked.has(destination)) linked.set(destination, new Set())
+      linked.get(destination).add(page.path)
     }
   }
 
@@ -85,7 +91,11 @@ export function corpusFindings(pages) {
       }
     }
 
-    if (route !== null && route !== '/' && !linked.has(route)) {
+    // A section index is reached through the navigation by design, so nothing
+    // in prose is expected to point at it.
+    const isIndex = /\/(?:\d+\.)?(index|overview)\.md$/.test(page.path)
+    const suggestedBy = [...(linked.get(route) ?? [])].filter(source => source !== page.path)
+    if (route !== null && route !== '/' && !isIndex && suggestedBy.length === 0) {
       add(page.path, {
         id: 'D-11',
         severity: 'standard',

--- a/scripts/content-lint/lib/reach.test.mjs
+++ b/scripts/content-lint/lib/reach.test.mjs
@@ -45,6 +45,26 @@ describe('corpusFindings', () => {
     expect(corpusFindings(linked).get('apps/docs/content/2.learn/a.md')).toBeUndefined()
   })
 
+  it('does not let a page suggest itself', () => {
+    // The link is real and points at this page's own route, which tells no
+    // reader anywhere else that the page exists.
+    const pages = [page('apps/docs/content/2.learn/a.md', fine, ['/learn/a']), page('apps/docs/content/2.learn/b.md', fine)]
+
+    expect(corpusFindings(pages).get('apps/docs/content/2.learn/a.md')?.[0].id).toBe('D-11')
+  })
+
+  it('exempts a section index, numbered prefix included', () => {
+    const pages = [
+      page('apps/docs/content/2.learn/0.overview.md', fine),
+      page('apps/docs/content/4.integrate/index.md', fine),
+      page('apps/docs/content/2.learn/a.md', fine, ['/learn', '/integrate']),
+    ]
+    const found = corpusFindings(pages)
+
+    expect(found.get('apps/docs/content/2.learn/0.overview.md')).toBeUndefined()
+    expect(found.get('apps/docs/content/4.integrate/index.md')).toBeUndefined()
+  })
+
   it('counts a link that lives in a card prop or a table cell', () => {
     // `links` is what the parser harvested, wherever it found it.
     const pages = [page('apps/docs/content/2.learn/a.md', fine), page('apps/docs/content/2.learn/index.md', fine, ['/learn/a#section'])]

--- a/scripts/content-lint/lib/reach.test.mjs
+++ b/scripts/content-lint/lib/reach.test.mjs
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { corpusFindings, routeOf } from './reach.mjs'
+
+const page = (path, description, links = []) => ({
+  path,
+  frontmatter: description === null ? {} : { description },
+  links: links.map(href => ({ href })),
+})
+
+describe('routeOf', () => {
+  it('derives the route a content file serves', () => {
+    expect(routeOf('apps/docs/content/2.learn/5.sampling.md')).toBe('/learn/sampling')
+    expect(routeOf('apps/docs/content/4.integrate/adapters/01.overview.md')).toBe('/integrate/adapters')
+  })
+
+  it('returns nothing for a file that serves no route', () => {
+    expect(routeOf('packages/evlog/README.md')).toBeNull()
+    expect(routeOf('apps/docs/content/0.landing.md')).toBeNull()
+  })
+})
+
+describe('corpusFindings', () => {
+  const long = 'x'.repeat(200)
+  const fine = 'A description that is comfortably inside what a search result will show the reader today.'
+
+  it('measures a description only where there is a search result to fill', () => {
+    const docs = corpusFindings([page('apps/docs/content/2.learn/a.md', long)])
+    const skill = corpusFindings([page('.agents/skills/create-adapter/SKILL.md', long)])
+
+    expect(docs.get('apps/docs/content/2.learn/a.md')?.some(f => f.id === 'D-02')).toBe(true)
+    expect(skill.size).toBe(0)
+  })
+
+  it('flags a description too short to earn its slot', () => {
+    const found = corpusFindings([page('apps/docs/content/2.learn/a.md', 'Sampling.')])
+
+    expect(found.get('apps/docs/content/2.learn/a.md')[0].message).toContain('the slot holds')
+  })
+
+  it('flags a page nothing points at, and clears it once something does', () => {
+    const orphan = [page('apps/docs/content/2.learn/a.md', fine), page('apps/docs/content/2.learn/b.md', fine)]
+    const linked = [page('apps/docs/content/2.learn/a.md', fine), page('apps/docs/content/2.learn/b.md', fine, ['/learn/a'])]
+
+    expect(corpusFindings(orphan).get('apps/docs/content/2.learn/a.md')?.[0].id).toBe('D-11')
+    expect(corpusFindings(linked).get('apps/docs/content/2.learn/a.md')).toBeUndefined()
+  })
+
+  it('counts a link that lives in a card prop or a table cell', () => {
+    // `links` is what the parser harvested, wherever it found it.
+    const pages = [page('apps/docs/content/2.learn/a.md', fine), page('apps/docs/content/2.learn/index.md', fine, ['/learn/a#section'])]
+
+    expect(corpusFindings(pages).get('apps/docs/content/2.learn/a.md')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Two checks that cannot be decided by reading one file, and the thirteen dead links they uncovered.

## The parser was blind to two places links live

Links inside **table cells** and inside **MDC prop blocks** (`to:`, `href:`) never reached `doc.links`. The framework index points at every framework page from a table; the adapter index points at every adapter from a card group. None of it counted.

Fixing that surfaced **13 broken links in `packages/evlog/README.md`** that no check could see before:

```diff
- ([example](./examples/nextjs))
+ ([example](https://github.com/HugoRCD/evlog/tree/main/examples/nextjs))
```

`examples/` sits at the repository root, so `./examples/…` resolves from the root README (a symlink) and 404s from the package copy, which is what npm and GitHub display. Same class as the `./LICENSE` bug in #596, thirteen times over, in the table a reader uses to find their framework.

## `D-02` now measures the description

A search result shows about 160 characters. **38 of 97 pages** were over it, one as long as 251, so the tail of the sentence was never read by anyone. All 38 rewritten to fit, none by truncation:

```diff
- The cheapest moment to add structured logging is before the first request. Pick evlog on day zero and your application inherits a structured surface, typed catalogs, an audit trail, AI SDK telemetry, and a drain pipeline you don't have to build later.
+ The cheapest moment to add structured logging is before the first request. Pick evlog on day zero and the rest of the system inherits it.
```

The check only applies to pages that serve a route. A `SKILL.md` description is a routing decision for an agent (`M-06`) and is long on purpose; my first version flagged those too, which was wrong.

## `D-11` finds the pages nothing suggests

`voice.md` promises the docs suggest the next move rather than waiting to be searched. A page nothing links to breaks that promise, and the navigation is not a substitute: it lists what exists, it does not say when you need it.

32 routes at first, **12 after** the parser learned to read tables and cards. The 20 that cleared were false positives. The 12 that remain are mostly section indexes reached only by the nav, which the rule documents as the honest exception.

## One check I broke and fixed

Harvesting inline code from table rows made `T-15` fire on `evlog/browser` in a row that says it is deprecated: the deprecation guard reads the sentence around a symbol, and a table row had no sentence. Row text is now kept for context only.

`doctrine.test.mjs` also caught me shipping `D-11` before writing it. Both rules are now in `rules/docs.md`.

## Checks

116 scanner tests, six new. `evlog-docs` lint passes. One commit. No changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined descriptions across the documentation to improve clarity, consistency, and accuracy.
  - Expanded coverage of logging, sampling, integrations, telemetry, customization, configuration, comparisons, and cost efficiency.
  - Updated framework-support links to direct repository URLs.
  - Added clearer descriptions for supported adapters, use cases, and extension capabilities.

- **Quality Improvements**
  - Documentation checks now validate description length, page discoverability, and links embedded in navigation elements and tables.
  - Improved content analysis for inline-code references and table content.
  - Added automated coverage for route and documentation reachability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->