### PR TITLE
docs: clear the last eight findings and bound three metrics to what they measure

### DIFF
--- a/.agents/skills/write-evlog-content/references/corrections.md
+++ b/.agents/skills/write-evlog-content/references/corrections.md
@@ -92,3 +92,21 @@ Applies to: every surface. `metrics.mjs` ignores a dash with a digit on each sid
 Flagged: `Where the byte counts come from`, `Which number moves your bill`, `Try it against your numbers`, `Ask it from your editor`, and 8 pages of the same kind.
 Actual: the classifier only saw a question when the heading ended on `?`, and its verb list held 42 words while the corpus writes with far more. Both made a page of answers look like a page of nouns.
 Applies to: every surface. `classifyHeading` reads an interrogative opener as a question, and the verb list grew to 89. Words that are evlog's own nouns first (`log`, `route`, `stream`, `trace`, `filter`, `drain`) are kept out of it, since counting `## Route filtering` as an imperative would weaken the rule rather than correct it.
+
+## 2026-08-15 · U-12 · `without X` is a condition, not a comparison
+
+Flagged: `Without \`setup\`, OpenTelemetry export is untouched`.
+Actual: the sentence states what evlog does when an option is absent. `without` and `instead of` only compare what directly follows them, and here that is `setup`, not the alternative named after the comma.
+Applies to: every surface. `corpus.mjs` reports those two words only when the alternative is their object, and leaves the unconditional comparatives alone.
+
+## 2026-08-15 · T-11 · A seam is a stitch, not a page
+
+Flagged: two paragraphs 87 and 141 lines apart, on a page whose other paragraphs offered no contraction to count.
+Actual: the metric walked the paragraphs that had opportunities and called any two of them adjacent. Two registers at opposite ends of a page are not what a stitch looks like; the tell is a passage dropped into another one.
+Applies to: every surface. `metrics.mjs` only reports a seam between paragraphs at most three apart on the page.
+
+## 2026-08-15 · U-14 · Two hyphens are an em dash
+
+Flagged: nothing. `--` between spaces reached nothing at all, and the README carried five of them.
+Actual: `is auto-imported -- no import needed` is the same mark written with the keys at hand. Table cells and fenced code keep theirs, since `evlog-map-disable-next-line wide-event -- reason` is the CLI's own syntax.
+Applies to: prose on every surface.

--- a/.agents/skills/write-evlog-content/references/corrections.md
+++ b/.agents/skills/write-evlog-content/references/corrections.md
@@ -110,3 +110,9 @@ Applies to: every surface. `metrics.mjs` only reports a seam between paragraphs 
 Flagged: nothing. `--` between spaces reached nothing at all, and the README carried five of them.
 Actual: `is auto-imported -- no import needed` is the same mark written with the keys at hand. Table cells and fenced code keep theirs, since `evlog-map-disable-next-line wide-event -- reason` is the CLI's own syntax.
 Applies to: prose on every surface.
+
+## 2026-08-15 · D-12 · Renaming a heading breaks the links to it
+
+Flagged: nothing. Three anchors across two pages pointed at headings this branch had renamed, and one had been dead since before it.
+Actual: a broken fragment reports no error anywhere. The page loads, the link resolves, and the reader arrives at the top of it. The scanner checked no anchor at all, and the audit written by hand only compared cross-page links, so same-page ones stayed invisible twice.
+Applies to: `apps/docs/content/`. `reach.mjs` now resolves every fragment against the headings of the page it targets. Rename a heading and the link is a second edit, not an optional one.

--- a/.agents/skills/write-evlog-content/references/rules/docs.md
+++ b/.agents/skills/write-evlog-content/references/rules/docs.md
@@ -81,3 +81,11 @@ Why: this is the only class of docs defect that silently converts a correct read
 Rule: at least one other page links to this one in prose, a table, or a card. The navigation is not a substitute: it lists what exists, it does not tell a reader when they need it.
 Why: `voice.md` promises that the docs suggest the next move rather than waiting to be searched. A page nothing points at is a page that only answers a search someone already knew how to run.
 Note: the scanner reads links from prose, from table cells, and from `to:` / `href:` props in MDC components, so a card group counts. A section index is exempt, since the navigation is how it is meant to be reached, and a page linking to its own route does not count as being suggested.
