### PR TITLE
feat: spare an ordered guide from the heading mould check

### DIFF
--- a/.agents/skills/write-evlog-content/references/ai-tells.md
+++ b/.agents/skills/write-evlog-content/references/ai-tells.md
@@ -66,6 +66,11 @@ Every heading on a page cut to the same grammatical shape: all imperatives, all 
 
 Note on this corpus: most evlog reference pages are all-noun and that is correct for them. Weigh this tell on pages that argue rather than enumerate.
 
+The scanner subtracts two twins before it reports anything, so a candidate that reaches you has already survived both:
+
+- **The section's shared shape.** Headings a page has in common with three or more of its siblings are the directory's template, not this page's mould. The adapter pages all carry Installation, Quick Start, Configuration and Troubleshooting because a reader comparing two of them wants the same section twice.
+- **A numbered sequence.** `1. Route filtering`, `2. Logger creation`, `3. Emit` are the steps of one procedure. They share a shape because they are one thing, which is the ordered guide named above.
+
 ---
 
 ## T-07 · One-frame bullets

--- a/.agents/skills/write-evlog-content/references/corrections.md
+++ b/.agents/skills/write-evlog-content/references/corrections.md
@@ -21,6 +21,12 @@ Flagged: 51 pages, "all N headings are noun". The adapter and framework pages ca
 Actual: a page set written to one shape is not a page written from a mould. A reader comparing Axiom and Datadog wants to land on the same section twice, and 14 of those headings are linked by anchor from elsewhere in the docs.
 Applies to: any directory of sibling pages. `scripts/content-lint/lib/score.mjs` now subtracts the headings a page shares with three or more siblings before judging the shape of what is left, which took the finding count from 51 to 47. The 47 that remain each have ten or more headings of their own, all nouns, and those are real.
 
+## 2026-08-15 · T-06 · A numbered sequence is not a mould
+
+Flagged: pages whose headings read `1. Route filtering`, `2. Logger creation`, `3. Emit`.
+Actual: the steps of one procedure share a shape because they are one procedure. `ai-tells.md` already named the ordered guide as the twin; the scanner did not know it.
+Applies to: any heading opening with a number or `Step N`. `metrics.mjs` classifies those as `sequence` and `T-06` ignores that shape, which took the count from 44 to 35.
+
 ## 2026-08-15 · U-14 · Punctuation is never mechanical
 
 Flagged: a codemod replacing `A — B — C` with `A, B, C`.

