### PR TITLE
feat(evi): put each tool's outcome on the turn wide event

### DIFF
--- a/apps/evi/AGENTS.md
+++ b/apps/evi/AGENTS.md
@@ -19,10 +19,10 @@ with a colocated test).
 ## What reaches PostHog
 
 Metadata only: tokens, cost, latency, model, tool names, and per-tool outcome
-fields — counts, reason codes, and identifiers Evi authored (the namespaces are
+fields (counts, reason codes, and identifiers Evi authored; the namespaces are
 listed in `docs/observability.md`). Prompts, responses, and tool payloads stay
 in the agent: turns carry third-party GitHub and Linear content. A new outcome
-field must follow the same rule: never a raw error string or an untrusted URL. Turning that off rules out LLM-judge evaluations in PostHog, which is
+field follows the same rule: never a raw error string or an untrusted URL. Turning that off rules out LLM-judge evaluations in PostHog, which is
 a deliberate trade.
 
 ## Evals cost real money

--- a/apps/evi/AGENTS.md
+++ b/apps/evi/AGENTS.md
@@ -18,9 +18,11 @@ with a colocated test).
 
 ## What reaches PostHog
 
-Metadata only: tokens, cost, latency, model, tool names. Prompts, responses,
-and tool payloads stay in the agent: turns carry third-party GitHub and Linear
-content. Turning that off rules out LLM-judge evaluations in PostHog, which is
+Metadata only: tokens, cost, latency, model, tool names, and per-tool outcome
+fields — counts, reason codes, and identifiers Evi authored (the namespaces are
+listed in `docs/observability.md`). Prompts, responses, and tool payloads stay
+in the agent: turns carry third-party GitHub and Linear content. A new outcome
+field must follow the same rule: never a raw error string or an untrusted URL. Turning that off rules out LLM-judge evaluations in PostHog, which is
 a deliberate trade.
 
 ## Evals cost real money

--- a/apps/evi/agent/tools/ai-gateway.ts
+++ b/apps/evi/agent/tools/ai-gateway.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { defaultReportTag, reportQuery, scopedReport } from '../lib/gateway'
@@ -80,7 +81,17 @@ export default defineDynamic({
               tags: query.tags?.join(','),
               tags_match: query.tagsMatch,
             })