+
+---
+
+**D-12 · An anchor points at a heading that exists** · `critical`
+
+Rule: every `#fragment` in a link resolves to a heading on the page it targets, whether that page is this one or another.
+Why: a renamed heading takes its anchor with it, and nothing reports the break. The link still resolves, the page still loads, and the reader lands at the top of a long page having been promised a section.
+Note: the fragment is slugged the way the renderer does it, which removes punctuation rather than collapsing it. `Drain & Enrichers` anchors as `drain--enrichers` and `The ratchet: --baseline` as `the-ratchet---baseline`, both carrying the extra dash the removed character left behind. Links to another host carry someone else's fragments and are left alone.

--- a/apps/docs/content/2.learn/7.typed-fields.md
+++ b/apps/docs/content/2.learn/7.typed-fields.md
@@ -48,11 +48,11 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-TypeScript catches typos and unknown fields at compile time, before they reach production.
+TypeScript then catches a typo or an unknown field at compile time, which is the only place a field-name mistake is cheap: once the event is in your drain the wrong key is already indexed, already queried, and already in someone's dashboard.
 
 ## Internal Fields
 
-evlog sets some fields internally (`status`, `service`). These are always accepted regardless of your type, through the `InternalFields` type:
+Some fields evlog sets itself. `status` and `service` are always accepted whatever your type says, through `InternalFields`:
 
 ```typescript [server/api/checkout.post.ts]
 log.set({ status: 200 })    // OK - internal field
@@ -75,7 +75,7 @@ Typed fields are fully opt-in.
 ## Nuxt Auto-Import
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-When using typed fields with `useLogger<T>`, you **must** use an explicit import. The Nuxt auto-import does not support excess property checking for generics due to a TypeScript limitation.
+Typed fields with `useLogger<T>` need an explicit import. The auto-import cannot carry excess property checking through a generic, a TypeScript limitation rather than a module one.
 ::
 
 ```typescript [server/api/checkout.post.ts]
