### PR TITLE
ci: fail a pull request that makes a content file worse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
       - name: Test content-lint
         run: pnpm run content:lint:test
 
+      # A ratchet, not a floor: every file this pull request touched has to score
+      # at least as well as the same file on the base branch, and introduce no
+      # finding id it did not already carry. A fixed bar would fail a new page
+      # written at 85 while a page sitting at 60 since last year sails through.
+      - name: Content did not regress
+        if: github.event_name == 'pull_request'
+        run: pnpm run content:lint -- --since origin/${{ github.base_ref }}
+
       # The coverage step bypasses turbo, so it inherits no dist/ from the
       # affected graph — on a docs-only change nothing is affected and the
       # dist-dependent tests (auto-import types, api-surface) would run

--- a/scripts/content-lint/README.md
+++ b/scripts/content-lint/README.md
@@ -79,6 +79,20 @@ Alongside the findings, every scan returns `modelChecks`: the questions no thres
 
 The pass carries them through to `content_review` untouched, and the reviewer answers every one in its report.
 
+## Keeping it from sliding back
+
+```bash
+pnpm content:lint --since origin/main
+```
+
+Scores every corpus file the branch changed against the same file on the base, and exits 1 when one comes back worse. Worse means a lower score, or a finding id that appears more often than it did: trading a dash for a hollow superlative costs the same and is not progress.
+
+It is a ratchet rather than a floor on purpose. A fixed `--min-score` fails a new page written at 85 while a page that has sat at 60 since last year passes untouched, so the bar punishes whoever writes next instead of whoever wrote last.
+
+Corpus-level findings are left out of the comparison. A page cannot answer `D-11` on its own: another page has to link to it.
+
+The Test job runs this on every pull request.
+
 ## Calibration
 
 `fixtures/generated.md` is saturated on purpose and `fixtures/written.md` carries the lawful twins. `fixtures.test.mjs` fails when the distance between their scores closes, in either direction. A tell that cannot separate those two files is measuring nothing, and the same pair backs the content evals in `apps/evi/evals/content/`.

--- a/scripts/content-lint/index.mjs
+++ b/scripts/content-lint/index.mjs
@@ -9,6 +9,7 @@
  *   node scripts/content-lint <file> --json                one page, machine-readable
  *   node scripts/content-lint --surface skill --top 5      one surface only
  *   node scripts/content-lint --min-score 70               exit 1 below the bar
+ *   node scripts/content-lint --since origin/main          exit 1 if a changed file got worse
  *   node scripts/content-lint --url https://…              a page that is not in the repo
  *   cat draft.md | node scripts/content-lint --stdin       prose that is not a file yet
  *
@@ -21,6 +22,7 @@
  * half: what no threshold reached on this page, which the reviewer owes.
  */
 
+import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -31,6 +33,7 @@ import { buildBaseline, evaluate } from './lib/score.mjs'
 import { SURFACES, corpusFiles, surfaceOf } from './lib/surfaces.mjs'
 import { modelChecks } from './lib/model-checks.mjs'
 import { corpusFindings } from './lib/reach.mjs'
+import { compare, render } from './lib/ratchet.mjs'
 import { extract } from './lib/extract.mjs'
 import { fetchPublic } from './lib/net.mjs'
 import { applyFixes, isSafeFix, loadRedirects } from './lib/fix.mjs'
