### PR TITLE
docs(cli): name the task in each CLI heading and close the bullet blind spots

### DIFF
--- a/.agents/skills/create-adapter/SKILL.md
+++ b/.agents/skills/create-adapter/SKILL.md
@@ -134,9 +134,9 @@ Create `packages/evlog/test/e2e/{name}.e2e.ts`, gated on the adapter's env vars 
 
 If the service is self-hostable, extend the local sandbox so the adapter can be exercised without cloud credentials:
 
-- `packages/evlog/test/e2e/docker-compose.yml` — add the service
-- `packages/evlog/test/e2e/seed.mjs` — fan the seeder out to the new backend
-- `packages/evlog/test/e2e/README.md` — document it
+- `packages/evlog/test/e2e/docker-compose.yml`: add the service
+- `packages/evlog/test/e2e/seed.mjs`: fan the seeder out to the new backend
+- `packages/evlog/test/e2e/README.md`: document it
 - Root `package.json` `sandbox:e2e` script — add the local env var if needed
 
 See the Loki and ClickHouse setups as references.

--- a/.agents/skills/create-enricher/SKILL.md
+++ b/.agents/skills/create-enricher/SKILL.md
@@ -47,7 +47,7 @@ Add the enricher to `packages/evlog/src/enrichers/index.ts`. Read [references/en
 
 The contract is `defineEnricher<T>({ name, field, compute }, options?)`. You only ship one piece of logic:
 
-- **`compute(ctx)`** — return the computed value (typed as `T`) or `undefined` to skip.
+- **`compute(ctx)`**: return the computed value (typed as `T`) or `undefined` to skip.
 
 `defineEnricher` handles the rest:
 
@@ -58,10 +58,10 @@ The contract is `defineEnricher<T>({ name, field, compute }, options?)`. You onl
 Key rules:
 
 - **Use the toolkit helpers**: `getHeader()` for case-insensitive header lookup, `normalizeNumber()` for numeric strings — both from `../shared/headers` (re-exported by `evlog/toolkit`).
-- **Single event field** — each enricher writes one top-level field on `ctx.event`. If the enricher must additionally pin top-level fields (like `createTraceContextEnricher` does for `event.traceId` / `event.spanId`), wrap the `defineEnricher` result in a closure — see that enricher for the pattern.
-- **Factory pattern** — `create{Name}Enricher(options: EnricherOptions = {})` returns the result of `defineEnricher(...)` — directly in the normal case, or through the thin closure wrapper when the enricher also pins top-level fields (see the single-event-field rule above).
-- **No side effects** — never throw, never log; rely on `defineEnricher`'s built-in error handling if something goes wrong.
-- **Export the Info type** — `{Name}Info` describing the field shape, exported alongside the factory.
+- **Single event field**: each enricher writes one top-level field on `ctx.event`. If the enricher must additionally pin top-level fields (like `createTraceContextEnricher` does for `event.traceId` / `event.spanId`), wrap the `defineEnricher` result in a closure — see that enricher for the pattern.
+- **Factory pattern**: `create{Name}Enricher(options: EnricherOptions = {})` returns the result of `defineEnricher(...)` — directly in the normal case, or through the thin closure wrapper when the enricher also pins top-level fields (see the single-event-field rule above).
+- **No side effects**: never throw, never log; rely on `defineEnricher`'s built-in error handling if something goes wrong.
+- **Export the Info type**: `{Name}Info` describing the field shape, exported alongside the factory.
 
 ## Step 2: Tests
 

--- a/.agents/skills/create-enricher/references/enricher-template.md
+++ b/.agents/skills/create-enricher/references/enricher-template.md
@@ -73,9 +73,9 @@ For lower-level merging (rarely needed) the toolkit also exports `mergeEventFiel
 
 Enrichers typically read from `ctx`:
 
-- **`ctx.headers`** — HTTP request headers (sensitive headers already filtered)
-- **`ctx.response?.headers`** — HTTP response headers
-- **`ctx.response?.status`** — HTTP response status code
-- **`ctx.request`** — Request metadata (method, path, requestId)
-- **`process.env`** — Environment variables (for deployment metadata)
-- **`ctx.event`** — The event itself (for computed/derived fields)
+- **`ctx.headers`**: HTTP request headers (sensitive headers already filtered)
+- **`ctx.response?.headers`**: HTTP response headers
+- **`ctx.response?.status`**: HTTP response status code
+- **`ctx.request`**: Request metadata (method, path, requestId)
+- **`process.env`**: Environment variables (for deployment metadata)
+- **`ctx.event`**: The event itself (for computed/derived fields)

--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -10,7 +10,7 @@ Add a new framework integration to evlog. The recommended path is the **manifest
 ## Two paths
 
 - **Manifest mode** (preferred, ~30–80 lines of glue) — call `defineFrameworkIntegration({ name, extractRequest, attachLogger, storage? })` once at module level, then write a tiny middleware that calls `integration.start(ctx, options)` and runs the framework's `next()` inside `runWith`. Reference implementations — all of `packages/evlog/src/{hono,express,fastify,elysia,nestjs,orpc,react-router,sveltekit,workers}/index.ts` use it.
-- **Custom mode** — use `createMiddlewareLogger` directly when the framework's lifecycle doesn't fit a standard middleware. Current custom-mode integrations: Next.js (`src/next/`), Nitro v2/v3 (`src/nitro/`, `src/nitro-v3/`), Eve (`src/eve/`).
+- **Custom mode**: use `createMiddlewareLogger` directly when the framework's lifecycle doesn't fit a standard middleware. Current custom-mode integrations: Next.js (`src/next/`), Nitro v2/v3 (`src/nitro/`, `src/nitro-v3/`), Eve (`src/eve/`).
 
 Manifest mode now covers all classic HTTP frameworks. Use custom mode only when you can't extract a request synchronously at the start of the lifecycle (server actions, module-level hooks, agent turns).
 

--- a/.agents/skills/create-map-rule/SKILL.md
+++ b/.agents/skills/create-map-rule/SKILL.md
@@ -7,8 +7,8 @@ description: Add a new rule or a new framework adapter to `evlog map` in @evlog/
 
 Extend the coverage scanner in `@evlog/cli`. Two kinds of extension:
 
-- **A rule** — a new question asked of every entry point (`packages/cli/src/lib/map/rules/`). This is the common case.
-- **A framework adapter** — teach `evlog map` to find entry points in a new framework (`packages/cli/src/lib/map/adapters/`). Rarer and heavier; see the last section.
+- **A rule**: a new question asked of every entry point (`packages/cli/src/lib/map/rules/`). This is the common case.
+- **A framework adapter**: teach `evlog map` to find entry points in a new framework (`packages/cli/src/lib/map/adapters/`). Rarer and heavier; see the last section.
 
 ## PR Title
 
@@ -88,9 +88,9 @@ Key rules:
 
 - **Reporting nothing means the rule passed.** `context.report()` only for gaps.
 - **Read `FileFacts` first** (`../facts.ts`) — if the answer isn't there, consider extending the facts rather than writing AST listeners; facts are computed once per file for all rules.
-- **`project` (`ProjectFacts`) is the gate for opportunities** — `project.features` (evlog features in use), `project.pairable` (installed packages evlog integrates with), `project.catalogs` (for naming things in suggestions).
+- **`project` (`ProjectFacts`) is the gate for opportunities**: `project.features` (evlog features in use), `project.pairable` (installed packages evlog integrates with), `project.catalogs` (for naming things in suggestions).
 - **Messages are report copy.** Concrete, lowercase, pointing at the evidence (`"X is spelled out here and in 2 other files — one catalog entry would cover them"`). No exclamation marks, no advice-column tone.
-- **Weights are a scoring decision** — look at `score.ts` and the existing spread (40 down to 15) and discuss the number in the PR rather than inventing precedent.
+- **Weights are a scoring decision**: look at `score.ts` and the existing spread (40 down to 15) and discuss the number in the PR rather than inventing precedent.
 - Every rule id is also a suppression target (`evlog-map-disable {id}`) and part of the public `evlog.map.json` contract — renaming later is a breaking change.
 
 ## Steps 2 and 3: Registry + CheckId

--- a/.agents/skills/write-evlog-content/references/corrections.md
+++ b/.agents/skills/write-evlog-content/references/corrections.md
@@ -68,3 +68,15 @@ Applies to: every term in `terminology.md`. `corpus.mjs` drops a hit whose parag
 Flagged: `Zero config.` closing a `::card` on the frameworks overview.
 Actual: a card is a link tile and its body is sized to the tile, so every one of them ends on a short line. Counting them measures the component, not the page's rhythm.
 Applies to: `::card` on every surface. `metrics.mjs` leaves card bodies out of the eligible population.
+
+## 2026-08-15 · T-06 · A page that lists is allowed parallel headings
+
+Flagged: `Exit codes`, `The JSON contract`, `The map file`, `Monorepos` on the CLI pages, and 19 other pages of the same shape.
+Actual: `ai-tells.md` already named the twin, parallel headings over parallel entries, and in the file that looks like a section holding a table or a fence and almost no prose. The tell is a mould over sections that argue.
+Applies to: every surface. `metrics.mjs` measures the share of sections that list, and `T-06` drops above 0.6, which cleared 20 pages.
+
+## 2026-08-15 · U-14 · A bullet is prose
+
+Flagged: nothing, for a year. The rule only ever read headings and paragraphs, so 273 dashes sat in list items untouched, most of them in the `Next steps` list at the bottom of a page.
+Actual: 159 were a bold term glossed after a dash, which the corpus elsewhere writes with a colon. The remaining 117 put a full clause after the dash and need a reader.
+Applies to: list items on every surface. Table cells stay out: a cell is a fragment and a dash between two of its parts is layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,9 @@ Default: anything that stays on the local clone is fine, anything that touches t
 - `gh pr view`, `gh pr list`, `gh pr diff`, `gh issue view`, `gh run view` — read-only GitHub queries
 
 **OK when the maintainer explicitly asks (in the current task):**
-- `git push -u origin <feature-branch>` — push a feature branch you just prepared
-- `git push --force-with-lease origin <feature-branch>` — only on a feature branch you authored, after a clean rebase
-- `gh pr create --base main --head <feature-branch>` — open a PR
+- `git push -u origin <feature-branch>`: push a feature branch you just prepared
+- `git push --force-with-lease origin <feature-branch>`: only on a feature branch you authored, after a clean rebase
+- `gh pr create --base main --head <feature-branch>`: open a PR
 - Write a **PR title** (Conventional Commits, see above) and a **PR body** — keep the body factual, mirror the changeset, reference the issue (`Closes #X`); no marketing copy
 
 **Never (no exceptions, even when asked):**

--- a/apps/docs/content/1.start/1.introduction.md
+++ b/apps/docs/content/1.start/1.introduction.md
@@ -70,9 +70,9 @@ Not running an HTTP framework? See [Standalone TypeScript](/integrate/frameworks
 evlog is a fully-featured general-purpose logger that happens to also do wide events. Concretely:
 
 - **Zero transitive dependencies** and ~6 kB gzip — nothing to audit, nothing that breaks on the next Node LTS. Benchmarked at [~3 µs/request](/reference/performance), 7.7x faster than pino in the wide event pattern (1 event vs 4 log lines) and competitive on every other path.
-- **Same API in every context** — scripts, frameworks, edge runtimes, browser, library code. No `pino-http` vs `pino` split, no separate `consola` reporters per environment.
-- **Structured errors with `why` / `fix` / `link` built in** — your error toast finally tells users what went wrong and what to do, your on-call stops reverse-engineering stack traces.
-- **Wide events as a free upgrade path** — when you need to correlate context across an operation, the same logger gives you `log.set` + `log.emit` instead of stitching log lines together later.
+- **Same API in every context**: scripts, frameworks, edge runtimes, browser, library code. No `pino-http` vs `pino` split, no separate `consola` reporters per environment.
+- **Structured errors with `why` / `fix` / `link` built in**: your error toast finally tells users what went wrong and what to do, your on-call stops reverse-engineering stack traces.
+- **Wide events as a free upgrade path**: when you need to correlate context across an operation, the same logger gives you `log.set` + `log.emit` instead of stitching log lines together later.
 
 See the full [feature comparison](/reference/vs-other-loggers) (parity matrix, honest gaps, and migration snippets) for a side-by-side with pino, winston, and consola.
 
@@ -170,4 +170,4 @@ Traditional `console.log` and generic `throw new Error()` provide no actionable 
 - [Quick Start](/start/quick-start) - Get up and running in minutes
 - [Logging Overview](/learn/overview) - Understand the three logging modes in depth
 - [evlog vs pino, winston, consola](/reference/vs-other-loggers) - Feature parity, honest gaps, and migration snippets
-- [Standalone TypeScript](/integrate/frameworks/standalone) — scripts, workers, libraries without a web framework
+- [Standalone TypeScript](/integrate/frameworks/standalone): scripts, workers, libraries without a web framework

--- a/apps/docs/content/1.start/2.why-evlog.md
+++ b/apps/docs/content/1.start/2.why-evlog.md
@@ -218,11 +218,11 @@ Audit: https://www.evlog.dev/use-cases/audit/overview
 
 ## Next steps
 
-- [Installation](/start/installation) — pick your framework
-- [Quick Start](/start/quick-start) — `useLogger`, `createLogger`, `createError` in 2 minutes
-- [Catalogs](/learn/catalogs) — typed errors and audit actions, day-0 to monorepo-scale
-- [Audit Logs](/use-cases/audit/overview) — day-0 compliance posture
-- [AI SDK](/use-cases/ai-sdk/overview) — token usage, tool calls, streaming metrics
-- [Better Auth](/use-cases/better-auth/overview) — auth events with one-line install
-- [Best Practices](/reference/best-practices) — what not to log, redaction, sampling
-- [evlog vs pino, winston, consola](/reference/vs-other-loggers) — feature parity matrix and migration snippets
+- [Installation](/start/installation): pick your framework
+- [Quick Start](/start/quick-start): `useLogger`, `createLogger`, `createError` in 2 minutes
+- [Catalogs](/learn/catalogs): typed errors and audit actions, day-0 to monorepo-scale
+- [Audit Logs](/use-cases/audit/overview): day-0 compliance posture
+- [AI SDK](/use-cases/ai-sdk/overview): token usage, tool calls, streaming metrics
+- [Better Auth](/use-cases/better-auth/overview): auth events with one-line install
+- [Best Practices](/reference/best-practices): what not to log, redaction, sampling
+- [evlog vs pino, winston, consola](/reference/vs-other-loggers): feature parity matrix and migration snippets

--- a/apps/docs/content/2.learn/0.overview.md
+++ b/apps/docs/content/2.learn/0.overview.md
@@ -168,11 +168,11 @@ All three modes share the same foundation:
 
 After the three modes, the rest of Learn covers the concepts that show up across every mode:
 
-- [Structured Errors](/learn/structured-errors) — `why`, `fix`, `link`, `internal`, and how `createError` differs from `throw new Error`
-- [Catalogs](/learn/catalogs) — typed error / audit catalogs that survive refactors
-- [Lifecycle](/learn/lifecycle) — exactly what happens between `emit()` and your drain
-- [Sampling](/learn/sampling) — keep all errors and slow requests; drop healthy noise
-- [Typed Fields](/learn/typed-fields) — augment `RequestLogger` so `log.set` is autocompleted
-- [Redaction](/learn/redaction) — the rules that strip `authorization`, `password`, `token`, etc. before drain
+- [Structured Errors](/learn/structured-errors): `why`, `fix`, `link`, `internal`, and how `createError` differs from `throw new Error`
+- [Catalogs](/learn/catalogs): typed error / audit catalogs that survive refactors
+- [Lifecycle](/learn/lifecycle): exactly what happens between `emit()` and your drain
+- [Sampling](/learn/sampling): keep all errors and slow requests; drop healthy noise
+- [Typed Fields](/learn/typed-fields): augment `RequestLogger` so `log.set` is autocompleted
+- [Redaction](/learn/redaction): the rules that strip `authorization`, `password`, `token`, etc. before drain
 
 When you're done with Learn, head to [Integrate](/integrate/frameworks/overview) to wire evlog into your stack, or run [`evlog map`](/cli/map) first to see which parts of your app currently have no way of telling you what went wrong.

--- a/apps/docs/content/3.cli/0.overview.md
+++ b/apps/docs/content/3.cli/0.overview.md
@@ -185,8 +185,8 @@ Add `--json` to get the whole event instead of the summary. `EVLOG_CLI_DEBUG=1` 
 
 ## Next
 
-- [`evlog init`](/cli/init) — wire evlog into an app that does not have it yet
-- [`evlog map`](/cli/map) — what it scans and how to read the report
-- [Rules](/cli/rules) — every check, what satisfies it, and how to fix it
-- [Scoring](/cli/scoring) — how the number is calculated
-- [CI](/cli/ci) — gate a pull request on the score
+- [`evlog init`](/cli/init): wire evlog into an app that does not have it yet
+- [`evlog map`](/cli/map): what it scans and how to read the report
+- [Rules](/cli/rules): every check, what satisfies it, and how to fix it
+- [Scoring](/cli/scoring): how the number is calculated
+- [CI](/cli/ci): gate a pull request on the score

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -335,7 +335,7 @@ The directory it writes to is `.evlog/logs`, and evlog gitignores it on first wr
 
 ## Next
 
-- [`evlog agents`](/cli/agents) — re-run the agent guidelines on their own, whenever the skills move on
-- [`evlog doctor`](/cli/doctor) — confirm the wiring resolves and logs are being written
-- [`evlog map`](/cli/map) — score what is still dark now that evlog is in place
-- [Quick Start](/start/quick-start) — the concepts behind the wiring
+- [`evlog agents`](/cli/agents): re-run the agent guidelines on their own, whenever the skills move on
+- [`evlog doctor`](/cli/doctor): confirm the wiring resolves and logs are being written
+- [`evlog map`](/cli/map): score what is still dark now that evlog is in place
+- [Quick Start](/start/quick-start): the concepts behind the wiring

--- a/apps/docs/content/3.cli/2.map.md
+++ b/apps/docs/content/3.cli/2.map.md
@@ -136,7 +136,7 @@ Money & auth deliberately overlaps the other rows. It is the group where a missi
 
 The three entry points with the most to gain, sensitive ones first, worst score first. Each gets the method, the path, a sensitivity marker, a sentence naming the actual problem, and the file, the line, and a docs link for the rule that failed.
 
-`$` is money, `A` is auth, `@` is PII. These come from the [sensitivity classifier](/cli/scoring#sensitivity), and a flagged entry point is held to one extra requirement: an audit trail.
+`$` is money, `A` is auth, `@` is PII. These come from the [sensitivity classifier](/cli/scoring#mark-what-touches-money-auth-or-pii), and a flagged entry point is held to one extra requirement: an audit trail.
 
 ### Then
 
@@ -301,7 +301,7 @@ Every run writes `evlog.map.json` to the project root: the score, the framework,
 
 Use `--no-write` when you do not want the file, for CI runs or a quick look at somebody else's project. Whether to commit it depends on how you gate:
 
-- **Not gating CI, or only `--min-score`**: the file is a build artifact, so [gitignore it](/cli/ci#the-map-file). It holds the same data as `--json`, so nothing is lost.
+- **Not gating CI, or only `--min-score`**: the file is a build artifact, so [gitignore it](/cli/ci#where-the-map-file-lives). It holds the same data as `--json`, so nothing is lost.
 - **Gating with `--baseline`**: track it, like a lockfile. The ratchet compares against the committed copy, so `git:<ref>` can only read a file that was committed. Regenerate it with `evlog map`, review it in the diff, never hand-edit it.
 
 ## What it will not tell you
@@ -315,6 +315,6 @@ Static analysis has limits, and knowing them is the difference between trusting 
 
 ## Next
 
-- [Rules](/cli/rules) — every check, what satisfies it, and the exact fix
-- [Scoring](/cli/scoring) — weights, grades, and the sensitivity classifier
-- [CI](/cli/ci) — gate a pull request on the score
+- [Rules](/cli/rules): every check, what satisfies it, and the exact fix
+- [Scoring](/cli/scoring): weights, grades, and the sensitivity classifier
+- [CI](/cli/ci): gate a pull request on the score

--- a/apps/docs/content/3.cli/3.rules.md
+++ b/apps/docs/content/3.cli/3.rules.md
@@ -131,7 +131,7 @@ throw createError({
 
 ### audit: does this sensitive entry point leave a trail?
 
-Applies only where the [sensitivity classifier](/cli/scoring#sensitivity) found money or auth. Everywhere else an audit record would be noise, so the rule reports `n/a` rather than passing for free.
+Applies only where the [sensitivity classifier](/cli/scoring#mark-what-touches-money-auth-or-pii) found money or auth. Everywhere else an audit record would be noise, so the rule reports `n/a` rather than passing for free.
 
 `log.audit()` satisfies it, including through optional chaining, so `log.audit?.deny()` counts.
 
@@ -230,10 +230,10 @@ Fires on entry points where auth is actually in play: the auth routes themselves
 
 Every rule that looks for a logger asks the same question: *is this evlog's?* It is answered from the AST, which is why a locally defined stub does not earn you points.
 
-- **Imported from evlog** — `import { useLogger } from 'evlog'`, including subpath imports.
-- **Auto-imported** — in Nuxt and Nitro, evlog's module injects `useLogger` and `createEvlogError`, so an un-imported call counts. Unless the file declares its own, in which case the local declaration wins.
-- **Re-exported from a local module** — `import { useLogger } from '@/lib/evlog'` counts when that module forwards evlog's export, which is the shape [the Next.js guide](/integrate/frameworks/nextjs) recommends. Exports destructured from a factory (`export const { useLogger } = createEvlog(...)`) are resolved too.
-- **Through an evlog wrapper** — `withEvlog` and `withAudit` instrument a handler without it ever naming a logger.
+- **Imported from evlog**: `import { useLogger } from 'evlog'`, including subpath imports.
+- **Auto-imported**: in Nuxt and Nitro, evlog's module injects `useLogger` and `createEvlogError`, so an un-imported call counts. Unless the file declares its own, in which case the local declaration wins.
+- **Re-exported from a local module**: `import { useLogger } from '@/lib/evlog'` counts when that module forwards evlog's export, which is the shape [the Next.js guide](/integrate/frameworks/nextjs) recommends. Exports destructured from a factory (`export const { useLogger } = createEvlog(...)`) are resolved too.
+- **Through an evlog wrapper**: `withEvlog` and `withAudit` instrument a handler without it ever naming a logger.
 
 Two things deliberately do **not** count:
 
@@ -305,5 +305,5 @@ In the meantime, [disable the check](#disabling-a-check) on that line. A false p
 
 ## Next
 
-- [Scoring](/cli/scoring) — how weights become a number, and how sensitivity is decided
-- [CI](/cli/ci) — gate a pull request on requirements without suggestions getting in the way
+- [Scoring](/cli/scoring): how weights become a number, and how sensitivity is decided
+- [CI](/cli/ci): gate a pull request on requirements without suggestions getting in the way

--- a/apps/docs/content/3.cli/4.scoring.md
+++ b/apps/docs/content/3.cli/4.scoring.md
@@ -56,7 +56,7 @@ Which makes the arithmetic legible in both directions. Here is the worst entry p
 ::map-score-climb
 ::
 
-## The project score
+## How the project score is computed
 
 The global score is the average of every entry point, weighted by how much a blind spot there would cost you:
 
@@ -78,7 +78,7 @@ Three entry points: a sensitive handler at 75, a plain handler at 100, and a pag
 
 A project with no entry points at all scores 100.
 
-## Grades
+## How a grade is assigned
 
 | Score | Grade |
 | --- | --- |
@@ -87,7 +87,7 @@ A project with no entry points at all scores 100.
 | 50–69 | `needs work` |
 | 0–49 | `at risk` |
 
-## Coverage classification
+## How a file is classified
 
 Alongside the score, each entry point is classified, which is what the `summary` block in the JSON counts, and what the coverage rows in the report are built from.
 
@@ -100,7 +100,7 @@ Alongside the score, each entry point is classified, which is what the `summary`
 
 `dark` is the number to watch. A dark entry point produces nothing you can query: when it misbehaves, the only evidence you will have is the user's description of it.
 
-## Sensitivity
+## Mark what touches money, auth, or PII
 
 Sensitivity is what promotes an entry point to double weight and adds the `audit` requirement, so it is worth knowing exactly how it is decided.
 
@@ -143,5 +143,5 @@ FLAGGED SENSITIVE BECAUSE
 
 ## Next
 
-- [CI](/cli/ci) — turn the score into a pass/fail check
-- [Rules](/cli/rules) — what each requirement actually looks for
+- [CI](/cli/ci): turn the score into a pass/fail check
+- [Rules](/cli/rules): what each requirement actually looks for

--- a/apps/docs/content/3.cli/5.ci.md
+++ b/apps/docs/content/3.cli/5.ci.md
@@ -19,7 +19,7 @@ links:
 
 A score you look at once is a nice afternoon. A score in CI is what stops the next handler from shipping dark.
 
-## The gate
+## Fail the build on a regression
 
 `--min-score <n>` prints an explicit verdict and exits 1 when the project is below the threshold:
 
@@ -139,7 +139,7 @@ regenerate the baseline: evlog map && git add evlog.map.json
 
 A release that ships a feature but no rule change keeps the rule-set version, so upgrading the CLI does not force everyone to regenerate. A map written before version reporting has no version fields; the CLI treats it as unknown and warns once instead of failing every project on upgrade.
 
-## Exit codes
+## What each exit code means
 
 | Code | Meaning |
 | --- | --- |
@@ -151,7 +151,7 @@ A release that ships a feature but no rule change keeps the rule-set version, so
 A pipe replaces `$?` with the exit code of the last command in it, so `evlog map --min-score 90 \| tee map.log` always looks green. Add `set -o pipefail` to the step.
 ::
 
-## GitHub Actions
+## Run it in GitHub Actions
 
 ```yaml [.github/workflows/observability.yml]
 name: Observability
@@ -199,7 +199,7 @@ evlog map --json --no-write | jq '.map.score'
 
 Each pull request that raises the score raises the floor with it. The report already tells you what the next step is worth: `▲ 76 → 86 by fixing the 3 above`.
 
-## The JSON contract
+## Consume the JSON output
 
 `--json` writes the whole map to stdout. The report goes to stderr, so the two never mix.
 
@@ -291,7 +291,7 @@ test "$(evlog map --json --no-write | jq '.summary.dark')" -eq 0
 evlog map --json --no-write | jq '.summary.suppressedChecks'
 ```
 
-## The map file
+## Where the map file lives
 
 Unless you pass `--no-write`, every run writes `evlog.map.json` to the project root. It holds the same data as `--json`. Whether to commit it depends on how you gate:
 
@@ -307,7 +307,7 @@ Unless you pass `--no-write`, every run writes `evlog.map.json` to the project r
 
 A tracked map is readable, and that is a feature, not a cost: the diff of a pull request shows exactly which entry points changed class, which is a useful thing to argue about. What it costs is churn on every run, since `generatedAt` changes each time.
 
-## Monorepos
+## Gate every package in a monorepo
 
 `evlog map` scans one app at a time. Gate each one:
 
@@ -330,5 +330,5 @@ Different apps can carry different thresholds, which is usually what you want: t
 
 ## Next
 
-- [Rules](/cli/rules) — what a failing check means and how to fix it
-- [Scoring](/cli/scoring) — how the number you are gating on is calculated
+- [Rules](/cli/rules): what a failing check means and how to fix it
+- [Scoring](/cli/scoring): how the number you are gating on is calculated

--- a/apps/docs/content/3.cli/6.doctor.md
+++ b/apps/docs/content/3.cli/6.doctor.md
@@ -47,11 +47,11 @@ In a workspace, the header names the workspace kind and `project` shows which pa
 
 A local drain is optional: the [fs drain](/integrate/adapters/self-hosted/fs) writes under `.evlog/logs` and creates the directory on first write, so a wired drain counts as a drain before any event. A project with no local drain gets no `logs` check at all.
 
-## Exit code
+## What the exit code means
 
 `0` when nothing failed, `1` when any check failed. Warnings do not fail the command, because a project that has not written logs yet is not broken.
 
-## JSON
+## Read the result as JSON
 
 ```bash [Terminal]
 evlog doctor --json | jq '.checks'
@@ -72,5 +72,5 @@ Each warning and failure also carries a code from the CLI's own error catalog: `
 
 ## Next
 
-- [Installation](/start/installation) — wire evlog into your framework
-- [`evlog map`](/cli/map) — once it is installed, see where it is missing
+- [Installation](/start/installation): wire evlog into your framework
+- [`evlog map`](/cli/map): once it is installed, see where it is missing

--- a/apps/docs/content/3.cli/8.agents.md
+++ b/apps/docs/content/3.cli/8.agents.md
@@ -102,6 +102,6 @@ evlog init --no-agents
 
 ## Next Steps
 
-- [Agent Skills](/reference/agent-skills) — what each skill teaches
-- [`evlog map`](/cli/map) — score what your agent still has not covered
-- [Wide Events](/learn/wide-events) — the conventions the block is summarising
+- [Agent Skills](/reference/agent-skills): what each skill teaches
+- [`evlog map`](/cli/map): score what your agent still has not covered
+- [Wide Events](/learn/wide-events): the conventions the block is summarising

--- a/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
@@ -172,7 +172,7 @@ const drain = createPostHogDrain({
 | `distinctId` | `string` | - | Static person identifier for every event |
 | `distinctIdField` | `string` | `userId` | Event field holding the person identifier (dot path) |
 | `sessionIdField` | `string` | `sessionId` | Event field holding the PostHog session id (dot path) |
-| `recordShape` | `'json' \| 'compact'` | `'json'` | Log record shape — see [below](#choosing-a-record-shape) |
+| `recordShape` | `'json' \| 'compact'` | `'json'` | Log record shape, see [below](#choose-a-record-shape) |
 | `timeout` | `number` | `5000` | Request timeout in milliseconds |
 | `retries` | `number` | `2` | Retry attempts on transient failures |
 
@@ -323,7 +323,7 @@ evlog maps wide events to PostHog events:
 | `environment` | `properties.environment` |
 | All other fields | `properties.*` |
 
-With `recordShape: 'compact'`, the other fields are flattened into dotted keys the same way as in logs mode: a nested `ai` object arrives as `properties.ai.costUsd` and `properties.ai.calls` instead of one opaque `properties.ai` value. PostHog can filter and break down on those individual properties; the default `json` shape keeps the nested object as a single serialized property. See [Choosing a Record Shape](#choosing-a-record-shape) for the trade-off and how it affects your saved views and alerts.
+With `recordShape: 'compact'`, the other fields are flattened into dotted keys the same way as in logs mode: a nested `ai` object arrives as `properties.ai.costUsd` and `properties.ai.calls` instead of one opaque `properties.ai` value. PostHog can filter and break down on those individual properties; the default `json` shape keeps the nested object as a single serialized property. See [Choose a record shape](#choose-a-record-shape) for the trade-off and how it affects your saved views and alerts.
 
 ### How the distinct ID is resolved
 

--- a/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/05.datadog.md
@@ -177,9 +177,9 @@ const drain = createDatadogDrain({
 
 Each wide event becomes one Datadog log with:
 
-- **`message`** — short one-line summary for the list view (e.g. `ERROR GET /api/checkout (400)`), built with `formatDatadogMessageLine`. Easier to scan than a full JSON blob in Live Tail.
-- **`evlog`** — full wide event as a **JSON object** (not a string). Numeric HTTP **`status`** fields anywhere in the tree are renamed to **`httpStatusCode`** so they never clash with Datadog’s reserved severity `status`.
-- **`dd`** — `{ trace_id, span_id }` when the event carries trace context. See [Trace correlation](#trace-correlation).
+- **`message`**: short one-line summary for the list view (e.g. `ERROR GET /api/checkout (400)`), built with `formatDatadogMessageLine`. Easier to scan than a full JSON blob in Live Tail.
+- **`evlog`**: full wide event as a **JSON object** (not a string). Numeric HTTP **`status`** fields anywhere in the tree are renamed to **`httpStatusCode`** so they never clash with Datadog’s reserved severity `status`.
+- **`dd`**: `{ trace_id, span_id }` when the event carries trace context. See [Trace correlation](#trace-correlation).
 - **`service`**, **`status`** (Datadog severity — drives Live Tail color), **`ddsource`**: `evlog`, **`ddtags`**: `env:…` and optional `version:…`
 - **`timestamp`**: Unix milliseconds from `WideEvent.timestamp`
 
@@ -270,5 +270,5 @@ await sendBatchToDatadog(events, {
 
 ## Next Steps
 
-- [OTLP Adapter](/integrate/adapters/hybrid/otlp) — Send logs via OpenTelemetry (works with Datadog Agent / OTLP endpoint)
-- [Custom Adapters](/extend/custom-drains) — Build your own destination
+- [OTLP Adapter](/integrate/adapters/hybrid/otlp): Send logs via OpenTelemetry (works with Datadog Agent / OTLP endpoint)
+- [Custom Adapters](/extend/custom-drains): Build your own destination

--- a/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/01.loki.md
@@ -337,7 +337,7 @@ await sendBatchToLoki(events, { endpoint: 'http://localhost:3100' })
 
 ## Next steps
 
-- [Sampling](/learn/sampling) — control log volume before it reaches Loki
-- [Enrichers](/use-cases/enrichers) — add derived fields to every event
-- [Drain pipeline](/extend/drain-pipeline) — batching, retries, and fan-out
-- [Adapters Overview](/integrate/adapters/overview) — all available destinations
+- [Sampling](/learn/sampling): control log volume before it reaches Loki
+- [Enrichers](/use-cases/enrichers): add derived fields to every event
+- [Drain pipeline](/extend/drain-pipeline): batching, retries, and fan-out
+- [Adapters Overview](/integrate/adapters/overview): all available destinations

--- a/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/02.clickhouse.md
@@ -377,7 +377,7 @@ await sendBatchToClickHouse(events, { endpoint: 'http://localhost:8123' })
 
 ## Next steps
 
-- [Sampling](/learn/sampling) — control volume before it reaches ClickHouse
-- [Enrichers](/use-cases/enrichers) — add derived fields to every event
-- [Pipeline](/extend/drain-pipeline) — batching, retries, and fan-out
-- [Adapters Overview](/integrate/adapters/overview) — all available destinations
+- [Sampling](/learn/sampling): control volume before it reaches ClickHouse
+- [Enrichers](/use-cases/enrichers): add derived fields to every event
+- [Pipeline](/extend/drain-pipeline): batching, retries, and fan-out
+- [Adapters Overview](/integrate/adapters/overview): all available destinations

--- a/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
+++ b/apps/docs/content/4.integrate/adapters/hybrid/03.otlp.md
@@ -290,7 +290,7 @@ Every field of the wide event is sent as an OTLP record field, a resource attrib
 
 `compact` is worth switching to when your backend charges by ingested volume or facets on attributes:
 
-- **The body is a one-line summary** — `POST /api/checkout (500)`, falling back to the service name — instead of the whole event repeated next to the attributes. Backends that cluster messages into templates can only do so with a stable body.
+- **The body is a one-line summary**: `POST /api/checkout (500)`, falling back to the service name — instead of the whole event repeated next to the attributes. Backends that cluster messages into templates can only do so with a stable body.
 - **Nested fields become dotted attributes**, so each leaf is its own facet:
 
   ```typescript [server/api/checkout.post.ts]

--- a/apps/docs/content/5.use-cases/4.audit/03.recording.md
+++ b/apps/docs/content/5.use-cases/4.audit/03.recording.md
@@ -194,8 +194,8 @@ billingAudit._actions                        // readonly ['billing.INVOICE_REFUN
 
 Both produce the same call-site factory shape. Pick by scale:
 
-- **`defineAuditAction(action, opts?)`** — one-off actions, or per-file organisation in very large repos. Mirrors `defineError`. Equivalent to a catalog with a single entry but with no prefix derivation: you write the full wire `action` directly.
-- **`defineAuditCatalog(prefix, map)`** — group anything beyond a handful of related actions under one prefix. Mirrors `defineErrorCatalog`. The wire `action` is auto-derived as `${prefix}.${KEY}`, catalog metadata (`_actions`, `_prefix`) is exposed for introspection, and a single `declare module 'evlog'` line surfaces the whole bundle in the typed `AuditAction` union.
+- **`defineAuditAction(action, opts?)`**: one-off actions, or per-file organisation in very large repos. Mirrors `defineError`. Equivalent to a catalog with a single entry but with no prefix derivation: you write the full wire `action` directly.
+- **`defineAuditCatalog(prefix, map)`**: group anything beyond a handful of related actions under one prefix. Mirrors `defineErrorCatalog`. The wire `action` is auto-derived as `${prefix}.${KEY}`, catalog metadata (`_actions`, `_prefix`) is exposed for introspection, and a single `declare module 'evlog'` line surfaces the whole bundle in the typed `AuditAction` union.
 
 You can mix the two in the same codebase. Keep cross-cutting one-off actions as `defineAuditAction`, group bounded contexts (`billing`, `auth`, `subscription`) as catalogs.
 

--- a/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
@@ -140,8 +140,8 @@ Try it locally: [`examples/telemetry-playground`](https://github.com/HugoRCD/evl
 
 ## See also
 
-- [Setup](/use-cases/telemetry/setup) — citty, scripts, GitHub Actions, delivery config
-- [Ingest](/use-cases/telemetry/ingest) — server endpoint, validation, storage
-- [Reference](/use-cases/telemetry/reference) — envelope, schema extensions, disclosure, consent
-- [Audit](/use-cases/audit/overview) — wide events for security-sensitive actions
-- [Drain pipeline](/extend/drain-pipeline) — forward ingested events into Axiom, Datadog, OTLP, or a custom store
+- [Setup](/use-cases/telemetry/setup): citty, scripts, GitHub Actions, delivery config
+- [Ingest](/use-cases/telemetry/ingest): server endpoint, validation, storage
+- [Reference](/use-cases/telemetry/reference): envelope, schema extensions, disclosure, consent
+- [Audit](/use-cases/audit/overview): wide events for security-sensitive actions
+- [Drain pipeline](/extend/drain-pipeline): forward ingested events into Axiom, Datadog, OTLP, or a custom store

--- a/apps/docs/content/5.use-cases/4.telemetry/04.reference.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/04.reference.md
@@ -245,9 +245,9 @@ collect: {
 Three kinds of parser noise are dropped before the event is built, so `flags` reads
 as what the user asked for rather than what the parser filled in:
 
-- **Positionals** — citty's `_` bucket holds argument values, not flag names
-- **Defaults** — a flag still sitting at its declared `default` is not a choice anyone made
-- **Kebab-case duplicates** — `--min-score` arrives as both `minScore` and `min-score`; only the camelCase name is kept, and that is the name `collect.flags` allowlists
+- **Positionals**: citty's `_` bucket holds argument values, not flag names
+- **Defaults**: a flag still sitting at its declared `default` is not a choice anyone made
+- **Kebab-case duplicates**: `--min-score` arrives as both `minScore` and `min-score`; only the camelCase name is kept, and that is the name `collect.flags` allowlists
 
 Negation still reports: `--no-write` against `write: { default: true }` records `write: false`.
 

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -374,7 +374,7 @@ The `examples/eve` project is a **support refund copilot** (Clearbill SaaS): loo
 
 ## What to read next
 
-- [eve hooks guide](https://eve.dev/docs/guides/hooks) — stream event vocabulary
-- [eve instrumentation](https://eve.dev/docs/guides/instrumentation) — OTel spans (complementary)
-- [AI SDK use case](/use-cases/ai-sdk/overview) — when you own the model loop directly
-- [Adapters overview](/integrate/adapters/overview) — drain destinations
+- [eve hooks guide](https://eve.dev/docs/guides/hooks): stream event vocabulary
+- [eve instrumentation](https://eve.dev/docs/guides/instrumentation): OTel spans (complementary)
+- [AI SDK use case](/use-cases/ai-sdk/overview): when you own the model loop directly
+- [Adapters overview](/integrate/adapters/overview): drain destinations

--- a/apps/docs/content/6.extend/1.stream.md
+++ b/apps/docs/content/6.extend/1.stream.md
@@ -8,8 +8,8 @@ navigation:
 
 evlog ships a **stream primitive** so any local consumer can subscribe to wide events without re-implementing a drain. There are two layers, building on each other:
 
-- **In-process bus** — `createStreamDrain()`, the canonical pub/sub. Sync listeners, async iterators, ring-buffered replay.
-- **Network bridge** — `startStreamServer()`, an opt-in HTTP mini-server that exposes the in-process bus over Server-Sent Events for browsers, CLIs, or external devtools.
+- **In-process bus**: `createStreamDrain()`, the canonical pub/sub. Sync listeners, async iterators, ring-buffered replay.
+- **Network bridge**: `startStreamServer()`, an opt-in HTTP mini-server that exposes the in-process bus over Server-Sent Events for browsers, CLIs, or external devtools.
 
 ::callout
 ---
@@ -215,5 +215,5 @@ es.onmessage = (msg) => {
 
 ## Going further
 
-- [FS reader](/extend/fs-reader) — replay or tail historic NDJSON files (cross-process, survives restarts)
-- [Consumer recipes](/extend/consumer-recipes) — build a minimal devtool, pipe to curl + jq, replay history then go live
+- [FS reader](/extend/fs-reader): replay or tail historic NDJSON files (cross-process, survives restarts)
+- [Consumer recipes](/extend/consumer-recipes): build a minimal devtool, pipe to curl + jq, replay history then go live

--- a/apps/docs/content/6.extend/10.custom-framework.md
+++ b/apps/docs/content/6.extend/10.custom-framework.md
@@ -273,9 +273,9 @@ Built an integration for a framework we don't support? [Open a PR](https://githu
 
 ## Next steps
 
-- [Custom Drains](/extend/custom-drains) — same toolkit shape for drain destinations
-- [Custom Enrichers](/extend/custom-enrichers) — same toolkit shape for derived event fields
-- [Plugins](/extend/plugins) — multi-hook extensions (drain + enrich + keep in one object)
-- [Wide Events](/learn/wide-events) — design comprehensive events with context layering
-- [Sampling](/learn/sampling) — control log volume with head and tail sampling
-- [Adapters](/integrate/adapters/overview) — send logs to Axiom, Sentry, PostHog, and more
+- [Custom Drains](/extend/custom-drains): same toolkit shape for drain destinations
+- [Custom Enrichers](/extend/custom-enrichers): same toolkit shape for derived event fields
+- [Plugins](/extend/plugins): multi-hook extensions (drain + enrich + keep in one object)
+- [Wide Events](/learn/wide-events): design comprehensive events with context layering
+- [Sampling](/learn/sampling): control log volume with head and tail sampling
+- [Adapters](/integrate/adapters/overview): send logs to Axiom, Sentry, PostHog, and more

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -161,13 +161,13 @@ These are equivalent to a `definePlugin({ name, drain | enrich })` shape but rea
 ## Common pitfalls
 
 - **Don't throw from a hook.** The plugin runner catches and logs errors with the plugin name, but a thrown error from `enrich` won't propagate the event downstream. Keep hooks defensive.
-- **`drain` runs for every event** — not just per-request. If you only care about per-request lifecycle, use `onRequestFinish` instead.
-- **`extendLogger` mutates the logger object** — augment `RequestLogger` in a `.d.ts` so `useLogger(event)` exposes the new methods to TypeScript. See [typed fields](/learn/typed-fields).
+- **`drain` runs for every event**: not just per-request. If you only care about per-request lifecycle, use `onRequestFinish` instead.
+- **`extendLogger` mutates the logger object**: augment `RequestLogger` in a `.d.ts` so `useLogger(event)` exposes the new methods to TypeScript. See [typed fields](/learn/typed-fields).
 - **Plugins are de-duplicated by `name`**. Re-registering with the same `name` replaces the previous version (last registration wins).
 
 ## Next steps
 
-- [Custom Enrichers](/extend/custom-enrichers) — single-hook enrichment
-- [Custom Drains](/extend/custom-drains) — single-destination output
-- [Tail Sampling](/extend/tail-sampling) — outcome-aware keep decisions
-- [Identity Headers](/extend/identity-headers) — tag every drain request
+- [Custom Enrichers](/extend/custom-enrichers): single-hook enrichment
+- [Custom Drains](/extend/custom-drains): single-destination output
+- [Tail Sampling](/extend/tail-sampling): outcome-aware keep decisions
+- [Identity Headers](/extend/identity-headers): tag every drain request

--- a/apps/docs/content/6.extend/5.custom-enrichers.md
+++ b/apps/docs/content/6.extend/5.custom-enrichers.md
@@ -270,6 +270,6 @@ If your feature mixes enrichment with other hooks (e.g. enrich + tail-sample + s
 
 ## Next steps
 
-- [Built-in Enrichers](/use-cases/enrichers) — User Agent, Geo, Request Size, Trace Context
-- [Plugins](/extend/plugins) — multi-hook extensions (drain + enrich + keep in one object)
-- [Adapters](/integrate/adapters/overview) — send enriched events to external services
+- [Built-in Enrichers](/use-cases/enrichers): User Agent, Geo, Request Size, Trace Context
+- [Plugins](/extend/plugins): multi-hook extensions (drain + enrich + keep in one object)
+- [Adapters](/integrate/adapters/overview): send enriched events to external services

--- a/apps/docs/content/6.extend/6.tail-sampling.md
+++ b/apps/docs/content/6.extend/6.tail-sampling.md
@@ -126,6 +126,6 @@ Setting `shouldKeep = true` forces the event through. Setting `shouldKeep = fals
 
 ## Next steps
 
-- [Sampling](/learn/sampling) — head sampling, tail sampling, the built-in declarative `keep` rules
-- [Plugins](/extend/plugins) — when keep belongs in a multi-hook plugin
-- [Best Practices](/reference/best-practices) — keep all errors, double-check the rules
+- [Sampling](/learn/sampling): head sampling, tail sampling, the built-in declarative `keep` rules
+- [Plugins](/extend/plugins): when keep belongs in a multi-hook plugin
+- [Best Practices](/reference/best-practices): keep all errors, double-check the rules

--- a/apps/docs/content/6.extend/7.identity-headers.md
+++ b/apps/docs/content/6.extend/7.identity-headers.md
@@ -61,5 +61,5 @@ await httpPost({
 
 ## Next steps
 
-- [Custom Drains](/extend/custom-drains) — `defineHttpDrain` injects identity headers automatically
-- [Drain Pipeline](/extend/drain-pipeline) — wrap any drain in batch + retry while keeping identity headers
+- [Custom Drains](/extend/custom-drains): `defineHttpDrain` injects identity headers automatically
+- [Drain Pipeline](/extend/drain-pipeline): wrap any drain in batch + retry while keeping identity headers

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -333,8 +333,8 @@ Built something great? [Open a PR](https://github.com/hugorcd/evlog/pulls) to ad
 
 ## Next steps
 
-- [Drain Pipeline](/extend/drain-pipeline) — wrap your drain in batch + retry + fanout for production
-- [Adapters Overview](/integrate/adapters/overview) — see how the built-in adapters use `defineHttpDrain`
-- [Custom Enrichers](/extend/custom-enrichers) — same toolkit shape for derived event fields
-- [Custom Framework Integration](/extend/custom-framework) — same toolkit shape for HTTP frameworks
-- [Best Practices](/reference/best-practices) — security and production tips
+- [Drain Pipeline](/extend/drain-pipeline): wrap your drain in batch + retry + fanout for production
+- [Adapters Overview](/integrate/adapters/overview): see how the built-in adapters use `defineHttpDrain`
+- [Custom Enrichers](/extend/custom-enrichers): same toolkit shape for derived event fields
+- [Custom Framework Integration](/extend/custom-framework): same toolkit shape for HTTP frameworks
+- [Best Practices](/reference/best-practices): security and production tips

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -247,9 +247,9 @@ export const drain = pipeline(async (batch) => {
 
 ### What fan-out guarantees
 
-- **Parallel dispatch** — every destination receives the batch concurrently via `Promise.allSettled`
-- **Tolerant fanout** — if Datadog's API throws, Axiom / Sentry / fs still complete; the pipeline only retries the whole batch when the wrapping function rejects
-- **Shared backpressure** — the buffer is sized once for the whole pipeline; if the wrapping drain falls behind, the oldest events are dropped consistently for every destination
+- **Parallel dispatch**: every destination receives the batch concurrently via `Promise.allSettled`
+- **Tolerant fanout**: if Datadog's API throws, Axiom / Sentry / fs still complete; the pipeline only retries the whole batch when the wrapping function rejects
+- **Shared backpressure**: the buffer is sized once for the whole pipeline; if the wrapping drain falls behind, the oldest events are dropped consistently for every destination
 
 ### Send different events to each drain
 
@@ -463,14 +463,14 @@ See the full [browser example](https://github.com/hugorcd/evlog/tree/main/exampl
 
 ## Mistakes that cost you events
 
-- **Don't forget `drain.flush()` on shutdown** — buffered events are lost otherwise
-- **Tune `batch.size` to match your provider's recommended payload** — too small wastes overhead, too big risks rejection
-- **Don't run one pipeline per drain unless you need per-destination retries** — sharing one pipeline keeps batching + buffering coherent
-- **Don't fan out to a serverless-incompatible target without checking** — the [stream server](/extend/stream) reaches every connected client through the in-process stream; it's not a drain
+- **Don't forget `drain.flush()` on shutdown**: buffered events are lost otherwise
+- **Tune `batch.size` to match your provider's recommended payload**: too small wastes overhead, too big risks rejection
+- **Don't run one pipeline per drain unless you need per-destination retries**: sharing one pipeline keeps batching + buffering coherent
+- **Don't fan out to a serverless-incompatible target without checking**: the [stream server](/extend/stream) reaches every connected client through the in-process stream; it's not a drain
 
 ## Next steps
 
-- [Custom Drains](/extend/custom-drains) — build a drain for any backend with `defineHttpDrain` / `defineDrain`
-- [Adapters Overview](/integrate/adapters/overview) — built-in adapters that work with the pipeline out of the box
-- [Best Practices](/reference/best-practices) — security and production tips
-- [Client logging](/use-cases/client-logging) — end-to-end browser → server flow
+- [Custom Drains](/extend/custom-drains): build a drain for any backend with `defineHttpDrain` / `defineDrain`
+- [Adapters Overview](/integrate/adapters/overview): built-in adapters that work with the pipeline out of the box
+- [Best Practices](/reference/best-practices): security and production tips
+- [Client logging](/use-cases/client-logging): end-to-end browser → server flow

--- a/apps/docs/content/7.reference/5.vs-other-loggers.md
+++ b/apps/docs/content/7.reference/5.vs-other-loggers.md
@@ -271,7 +271,7 @@ Be honest with yourself. Don't switch if:
 
 ## Next Steps
 
-- [Simple Logging](/learn/simple-logging) — the `log.*` API, migration tabs, and patterns
-- [Wide Events](/learn/wide-events) — what unlocks when you accumulate context per operation
-- [Performance Benchmarks](/reference/performance) — the methodology behind the numbers above
-- [Standalone TypeScript](/integrate/frameworks/standalone) — scripts, workers, and libraries without a web framework
+- [Simple Logging](/learn/simple-logging): the `log.*` API, migration tabs, and patterns
+- [Wide Events](/learn/wide-events): what unlocks when you accumulate context per operation
+- [Performance Benchmarks](/reference/performance): the methodology behind the numbers above
+- [Standalone TypeScript](/integrate/frameworks/standalone): scripts, workers, and libraries without a web framework

--- a/apps/docs/content/7.reference/7.cost.md
+++ b/apps/docs/content/7.reference/7.cost.md
@@ -93,6 +93,6 @@ It returns both shapes, the saving, and the basis it used: the measured byte cou
 
 ## Next
 
-- [Sampling](/learn/sampling) — the two tiers, and what each one costs you in visibility
-- [Performance](/reference/performance) — the benchmarks these byte counts come from
-- [Drain adapters](/integrate/adapters/overview) — every destination, and how to change your mind later
+- [Sampling](/learn/sampling): the two tiers, and what each one costs you in visibility
+- [Performance](/reference/performance): the benchmarks these byte counts come from
+- [Drain adapters](/integrate/adapters/overview): every destination, and how to change your mind later

--- a/apps/docs/skills/build-audit-logs/SKILL.md
+++ b/apps/docs/skills/build-audit-logs/SKILL.md
@@ -108,8 +108,8 @@ Skip if:
 
 Strategies:
 
-- `'hmac'` — per-event signature; quick to verify; rotate `secret` annually and embed a key id (extend `AuditFields`).
-- `'hash-chain'` — sequence integrity; deleting a row breaks the chain forward; persist `state.{load,save}` if you run multiple processes (Redis is the typical store).
+- `'hmac'`: per-event signature; quick to verify; rotate `secret` annually and embed a key id (extend `AuditFields`).
+- `'hash-chain'`: sequence integrity; deleting a row breaks the chain forward; persist `state.{load,save}` if you run multiple processes (Redis is the typical store).
 
 ### 3. Multi-tenancy?
 
@@ -453,14 +453,14 @@ Then map each finding to the relevant step in the buildout above (e.g. P0 → St
 
 ## Glossary
 
-- **Action** — `audit.action`, the verb-on-noun identifier (`invoice.refund`).
-- **Actor** — who/what performed the action (`user`, `system`, `api`, `agent`).
-- **Target** — the resource the action was performed on.
-- **Outcome** — `success`, `failure`, or `denied`.
-- **Idempotency key** — auto-derived hash of `action + actor + target + timestamp`; safe retries across drains.
-- **Causation id** — id of the action that caused this one (admin action → system reactions).
-- **Correlation id** — shared by every action in one logical operation.
-- **Hash-chain** — each event's `prevHash` matches the previous event's `hash`, forming a verifiable sequence.
+- **Action**: `audit.action`, the verb-on-noun identifier (`invoice.refund`).
+- **Actor**: who/what performed the action (`user`, `system`, `api`, `agent`).
+- **Target**: the resource the action was performed on.
+- **Outcome**: `success`, `failure`, or `denied`.
+- **Idempotency key**: auto-derived hash of `action + actor + target + timestamp`; safe retries across drains.
+- **Causation id**: id of the action that caused this one (admin action → system reactions).
+- **Correlation id**: shared by every action in one logical operation.
+- **Hash-chain**: each event's `prevHash` matches the previous event's `hash`, forming a verifiable sequence.
 
 ## Reference
 

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -87,8 +87,8 @@ npx @evlog/cli map --no-write
 What you get:
 
 - A project score and which entry points are still dark
-- **FIX FIRST** — the three most valuable places to fix
-- **GOING FURTHER** — opportunities (catalogs, audit coverage, AI logging, auth identity) that never cost points
+- **FIX FIRST**: the three most valuable places to fix
+- **GOING FURTHER**: opportunities (catalogs, audit coverage, AI logging, auth identity) that never cost points
 - Per-file inspect: `npx @evlog/cli map <file> --no-write` shows the shape the handler could take
 - Re-run after fixes and watch the score move
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -165,8 +165,8 @@ src/
 
 ## Docs
 
-- [CLI overview](https://evlog.dev/cli/overview) — commands, global flags, exit codes
-- [`evlog map`](https://evlog.dev/cli/map) — what it scans and how to read the report
-- [Rules](https://evlog.dev/cli/rules) — every check, what satisfies it, how to fix it
-- [Scoring](https://evlog.dev/cli/scoring) — weights, grades, sensitivity
-- [CI](https://evlog.dev/cli/ci) — gate a pull request on the score
+- [CLI overview](https://evlog.dev/cli/overview): commands, global flags, exit codes
+- [`evlog map`](https://evlog.dev/cli/map): what it scans and how to read the report
+- [Rules](https://evlog.dev/cli/rules): every check, what satisfies it, how to fix it
+- [Scoring](https://evlog.dev/cli/scoring): weights, grades, sensitivity
+- [CI](https://evlog.dev/cli/ci): gate a pull request on the score

--- a/scripts/content-lint/lib/metrics.mjs
+++ b/scripts/content-lint/lib/metrics.mjs
@@ -207,7 +207,40 @@ function dashes(doc) {
     }
   }
 
+  // A bullet is prose too, and a `Next steps` list is where the dash survives
+  // longest. Table cells are left alone: a cell is a fragment, and a dash
+  // between two of its parts is layout rather than punctuation.
+  for (const list of doc.lists) {
+    for (const item of list.items) {
+      if (/[—–]/.test(item.text)) found.push({ line: item.line, text: item.text })
+    }
+  }
+
   return { count: found.length, occurrences: found.slice(0, 8) }
+}
+
+/** Above this many words of prose, a section is explaining rather than listing. */
+const ENUMERATING_PROSE = 40
+
+/**
+ * Share of sections that list rather than argue: a table or a fence, and barely
+ * any prose around it. Parallel headings over parallel entries is the twin
+ * `ai-tells.md` names for T-06, and this is what it looks like in the file.
+ *
+ * @param {import('./mdc.mjs').ParsedDoc} doc
+ * @param {{ line: number }[]} targets Headings that open a section.
+ */
+function enumerationShare(doc, targets) {
+  let enumerating = 0
+
+  for (const [index, heading] of targets.entries()) {
+    const end = targets[index + 1]?.line ?? Number.POSITIVE_INFINITY
+    const within = span => span.line > heading.line && span.line < end
+    const prose = doc.paragraphs.filter(within).reduce((total, paragraph) => total + wordCount(paragraph.text), 0)
+    if (prose < ENUMERATING_PROSE && (doc.tableRows.some(within) || doc.code.some(within))) enumerating += 1
+  }
+
+  return round(enumerating / targets.length)
 }
 
 /**
@@ -219,7 +252,7 @@ function dashes(doc) {
  */
 function headingShape(doc) {
   const targets = doc.headings.filter(heading => heading.depth === 2 || heading.depth === 3)
-  if (targets.length < 3) return { count: targets.length, dominant: null, share: 0, symbolShare: 0 }
+  if (targets.length < 3) return { count: targets.length, dominant: null, share: 0, symbolShare: 0, enumerationShare: 0 }
 
   const shapes = targets.map(heading => classifyHeading(heading.text))
   const tally = new Map()
@@ -231,6 +264,7 @@ function headingShape(doc) {
     dominant,
     share: round(top / targets.length),
     symbolShare: round(shapes.filter(shape => shape === 'symbol').length / targets.length),
+    enumerationShare: enumerationShare(doc, targets),
     // Kept so the scorer can subtract the headings this page shares with its
     // siblings and re-judge the shape of what is left.
     texts: targets.map(heading => heading.text.trim().toLowerCase()),
@@ -280,7 +314,11 @@ function bulletFrames(doc) {
       .map(item => item.text
         .toLowerCase()
         .replace(/^\[[ x]?\]\s*/, '')
+        // Emphasis around the opener is styling. `**code**` is the same symbol
+        // as `code` and carries the same absence of voice.
+        .replace(/^[*_]+/, '')
         .split(/\s+/)[0] ?? '')
+      .map(first => first.replace(/^code\b.*/, 'code'))
       // `code` is the placeholder a symbol or a code-labelled link leaves
       // behind. Several items opening on one carries no voice, so it cannot be
       // the anaphora this looks for.

--- a/scripts/content-lint/lib/metrics.test.mjs
+++ b/scripts/content-lint/lib/metrics.test.mjs
@@ -95,6 +95,15 @@ describe('dashes', () => {
   })
 })
 
+describe('bullet frames', () => {
+  it('reads a bolded symbol as the symbol it is', () => {
+    const items = ['`message`', '`evlog`', '`dd`', '`service`', '`timestamp`']
+    const source = items.map(name => `- **${name}**: what the field carries and why`).join('\n')
+
+    expect(measureSource(source).bulletFrames).toEqual([])
+  })
+})
+
 describe('epigram closers', () => {
   it('leaves a card body out of the rhythm', () => {
     const source = ['::card-group', '  :::card', '  ---', '  title: Nuxt', '  ---', '  Auto-imported helpers. Zero config.', '  :::', '::'].join('\n')

--- a/scripts/content-lint/lib/score.mjs
+++ b/scripts/content-lint/lib/score.mjs
@@ -212,7 +212,8 @@ function rhythm(metrics, profile, rates, template) {
   }
 
   const own = ownHeadings(metrics.headings, template)
-  if (own.count >= 4 && own.share >= 0.9 && own.dominant !== 'symbol' && own.dominant !== 'sequence') {
+  const enumerates = metrics.headings.enumerationShare >= 0.6
+  if (own.count >= 4 && own.share >= 0.9 && !enumerates && own.dominant !== 'symbol' && own.dominant !== 'sequence') {
     findings.push({
       id: 'T-06',
       severity: 'standard',

--- a/scripts/content-lint/lib/score.test.mjs
+++ b/scripts/content-lint/lib/score.test.mjs
@@ -160,6 +160,23 @@ describe('evaluate', () => {
     expect(result.findings.map(finding => finding.id)).not.toContain('U-15')
   })
 
+  it('spares a page whose sections list rather than argue', () => {
+    const sections = ['Exit codes', 'The JSON contract', 'The map file', 'Monorepos', 'Options']
+    const source = sections.map(title => `## ${title}\n\n| Key | Meaning |\n|---|---|\n| a | b |`).join('\n\n')
+    const result = evaluate(page('apps/docs/content/3.cli/a.md', source), quiet)
+
+    expect(result.findings.map(finding => finding.id)).not.toContain('T-06')
+  })
+
+  it('still flags one mould over sections that argue', () => {
+    const sections = ['Exit codes', 'The JSON contract', 'The map file', 'Monorepos', 'Options']
+    const prose = 'The gate reads the map file and compares it against the baseline the previous run wrote, so a rule that moved is never counted as a regression by mistake, and the exit code stays the contract.'
+    const source = sections.map(title => `## ${title}\n\n${prose}`).join('\n\n')
+    const result = evaluate(page('apps/docs/content/3.cli/a.md', source), quiet)
+
+    expect(result.findings.map(finding => finding.id)).toContain('T-06')
+  })
+
   it('spares the sentence that is describing the other tool', () => {
     const result = evaluate(page('apps/docs/content/7.reference/a.md', 'pino writes through a transport, which runs in a worker thread.'), quiet)
 


### PR DESCRIPTION
Stacked on #605.

The CLI pages headed their sections with the artifact rather than the question: `The gate`, `Exit codes`, `The JSON contract`. Inbound anchors follow the moved headings.

Three scanner corrections, all recorded in `corrections.md`:

- `T-06` now measures how much of a page lists rather than argues. A section holding a table or a fence and almost no prose is an entry, and parallel headings over parallel entries is the twin `ai-tells.md` already named. That cleared 20 pages the rule had no business flagging.
- `U-14` now reads list items. It never did, so 273 dashes sat in bullets, 159 of them a bold term glossed after a dash where the corpus elsewhere writes a colon. Those 159 are converted here; the 117 that put a full clause after the dash need a reader and come next.
- A bullet opening on `**\`field\`**` is the same symbol as `\`field\`` and no longer counts as a shared opener for `T-07`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized list, link, and guidance formatting across documentation and authoring resources.
  * Clarified several CLI, scoring, CI, and exit-code headings.
  * Updated documentation links and navigation for improved consistency.
  * Added guidance for distinguishing glossary-style dashes, list items, and table content.

* **Bug Fixes**
  * Improved content-quality checks to reduce false positives for structured pages, enumerated headings, and formatted bullet items.

* **Tests**
  * Added coverage for heading and bullet-format detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->