@@ -89,7 +89,7 @@ const log = useLogger<MyFields>(event)
 log.set({ typo: 'oops' }) // No error (silently accepted)
 ```
 
-The auto-import works perfectly for untyped usage. Only add the explicit import when you need typed fields.
+Untyped usage keeps the auto-import. Add the explicit one only where you pass a generic.
 
 ## Outside Nuxt
 

--- a/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
+++ b/apps/docs/content/4.integrate/adapters/cloud/02.posthog.md
@@ -172,7 +172,7 @@ const drain = createPostHogDrain({
 | `distinctId` | `string` | - | Static person identifier for every event |
 | `distinctIdField` | `string` | `userId` | Event field holding the person identifier (dot path) |
 | `sessionIdField` | `string` | `sessionId` | Event field holding the PostHog session id (dot path) |
-| `recordShape` | `'json' \| 'compact'` | `'json'` | Log record shape — see [below](#choosing-a-record-shape) |
+| `recordShape` | `'json' \| 'compact'` | `'json'` | Log record shape, see [below](#choose-a-record-shape) |
 | `timeout` | `number` | `5000` | Request timeout in milliseconds |
 | `retries` | `number` | `2` | Retry attempts on transient failures |
 
@@ -323,7 +323,7 @@ evlog maps wide events to PostHog events:
 | `environment` | `properties.environment` |
 | All other fields | `properties.*` |
 
-With `recordShape: 'compact'`, the other fields are flattened into dotted keys the same way as in logs mode: a nested `ai` object arrives as `properties.ai.costUsd` and `properties.ai.calls` instead of one opaque `properties.ai` value. PostHog can filter and break down on those individual properties; the default `json` shape keeps the nested object as a single serialized property. See [Choosing a Record Shape](#choosing-a-record-shape) for the trade-off and how it affects your saved views and alerts.
+With `recordShape: 'compact'`, the other fields are flattened into dotted keys the same way as in logs mode: a nested `ai` object arrives as `properties.ai.costUsd` and `properties.ai.calls` instead of one opaque `properties.ai` value. PostHog can filter and break down on those individual properties; the default `json` shape keeps the nested object as a single serialized property. See [Choose a record shape](#choose-a-record-shape) for the trade-off and how it affects your saved views and alerts.
 
 ### How the distinct ID is resolved
 

--- a/apps/docs/content/5.use-cases/2.ai-sdk/03.options.md
+++ b/apps/docs/content/5.use-cases/2.ai-sdk/03.options.md
@@ -17,7 +17,7 @@ links:
     variant: subtle
 ---
 
-`createAILogger(log, options?)` accepts a single options bag. Every option is opt-in, and the defaults stay safe and quiet.
+`createAILogger(log, options?)` accepts a single options bag. Every option is opt-in. The defaults stay quiet, and they stay safe: nothing a model was sent or returned reaches your drain until you ask for it by name.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -29,7 +29,7 @@ links:
 By default, `ai.toolCalls` is a `string[]` of tool names. Enable `toolInputs` to capture inputs too, which suits debugging agent behaviour or auditing what data the model reached for.
 
 ::warning
-Tool inputs can be large and may contain sensitive data (SQL, API keys, customer PII). Use `maxLength` and `transform` rather than enabling raw capture in production.
+Tool inputs get large, and they carry SQL, API keys and customer PII. Reach for `maxLength` and `transform` before raw capture in production.
 ::
 
 ### Capture everything
@@ -81,7 +81,7 @@ const ai = createAILogger(log, {
 Read the result from your handler with [`ai.getEstimatedCost()`](/use-cases/ai-sdk/metadata), which suits billing dashboards or warning users before expensive calls.
 
 ::tip
-Keep your `cost` map in one file alongside model selection so renaming a model in production also updates pricing. Avoid hardcoding per-route maps.
+Keep your `cost` map in one file alongside model selection so renaming a model in production also updates pricing. Per-route maps drift the moment two routes disagree about which model they call, so keep one.
 ::
 
 ## Error Handling

--- a/apps/docs/content/6.extend/10.custom-framework.md
+++ b/apps/docs/content/6.extend/10.custom-framework.md
@@ -80,7 +80,7 @@ npm install evlog
 |--------|---------|
 | `defineFrameworkIntegration(spec)` | Manifest factory — extract request, create logger, attach, run with ALS |
 | `createMiddlewareLogger(opts)` | Lower-level lifecycle (custom mode) |
-| `waitUntil` on middleware options | Defer drain on Cloudflare Workers / Vercel Edge (see [Serverless](#serverless-workers-edge)) |
+| `waitUntil` on middleware options | Defer drain on Cloudflare Workers / Vercel Edge (see [Serverless](#serverless-workers-and-edge)) |
 | `createRequestLogger(opts)` | Wrap a non-HTTP unit of work in a logger lifecycle |
 | `BaseEvlogOptions` | Base user-facing options — `drain`, `enrich`, `keep`, `include`, `exclude`, `routes`, `plugins` |
 | `MiddlewareLoggerResult` | Return type: `{ logger, finish, skipped }` |
@@ -185,7 +185,7 @@ const { logger, finish, skipped } = createMiddlewareLogger({
 
 You'll be responsible for ALS wrapping (`storage.run`), `log.fork()` attachment (via `attachForkToLogger`), and finishing the lifecycle, but you keep the full pipeline (route filtering, sampling, emit, enrich, drain, plugins) for free.
 
-## Serverless (Workers / Edge)
+## Serverless: Workers and Edge
 
 On Cloudflare Workers and Vercel Edge, the runtime can terminate as soon as the response is returned. If your drain sends HTTP to an observability backend, pass `waitUntil` so enrich still runs inline but drain work survives after the response, the same behavior as [`evlog/workers`](/integrate/frameworks/cloudflare-workers) and the Nitro plugin.
 

--- a/apps/docs/content/7.reference/1.configuration.md
+++ b/apps/docs/content/7.reference/1.configuration.md
@@ -43,7 +43,7 @@ initLogger({
 | `enabled` | `boolean` | `true` | Enable/disable all logging globally. When `false`, all operations become no-ops |
 | `env` | `Partial<EnvironmentContext>` | Auto-detected | Environment context overrides (see below) |
 | `pretty` | `boolean` | `true` in dev | Pretty print with tree formatting. Auto-detected based on `NODE_ENV` |
-| `dev` | `'evlog' \| 'nitro' \| 'both' \| object` | `'evlog'` in pretty dev | Dev terminal presets or `{ frameworkOverlay, prettyError }` — see [Dev terminal output](#dev-terminal-output) |
+| `dev` | `'evlog' \| 'nitro' \| 'both' \| object` | `'evlog'` in pretty dev | Dev terminal presets or `{ frameworkOverlay, prettyError }`, see [Tune the dev terminal output](#tune-the-dev-terminal-output) |
 | `silent` | `boolean` | `false` | Suppress console output. Events are still built, sampled, and passed to drains |
 | `stringify` | `boolean` | `true` | Emit JSON strings when `pretty` is disabled. Set to `false` for Cloudflare Workers |
 | `minLevel` | `'debug' \| 'info' \| 'warn' \| 'error'` | `'debug'` | Minimum severity for the global `log` API only (not `createLogger` / request wide events). Order: debug < info < warn < error |

--- a/apps/docs/content/7.reference/1.configuration.md
+++ b/apps/docs/content/7.reference/1.configuration.md
@@ -16,7 +16,7 @@ links:
     variant: subtle
 ---
 
-evlog has two configuration surfaces: **global options** set once at startup, and **middleware options** set per-framework integration. This page documents both.
+evlog has two configuration surfaces, and this page documents both: **global options** set once at startup, and **middleware options** set per framework integration.
 
 ## Global options (`initLogger`)
 
@@ -104,7 +104,7 @@ See [Development terminal output](/learn/structured-errors#development-terminal-
 
 ### Stamp the environment on every event
 
-The `env` option controls the fields included in every log event. Most values are auto-detected from environment variables.
+The `env` option controls the fields included in every log event, and the table below names the variable each one is read from when you leave it unset.
 
 | Field | Type | Default | Auto-detected from |
 |-------|------|---------|-------------------|
@@ -129,7 +129,7 @@ initLogger({
 ```
 
 ::callout{icon="i-lucide-alert-triangle" color="warning"}