@@ -51,6 +54,7 @@ const options = {
   dryRun: argv.includes('--dry-run'),
   top: numberFlag('--top', { min: 1, integer: true }),
   minScore: numberFlag('--min-score', { min: 0, max: 100 }),
+  since: stringFlag('--since'),
   surface: surfaceFlag('--surface'),
   url: stringFlag('--url'),
   as: surfaceFlag('--as') ?? 'docs',
@@ -102,7 +106,9 @@ const loose = options.url
     ? { path: '<stdin>', surface: options.as, ...scanSource(await readStdin()) }
     : null
 
-const corpus = corpusFiles(REPO_ROOT).map(file => join(REPO_ROOT, file))
+const corpusRelative = corpusFiles(REPO_ROOT)
+const corpusPaths = new Set(corpusRelative)
+const corpus = corpusRelative.map(file => join(REPO_ROOT, file))
 
 const files = loose || options.targets.length > 0
   ? options.targets.flatMap((target) => {
@@ -154,6 +160,39 @@ const pages = scanned
   .sort((a, b) => a.score - b.score || a.path.localeCompare(b.path))
 
 const selected = options.top ? pages.slice(0, options.top) : pages
+
+if (options.since !== null) {
+  const base = options.since
+  const changed = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { encoding: 'utf8' })
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => corpusPaths.has(line))
+
+  const results = changed.map((path) => {
+    const now = pages.find(page => page.path === path)
+      ?? { ...evaluate({ path, surface: surfaceOf(path), ...scanSource(readFileSync(join(REPO_ROOT, path), 'utf8')) }, baseline), path }
+
+    let previous = null
+    try {
+      const source = execFileSync('git', ['show', `${base}:${path}`], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
+      previous = { ...evaluate({ path, surface: surfaceOf(path), ...scanSource(source) }, baseline), path }
+    } catch {
+      previous = null
+    }
+
+    // The score carries the corpus penalty too, so it is recomputed from what
+    // is left rather than reused.
+    const own = (scored) => {
+      const findings = scored.findings.filter(finding => finding.corpus !== true)
+      const penalty = findings.reduce((total, finding) => total + (finding.severity === 'critical' ? 15 : 5), 0)
+      return { ...scored, findings, score: Math.max(0, 100 - penalty) }
+    }
+    return compare(previous === null ? null : own(previous), own(now))
+  })
+
+  process.stdout.write(render(results))
+  process.exit(results.some(result => result.verdict === 'worse') ? 1 : 0)
+}
 
 if (options.json) {
   process.stdout.write(`${JSON.stringify({ baseline, fixed: fixes, pages: selected }, null, 2)}\n`)
@@ -425,5 +464,5 @@ function surfaceFlag(name) {
  */
 function isFlagValue(arg) {
   const at = argv.indexOf(arg)
-  return at > 0 && ['--top', '--min-score', '--surface', '--url', '--as'].includes(argv[at - 1])
+  return at > 0 && ['--top', '--min-score', '--surface', '--url', '--as', '--since'].includes(argv[at - 1])
 }

--- a/scripts/content-lint/lib/ratchet.mjs
+++ b/scripts/content-lint/lib/ratchet.mjs
@@ -1,0 +1,75 @@
+/**
+ * The check that keeps the corpus from sliding back.
+ *
+ * A fixed floor is the wrong gate: it fails a new page written at 85 while a
+ * page sitting at 60 since last year passes untouched. What a pull request owes
+ * is that the files it touched did not get worse, which is a comparison against
+ * the same file on the base branch and nothing else.
+ */
+
+/**
+ * @typedef {{ path: string, score: number, findings: { id: string }[] }} Scored
+ */
+
+/**
+ * @param {{ id: string }[]} findings
+ * @param {string} id
+ * @returns {number}
+ */
+function count(findings, id) {
+  return findings.filter(finding => finding.id === id).length
+}
+
+/**
+ * Compare a file against its own past.
+ *
+ * A lower score is a regression. So is a finding id that appears more often
+ * than it did, even at an equal score: trading a dash for a hollow superlative
+ * is not progress, and the total says nothing about which one moved.
+ *
+ * @param {Scored | null} before Null when the file is new.
+ * @param {Scored} after
+ * @returns {{ path: string, verdict: 'new' | 'same' | 'better' | 'worse', before: number | null, after: number, appeared: string[] }}
+ */
+export function compare(before, after) {
+  if (before === null) return { path: after.path, verdict: 'new', before: null, after: after.score, appeared: [] }
+
+  const appeared = [...new Set(after.findings.map(finding => finding.id))]
+    .filter(id => count(after.findings, id) > count(before.findings, id))
+    .sort()
+
+  if (after.score < before.score || appeared.length > 0) {
+    return { path: after.path, verdict: 'worse', before: before.score, after: after.score, appeared }
+  }
+  return {
+    path: after.path,
+    verdict: after.score > before.score ? 'better' : 'same',
+    before: before.score,
+    after: after.score,
+    appeared: [],
+  }
+}
+
+/**
+ * @param {ReturnType<typeof compare>[]} results
+ * @returns {string}
+ */
+export function render(results) {
+  const worse = results.filter(result => result.verdict === 'worse')
+  const better = results.filter(result => result.verdict === 'better')
+  const fresh = results.filter(result => result.verdict === 'new')
+
+  const lines = [`content-lint --since · ${results.length} file${results.length === 1 ? '' : 's'} changed`, '']
+
+  for (const result of worse) {
+    const why = result.appeared.length > 0 ? `introduced ${result.appeared.join(', ')}` : `${result.before} → ${result.after}`
+    lines.push(`  worse   ${result.path}  ${why}`)
+  }
+  for (const result of better) lines.push(`  better  ${result.path}  ${result.before} → ${result.after}`)
+  for (const result of fresh) lines.push(`  new     ${result.path}  ${result.after}`)
+
+  if (worse.length === 0) lines.push('', '  Nothing this pull request touched came back worse.')
+  else lines.push('', `  ${worse.length} file${worse.length === 1 ? '' : 's'} regressed. Run the scanner on them to see what changed.`)
+
+  return `${lines.join('\n')}\n`
+}

--- a/scripts/content-lint/lib/ratchet.test.mjs
+++ b/scripts/content-lint/lib/ratchet.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { compare, render } from './ratchet.mjs'
+
+const scored = (score, ids = []) => ({ path: 'a.md', score, findings: ids.map(id => ({ id })) })
+
+describe('compare', () => {
+  it('passes a file that improved or held', () => {
+    expect(compare(scored(85, ['U-14']), scored(90)).verdict).toBe('better')
+    expect(compare(scored(90), scored(90)).verdict).toBe('same')
+  })
+
+  it('fails a file that lost points', () => {
+    expect(compare(scored(90), scored(85, ['U-14'])).verdict).toBe('worse')
+  })
+
+  it('fails a trade at an equal score', () => {
+    // A dash swapped for a hollow superlative costs the same and is not progress.
+    const verdict = compare(scored(95, ['U-14']), scored(95, ['T-01']))
+
+    expect(verdict.verdict).toBe('worse')
+    expect(verdict.appeared).toEqual(['T-01'])
+  })
+
+  it('treats a file with no past as new rather than as a regression', () => {
+    expect(compare(null, scored(80, ['U-14'])).verdict).toBe('new')
+  })
+})
+
+describe('render', () => {
+  it('says plainly when nothing regressed', () => {
+    expect(render([compare(scored(90), scored(95))])).toContain('came back worse')
+  })
+
+  it('names what appeared when something did', () => {
+    expect(render([compare(scored(95), scored(95, ['T-03']))])).toContain('introduced T-03')
+  })
+})

--- a/scripts/content-lint/lib/reach.mjs
+++ b/scripts/content-lint/lib/reach.mjs
@@ -99,6 +99,9 @@ export function corpusFindings(pages) {
       add(page.path, {
         id: 'D-11',
         severity: 'standard',
+        // A page cannot fix this alone: another page has to link to it. The
+        // ratchet drops it for that reason.
+        corpus: true,
         line: 0,
         message: `no page links to ${route} in prose; the nav can reach it, the docs never suggest it`,
       })


### PR DESCRIPTION
Stacked on #601. Nothing currently protects the work in this stack: the corpus went from 220 findings to 68, and a page added tomorrow can put dashes back with nobody noticing.

```bash
pnpm content:lint --since origin/main
```

Scores every corpus file the branch changed against the same file on the base branch, and exits 1 when one comes back worse. The Test job runs it on every pull request.

## A ratchet, not a floor

`--min-score` already existed and is the wrong gate. A fixed bar fails a new page written at 85 while a page that has sat at 60 since last year passes untouched, so it punishes whoever writes next instead of whoever wrote last. Comparing a file against its own past asks the only question a pull request can answer.

## Worse means two things

A lower score, and a finding id that appears more often than it did. The second matters at an equal score: swapping an em dash for a hollow superlative costs the same five points and is not progress. `compare()` reports what appeared, so the failure names the rule rather than a number.

## What it deliberately ignores

Corpus-level findings. A page cannot answer `D-11` on its own, since another page has to link to it, so those are dropped from both sides and the score is recomputed without their penalty.

That asymmetry was a real bug on the first run: `now` came from the corpus pass and carried `D-11`, `previous` was scored file-only and did not, so the introduction page was reported as regressing over a rule it had no way to satisfy. Both sides are now scored the same way.

## Checks

Run against this stack, it reports four files better and none worse. 126 scanner tests, six new on the comparison. No changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Pull requests now automatically detect content-quality regressions by comparing changed pages with their base versions.
  - Reports identify improved, unchanged, new, and regressed content, including newly introduced findings.

- **Documentation**
  - Added guidance for preventing content-quality issues from recurring.
  - Clarified how to resolve site-wide linking findings and verify improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->