-            return scopedReport(payload, query)
+            const report = scopedReport(payload, query)
+            useLogger(toolCtx).set({
+              gateway: {
+                report: {
+                  mode: report.scope.mode,
+                  groupBy: query.groupBy,
+                  matchedRows: report.scope.matchedRows,
+                },
+              },
+            })
+            return report
           },
         }),
         ai_gateway__generation: defineTool({

--- a/apps/evi/agent/tools/blob.ts
+++ b/apps/evi/agent/tools/blob.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { uploadSandboxImage } from '../lib/blob'
@@ -19,8 +20,13 @@ export default defineDynamic({
             if (!canAccessAdminTools(toolCtx.session.auth.current)) {
               return { success: false as const, error: 'Image upload is not available in this session.' }
             }
+            const log = useLogger(toolCtx)
             const uploaded = await uploadSandboxImage(await toolCtx.getSandbox(), input.path)
-            if ('error' in uploaded) return { success: false as const, error: uploaded.error }
+            if ('error' in uploaded) {
+              log.set({ blob: { uploaded: false } })
+              return { success: false as const, error: uploaded.error }
+            }
+            log.set({ blob: { uploaded: true, bytes: uploaded.bytes } })
             return { success: true as const, ...uploaded }
           },
         }),

--- a/apps/evi/agent/tools/capture.ts
+++ b/apps/evi/agent/tools/capture.ts
@@ -1,4 +1,5 @@
 import { runAgentBrowser, type EveToolContext } from '@agent-browser/eve/sandbox'
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { missingBlobTokenError, uploadSandboxImage } from '../lib/blob'
@@ -72,12 +73,19 @@ export default defineDynamic({
             if (!canAccessAdminTools(toolCtx.session.auth.current)) {
               return { success: false as const, error: 'Captures are not available in this session.' }
             }
+            const log = useLogger(toolCtx)
             for (const url of [input.beforeUrl, input.afterUrl]) {
               const refusal = validateCaptureUrl(url)
-              if (refusal) return { success: false as const, error: refusal }
+              if (refusal) {
+                log.set({ capture: { published: false, reason: 'origin_refused' } })
+                return { success: false as const, error: refusal }
+              }
             }
             const missingToken = missingBlobTokenError()
-            if (missingToken) return { success: false as const, error: missingToken }
+            if (missingToken) {
+              log.set({ capture: { published: false, reason: 'missing_token' } })
+              return { success: false as const, error: missingToken }
+            }
             const viewport = input.viewport ?? 'desktop'
             const target: CaptureTarget | null = input.selector || input.text
               ? { selector: input.selector, text: input.text }
@@ -87,9 +95,24 @@ export default defineDynamic({
             const before = await captureFrame(toolCtx, { side: 'before', url: input.beforeUrl, target, viewport })
             const after = await captureFrame(toolCtx, { side: 'after', url: input.afterUrl, target, viewport })
             const beforeUpload = await uploadSandboxImage(sandbox, before.path)
-            if ('error' in beforeUpload) return { success: false as const, error: beforeUpload.error }
+            if ('error' in beforeUpload) {
+              log.set({ capture: { published: false, reason: 'upload_failed' } })
+              return { success: false as const, error: beforeUpload.error }
+            }
             const afterUpload = await uploadSandboxImage(sandbox, after.path)
-            if ('error' in afterUpload) return { success: false as const, error: afterUpload.error }
+            if ('error' in afterUpload) {
+              log.set({ capture: { published: false, reason: 'upload_failed' } })
+              return { success: false as const, error: afterUpload.error }
+            }
+            log.set({
+              capture: {
+                published: true,
+                viewport,
+                target: after.how ?? 'viewport',
+                beforeHost: new URL(input.beforeUrl).hostname,
+                afterHost: new URL(input.afterUrl).hostname,
+              },
+            })
             // Only the composed block is returned: handing back the bare image URLs
             // invites a hand-assembled table that drops the attestation receipt.
             return {

--- a/apps/evi/agent/tools/content-targets.ts
+++ b/apps/evi/agent/tools/content-targets.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog/eve'
 import { defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { parseLintReport } from '../lib/content/scan'
@@ -43,6 +44,17 @@ export default defineTool({
       pages: report.pages as LintPage[],
       recentlyTouched: touchedPaths(String(log.stdout)),
       limit: input.limit,
+    })
+
+    useLogger(toolCtx).set({
+      content: {
+        scanned: report.pages.length,
+        candidates: selection.candidates,
+        eligible: selection.eligible,
+        targets: selection.targets.length,
+        ...(selection.group ? { group: selection.group } : {}),
+        ...(input.surface ? { surface: input.surface } : {}),
+      },
     })
 
     return {

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -1,3 +1,4 @@
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { githubCredentials } from '../lib/github/credentials'
@@ -28,8 +29,12 @@ export default defineDynamic({
             if (!isMaintainer(toolCtx.session.auth.current) && !isScheduleAppAuth(toolCtx.session.auth.current)) {
               return { success: false as const, error: 'Only maintainer and schedule-app sessions may push.' }
             }
+            const log = useLogger(toolCtx)
             const refusal = validatePushBranch(input.branch)
-            if (refusal) return { success: false as const, error: refusal }
+            if (refusal) {
+              log.set({ git: { branch: input.branch, pushed: false, reason: 'refused' } })
+              return { success: false as const, error: refusal }
+            }
             const sandbox = await toolCtx.getSandbox()
             const token = await mintInstallationToken(githubCredentials)
             await sandbox.setNetworkPolicy(pushBrokerPolicy(token))
@@ -38,13 +43,16 @@ export default defineDynamic({
                 command: `git -C ${REPO_DIR} push ${PUSH_URL} 'refs/heads/${input.branch}:refs/heads/${input.branch}'`,
               })
               if (push.exitCode !== 0) {
+                log.set({ git: { branch: input.branch, pushed: false, reason: `exit_${push.exitCode}` } })
                 return { success: false as const, error: `git push exited ${push.exitCode}: ${runOutput(push)}` }
               }
               const head = await sandbox.run({ command: `git -C ${REPO_DIR} rev-parse '${input.branch}'` })
+              const sha = String(head.stdout).trim()
+              log.set({ git: { branch: input.branch, pushed: true, sha } })
               return {
                 success: true as const,
                 branch: input.branch,
-                sha: String(head.stdout).trim(),
+                sha,
                 repository: 'HugoRCD/evlog',
               }
             } finally {

--- a/apps/evi/agent/tools/images.ts
+++ b/apps/evi/agent/tools/images.ts
@@ -1,4 +1,5 @@
 import { getToken } from '@vercel/connect'
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool, toolOutput, toolOutputPart } from 'eve/tools'
 import { z } from 'zod'
 import { classifyImageUrl, fetchImage } from '../lib/images'
@@ -27,8 +28,13 @@ export default defineDynamic({
               }
               authorization = `Bearer ${await getToken('linear/evi', { subject: { type: 'app' } })}`
             }
+            const log = useLogger(toolCtx)
             const fetched = await fetchImage(classified.url, { authorization })
-            if ('error' in fetched) return { success: false as const, error: fetched.error }
+            if ('error' in fetched) {
+              log.set({ image: { host: classified.host, fetched: false } })
+              return { success: false as const, error: fetched.error }
+            }
+            log.set({ image: { host: classified.host, fetched: true, bytes: fetched.bytes, mediaType: fetched.mediaType } })
             return { success: true as const, url: input.url, ...fetched }
           },
           toModelOutput(output) {

--- a/apps/evi/agent/tools/turbo.ts
+++ b/apps/evi/agent/tools/turbo.ts
@@ -1,4 +1,5 @@
 import { getVercelOidcToken } from '@vercel/oidc'
+import { useLogger } from 'evlog/eve'
 import { defineDynamic, defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { canAccessAdminTools } from '../lib/trust'
@@ -19,9 +20,11 @@ export default defineDynamic({
             if (!canAccessAdminTools(toolCtx.session.auth.current)) {
               return { success: false as const, error: 'Remote cache access is not available in this session.' }
             }
+            const log = useLogger(toolCtx)
             const teamSlug = process.env.TURBO_TEAM
             const teamId = process.env.VERCEL_TEAM_ID
             if (!teamSlug || !teamId) {
+              log.set({ turbo: { remoteCache: false, reason: 'not_configured' } })
               return { success: false as const, error: 'TURBO_TEAM and VERCEL_TEAM_ID must be configured for remote caching.' }
             }
             // Fetched per call: the env token is minted at boot and expires on a warm instance.
@@ -29,19 +32,23 @@ export default defineDynamic({
             try {
               oidc = await getVercelOidcToken()
             } catch (error) {
+              log.set({ turbo: { remoteCache: false, reason: 'no_oidc_token' } })
               return { success: false as const, error: `No Vercel OIDC token available: ${error instanceof Error ? error.message : String(error)}` }
             }
             let token: string
             try {
               token = await exchangeTurboToken(oidc, teamSlug)
             } catch {
+              log.set({ turbo: { remoteCache: false, reason: 'exchange_failed' } })
               return { success: false as const, error: 'Turborepo token exchange failed; remote caching is unavailable for this run.' }
             }
             const sandbox = await toolCtx.getSandbox()
             const write = await sandbox.run({ command: turboConfigCommand(token, teamId, teamSlug) })
             if (write.exitCode !== 0) {
+              log.set({ turbo: { remoteCache: false, reason: 'config_write_failed' } })
               return { success: false as const, error: `Writing the turbo config failed: ${runOutput(write)}` }
             }
+            log.set({ turbo: { remoteCache: true } })
             return {
               success: true as const,
               team: teamSlug,

--- a/apps/evi/docs/observability.md
+++ b/apps/evi/docs/observability.md
@@ -14,6 +14,21 @@ called and whether each succeeded, how much of the context was cache-served, and
 which surface it came from. Every cost claim in this project was measured from
 these events rather than estimated.
 
+Tool executes enrich the same event with their outcome, in the pattern
+`tools/memory.ts` set: one namespace per domain, holding counts, reason codes,
+and identifiers Evi authored — never raw error strings, tool payloads, or
+untrusted URLs, so the metadata-only PostHog policy holds. The namespaces:
+`git.{branch,pushed,sha,reason}`,
+`capture.{published,viewport,target,beforeHost,afterHost,reason}`,
+`blob.{uploaded,bytes}`, `turbo.{remoteCache,reason}`,
+`gateway.report.{mode,groupBy,matchedRows}`,
+`content.{scanned,candidates,eligible,targets,group,surface}`,
+`image.{host,fetched,bytes,mediaType}`, and
+`memory.{saved,refused,searched,hits}`. A content pass that held everything or
+a push that was refused is chartable from the turn event alone. Tool executes
+are the one place `useLogger()` is contractually bound (see the caller gap
+below), which is why hooks, schedules, and the subagents stay uninstrumented.
+
 `environment` comes from `agent/lib/environment.ts`, the same function that
 builds the gateway spend tags. That is deliberate: a run that bills as `eval`
 also logs as `eval`, so the two views line up. Before, wide events reported

--- a/apps/evi/docs/observability.md
+++ b/apps/evi/docs/observability.md
@@ -16,7 +16,7 @@ these events rather than estimated.
 
 Tool executes enrich the same event with their outcome, in the pattern
 `tools/memory.ts` set: one namespace per domain, holding counts, reason codes,
-and identifiers Evi authored — never raw error strings, tool payloads, or
+and identifiers Evi authored. Never raw error strings, tool payloads, or
 untrusted URLs, so the metadata-only PostHog policy holds. The namespaces:
 `git.{branch,pushed,sha,reason}`,
 `capture.{published,viewport,target,beforeHost,afterHost,reason}`,


### PR DESCRIPTION
Was stacked on #623, now rebased onto main after its merge. Evi is evlog's own agent, yet its turn events said what a turn cost and which tools ran — never what they decided. Every tool execute now enriches the turn wide event through `useLogger(toolCtx)`, the pattern `tools/memory.ts` already used.

## Namespaces added

- `git.{branch,pushed,sha,reason}` — a refused or failed push carries a reason code (`refused`, `exit_<code>`), a successful one its sha.
- `capture.{published,viewport,target,beforeHost,afterHost,reason}`
- `blob.{uploaded,bytes}`
- `turbo.{remoteCache,reason}` (`not_configured`, `no_oidc_token`, `exchange_failed`, `config_write_failed`)
- `gateway.report.{mode,groupBy,matchedRows}` — how a spend report was scoped and whether it matched anything.
- `content.{scanned,candidates,eligible,targets,group,surface}` — the scheduled content pass is now chartable from the turn event alone.
- `image.{host,fetched,bytes,mediaType}`

## The discipline

Counts, reason codes, and identifiers Evi authored — never raw error strings, tool payloads, or untrusted URLs, so the metadata-only PostHog policy in `AGENTS.md` still holds (that section and `docs/observability.md` are updated with the namespaces and the rule).

## Deliberate boundaries

- Only tool executes are instrumented: that is the one place `useLogger()` is contractually bound (`docs/observability.md`, the caller gap). Hooks, schedules, channel failure handlers, and subagents stay as they are — turn/session failures already land on the event as `eve.failure` via the hook.
- The error catalog and the audit trail need an evlog/eve extension to be worth wiring (a system to define per-agent log logic); that is follow-up work, not this PR.

No new lib logic, so no new tests: the change is `log.set` calls in wiring, and `ai.tools[]` already records call success and duration. No changeset (apps/*). Verified with lint on the touched files, `pnpm --filter evi typecheck test`, and `eve build` on Node 24.