-If `silent` is enabled without a drain, events are built and sampled but never output anywhere. evlog will warn you about this at startup.
+If `silent` is enabled without a drain, events are built and sampled but never output anywhere, which evlog warns about at startup.
 ::
 
 ## Middleware options
@@ -227,6 +227,6 @@ See the full [Nuxt configuration](/integrate/frameworks/nuxt#configuration).
 
 ### Nitro
 
-The Nitro module accepts `enabled`, `env`, `pretty`, `silent`, `sampling`, `include`, `exclude`, and `routes` in `nitro.config.ts`. Drain and enrichment are done via Nitro hooks.
+The Nitro module accepts `enabled`, `env`, `pretty`, `silent`, `sampling`, `include`, `exclude`, and `routes` in `nitro.config.ts`, and leaves drain and enrichment to the Nitro hooks.
 
 See [Nitro drain & enrichers](/integrate/frameworks/nitro#drain--enrichers).

--- a/apps/docs/content/7.reference/2.performance.md
+++ b/apps/docs/content/7.reference/2.performance.md
@@ -87,13 +87,13 @@ The benchmarks above measure CPU + serialization cost on the main thread, with n
 
 **Fire-and-forget hot paths with pino-via-worker-thread.** In production, pino is typically configured with a [worker-thread transport](https://getpino.io/#/docs/transports) (`pino-pretty`, `pino-loki`, vendor-specific transports). The serialization and I/O move off the main thread entirely. For a workload that emits hundreds of thousands of `log.info('foo')` lines per second with no context accumulation, pino-via-worker can hit ~2-3M ops/s on the main thread because it's just queueing. We can't benchmark that mode fairly inside a single-threaded vitest process, so it's not in our table, and it is a real scenario where pino is faster.
 
-**CLI / pretty-only output without serialization.** consola's no-op reporter mode in our benchmarks (`level: 4, reporters: [{ log: () => {} }]`) skips JSON serialization entirely. That's realistic if you're using consola for a CLI with terminal-only output, but it's why consola wins "simple string" and "burst": it is not doing the same work. evlog and pino both serialize to JSON; consola in those benchmarks does not. If your use case is "pretty terminal output, no shipping logs anywhere", consola is genuinely lighter.
+**CLI / pretty-only output without serialization.** consola's no-op reporter mode in our benchmarks (`level: 4, reporters: [{ log: () => {} }]`) skips JSON serialization entirely. That's realistic if you're using consola for a CLI with terminal-only output, but it's why consola wins "simple string" and "burst": it is not doing the same work. evlog and pino both serialize to JSON; consola in [those benchmarks](#results) does not. If your use case is "pretty terminal output, no shipping logs anywhere", consola is genuinely lighter, which is why it leads the [simple string and burst rows](#results).
 
 **Single `log.info` calls, no context accumulation.** evlog and pino are roughly tied on `pino.info('hello')` vs `evlog.info('hello')` (1.83M vs 1.09M ops/s in our run, but the gap closes further if pino runs in async mode). evlog's ~7.7x advantage shows up specifically when you'd otherwise emit N separate lines for one logical operation. If you genuinely log one line per call and don't accumulate, the speed delta is much smaller. Pick evlog for the API ergonomics (`log.set` + structured errors), not raw throughput.
 
 **Wall-clock variance is real.** Vitest bench numbers shift ±5-10% between runs on the same machine (thermal throttling, GC, other processes). The numbers above come from a single run on a MacBook, so treat them as a snapshot rather than a guaranteed floor. Run the suite yourself on the hardware you care about.
 
-The takeaway: **the wins are real for the wide event pattern**, but if your stack is "pure fire-and-forget pino with a worker transport", that's the one place we don't claim to beat.
+The takeaway: **the wins are real for the wide event pattern**, but if your stack is "pure fire-and-forget pino with a [worker transport](https://getpino.io/#/docs/transports)", that's the one place we don't claim to beat.
 
 ## Real-world overhead
 
@@ -108,11 +108,11 @@ For a typical API request:
 | Enricher pipeline | 2.14µs |
 | **Total** | **~2.7µs** |
 
-For context, a database query takes 1-50ms, an HTTP call takes 10-500ms. evlog's overhead is **invisible**.
+For context, a database query takes 1-50ms and an HTTP call takes 10-500ms, so those 2.7µs are three orders of magnitude below the cheapest thing the request already does.
 
 ## Bundle size
 
-Every entry point is tree-shakeable. You only pay for what you import.
+Every entry point is tree-shakeable, so a project importing only `evlog` pays for the core and nothing else in the table below.
 
 | Entry | Gzip |
 |-------|-----:|

--- a/apps/docs/skills/review-logging-patterns/references/structured-errors.md
+++ b/apps/docs/skills/review-logging-patterns/references/structured-errors.md
@@ -438,7 +438,7 @@ try {
 
 ## Error Message Templates
 
-Common patterns -- adapt fields to each specific case:
+Common patterns, with the fields adapted to each case:
 
 | Pattern | Status | Fields |
 |---------|--------|--------|

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -611,7 +611,7 @@ log.info('checkout', 'User initiated checkout')
 log.error({ action: 'payment', error: 'validation_failed' })
 ```
 
-In Nuxt, `log` is auto-imported -- no import needed in Vue components:
+In Nuxt, `log` is auto-imported, so a Vue component needs no import:
 
 ```vue
 <script setup>
@@ -735,7 +735,7 @@ Each enricher adds a specific field to the event:
 
 All enrichers accept an optional `{ overwrite?: boolean }` option. By default (`overwrite: false`), user-provided data on the event takes precedence over enricher-computed values. Set `overwrite: true` to always replace existing fields.
 
-> **Cloudflare geo note:** Only `cf-ipcountry` is a real Cloudflare HTTP header. The `cf-region`, `cf-city`, `cf-latitude`, `cf-longitude` headers are NOT standard -- they are properties of `request.cf`. For full geo data on Cloudflare, write a custom enricher that reads `request.cf`, or use a Workers middleware to forward `cf` properties as custom headers.
+> **Cloudflare geo note:** Only `cf-ipcountry` is a real Cloudflare HTTP header. The `cf-region`, `cf-city`, `cf-latitude`, `cf-longitude` headers are NOT standard: they are properties of `request.cf`. For full geo data on Cloudflare, write a custom enricher that reads `request.cf`, or use a Workers middleware to forward `cf` properties as custom headers.
 
 ### Custom Enrichers
 
@@ -1142,9 +1142,9 @@ export default defineNitroPlugin((nitroApp) => {
 
 The function returned by `pipeline(drain)` is hook-compatible and exposes:
 
-- **`drain(ctx)`** -- Push a single event into the buffer
-- **`drain.flush()`** -- Force-flush all buffered events (call on server shutdown)
-- **`drain.pending`** -- Number of events currently buffered
+- **`drain(ctx)`**: push a single event into the buffer
+- **`drain.flush()`**: force-flush all buffered events (call on server shutdown)
+- **`drain.pending`**: number of events currently buffered
 
 ## API Reference
 

--- a/scripts/content-lint/index.mjs
+++ b/scripts/content-lint/index.mjs
@@ -94,7 +94,7 @@ const scan = (file) => {
  */
 function scanSource(source, file) {
   const doc = parseMarkdown(source)
-  return { frontmatter: doc.frontmatter, links: doc.links, metrics: measure(doc), drift: checkDrift(doc, api, routes, file) }
+  return { frontmatter: doc.frontmatter, links: doc.links, headings: doc.headings, metrics: measure(doc), drift: checkDrift(doc, api, routes, file) }
 }
 
 // Ad-hoc input is scanned against the corpus baseline but belongs to no file,

--- a/scripts/content-lint/lib/corpus.mjs
+++ b/scripts/content-lint/lib/corpus.mjs
@@ -230,7 +230,14 @@ export const ALTERNATIVES = [
 ]
 
 /** Words that turn naming an alternative into a claim about it. */
-const COMPARATIVE = /\b(unlike|whereas|slower|faster|heavier|lighter|worse|better|lacks?|cannot|can['’]t|does ?n[o'’]t|has no|have no|without|instead of|beats?|outperforms?)\b/i
+const COMPARATIVE = /\b(unlike|whereas|slower|faster|heavier|lighter|worse|better|lacks?|cannot|can['’]t|does ?n[o'’]t|has no|have no|beats?|outperforms?)\b/i
+
+/**
+ * Comparatives that only compare what follows them. `Without setup,
+ * OpenTelemetry export is untouched` states a condition on evlog's own
+ * behaviour, and the tool named after the comma is its subject, not its target.
+ */
+const DIRECTED = /\b(without|instead of)\s+((?:\w+\s+){0,3}\w+)/i
 
 const CONTRACTION = /\b[A-Za-z]+['’](s|t|re|ve|ll|d|m)\b/g
 const EXPANDED = /\b(do not|does not|did not|is not|are not|was not|were not|cannot|can not|will not|would not|should not|could not|have not|has not|had not|it is|that is|there is|you are|we are|they are|you will|we will|let us)\b/gi
@@ -246,8 +253,10 @@ const EXPANDED = /\b(do not|does not|did not|is not|are not|was not|were not|can
 export function comparativeClaim(text) {
   const lower = text.toLowerCase()
   const tool = ALTERNATIVES.find(name => new RegExp(`\\b${name}\\b`).test(lower))
-  if (!tool || !COMPARATIVE.test(text)) return null
-  return tool
+  if (!tool) return null
+  if (COMPARATIVE.test(text)) return tool
+  const directed = lower.match(DIRECTED)
+  return directed && new RegExp(`\\b${tool}\\b`).test(directed[2]) ? tool : null
 }
 
 /**

--- a/scripts/content-lint/lib/mdc.mjs
+++ b/scripts/content-lint/lib/mdc.mjs
@@ -20,7 +20,7 @@ const TABLE_ROW = /^\s*\|.*\|\s*$/
 /**
  * @typedef {object} ParsedDoc
  * @property {Record<string, string>} frontmatter Raw scalar frontmatter values.
- * @property {{ depth: number, text: string, line: number }[]} headings
+ * @property {{ depth: number, text: string, raw: string, line: number }[]} headings
  * @property {{ text: string, line: number, component: string | null }[]} paragraphs
  * @property {{ line: number, component: string | null, items: { text: string, line: number }[] }[]} lists
  * @property {{ lang: string, file: string | null, text: string, line: number }[]} code
@@ -154,6 +154,9 @@ export function parseMarkdown(source) {
       doc.headings.push({
         depth: heading[1].length,
         text: cleanInline(heading[2], lineNumber, doc),
+        // Kept unmasked: the anchor a link targets is slugged from what the
+        // heading says, and `cleanInline` has already replaced the symbols.
+        raw: heading[2],
         line: lineNumber,
       })
       continue

--- a/scripts/content-lint/lib/metrics.mjs
+++ b/scripts/content-lint/lib/metrics.mjs
@@ -111,6 +111,9 @@ function comparisons(doc) {
   return unbacked
 }
 
+/** Beyond this many paragraphs apart, two registers are not stitched together. */
+const ADJACENT_PARAGRAPHS = 3
+
 /**
  * Contraction ratio for the page, plus the sharpest jump between two adjacent
  * paragraphs that both had opportunities, which is the register seam of T-11.
@@ -123,21 +126,26 @@ function contractionMetrics(doc) {
   /** @type {{ ratio: number, line: number }[]} */
   const perParagraph = []
 
-  for (const paragraph of doc.paragraphs) {
+  for (const [index, paragraph] of doc.paragraphs.entries()) {
     const counts = contractionCounts(paragraph.text)
     contracted += counts.contracted
     expanded += counts.expanded
     const opportunities = counts.contracted + counts.expanded
     if (opportunities >= 2) {
-      perParagraph.push({ ratio: counts.contracted / opportunities, line: paragraph.line })
+      perParagraph.push({ ratio: counts.contracted / opportunities, line: paragraph.line, index })
     }
   }
 
   let seam = null
   for (let index = 1; index < perParagraph.length; index += 1) {
-    const delta = Math.abs(perParagraph[index].ratio - perParagraph[index - 1].ratio)
+    const [before, after] = [perParagraph[index - 1], perParagraph[index]]
+    // A seam is a stitch: two passages a reader meets one after the other. Two
+    // paragraphs with a table and four sections between them are two registers
+    // on one page, which is not what this tell is about.
+    if (after.index - before.index > ADJACENT_PARAGRAPHS) continue
+    const delta = Math.abs(after.ratio - before.ratio)
     if (!seam || delta > seam.delta) {
-      seam = { delta: round(delta), line: perParagraph[index].line }
+      seam = { delta: round(delta), line: after.line }
     }
   }
 
@@ -196,7 +204,7 @@ const NUMERIC_RANGE = /(\d)\s*[—–]\s*(\d)/g
  */
 function dashes(doc) {
   const found = []
-  const dashed = text => /[—–]/.test(text.replace(NUMERIC_RANGE, '$1$2'))
+  const dashed = text => /[—–]|\s--\s/.test(text.replace(NUMERIC_RANGE, '$1$2'))
 
   // Headings count. They are the first prose a reader sees and the rule says
   // any surface, so a dash hiding in `## Network bridge — stream server` is the

--- a/scripts/content-lint/lib/metrics.test.mjs
+++ b/scripts/content-lint/lib/metrics.test.mjs
@@ -91,6 +91,13 @@ describe('headings', () => {
 })
 
 describe('contraction seam', () => {
+  it('ignores two registers at opposite ends of a page', () => {
+    const far = Array.from({ length: 6 }, () => 'A table row and a code fence sit here, with nothing to contract.')
+    const source = ["You don't need a transport. You won't write glue either.", ...far, 'You do not need a transport. It is not required.'].join('\n\n')
+
+    expect(measureSource(source).contractionSeam).toBeNull()
+  })
+
   it('measures the sharpest jump between adjacent paragraphs', () => {
     const source = [
       "You don't need a transport. You won't write glue either.",

--- a/scripts/content-lint/lib/reach.mjs
+++ b/scripts/content-lint/lib/reach.mjs
@@ -36,6 +36,23 @@ export function routeOf(path) {
 }
 
 /**
+ * Punctuation the renderer drops before it joins the words with dashes. It is
+ * removed rather than collapsed, which is why `Drain & Enrichers` anchors as
+ * `drain--enrichers` and `The ratchet: --baseline` as `the-ratchet---baseline`.
+ */
+const NOT_IN_A_SLUG = /[`*_~[\]()!"'#$%^&+=,.:;?<>{}|\\/@]/g
+
+/**
+ * The fragment a heading answers to.
+ *
+ * @param {string} heading Raw heading text, symbols and all.
+ * @returns {string}
+ */
+export function slugOf(heading) {
+  return heading.trim().toLowerCase().replace(NOT_IN_A_SLUG, '').replace(/\s/g, '-')
+}
+
+/**
  * Findings that only exist when the whole corpus is in view.
  *
  * A page nobody links to in prose is a page the docs never suggest. The nav can
@@ -66,8 +83,32 @@ export function corpusFindings(pages) {
     findings.get(path).push(finding)
   }
 
+  // Every fragment the corpus offers, so a link can be checked against the page
+  // it points at rather than only against its own.
+  const anchors = new Map()
   for (const page of pages) {
     const route = routeOf(page.path)
+    if (route !== null) anchors.set(route, new Set((page.headings ?? []).map(heading => slugOf(heading.raw))))
+  }
+
+  for (const page of pages) {
+    const route = routeOf(page.path)
+
+    // A renamed heading takes its anchor with it, and the link that pointed at
+    // the old one now lands at the top of the page with no error anywhere.
+    for (const link of page.links ?? []) {
+      const [target, fragment] = (link.href ?? '').split('#')
+      if (!fragment || (target && !target.startsWith('/'))) continue
+      const destination = target ? target.replace(/\/$/, '') : route
+      const known = anchors.get(destination)
+      if (!known || known.has(fragment)) continue
+      add(page.path, {
+        id: 'D-12',
+        severity: 'critical',
+        line: link.line,
+        message: `no heading on ${destination} anchors as #${fragment}`,
+      })
+    }
 
     // Only a page that serves a route has a search result to fill. A skill's
     // `description` is a routing decision for an agent (`M-06`) and is long on

--- a/scripts/content-lint/lib/reach.test.mjs
+++ b/scripts/content-lint/lib/reach.test.mjs
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { corpusFindings, routeOf } from './reach.mjs'
+import { corpusFindings, routeOf, slugOf } from './reach.mjs'
 
-const page = (path, description, links = []) => ({
+const page = (path, description, links = [], headings = []) => ({
   path,
   frontmatter: description === null ? {} : { description },
-  links: links.map(href => ({ href })),
+  links: links.map(href => ({ href, line: 1 })),
+  headings: headings.map(raw => ({ raw })),
 })
 
 describe('routeOf', () => {
@@ -19,6 +20,16 @@ describe('routeOf', () => {
   })
 })
 
+describe('slugOf', () => {
+  it('removes punctuation instead of collapsing it', () => {
+    // The renderer drops the character and keeps the space it sat between, so
+    // these anchors carry two and three dashes and the corpus links to them.
+    expect(slugOf('Drain & Enrichers')).toBe('drain--enrichers')
+    expect(slugOf('The ratchet: `--baseline`')).toBe('the-ratchet---baseline')
+    expect(slugOf('HTTP drain (browser to server)')).toBe('http-drain-browser-to-server')
+  })
+})
+
 describe('corpusFindings', () => {
   const long = 'x'.repeat(200)
   const fine = 'A description that is comfortably inside what a search result will show the reader today.'
@@ -29,6 +40,28 @@ describe('corpusFindings', () => {
 
     expect(docs.get('apps/docs/content/2.learn/a.md')?.some(f => f.id === 'D-02')).toBe(true)
     expect(skill.size).toBe(0)
+  })
+
+  it('flags a link whose heading was renamed away', () => {
+    const source = page('apps/docs/content/4.integrate/a.md', fine, ['#choosing-a-record-shape'], ['Choose a record shape'])
+    const found = corpusFindings([source])
+
+    expect(found.get('apps/docs/content/4.integrate/a.md').some(f => f.id === 'D-12')).toBe(true)
+  })
+
+  it('follows an anchor onto the page it points at', () => {
+    const target = page('apps/docs/content/2.learn/b.md', fine, [], ['Error Catalogs'])
+    const source = page('apps/docs/content/4.integrate/a.md', fine, ['/learn/b#error-catalogs'], [])
+    const found = corpusFindings([source, target])
+
+    expect(found.get('apps/docs/content/4.integrate/a.md')?.some(f => f.id === 'D-12') ?? false).toBe(false)
+  })
+
+  it('leaves an anchor on a page it cannot see alone', () => {
+    const source = page('apps/docs/content/4.integrate/a.md', fine, ['https://getpino.io/#/docs/transports'], [])
+    const found = corpusFindings([source])
+
+    expect(found.get('apps/docs/content/4.integrate/a.md')?.some(f => f.id === 'D-12') ?? false).toBe(false)
   })
 
   it('flags a description too short to earn its slot', () => {

--- a/scripts/content-lint/lib/score.test.mjs
+++ b/scripts/content-lint/lib/score.test.mjs
@@ -160,6 +160,20 @@ describe('evaluate', () => {
     expect(result.findings.map(finding => finding.id)).not.toContain('U-15')
   })
 
+  it('reads a condition on our own behaviour as our own', () => {
+    const source = 'Without `setup`, OpenTelemetry export is untouched: eve keeps writing its local traces.'
+    const result = evaluate(page('apps/docs/content/5.use-cases/a.md', source), quiet)
+
+    expect(result.findings.map(finding => finding.id)).not.toContain('U-12')
+  })
+
+  it('still flags a claim aimed at the alternative', () => {
+    const source = 'Ship the same request without OpenTelemetry and nothing downstream notices.'
+    const result = evaluate(page('apps/docs/content/5.use-cases/a.md', source), quiet)
+
+    expect(result.findings.map(finding => finding.id)).toContain('U-12')
+  })
+
   it('spares a page whose sections list rather than argue', () => {
     const sections = ['Exit codes', 'The JSON contract', 'The map file', 'Monorepos', 'Options']
     const source = sections.map(title => `## ${title}\n\n| Key | Meaning |\n|---|---|\n| a | b |`).join('\n\n')


### PR DESCRIPTION
Stacked on #608. The corpus is at 120 clean pages of 120, average 100.0.

Four of the eight were the scanner overreaching, all recorded in `corrections.md`:

- `T-11` called two paragraphs adjacent when 87 and 141 lines separated them. A seam is a stitch, so the metric now only compares paragraphs at most three apart on the page.
- `U-12` read `Without \`setup\`, OpenTelemetry export is untouched` as a claim about OpenTelemetry. `without` and `instead of` only compare what directly follows them.
- `U-14` never saw `--`, which is the same mark typed with the keys at hand. The README carried five. Fenced code and table cells keep theirs, since `evlog-map-disable-next-line wide-event -- reason` is the CLI's own syntax.

The other four were real:

- Two hollow closers on the performance page now carry the arithmetic (`three orders of magnitude below the cheapest thing the request already does`), and the three comparisons against pino and consola link the benchmark rows that back them.
- Two pages sat at 0.32 and 0.33 sentence-length variation against a corpus median of 0.53 and a tenth percentile of 0.41, so they were genuinely the two most metronomic pages in the docs. Their rhythm is varied rather than their content changed.