--- a/apps/docs/content/2.learn/0.overview.md
+++ b/apps/docs/content/2.learn/0.overview.md
@@ -68,7 +68,7 @@ Not running an HTTP framework? See [Standalone TypeScript](/integrate/frameworks
   :::
 ::
 
-## Quick comparison
+## Compare the three at a glance
 
 ### Simple Logging (`log`)
 
@@ -123,7 +123,7 @@ export default defineEventHandler(async (event) => {
 `useLogger(event)` doesn't create a logger, it retrieves the one the framework middleware already attached to the event. Each framework has its own way to access it (`useLogger`, `req.log`, `c.get('log')`, etc.). In Nuxt, `useLogger` is auto-imported.
 ::
 
-## When to use what
+## Choose the mode for the job
 
 | | `log` | `createLogger` / `createRequestLogger` | Framework middleware |
 |--|-------|----------------------------------------|---------------------|
@@ -153,7 +153,7 @@ export default defineEventHandler(async (event) => {
 None of these is an "upgrade" of another. Use `log` and `createLogger` in the same file when it makes sense, since they share the global drain, redaction, and types.
 ::
 
-## Shared foundation
+## What all three share
 
 All three modes share the same foundation:
 
@@ -164,7 +164,7 @@ All three modes share the same foundation:
 - **Redaction** that wipes secrets before they ever leave the process
 - **Zero dependencies**, ~6 kB gzip
 
-## The rest of this section
+## Where to go from here
 
 After the three modes, the rest of Learn covers the concepts that show up across every mode:
 

--- a/apps/docs/content/2.learn/4.lifecycle.md
+++ b/apps/docs/content/2.learn/4.lifecycle.md
@@ -21,7 +21,7 @@ evlog events follow a pipeline from creation to delivery. The pipeline differs s
 ::lifecycle-flow
 ::
 
-## Overview by Mode
+## Follow an event through each mode
 
 | Stage | `log` (simple) | `createLogger` / `createRequestLogger` | Framework middleware |
 |-------|----------------|----------------------------------------|---------------------|
@@ -34,7 +34,7 @@ evlog events follow a pipeline from creation to delivery. The pipeline differs s
 
 After **`emit`** (including when sampling returns no output), the request logger is **sealed**: later `set` / `error` / `info` / `warn` calls are ignored with a console warning. For background work that needs its own event, use **`log.fork()`** where your integration supports it. See [After emit](/learn/wide-events#after-emit-sealing-and-background-work) in Wide events.
 
-## Request Logging — Step by Step
+## Trace a request, step by step
 
 For framework-managed request logging, every request walks the pipeline above. Each stage is detailed below.
 
@@ -204,7 +204,7 @@ export default defineNitroPlugin((nitroApp) => {
 
 On platforms with `waitUntil` (Cloudflare Workers, Vercel Edge), the drain runs after the response is sent to avoid adding latency. On traditional servers, the drain is awaited to prevent losing events in serverless cold shutdowns.
 
-## Hook Execution Order
+## Know when each hook runs
 
 | Order | Hook | When | Purpose |
 |-------|------|------|---------|
@@ -212,7 +212,7 @@ On platforms with `waitUntil` (Cloudflare Workers, Vercel Edge), the drain runs 
 | 2 | `evlog:enrich` | After emit, before drain | Add derived context to the event |
 | 3 | `evlog:drain` | After enrichment | Send event to external services |
 
-## Error vs Success Path
+## See where the error path diverges
 
 Both paths converge at the same emit/enrich/drain pipeline. The only difference is _when_ the emit is triggered:
 
@@ -224,7 +224,7 @@ Both paths converge at the same emit/enrich/drain pipeline. The only difference 
 | **Error context** | None | `error` field with message, stack, `why`, `fix` |
 | **Double-emit guard** | Checks `_evlogEmitted` flag | Sets `_evlogEmitted = true` |
 
-## Simple Logging Pipeline
+## Follow a simple log call
 
 When using the `log` singleton, the pipeline is shorter:
 
@@ -234,7 +234,7 @@ When using the `log` singleton, the pipeline is shorter:
 
 Tagged logs (`log.info('tag', 'message')`) are console-only in pretty mode. Object-form logs (`log.info({ ... })`) always flow through the drain pipeline.
 
-## Standalone Wide Event Pipeline
+## Follow a standalone wide event
 
 When using `createLogger()` outside a framework:
 

--- a/apps/docs/content/2.learn/5.sampling.md
+++ b/apps/docs/content/2.learn/5.sampling.md
@@ -42,7 +42,7 @@ Best practices: https://www.evlog.dev/reference/best-practices
 
 ::
 
-## Head Sampling
+## Drop noise before it is built
 
 Head sampling randomly keeps a percentage of logs per level. It runs **before** the request completes, acting as a coin flip at emission time.
 
@@ -103,7 +103,7 @@ Each level is a percentage from 0 to 100. Levels you don't configure default to 
 Head sampling is random. A `10%` rate means roughly 1 in 10 info logs are kept, not exactly 1 in 10.
 ::
 
-## Tail Sampling
+## Keep an event once you know its outcome
 
 Head sampling is blind: it doesn't know if a request was slow, failed, or hit a critical path. Tail sampling fixes this by evaluating **after** the request completes and force-keeping logs that match specific conditions.
 
@@ -123,7 +123,7 @@ evlog: {
 
 Conditions use **>=** comparison for `status` and `duration`, and glob matching for `path`. If **any** condition matches, the log is kept regardless of head sampling (OR logic).
 
-### Available Conditions
+### Conditions you can match on
 
 | Condition | Type | Description |
 |-----------|------|-------------|
@@ -131,7 +131,7 @@ Conditions use **>=** comparison for `status` and `duration`, and glob matching 
 | `duration` | `number` | Keep if request duration >= value in milliseconds |
 | `path` | `string` | Keep if request path matches glob pattern (e.g., `'/api/critical/**'`) |
 
-## How They Work Together
+## Combine head and tail sampling
 
 The two tiers complement each other:
 
@@ -163,7 +163,7 @@ POST /api/checkout  200  120ms  → 10% chance (head sampling)
 ```
 ::
 
-## Custom Tail Sampling
+## Write your own keep rule
 
 For conditions beyond status, duration, and path, use the `evlog:emit:keep` hook in Nuxt/Nitro or the `keep` callback in other frameworks.
 
@@ -217,7 +217,7 @@ The `ctx` object contains:
 | `context` | `Record<string, unknown>` | All fields set via `log.set()` |
 | `shouldKeep` | `boolean` | Set to `true` to force-keep |
 
-## Production Example
+## A configuration that ships
 
 A typical production configuration that balances cost and visibility:
 

--- a/apps/docs/content/2.learn/6.redaction.md
+++ b/apps/docs/content/2.learn/6.redaction.md
@@ -20,7 +20,7 @@ Wide events capture comprehensive context, which makes it easy to accidentally l
 
 **Redaction is enabled by default in production** (`NODE_ENV === 'production'`). In development, it is off so you see full values for debugging. No configuration needed, just deploy.
 
-## Opting Out
+## Turn it off, or narrow it
 
 If you need to disable redaction in production:
 
@@ -56,7 +56,7 @@ You can also enable redaction explicitly in development with `redact: true`.
 ::redaction-stream
 ::
 
-## Smart Masking
+## Mask enough to still debug
 
 Built-in patterns use **partial masking** instead of flat `[REDACTED]`, preserving enough context for debugging while protecting the actual data.
 
@@ -207,7 +207,7 @@ evlog: {
 
 Available built-in names: `creditCard`, `email`, `ipv4`, `phone`, `jwt`, `bearer`, `iban`.
 
-## How It Works
+## Where redaction runs in the pipeline
 
 Redaction runs inside the emit pipeline, after the wide event is fully built but before any output:
 
@@ -224,7 +224,7 @@ Redaction is the only stage that runs before the console write. `enrich` and dra
 Redaction runs **after** the HTTP response is sent, so it adds zero latency to your API responses.
 ::
 
-## Production Example
+## A configuration that ships
 
 Redaction is already on by default in production. Combine with sampling for a typical setup:
 
@@ -269,7 +269,7 @@ initLogger({
 ```
 ::
 
-## Before / After
+## See what a redacted event looks like
 
 Without redaction, sensitive data lands in your logs and drains:
 

--- a/apps/docs/content/6.extend/3.consumer-recipes.md
+++ b/apps/docs/content/6.extend/3.consumer-recipes.md
@@ -285,7 +285,7 @@ for await (const event of tailFsLogs({ signal: ac.signal })) {
 
 Works without instrumenting the running app, which suits sidecar / observer processes that watch a directory.
 
-## What not to do
+## What breaks a consumer
 
 - **Don't run the stream server on Vercel Functions / Cloudflare Workers / Lambda.** Each invocation is a separate isolate; subscribers in one isolate never see events emitted by other isolates. Use a real broker (Redis Streams, NATS, Pub/Sub) for cross-instance fan-out.
 - **Don't put auth-sensitive data in wide events** unless your evlog config redacts them. The server relays exactly what your app emitted — including any unredacted PII.

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -140,7 +140,7 @@ export function createLokiDrain(overrides?: { url?: string, token?: string }) {
 }
 ```
 
-## Standardized config priority
+## Know which config wins
 
 `resolveAdapterConfig(namespace, fields, overrides)` walks the standard chain so users get the same configuration UX as built-in adapters:
 
@@ -151,7 +151,7 @@ export function createLokiDrain(overrides?: { url?: string, token?: string }) {
 
 Field names should follow the project conventions: `apiKey`, `endpoint`, `serviceName`, `timeout`. If you're renaming an existing field (e.g. `token` → `apiKey`), keep both as `ConfigField` entries for one major version. See `axiom.ts` and `better-stack.ts` for the deprecation pattern.
 
-## Wiring the drain into your framework
+## Wire the drain into your framework
 
 Once `createMyServiceDrain()` returns the drain, wire it like any other:
 
@@ -196,7 +196,7 @@ initLogger({ drain: createMyServiceDrain() })
 
 For production, wrap it once in [`createDrainPipeline`](/extend/drain-pipeline) so events are batched and retried.
 
-## Filtering and transforming events
+## Filter or transform before sending
 
 `encode()` receives the full batch of `WideEvent[]` plus the resolved config. Filter or transform inline, and returning `null` is a clean opt-out for that batch:
 
@@ -238,7 +238,7 @@ export const createCustomTransportDrain = () =>
 
 When you fall back to `defineDrain`, follow the same rules manually that `defineHttpDrain` enforces: wrap the transport in `try/catch`, log with `console.error('[evlog/<name>] …')`, and never re-throw.
 
-## DrainContext reference
+## What a DrainContext carries
 
 When evlog calls your drain through `evlog:drain`, it passes a `DrainContext` per event:
 
@@ -274,7 +274,7 @@ interface WideEvent {
 
 In the batched form your `encode()` / `send()` receives, you get `WideEvent[]` directly (the toolkit unwraps `event` from each context).
 
-## Toolkit helpers
+## Reach for a toolkit helper
 
 `evlog/toolkit` exposes the same helpers every built-in adapter uses. The ones relevant to drains:
 
@@ -289,7 +289,7 @@ In the batched form your `encode()` / `send()` receives, you get `WideEvent[]` d
 | `toOtlpAttributeValue(value)` | Convert any value to the OTLP `AnyValue` shape (used by OTLP / HyperDX / PostHog logs) |
 | `OTEL_SEVERITY_NUMBER`, `OTEL_SEVERITY_TEXT` | OTEL log severity tables |
 
-## Identity headers
+## Identify your traffic to the receiver
 
 `defineHttpDrain` automatically tags every request with two headers so receivers can identify the traffic:
 
@@ -300,7 +300,7 @@ In the batched form your `encode()` / `send()` receives, you get `WideEvent[]` d
 
 If you build a drain on top of `httpPost` directly, you can override or suppress them. See [Identity headers](/extend/identity-headers).
 
-## Error handling — already done for you
+## Errors are already handled for you
 
 `defineHttpDrain` enforces every best practice automatically:
 
@@ -311,7 +311,7 @@ If you build a drain on top of `httpPost` directly, you can override or suppress
 
 If you fall back to `defineDrain`, follow the same rules manually.
 
-## Publishing as a community package
+## Publish it as a community package
 
 Recommended structure for a community drain:
 

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -123,7 +123,7 @@ await drain.flush() // before exit
 Always flush the pipeline before the process exits (`drain.flush()`). On Nitro use the `close` hook; on standalone scripts call it before `process.exit`; on serverless runtimes use `waitUntil(drain.flush())`.
 ::
 
-## How it works
+## What the pipeline does to an event
 
 Events are buffered as they arrive on `evlog:drain`. A batch flushes when either `batch.size` is reached or `batch.intervalMs` expires (whichever comes first). On failure, the same batch is retried with the configured backoff; once `retry.maxAttempts` is exhausted, `onDropped` is called with the lost events. The buffer is bounded by `maxBufferSize`. Once full, the oldest events are dropped to keep memory flat.
 
@@ -154,7 +154,7 @@ const pipeline = createDrainPipeline<DrainContext>({
 export const drain = pipeline(createAxiomDrain())
 ```
 
-### Options reference
+### Every option, and its default
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -167,7 +167,7 @@ export const drain = pipeline(createAxiomDrain())
 | `maxBufferSize` | `1000` | Max buffered events before dropping oldest |
 | `onDropped` | - | Callback when events are dropped (overflow or retry exhaustion) |
 
-### Backoff strategies
+### Choose how retries space out
 
 | Strategy | Delay pattern | Use case |
 |----------|--------------|----------|
@@ -175,7 +175,7 @@ export const drain = pipeline(createAxiomDrain())
 | `linear` | 1s, 2s, 3s, 4s… | Predictable delay growth |
 | `fixed` | 1s, 1s, 1s, 1s… | Same delay every time. Useful for rate-limited APIs |
 
-### Returned drain function
+### What the wrapper hands back
 
 The function returned by `pipeline(drain)` is hook-compatible and exposes:
 
@@ -214,7 +214,7 @@ Docs: https://www.evlog.dev/extend/drain-pipeline
 
 ::
 
-### The recipe
+### Wire the fan-out
 
 ```ts
 import { createDrainPipeline } from 'evlog/pipeline'
@@ -245,13 +245,13 @@ export const drain = pipeline(async (batch) => {
 })
 ```
 
-### What you get
+### What fan-out guarantees
 
 - **Parallel dispatch** — every destination receives the batch concurrently via `Promise.allSettled`
 - **Tolerant fanout** — if Datadog's API throws, Axiom / Sentry / fs still complete; the pipeline only retries the whole batch when the wrapping function rejects
 - **Shared backpressure** — the buffer is sized once for the whole pipeline; if the wrapping drain falls behind, the oldest events are dropped consistently for every destination
 
-### Per-drain filtering
+### Send different events to each drain
 
 Wrap a destination drain so it only sees events you care about:
 
@@ -275,7 +275,7 @@ export const drain = pipeline(async (batch) => {
 
 Most built-in drains expose `minLevel` directly, so you only need this pattern for non-level filters (path, custom field, etc.).
 
-## Custom drain function
+## Write the drain yourself
 
 You don't need an adapter. Pass any async function that accepts a batch:
 
@@ -349,7 +349,7 @@ log.info({ action: 'page_view', path: location.pathname })
 4. When the page becomes hidden (tab switch, navigation), buffered events are flushed via `navigator.sendBeacon` as a fallback
 5. Your server endpoint receives a `DrainContext[]` JSON array and processes it however you like
 
-### Two-tier API
+### Pick the tier you need
 
 #### `createHttpLogDrain(options)`
 
@@ -388,7 +388,7 @@ const pipeline = createDrainPipeline<DrainContext>({
 const drain = pipeline(transport)
 ```
 
-### Configuration reference
+### Every browser option
 
 #### `HttpDrainConfig`
 
@@ -408,7 +408,7 @@ const drain = pipeline(transport)
 | `pipeline` | `{ batch: { size: 25, intervalMs: 2000 }, retry: { maxAttempts: 2 } }` | Pipeline configuration overrides |
 | `autoFlush` | `true` | Auto-register `visibilitychange` flush listener |
 
-### sendBeacon fallback
+### Survive a closing tab
 
 ::callout{icon="i-lucide-radio" color="info"}
 When `useBeacon` is enabled (the default) and the page becomes hidden, the drain automatically switches from `fetch` to `navigator.sendBeacon`. This ensures logs are delivered even when the user closes the tab or navigates away.
@@ -416,7 +416,7 @@ When `useBeacon` is enabled (the default) and the page becomes hidden, the drain
 
 `sendBeacon` has a browser-imposed payload limit (~64 KB). If the payload exceeds this, the drain throws an error. Keep batch sizes reasonable (the default of 25 is well within limits).
 
-### Authentication
+### Authenticate the browser request
 
 Pass custom headers to protect your ingest endpoint:
 
@@ -461,7 +461,7 @@ app.post('/v1/ingest', async (c) => {
 
 See the full [browser example](https://github.com/hugorcd/evlog/tree/main/examples/browser) for a working Hono server + browser page.
 
-## Common pitfalls
+## Mistakes that cost you events
 
 - **Don't forget `drain.flush()` on shutdown** — buffered events are lost otherwise
 - **Tune `batch.size` to match your provider's recommended payload** — too small wastes overhead, too big risks rejection

--- a/scripts/content-lint/lib/metrics.mjs
+++ b/scripts/content-lint/lib/metrics.mjs
@@ -232,6 +232,10 @@ function headingShape(doc) {
 function classifyHeading(text) {
   const trimmed = text.trim()
   if (/^code$/.test(trimmed) || /^[a-z][A-Za-z]*\(\)?$/.test(trimmed)) return 'symbol'
+  // A numbered heading is a position in an ordered guide. The steps of one
+  // procedure share a shape because they are one procedure, which is the twin
+  // `T-06` is meant to spare.
+  if (/^(?:step\s+)?\d+[.):]\s/i.test(trimmed)) return 'sequence'
   if (trimmed.endsWith('?')) return 'question'
   const first = trimmed.toLowerCase().split(/\s+/)[0]
   if (IMPERATIVE_VERBS.includes(first)) return 'imperative'

--- a/scripts/content-lint/lib/score.mjs
+++ b/scripts/content-lint/lib/score.mjs
@@ -212,7 +212,7 @@ function rhythm(metrics, profile, rates, template) {
   }
 
   const own = ownHeadings(metrics.headings, template)
-  if (own.count >= 4 && own.share >= 0.9 && own.dominant !== 'symbol') {
+  if (own.count >= 4 && own.share >= 0.9 && own.dominant !== 'symbol' && own.dominant !== 'sequence') {
     findings.push({
       id: 'T-06',
       severity: 'standard',

--- a/scripts/content-lint/lib/score.test.mjs
+++ b/scripts/content-lint/lib/score.test.mjs
@@ -54,6 +54,22 @@ describe('heading templates', () => {
   })
 })
 
+describe('numbered headings', () => {
+  it('reads an ordered guide as a sequence, not a mould', () => {
+    const steps = ['1. Route filtering', '2. Logger creation', '3. Context accumulation', '4. Request end', '5. Emit']
+    const source = steps.map(h => `## ${h}\n\nProse about the step.`).join('\n\n')
+
+    expect(evaluate(page('apps/docs/content/2.learn/a.md', source), quiet).findings.map(f => f.id)).not.toContain('T-06')
+  })
+
+  it('still flags five noun headings that are not a sequence', () => {
+    const labels = ['Configuration', 'Options', 'Reference', 'Limitations', 'Notes']
+    const source = labels.map(h => `## ${h}\n\nProse about it.`).join('\n\n')
+
+    expect(evaluate(page('apps/docs/content/2.learn/a.md', source), quiet).findings.map(f => f.id)).toContain('T-06')
+  })
+})
+
 describe('evaluate', () => {
   it('carries drift findings through and deducts for them', () => {
     const drift = [{ id: 'T-15', severity: 'critical', line: 4, message: 'gone' }]


### PR DESCRIPTION
Stacked on #600. `T-06` from 46 to 33, mostly by teaching the scanner a twin its own doctrine already documented.

## A numbered sequence is not a mould

`ai-tells.md` has always named the exception: *"an ordered guide where every heading is the step's imperative. Both are parallel because the content is parallel."* The scanner did not know it, so it reported the lifecycle page for `1. Route Filtering`, `2. Logger Creation`, `3. Context Accumulation`, and the consumer recipes for `1. Build a minimal devtool` through `6. Self-hosted tail -f`.

`metrics.mjs` now classifies a heading opening with a number or `Step N` as `sequence`, and `T-06` ignores that shape the way it already ignores an API symbol. **44 → 35 on that change alone**, with no page edited.

`ai-tells.md` now lists both twins the scanner subtracts before reporting, so a candidate that reaches a reviewer has already survived them. `corrections.md` records it.

## 43 headings renamed

On `2.learn` and `6.extend`, where the reader is being taught rather than looking something up:

| Before | After |
| --- | --- |
| `## How it works` | `## What the pipeline does to an event` |
| `## Common pitfalls` | `## Mistakes that cost you events` |
| `## Head Sampling` | `## Drop noise before it is built` |
| `## Tail Sampling` | `## Keep an event once you know its outcome` |
| `## Opting Out` | `## Turn it off, or narrow it` |
| `## Smart Masking` | `## Mask enough to still debug` |
| `## When to use what` | `## Choose the mode for the job` |
| `### Returned drain function` | `### What the wrapper hands back` |
| `### sendBeacon fallback` | `### Survive a closing tab` |

## The anchor audit caught one

Every rename was checked against the index of referenced anchors. Two came back linked:

- `#configuration-reference` points at `/learn/redaction`, which I did not touch. False alarm.
- `#server-endpoint` is linked from `5.use-cases/1.client-logging.md` and points at the section I had just renamed. **Reverted**, so the link still resolves.

That is the whole reason this work is done with an audit rather than a find-and-replace.

## Checks

120 scanner tests, two new. `evlog-docs` lint passes. Clean pages 55 → 67 of 120, average 96.6 → 97.2. One commit. No changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved section headings across learning and extension guides with clearer, action-oriented wording.
  * Clarified guidance for consumer limitations, event processing, retries, authentication, and event-loss warnings.
  * Documented numbered procedure headings and shared section structures as valid documentation patterns.

* **Bug Fixes**
  * Reduced incorrect content-lint findings for legitimate numbered sequences and other recognized heading patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->